### PR TITLE
Shortcode filter added to new core text widget hook

### DIFF
--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -49,7 +49,7 @@ class FrmHooksController {
         }
 
         add_action( 'plugins_loaded', 'FrmAppController::load_lang' );
-        add_filter( 'widget_text', 'FrmAppController::widget_text_filter', 8 );
+        add_filter( 'widget_text_content', 'FrmAppController::widget_text_filter', 10 );
 
         // Entries controller
         add_action( 'wp_loaded', 'FrmEntriesController::process_entry', 10, 0 );


### PR DESCRIPTION
Changed the hook for widget_text_filter function to hook to widget_text_content instead of widget_text in order to match changes in WordPress 4.8. This prevents the formidable shortcode being processed before wpautop, which causes all kinds of problems.