### PR TITLE
Fix Travis build on PHP 7.1 + master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ install:
 - if [[ $TRAVIS_PHP_VERSION == "5.2.17" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local --unset; fi
 
 before_script:
+- phpunit --version
 - export PHPCS_DIR=/tmp/phpcs
 - export SNIFFS_DIR=/tmp/sniffs
 # Install CodeSniffer for WordPress Coding Standards checks.


### PR DESCRIPTION
Travis uses PHPUnit 7 on PHP 7.1, which results in this [compat code from WordPress-develop](https://github.com/WordPress/wordpress-develop/blob/master/tests/phpunit/includes/phpunit6-compat.php#L18) being executed:

```
class PHPUnit_Util_Test extends PHPUnit\Util\Test {
....
}
```

but `PHPUnit\Util\Test` is a **final** class on PHPUnit 7.0, which produces a fatal error and the failure of the build:

```
PHP Fatal error:  Class PHPUnit_Util_Test may not inherit from final class (PHPUnit\Util\Test) in /tmp/wordpress/tests/phpunit/includes/phpunit6-compat.php on line 18
```