### PR TITLE
always include aria invalid tag

### DIFF
--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -359,9 +359,7 @@ class FrmFieldFormHtml {
 			unset( $shortcode_atts['class'] );
 		}
 
-		if ( isset( $this->pass_args['errors'][ 'field' . $this->field_id ] ) ) {
-			$shortcode_atts['aria-invalid'] = 'true';
-		}
+		$shortcode_atts['aria-invalid'] = isset( $this->pass_args['errors'][ 'field' . $this->field_id ] ) ? 'true' : 'false';
 
 		$this->field_obj->set_field_column( 'shortcodes', $shortcode_atts );
 


### PR DESCRIPTION
https://github.com/Strategy11/formidable-pro/issues/2584

This will not update in real time without JavaScript validation turned on. But it will always render `aria-invalid="false"` now for valid inputs.

This should be fine. Mozilla's documentation states:
```
Note that it is not necessary to validate the fields immediately on blur; the application could wait until the form is submitted (though this is not necessarily recommended).
```