### PR TITLE
Fixed license response on activation

### DIFF
--- a/classes/models/FrmAddon.php
+++ b/classes/models/FrmAddon.php
@@ -95,7 +95,8 @@ class FrmAddon {
 			$is_valid = 'invalid';
 			if ( is_array( $license_data ) && $license_data['license'] == 'valid' ) {
 				$is_valid = $license_data['license'];
-				$response['success'] = __( 'Enjoy!', 'formidable' );
+				$response['success'] = true;
+				$response['message'] = __( 'Enjoy!', 'formidable' );
 			} else {
 				$response['message'] = __( 'That license is invalid', 'formidable' );
 			}


### PR DESCRIPTION
The response for an activated response from the license server was incorrect. I've fixed it and also #18  has additional fixes for that page as well.