### PR TITLE
Add support for '0' in 'other' field text input

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1132,7 +1132,7 @@ class FrmFieldsHelper {
 		self::set_other_name( $args, $other_args );
 		self::set_other_value( $args, $other_args );
 
-		if ( $other_args['value'] ) {
+		if ( '' !== $other_args['value'] ) {
 			$checked = 'checked="checked" ';
 		}
 


### PR DESCRIPTION
@stephywells I hadn't pushed this change before you merged issue/pro/2189