### PR TITLE
sep is null bug fix

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3309,7 +3309,7 @@ function frmAdminBuildJS() {
 			fieldId = getOptionFieldId( parentLi, key ),
 			sep = document.getElementById( 'separate_value_' + fieldId );
 
-		if ( sep.checked === false ) {
+		if ( sep !== null && sep.checked === false ) {
 			// If separate values are not turned on.
 			savedVal = document.getElementById( 'field_key_' + fieldId + '-' + key );
 			savedVal.value = input.value;


### PR DESCRIPTION
While checking if there were issues with pro disabled on https://github.com/Strategy11/formidable-forms/pull/241 I ran into this error that was totally unrelated to my own update.

Happens when I change the text for one of my radio options.

<img width="755" alt="Screen Shot 2020-09-04 at 4 40 01 PM" src="https://user-images.githubusercontent.com/9134515/92279151-15393b00-eecd-11ea-953b-6f0698e3b119.png">
