### PR TITLE
Issue/pro/2420

### DIFF
--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -1419,7 +1419,7 @@ BEFORE_HTML;
 	 */
 	private static function get_unsafe_params( $url ) {
 		$redirect_components = parse_url( $url );
-		if ( empty ( $redirect_components['query'] ) ) {
+		if ( empty( $redirect_components['query'] ) ) {
 			return array();
 		}
 		parse_str( $redirect_components['query'], $redirect_params );

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -1419,6 +1419,9 @@ BEFORE_HTML;
 	 */
 	private static function get_unsafe_params( $url ) {
 		$redirect_components = parse_url( $url );
+		if ( empty ( $redirect_components['query'] ) ) {
+			return array();
+		}
 		parse_str( $redirect_components['query'], $redirect_params );
 		$redirect_param_names      = array_keys( $redirect_params );
 		$reserved_words            = self::reserved_words();


### PR DESCRIPTION
Fixes warning from FrmFieldHelper::get_unsafe_params when the URL doesn't have a query.

https://github.com/Strategy11/formidable-pro/issues/2420