### PR TITLE
register post types and widgets in frm unit test constructor

### DIFF
--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -22,6 +22,9 @@ class FrmUnitTest extends WP_UnitTestCase {
 		if ( class_exists( 'FrmProHooksController' ) ) {
 			FrmProHooksController::load_hooks();
 		}
+
+		FrmFormsController::register_widgets();
+		FrmFormActionsController::register_post_types();
 	}
 
 	/**


### PR DESCRIPTION
Resolves my final 2 failures when running phpunit on formidable lite.

<img width="871" alt="Screen Shot 2020-08-12 at 2 45 47 PM" src="https://user-images.githubusercontent.com/9134515/90048929-8f99e500-dcaa-11ea-9a50-e8c9c60accb3.png">