### PR TITLE
Workaround WP unit testing bootstrap issue for multisite

### DIFF
--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -22,7 +22,8 @@ class FrmUnitTest extends WP_UnitTestCase {
 		parent::setUp();
 
 		if ( is_multisite() ) {
-			$this->is_pro_active = get_site_option( 'frmpro-authorized' );
+			// WP unit testing bootstrap doesn't bother hooking into `pre_site_option` so we need to get_option() instead.
+			$this->is_pro_active = get_site_option( 'frmpro-authorized' ) || get_option( 'frmpro-authorized' );
 		} else {
 			$this->is_pro_active = get_option( 'frmpro-authorized' );
 		}


### PR DESCRIPTION
The WP-develop bootstrap file only hooks into `pre_option` for options added to the `wp_tests_options` array, but `pre_option` is not used by `get_site_option()`, which affects multisite testing. Even though Pro is installed and active, the `is_pro_active` var shared by all unit tests is set to `false` because of this, and producing some errors such as field counts not matching.