### PR TITLE
add unit testing for get multi opts for import

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1201,8 +1201,7 @@ DEFAULT_HTML;
 	 * @return array
 	 */
 	protected function get_multi_opts_for_import( $value ) {
-
-		if ( ! $this->field || empty( $value ) || in_array( $value, (array) $this->field->options ) ) {
+		if ( ! $this->field || ! $value || in_array( $value, (array) $this->field->options ) ) {
 			return $value;
 		}
 
@@ -1210,14 +1209,20 @@ DEFAULT_HTML;
 		FrmAppHelper::unserialize_or_decode( $checked );
 
 		if ( ! is_array( $checked ) ) {
-			$filtered_checked = $checked;
+			$filtered_checked   = $checked;
 			$csv_values_checked = array();
-			foreach ( (array) $this->field->options as $option ) {
-				if ( strpos( $checked, $option['value'] ) !== false ) {
+
+			$options = (array) $this->field->options;
+			$options = array_reverse( $options );
+
+			foreach ( $options as $option ) {
+				if ( isset( $option['value'] ) && strpos( $filtered_checked, $option['value'] ) !== false ) {
 					$csv_values_checked[] = $option['value'];
-					$filtered_checked = str_replace( $option['value'], '', $checked );
+					$filtered_checked     = str_replace( $option['value'], '', $filtered_checked );
 				}
 			}
+
+			$csv_values_checked = array_reverse( $csv_values_checked );
 
 			$checked = array_merge( $csv_values_checked, array_filter( explode( ',', $filtered_checked ) ) );
 		}

--- a/tests/fields/test_FrmFieldType.php
+++ b/tests/fields/test_FrmFieldType.php
@@ -131,4 +131,26 @@ class test_FrmFieldType extends FrmUnitTest {
 			$this->assertEquals( $value['expected'], $value['value'] );
 		}
 	}
+
+	/**
+	 * @covers FrmFieldType::get_import_value
+	 */
+	public function test_get_import_value() {
+		$field = new stdClass;
+		$field->type = 'checkbox';
+		$field->options = array(
+			array( 'value' => 'a', 'label' => 'A' ),
+			array( 'value' => 'b', 'label' => 'B' ),
+			array( 'value' => 'c', 'label' => 'C' ),
+			array( 'value' => 'a,b', 'label' => 'A, B' ),
+			array( 'value' => 'a,b,c', 'label' => 'A, B, C' ),
+			array( 'value' => 'a, b, c', 'label' => 'A, B, C' ),
+		);
+
+		$checkbox = FrmFieldFactory::get_field_type( 'checkbox', $field );
+
+		$this->assertEquals( $checkbox->get_import_value( 'a,b' ), 'a,b' );
+		$this->assertEquals( $checkbox->get_import_value( 'a,c' ), array( 'a', 'c' ) );
+		$this->assertEquals( $checkbox->get_import_value( 'a,b,c' ), 'a,b,c' );
+	}
 }


### PR DESCRIPTION
Another follow-up to https://github.com/Strategy11/formidable-forms/pull/207

I took some liberty here in reversing the array. I assume it's more likely that the options would appear as 

```
$field->options = array(
    array( 'value' => 'a', 'label' => 'A' ),
    array( 'value' => 'b', 'label' => 'B' ),
    array( 'value' => 'c', 'label' => 'C' ),
    array( 'value' => 'a,b', 'label' => 'A, B' ),
    array( 'value' => 'a,b,c', 'label' => 'A, B, C' ),
    array( 'value' => 'a, b, c', 'label' => 'A, B, C' ),
);
```

than as

```
$field->options = array(
    array( 'value' => 'a,b', 'label' => 'A, B' ),
    array( 'value' => 'a,b,c', 'label' => 'A, B, C' ),
    array( 'value' => 'a, b, c', 'label' => 'A, B, C' ),
    array( 'value' => 'a', 'label' => 'A' ),
    array( 'value' => 'b', 'label' => 'B' ),
    array( 'value' => 'c', 'label' => 'C' ),
);
```

But maybe we want a more robust option. We could sort them by longest to shortest, try that way instead.

I also added an `isset` to the options key. It seems that it was breaking a few formidable-pro unit tests in travis.

```
1) test_FrmProImportCSV::test_import_csv

Illegal string offset 'value'

/tmp/wordpress/src/wp-content/plugins/formidable/classes/models/fields/FrmFieldType.php:1216

/tmp/wordpress/src/wp-content/plugins/formidable/classes/models/fields/FrmFieldCheckbox.php:83

/tmp/wordpress/src/wp-content/plugins/formidable/classes/models/fields/FrmFieldType.php:1159

/tmp/wordpress/src/wp-content/plugins/formidable-pro/classes/helpers/FrmProXMLHelper.php:294

/tmp/wordpress/src/wp-content/plugins/formidable-pro/classes/helpers/FrmProXMLHelper.php:251

/tmp/wordpress/src/wp-content/plugins/formidable-pro/classes/helpers/FrmProXMLHelper.php:224

/tmp/wordpress/src/wp-content/plugins/formidable-pro/classes/helpers/FrmProXMLHelper.php:190

/tmp/wordpress/src/wp-content/plugins/formidable-pro/tests/import-export/test_FrmProImportCSV.php:112

2) test_FrmProImportCSV::test_update_by_key

Illegal string offset 'value'

/tmp/wordpress/src/wp-content/plugins/formidable/classes/models/fields/FrmFieldType.php:1216

/tmp/wordpress/src/wp-content/plugins/formidable/classes/models/fields/FrmFieldCheckbox.php:83

/tmp/wordpress/src/wp-content/plugins/formidable/classes/models/fields/FrmFieldType.php:1159

/tmp/wordpress/src/wp-content/plugins/formidable-pro/classes/helpers/FrmProXMLHelper.php:294

/tmp/wordpress/src/wp-content/plugins/formidable-pro/classes/helpers/FrmProXMLHelper.php:251

/tmp/wordpress/src/wp-content/plugins/formidable-pro/classes/helpers/FrmProXMLHelper.php:224

/tmp/wordpress/src/wp-content/plugins/formidable-pro/classes/helpers/FrmProXMLHelper.php:190

/tmp/wordpress/src/wp-content/plugins/formidable-pro/tests/import-export/test_FrmProImportCSV.php:147
```