### PR TITLE
Adding a `frm_pre_get_one` filter 

### DIFF
--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -589,7 +589,7 @@ class FrmForm {
 			FrmAppHelper::unserialize_or_decode( $results->options );
 		}
 
-		return apply_filters( 'frm_pre_get_form', wp_unslash( $results ) );
+		return apply_filters( 'frm_pre_get_one', wp_unslash( $results ) );
 	}
 
 	/**

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -589,7 +589,7 @@ class FrmForm {
 			FrmAppHelper::unserialize_or_decode( $results->options );
 		}
 
-		return wp_unslash( $results );
+		return apply_filters( 'frm_pre_get_form', wp_unslash( $results ) );
 	}
 
 	/**

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -589,7 +589,7 @@ class FrmForm {
 			FrmAppHelper::unserialize_or_decode( $results->options );
 		}
 
-		return apply_filters( 'frm_pre_get_one', wp_unslash( $results ) );
+		return apply_filters( 'frm_form_object', wp_unslash( $results ) );
 	}
 
 	/**


### PR DESCRIPTION
Hi,

Could we add this filter to the FrmForm::getOne method so we can hook on form attributes ? 

The `frm_pre_display_form` filter is not called on the `getOne` method which is called when autosaving drafts on multiple steps forms.

Thanks.