### PR TITLE
Blank Widget Title like WordPress Core

### DIFF
--- a/classes/widgets/FrmShowForm.php
+++ b/classes/widgets/FrmShowForm.php
@@ -8,12 +8,7 @@ class FrmShowForm extends WP_Widget {
 	}
 
 	public function widget( $args, $instance ) {
-        if ( empty($instance['title']) ) {
-            $title = FrmForm::getName( $instance['form'] );
-        } else {
-            $title = $instance['title'];
-        }
-        $title = apply_filters('widget_title', $title);
+        $title = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'], $instance, $this->id_base );
 
 		echo $args['before_widget'];
 


### PR DESCRIPTION
Changed title processing to match WordPress core widgets. A blank title will output nothing, just like core widgets, instead of using the form title in the absence of a widget title. I think this is more predictable behaviour. WordPress core implementation can be found at `wp-includes/widgets/class-wp-widget-pages.php line 55`.