### PR TITLE
Extra space in failed_msg text

### DIFF
--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -94,7 +94,7 @@ class FrmSettings {
             'blank_msg' => __( 'This field cannot be blank.', 'formidable' ),
             'unique_msg' => __( 'This value must be unique.', 'formidable' ),
             'invalid_msg' => __( 'There was a problem with your submission. Errors are marked below.', 'formidable' ),
-            'failed_msg' => __( 'We\'re sorry. It looks like you\'ve  already submitted that.', 'formidable' ),
+            'failed_msg' => __( 'We\'re sorry. It looks like you\'ve already submitted that.', 'formidable' ),
             'submit_value' => __( 'Submit', 'formidable' ),
             'login_msg' => __( 'You do not have permission to view this form.', 'formidable' ),
             'admin_permission' => __( 'You do not have permission to do that', 'formidable' ),


### PR DESCRIPTION
There is an extra space in the default `failed_msg` text string.