### PR TITLE
Xml field import fix for preexisting fields

### DIFF
--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -400,6 +400,8 @@ class FrmXMLHelper {
 				self::create_imported_field( $f, $imported );
 			}
 		}
+
+		self::maybe_update_field_ids( $form_id );
 	}
 
 	private static function fill_field( $field, $form_id ) {
@@ -611,6 +613,33 @@ class FrmXMLHelper {
 		if ( $new_id != false ) {
 			$imported['imported']['fields'] ++;
 			do_action( 'frm_after_field_is_imported', $f, $new_id );
+		}
+	}
+
+	/**
+	 * Update any field ids for fields created later than the existing field.
+	 *
+	 * @since 4.06
+	 */
+	protected static function maybe_update_field_ids( $form_id ) {
+		$where  = array(
+			array(
+				'or'                => 1,
+				'fi.form_id'        => $form_id,
+				'fr.parent_form_id' => $form_id,
+			),
+		);
+		$fields = FrmField::getAll( $where, 'field_order' );
+		foreach ( $fields as $field ) {
+			$before = (array) clone $field;
+			$field  = (array) $field;
+			erroR_log( 'Default1: '. print_r($before['default_value'],1 ) );
+			$after  = apply_filters( 'frm_duplicated_field', $field, array( 'after' => true ) );
+			erroR_log( 'Default2: '. print_r($before['default_value'],1 ) );
+			if ( $before !== $after ) {
+				// Update field again.
+				error_log('UPDATE '. $after['id'] .' '. $after['name']);
+			}
 		}
 	}
 

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -358,9 +358,8 @@ class FrmXMLHelper {
 	 * TODO: Cut down on params
 	 */
 	private static function import_xml_fields( $xml_fields, $form_id, $this_form, &$form_fields, &$imported ) {
+		$in_section                = 0;
 		$keys_by_original_field_id = array();
-
-		$in_section = 0;
 
 		foreach ( $xml_fields as $field ) {
 			$f = self::fill_field( $field, $form_id );

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -358,8 +358,7 @@ class FrmXMLHelper {
 	 * TODO: Cut down on params
 	 */
 	private static function import_xml_fields( $xml_fields, $form_id, $this_form, &$form_fields, &$imported ) {
-		global $frm_keys_by_original_field_id;
-		$frm_keys_by_original_field_id = array();
+		$keys_by_original_field_id = array();
 
 		$in_section = 0;
 
@@ -386,7 +385,7 @@ class FrmXMLHelper {
 						unset( $form_fields[ $f['field_key'] ] );
 					}
 				} elseif ( isset( $form_fields[ $f['field_key'] ] ) ) {
-					$frm_keys_by_original_field_id[ $f['id'] ] = $f['field_key'];
+					$keys_by_original_field_id[ $f['id'] ] = $f['field_key'];
 
 					// check for field to edit by field key
 					unset( $f['id'] );
@@ -406,7 +405,9 @@ class FrmXMLHelper {
 			}
 		}
 
-		self::maybe_update_field_ids( $form_id );
+		if ( $keys_by_original_field_id ) {
+			self::maybe_update_field_ids( $form_id, $keys_by_original_field_id );
+		}
 	}
 
 	private static function fill_field( $field, $form_id ) {
@@ -625,10 +626,11 @@ class FrmXMLHelper {
 	 * Fix field ids for fields that already exist prior to import.
 	 *
 	 * @since 4.07
+	 * @param int $form_id
+	 * @param array $keys_by_original_field_id
 	 */
-	protected static function maybe_update_field_ids( $form_id ) {
+	protected static function maybe_update_field_ids( $form_id, $keys_by_original_field_id ) {
 		global $frm_duplicate_ids;
-		global $frm_keys_by_original_field_id;
 
 		$former_duplicate_ids = $frm_duplicate_ids;
 		$where                = array(
@@ -644,7 +646,7 @@ class FrmXMLHelper {
 		foreach ( $fields as $field ) {
 			$before            = (array) clone $field;
 			$field             = (array) $field;
-			$frm_duplicate_ids = $frm_keys_by_original_field_id;
+			$frm_duplicate_ids = $keys_by_original_field_id;
 			$after             = FrmFieldsHelper::switch_field_ids( $field );
 
 			if ( $before['field_options'] !== $after['field_options'] ) {


### PR DESCRIPTION
Working from Steph's commit [here](https://github.com/Strategy11/formidable-forms/commit/43bc0cd6f91ad3358ac4fcd014882125b57c4bdd) I have a branch that can successfully import the default calculator value in from [here](https://github.com/Strategy11/formidable-pro/issues/2566).

I don't know for sure if this encompasses the whole issue for https://github.com/Strategy11/formidable-pro/issues/1362
My issue seems mostly specific to the fact that these fields already existed and weren't being created new on import.

I have to do two replaces, one that changes their original expected id to their field key, and one that changes their field key to their new id. This way I can avoid issues of it changing my value into an id, and then changing that id into another id that wasn't the proper match.

Sounds related to https://github.com/Strategy11/formidable-pro/issues/2487 as well.