### PR TITLE
Adds frm-width-auto class to admin CSS

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6266,6 +6266,10 @@ iframe#dyncontent_ifr {
 	outline: 0;
 }
 
+.frm-fields select.frm-width-auto {
+	width: auto;
+}
+
 .frm-fields button.btn {
 	line-height: normal;
 	height: auto;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6266,7 +6266,10 @@ iframe#dyncontent_ifr {
 	outline: 0;
 }
 
-.frm-fields select.frm-width-auto {
+.frm-fields input[type="text"].frm-width-auto,
+.frm-fields select.frm-width-auto,
+.field-group input[type="text"].frm-width-auto,
+.field-group select.frm-width-auto {
 	width: auto;
 }
 


### PR DESCRIPTION
Adds frm-width-auto class for text and select fields in the admin.  https://github.com/Strategy11/formidable-pro/issues/2257