### PR TITLE
add role option to multiselect li

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4997,7 +4997,10 @@ function frmAdminBuildJS() {
 
 	function initiateMultiselect() {
 		jQuery( '.frm_multiselect' ).multiselect({
-			templates: {ul: '<ul class="multiselect-container frm-dropdown-menu"></ul>'},
+			templates: {
+				ul: '<ul class="multiselect-container frm-dropdown-menu"></ul>',
+				li: '<li role="option"><a tabindex="0"><label></label></a></li>'
+			},
 			buttonContainer: '<div class="btn-group frm-btn-group dropdown" />',
 			nonSelectedText: '',
 			onDropdownShown: function( event ) {


### PR DESCRIPTION
I don't think this is a full solution to https://github.com/Strategy11/formidable-pro/issues/2599 by any means.

[Bootstrap multiselect](https://github.com/davidstutz/bootstrap-multiselect) hasn't had an update in over 2 years, and doesn't really seem compliant.

There are some demo listboxes on [w3.org](https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/listbox/listbox.html). [Listboxes seem pretty heavy](https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/listbox/js/listbox.js) they don't seem to work out of the box.

Current keyboard support - http://davidstutz.de/bootstrap-multiselect/#keyboard-support

Steph has mentioned a checkbook list. This is a pretty big rewrite and the front end component could likely be a fairly large amount of work if we don't use something already done before.

I think it's possible that we can stick with bootstrap though. My next idea is to try aria descriptions. 