### PR TITLE
Caused fatal error in WP 4.2.2

### DIFF
--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -52,7 +52,9 @@ class FrmXMLHelper {
 			return new WP_Error( 'SimpleXML_parse_error', __( 'There was an error when reading this XML file', 'formidable' ), libxml_get_errors() );
 		}
 
-		$xml = simplexml_import_dom( $dom );
+		if(function_exists('simplexml_import_dom')){
+	            $xml = simplexml_import_dom( $dom );
+	        }
 		unset( $dom );
 
 		// halt if loading produces an error


### PR DESCRIPTION
Caused fatal error "Call to undefined function simplexml_import_dom() in FrmXMLHelper.php on line 55"

Fixed by checking if the function exists before calling it.