### PR TITLE
top bar updated message margin fix

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1528,7 +1528,8 @@ div.frm_updated_message {
 
 #frm_top_bar + .wrap > .frm_updated_message {
 	display: inline-block;
-	width: calc( 100% - 50px );
+	width: 100%;
+	box-sizing: border-box;
 }
 
 #post-body-content > .frm_updated_message {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1526,6 +1526,11 @@ div.frm_updated_message {
 	text-align: center;
 }
 
+#frm_top_bar + .wrap > .frm_updated_message {
+	display: inline-block;
+	width: calc( 100% - 50px );
+}
+
 #post-body-content > .frm_updated_message {
 	margin: 5px 65px;
 }


### PR DESCRIPTION
This was kind of bugging me a couple of times. There's margin on the div but it's not actually being applied with the current styles.

**Before**
![Screen Shot 2020-09-09 at 4 52 07 PM](https://user-images.githubusercontent.com/9134515/92646277-91ac8f00-f2bc-11ea-834d-f23e74aad372.png)

**After**
![Screen Shot 2020-09-09 at 4 50 50 PM](https://user-images.githubusercontent.com/9134515/92646298-9709d980-f2bc-11ea-8b11-f1fe6531d845.png)