### PR TITLE
loggedout is not a valid form visibility fix

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1207,7 +1207,7 @@ class FrmAppHelper {
 	 * @return bool
 	 */
 	public static function current_user_can( $role ) {
-		if ( $role == '-1' ) {
+		if ( $role === '-1' ) {
 			return false;
 		}
 
@@ -1223,7 +1223,12 @@ class FrmAppHelper {
 			$role = 'administrator';
 		}
 
-		return current_user_can( $role );
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		$user = wp_get_current_user();
+		return in_array( $role, $user->roles, true );
 	}
 
 	/**

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -587,6 +587,8 @@ class FrmUnitTest extends WP_UnitTestCase {
 
 				add_role( 'formidable_custom_role', 'Custom Role' );
 				$user->add_role( 'formidable_custom_role' );
+
+				$this->set_user_by_role( 'formidable_custom_role' );
 				break;
 
 			default:

--- a/tests/forms/test_FrmFormsHelper.php
+++ b/tests/forms/test_FrmFormsHelper.php
@@ -26,9 +26,9 @@ class test_FrmFormsHelper extends FrmUnitTest {
 		$this->assert_form_is_hidden( 'editor', array( 'contributor', 'author' ), 'Editors should not set a form assigned to contributors and authors' );
 		$this->assert_form_is_hidden( 'subscriber', array( 'editor', 'author' ), 'Contributors should not set a form assigned to editors and authors' );
 		$this->assert_form_is_hidden( 'subscriber', array( 'author', 'administrator' ), 'Contributors should not set a form assigned to authors and administrators' );
-		$this->assert_form_is_hidden( 'administrator', array( 'subscriber' ), 'Adminstrator should not be able to see a form without an exact array match' );
-		$this->assert_form_is_hidden( 'administrator', array( 'editor', 'author' ), 'Adminstrator should not be able to see a form without an exact array match' );
-		
+		$this->assert_form_is_hidden( 'administrator', array( 'subscriber' ), 'Administrator should not be able to see a form without an exact array match' );
+		$this->assert_form_is_hidden( 'administrator', array( 'editor', 'author' ), 'Administrator should not be able to see a form without an exact array match' );
+
 		// test custom roles
 		$this->assert_form_is_visible( 'formidable_custom_role', 'formidable_custom_role', 'Custom role should be able to see a form assigned to it' );
 		$this->assert_form_is_visible( 'formidable_custom_role', '', 'Custom role should be able to see a form assigned to logged in users' );

--- a/tests/forms/test_FrmFormsHelper.php
+++ b/tests/forms/test_FrmFormsHelper.php
@@ -32,7 +32,7 @@ class test_FrmFormsHelper extends FrmUnitTest {
 		// test custom roles
 		$this->assert_form_is_visible( 'formidable_custom_role', 'formidable_custom_role', 'Custom role should be able to see a form assigned to it' );
 		$this->assert_form_is_visible( 'formidable_custom_role', '', 'Custom role should be able to see a form assigned to logged in users' );
-		$this->assert_form_is_hidden( 'formidable_custom_role', 'editor', 'Custom role should not be able to see a form not assigned to it' );
+		$this->assert_form_is_hidden( 'formidable_custom_role', array( 'administrator' ), 'Custom role should not be able to see a form not assigned to it' );
 		$this->assert_form_is_hidden( 'formidable_custom_role', array( 'editor', 'subscriber' ), 'Custom role should not be able to see a form not assigned to it' );
 	}
 

--- a/tests/forms/test_FrmFormsHelper.php
+++ b/tests/forms/test_FrmFormsHelper.php
@@ -22,11 +22,11 @@ class test_FrmFormsHelper extends FrmUnitTest {
 		$this->assert_form_is_hidden( 'loggedout', 'editor', 'Logged out user cannot view form set to editors' );
 
 		// Array options are expected to only match directly
-		$this->assert_form_is_hidden( 'editor', array( 'loggedout', 'subscriber' ), 'Editors should not set a form assigned to logged out users and subscribers' );
+		$this->assert_form_is_hidden( 'editor', array( 'subscriber' ), 'Editors should not set a form assigned to subscribers' );
 		$this->assert_form_is_hidden( 'editor', array( 'contributor', 'author' ), 'Editors should not set a form assigned to contributors and authors' );
 		$this->assert_form_is_hidden( 'subscriber', array( 'editor', 'author' ), 'Contributors should not set a form assigned to editors and authors' );
 		$this->assert_form_is_hidden( 'subscriber', array( 'author', 'administrator' ), 'Contributors should not set a form assigned to authors and administrators' );
-		$this->assert_form_is_hidden( 'administrator', array( 'loggedout', 'subscriber' ), 'Adminstrator should not be able to see a form without an exact array match' );
+		$this->assert_form_is_hidden( 'administrator', array( 'subscriber' ), 'Adminstrator should not be able to see a form without an exact array match' );
 		$this->assert_form_is_hidden( 'administrator', array( 'editor', 'author' ), 'Adminstrator should not be able to see a form without an exact array match' );
 		
 		// test custom roles


### PR DESCRIPTION
Follow-up from the broken tests in https://github.com/Strategy11/formidable-forms/pull/193

Took a couple of tries to get this working in travis (it was fine locally).

`Adminstrator should not be able to see a form without an exact array match`.

First thought was that the tests are checking for things that aren't valid settings, but that didn't seem to effect the test breaking.

Second thought, is that administrator might actually pass the "current_user_can" check for subscriber, so I'm switching to an exact array match.

It was still failing for custom roles though, so I fixed that as well by calling `set_user_by_role` like we do for other roles. I also think it's possible that the custom role would have originally passed an editor check, so I'm changing the test to check for exact matches instead.

Also, I had administrator spelled wrong (missing an i) in two of the error messages.

I also made the `-1` check a strict match to shut up the code styling warnings I have on now 😁