### PR TITLE
use strpos for partial matches

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1213,7 +1213,7 @@ DEFAULT_HTML;
 			$filtered_checked = $checked;
 			$csv_values_checked = array();
 			foreach ( (array) $this->field->options as $option ) {
-				if ( $checked === $option['value'] ) {
+				if ( strpos( $checked, $option['value'] ) !== false ) {
 					$csv_values_checked[] = $option['value'];
 					$filtered_checked = str_replace( $option['value'], '', $checked );
 				}


### PR DESCRIPTION
[The first commit](https://github.com/Strategy11/formidable-forms/pull/204) was merged pretty quickly, but I had actually made a second that changes the equals to a strpos check. I think the first fix would only work is there was one item selected.

May also be nice to add unit tests around this.