### PR TITLE
import fix for csv checkbox values

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1210,7 +1210,16 @@ DEFAULT_HTML;
 		FrmAppHelper::unserialize_or_decode( $checked );
 
 		if ( ! is_array( $checked ) ) {
-			$checked = explode( ',', $checked );
+			$filtered_checked = $checked;
+			$csv_values_checked = array();
+			foreach ( (array) $this->field->options as $option ) {
+				if ( $checked === $option['value'] ) {
+					$csv_values_checked[] = $option['value'];
+					$filtered_checked = str_replace( $option['value'], '', $checked );
+				}
+			}
+
+			$checked = array_merge( $csv_values_checked, array_filter( explode( ',', $filtered_checked ) ) );
 		}
 
 		if ( ! empty( $checked ) && count( $checked ) > 1 ) {


### PR DESCRIPTION
https://github.com/Strategy11/formidable-pro/issues/2405

Before the explode, I'm checking for exact matches on the csv string, and removing the specific csv items.

This could possibly fall apart if we had too many similar looking options, like:

"red, green, blue"
"red, green, blue, white"

Where if red, green, blue was selected, it would also remove the red, green, blue from red, green, blue, white.

But I think this update will at least leave us in better shape without having to change much.