### PR TITLE
do not allow captcha override

### DIFF
--- a/classes/models/fields/FrmFieldCaptcha.php
+++ b/classes/models/fields/FrmFieldCaptcha.php
@@ -64,6 +64,14 @@ class FrmFieldCaptcha extends FrmFieldType {
 		return str_replace( ' for="field_[key]"', ' for="g-recaptcha-response"', $html );
 	}
 
+	/**
+	 * @return bool
+	 */
+	protected function should_show_captcha() {
+		$frm_settings = FrmAppHelper::get_settings();
+		return ! empty( $frm_settings->pubkey );
+	}
+
 	public function front_field_input( $args, $shortcode_atts ) {
 		$frm_settings = FrmAppHelper::get_settings();
 		if ( empty( $frm_settings->pubkey ) ) {
@@ -139,13 +147,7 @@ class FrmFieldCaptcha extends FrmFieldType {
 		}
 
 		if ( ! isset( $_POST['g-recaptcha-response'] ) ) {
-			// If captcha is missing, check if it was already verified.
-			$checked = FrmAppHelper::get_param( 'recaptcha_checked', '', 'post', 'sanitize_text_field' );
-			if ( ! isset( $_POST['recaptcha_checked'] ) || ! wp_verify_nonce( $checked, 'frm_ajax' ) ) {
-				// There was no captcha submitted.
-				$errors[ 'field' . $args['id'] ] = __( 'The captcha is missing from this form', 'formidable' );
-			}
-
+			$errors[ 'field' . $args['id'] ] = __( 'The captcha is missing from this form', 'formidable' );
 			return $errors;
 		}
 
@@ -173,13 +175,8 @@ class FrmFieldCaptcha extends FrmFieldType {
 			return false;
 		}
 
-		$frm_settings = FrmAppHelper::get_settings();
-		if ( empty( $frm_settings->pubkey ) ) {
-			// don't require the captcha if it shouldn't be shown
-			return false;
-		}
-
-		return true;
+		// don't require the captcha if it shouldn't be shown
+		return $this->should_show_captcha();
 	}
 
 	protected function send_api_check( $frm_settings ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -767,7 +767,7 @@ function frmFrontFormJS() {
 					return;
 				}
 			}
-			$recapField.closest( '.frm_form_field' ).replaceWith( '<input type="hidden" name="recaptcha_checked" value="' + frm_js.nonce + '">' );
+			$recapField.closest( '.frm_form_field' ).replaceWith( '' );
 		}
 	}
 


### PR DESCRIPTION
https://github.com/Strategy11/formidable-pro/issues/2582

This _should_ be fine. replaceCheckedRecaptcha actually only gets called when captcha is actually broken (which I guess we're basically out of luck because you can't really track that in any way that isn't exploitable), or if captcha isn't actually configured properly (should_show_captcha).

As far as I understand, there is no actual "if it was already verified." logic here.