### PR TITLE
don't load CSS for unused custom styles

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -621,8 +621,14 @@ legend.frm_hidden{
 }
 
 <?php
+$forms = FrmForm::get_published_forms();
+$used_styles = array( $default_style->ID );
+foreach ( $forms as $form ) {
+	$used_styles[] = $form->options['custom_style'];
+}
 foreach ( $styles as $style ) {
-	include( dirname( __FILE__ ) . '/_single_theme.css.php' );
+	if ( in_array( $style->ID, $used_styles) )
+		include( dirname( __FILE__ ) . '/_single_theme.css.php' );
 	unset( $style );
 }
 


### PR DESCRIPTION
this would avoid adding CSS for unused styles.  (I'm not sure this gets re-generated when the "manage" settings are saved though.)