### PR TITLE
confirm backend exit

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2366,12 +2366,13 @@ class FrmAppHelper {
 		wp_register_script( 'formidable_admin_global', self::plugin_url() . '/js/formidable_admin_global.js', array( 'jquery' ), $version );
 
 		$global_strings = array(
-			'updating_msg' => __( 'Please wait while your site updates.', 'formidable' ),
-			'deauthorize'  => __( 'Are you sure you want to deauthorize Formidable Forms on this site?', 'formidable' ),
-			'url'          => self::plugin_url(),
-			'app_url'      => 'https://formidableforms.com/',
-			'loading'      => __( 'Loading&hellip;', 'formidable' ),
-			'nonce'        => wp_create_nonce( 'frm_ajax' ),
+			'updating_msg'  => __( 'Please wait while your site updates.', 'formidable' ),
+			'deauthorize'   => __( 'Are you sure you want to deauthorize Formidable Forms on this site?', 'formidable' ),
+			'url'           => self::plugin_url(),
+			'app_url'       => 'https://formidableforms.com/',
+			'loading'       => __( 'Loading&hellip;', 'formidable' ),
+			'nonce'         => wp_create_nonce( 'frm_ajax' ),
+			'fieldsUpdated' => 0,
 		);
 		wp_localize_script( 'formidable_admin_global', 'frmGlobal', $global_strings );
 

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2366,13 +2366,12 @@ class FrmAppHelper {
 		wp_register_script( 'formidable_admin_global', self::plugin_url() . '/js/formidable_admin_global.js', array( 'jquery' ), $version );
 
 		$global_strings = array(
-			'updating_msg'  => __( 'Please wait while your site updates.', 'formidable' ),
-			'deauthorize'   => __( 'Are you sure you want to deauthorize Formidable Forms on this site?', 'formidable' ),
-			'url'           => self::plugin_url(),
-			'app_url'       => 'https://formidableforms.com/',
-			'loading'       => __( 'Loading&hellip;', 'formidable' ),
-			'nonce'         => wp_create_nonce( 'frm_ajax' ),
-			'fieldsUpdated' => 0,
+			'updating_msg' => __( 'Please wait while your site updates.', 'formidable' ),
+			'deauthorize'  => __( 'Are you sure you want to deauthorize Formidable Forms on this site?', 'formidable' ),
+			'url'          => self::plugin_url(),
+			'app_url'      => 'https://formidableforms.com/',
+			'loading'      => __( 'Loading&hellip;', 'formidable' ),
+			'nonce'        => wp_create_nonce( 'frm_ajax' ),
 		);
 		wp_localize_script( 'formidable_admin_global', 'frmGlobal', $global_strings );
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -299,7 +299,7 @@ function frmAdminBuildJS() {
 		thisForm = document.getElementById( 'form_id' ),
 		cancelSort = false,
 		copyHelper = false,
-		fieldsUpdated = false,
+		fieldsUpdated = 0,
 		thisFormId = 0;
 
 	if ( thisForm !== null ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4497,6 +4497,22 @@ function frmAdminBuildJS() {
 		}
 	}
 
+	function fieldUpdated() {
+		frmGlobal.fieldsUpdated = 1;
+		window.addEventListener( 'beforeunload', confirmExit );
+	}
+
+	function buildSubmittedNoAjax() {
+		// set frmGlobal.fieldsUpdate to 0 to avoid the unsaved changes pop up
+		frmGlobal.fieldsUpdated = 0;
+	}
+
+	function confirmExit( event ) {
+		if ( frmGlobal.fieldsUpdated ) {
+			event.preventDefault();
+		}
+	}
+
 	/**
 	 * Get the input box for the selected ... icon.
 	 */
@@ -5939,6 +5955,9 @@ function frmAdminBuildJS() {
 
 			$builderForm.on( 'change', '.frm_include_extras_field', rePopCalcFieldsForSummary );
 			$builderForm.on( 'change', 'select[name^="field_options[form_select_"]', maybeChangeEmbedFormMsg );
+
+			jQuery( document ).on( 'submit', '#frm_js_build_form', buildSubmittedNoAjax );
+			jQuery( document ).on( 'change', '#frm_builder_page input, #frm_builder_page select', fieldUpdated );
 
 			popAllProductFields();
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -294,13 +294,14 @@ function frmAdminBuildJS() {
 
 	/*global jQuery:false, frm_admin_js, frmGlobal, ajaxurl */
 
-	var $newFields = jQuery( document.getElementById( 'frm-show-fields' ) );
-	var builderForm = document.getElementById( 'new_fields' );
-	var thisForm = document.getElementById( 'form_id' );
-	var cancelSort = false;
-	var copyHelper = false;
+	var $newFields = jQuery( document.getElementById( 'frm-show-fields' ) ),
+		builderForm = document.getElementById( 'new_fields' ),
+		thisForm = document.getElementById( 'form_id' ),
+		cancelSort = false,
+		copyHelper = false,
+		fieldsUpdated = false,
+		thisFormId = 0;
 
-	var thisFormId = 0;
 	if ( thisForm !== null ) {
 		thisFormId = thisForm.value;
 	}
@@ -4498,17 +4499,17 @@ function frmAdminBuildJS() {
 	}
 
 	function fieldUpdated() {
-		frmGlobal.fieldsUpdated = 1;
+		fieldsUpdated = 1;
 		window.addEventListener( 'beforeunload', confirmExit );
 	}
 
 	function buildSubmittedNoAjax() {
-		// set frmGlobal.fieldsUpdate to 0 to avoid the unsaved changes pop up
-		frmGlobal.fieldsUpdated = 0;
+		// set fieldsUpdated to 0 to avoid the unsaved changes pop up
+		fieldsUpdated = 0;
 	}
 
 	function confirmExit( event ) {
-		if ( frmGlobal.fieldsUpdated ) {
+		if ( fieldsUpdated ) {
 			event.preventDefault();
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/Strategy11/formidable-pro/issues/2564

I looked into customizing the text in the pop up but it's a no go these days.

From [a quote I found here](https://stackoverflow.com/questions/38879742/is-it-possible-to-display-a-custom-message-in-the-beforeunload-popup#answer-38880926)

> tl;dr - You can't set custom message anymore in most modern browsers
> A quick note (since this is an old answer) - these days all major browsers don't support custom message in the beforeunload popup. There is no new way to do this. In case you still do need to support old browsers - you can find the information below.

![Screen Shot 2020-09-04 at 2 41 31 PM](https://user-images.githubusercontent.com/9134515/92270484-86242700-eebc-11ea-9e04-6b8942e1e8cb.png)

I don't know if we want to go above and beyond this. It seems to cover most cases at least. If you were to toggle a checkbox on and off for instance, it would still say you've made changes even if you returned to the default. Maybe we want to check for that, but it adds a lot of complexity.