### PR TITLE
chrome does not confirm backend exit fix

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4500,8 +4500,10 @@ function frmAdminBuildJS() {
 	}
 
 	function fieldUpdated() {
-		fieldsUpdated = 1;
-		window.addEventListener( 'beforeunload', confirmExit );
+		if ( ! fieldsUpdated ) {
+			fieldsUpdated = 1;
+			window.addEventListener( 'beforeunload', confirmExit );
+		}
 	}
 
 	function buildSubmittedNoAjax() {
@@ -4512,6 +4514,7 @@ function frmAdminBuildJS() {
 	function confirmExit( event ) {
 		if ( fieldsUpdated ) {
 			event.preventDefault();
+			event.returnValue = '';
 		}
 	}
 


### PR DESCRIPTION
Didn't notice this in the first go, but on https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload they even mention

```
// Chrome requires returnValue to be set
e.returnValue = '';
```

Also adjusted the fieldsUpdated logic to avoid adding the event listener on every field update.