### PR TITLE
Add new frm_include_field_in_content filter in include_field_in_content method

### DIFF
--- a/classes/models/FrmEntryFormatter.php
+++ b/classes/models/FrmEntryFormatter.php
@@ -749,7 +749,7 @@ class FrmEntryFormatter {
 			$include = false;
 		}
 
-		return $include;
+		return apply_filters( 'frm_include_field_in_content', $include, $field_value );
 	}
 
 	/**


### PR DESCRIPTION
So we can choose which fields has to be hidden from [default-message] email content.