### PR TITLE
Fix unit tests (2.x) (Work In Progress)

### DIFF
--- a/tests/entries/test_FrmEntry.php
+++ b/tests/entries/test_FrmEntry.php
@@ -40,6 +40,10 @@ class WP_Test_FrmEntry extends FrmUnitTest {
 			$this->markTestSkipped( 'Pro is not active' );
 		}
 
+		if ( ! version_compare( PHP_VERSION, '5.3.2', '>=' ) ) {
+			$this->markTestSkipped( 'ReflectionMethod::setAccessible() requires PHP 5.3.2 or higher.' );
+		}		
+
 		$entry = FrmEntry::getOne( 'post-entry-1', true );
 		$this->assertNotEmpty( $entry, 'Entry not found: post-entry-1' );
 		$values = self::_setup_test_update_values( $entry );

--- a/tests/entries/test_FrmProEntriesController.php
+++ b/tests/entries/test_FrmProEntriesController.php
@@ -363,6 +363,11 @@ class WP_Test_FrmProEntriesController extends FrmUnitTest {
 	* TODO: Test with post fields, IP, and user_id parameters
 	*/
 	function test_get_frm_field_value_entry(){
+		if ( ! version_compare( PHP_VERSION, '5.3.2', '>=' ) ) {
+			$this->markTestSkipped( 'ReflectionMethod::setAccessible() requires PHP 5.3.2 or higher.' );
+		}
+
+
 		$tests = array( 1, 2, 3, 4, 5, 6, 7, 8, 9 );
 		$field = FrmField::getOne( 'text-field' );
 		$entry_id = $this->factory->entry->get_id_by_key( 'jamie_entry_key' );

--- a/tests/entries/test_FrmShowEntryShortcode.php
+++ b/tests/entries/test_FrmShowEntryShortcode.php
@@ -740,7 +740,14 @@ class test_FrmShowEntryShortcode extends FrmUnitTest {
 		$table .= $this->two_cell_table_row( 'free-number-field', $atts );
 		$table .= $this->two_cell_table_row( 'free-phone-field', $atts );
 		$table .= $this->two_cell_table_row( 'free-hidden-field', $atts );
-		//$table .= $this->one_cell_table_row( 'free-html-field', $atts );
+
+  		if ( ! empty( $atts['include_extras'] ) ) {
+  			$include_extras = array_map( 'trim', explode( ',',  $atts['include_extras'] ) );
+
+  			if ( $this->is_pro_active && in_array( 'html', $include_extras ) ) {
+				$table .= $this->one_cell_table_row( 'free-html-field', $atts );
+  			}
+  		}
 
 		$table .= $this->user_info_rows( $atts );
 
@@ -760,7 +767,14 @@ class test_FrmShowEntryShortcode extends FrmUnitTest {
 		$content .= $this->label_and_value_plain_text_row( 'free-number-field', $atts );
 		$content .= $this->label_and_value_plain_text_row( 'free-phone-field', $atts );
 		$content .= $this->label_and_value_plain_text_row( 'free-hidden-field', $atts );
-		//$content .= $this->single_value_plain_text_row( 'free-html-field', $atts );
+
+  		if ( ! empty( $atts['include_extras'] ) ) {
+  			$include_extras = array_map( 'trim', explode( ',',  $atts['include_extras'] ) );
+
+  			if ( $this->is_pro_active && in_array( 'html', $include_extras ) ) {
+				$content .= $this->single_value_plain_text_row( 'free-html-field', $atts );
+  			}
+  		}
 
 		$content .= $this->user_info_plain_text_rows( $atts );
 

--- a/tests/misc/test_FrmProAppHelper.php
+++ b/tests/misc/test_FrmProAppHelper.php
@@ -35,6 +35,10 @@ class WP_Test_FrmProAppHelper extends FrmUnitTest {
 	 * @covers FrmProAppHelper::prepare_dfe_text
 	 */
 	function test_prepare_dfe_text() {
+		if ( ! version_compare( PHP_VERSION, '5.3.2', '>=' ) ) {
+			$this->markTestSkipped( 'ReflectionMethod::setAccessible() requires PHP 5.3.2 or higher.' );
+		}
+		
 		$test_values_array = self::_setup_test_values();
 
 		foreach( $test_values_array as $test_values ) {

--- a/tests/views/test_FrmProDisplaysController.php
+++ b/tests/views/test_FrmProDisplaysController.php
@@ -2596,6 +2596,10 @@ class WP_Test_FrmProDisplaysController extends FrmUnitTest {
 	 * @covers FrmProDisplaysController::get_where_query_for_view_listing_page
 	 */
 	function test_query_size_for_no_filter_view() {
+		if ( ! version_compare( PHP_VERSION, '5.3.2', '>=' ) ) {
+			$this->markTestSkipped( 'ReflectionMethod::setAccessible() requires PHP 5.3.2 or higher.' );
+		}
+
 		$view = self::get_view_by_key( 'dynamic-view' );
 		$atts = self::get_default_atts_for_view( $view );
 
@@ -2613,6 +2617,10 @@ class WP_Test_FrmProDisplaysController extends FrmUnitTest {
 	 * @covers FrmProDisplaysController::get_where_query_for_view_listing_page
 	 */
 	function test_query_size_for_draft_filter_view() {
+		if ( ! version_compare( PHP_VERSION, '5.3.2', '>=' ) ) {
+			$this->markTestSkipped( 'ReflectionMethod::setAccessible() requires PHP 5.3.2 or higher.' );
+		}
+		
 		$view = self::get_view_by_key( 'dynamic-view' );
 		$atts = self::get_default_atts_for_view( $view );
 


### PR DESCRIPTION
I'm going through the unit tests to see why some are not passing and fixing what needs to be fixed.

In Travis some of the builds are failing due to the tests using some reflection functions that weren't introduced until PHP 5.3.2 (this should be fixed now).
Some other builds seem to be failing due to Composer version constraints (not addressed yet).

I'm still running some of the tests, so this is *work in progress*. Will update the PR when I'm done.