### PR TITLE
Reduces cases that trigger admin calculation warning.

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -755,7 +755,7 @@ function frmAdminBuildJS(){
 	 * @returns {RegExp}
 	 */
 	function getNonFormShortcodes() {
-		return /\[(if\b|foreach|created-at|created-by|updated-at|updated-by)|((key|id)\])/;
+		return /\[id\]|\[key\]|\[if\s\w+\]|\[foreach\s\w+\]|\[created-at\]|\[created-at\sformat=[\'\"][\w/\-\/]+[\'\"]\]/g;
 	}
 
 	function popCalcFields(v){


### PR DESCRIPTION
Thank you for this -- https://github.com/Strategy11/formidable/issues/2049.

I like this approach much more.  It should eliminate all or most of the false positives that annoy people.  

I've allowed more formats with created_at to trigger the warning.  Is that okay?  If not, I'd be happy to do just Y-m-d.  And make any other changes you'd like.