### PR TITLE
load pro hooks in frm unit test constructor

### DIFF
--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -17,7 +17,11 @@ class FrmUnitTest extends WP_UnitTestCase {
 
 	public function __construct() {
 		parent::__construct();
-		FrmHooksController::load_hooks();		
+		FrmHooksController::load_hooks();
+
+		if ( class_exists( 'FrmProHooksController' ) ) {
+			FrmProHooksController::load_hooks();
+		}
 	}
 
 	/**


### PR DESCRIPTION
One step closer to running unit tests normally in PHP 7.3 :)