### PR TITLE
use frm role formidable custom role case logic update

### DIFF
--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -597,7 +597,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 				add_role( 'formidable_custom_role', 'Custom Role' );
 				$user->add_role( 'formidable_custom_role' );
 
-				$this->set_user_by_role( 'formidable_custom_role' );
+				wp_set_current_user( $user->ID );
 				break;
 
 			default:


### PR DESCRIPTION
I think this should fix the issue with https://travis-ci.com/github/Strategy11/formidable-pro/jobs/371232530 failing, but I'm not actually getting the error.

I just think that set_user_by_role might be getting another user then the one I just stripped, that has editor permissions for whatever reason.

This should be safer, guarantees we actually set the user we're modifying.