### PR TITLE
add pro redirect from pro upgrade page

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -25,6 +25,9 @@ class FrmAddonsController {
 				'formidable-pro-upgrade',
 				'FrmAddonsController::upgrade_to_pro'
 			);
+		} elseif ( 'formidable-pro-upgrade' === FrmAppHelper::get_param( 'page' ) ) {
+			wp_safe_redirect( admin_url( 'admin.php?page=formidable' ) );
+			exit;
 		}
 	}
 


### PR DESCRIPTION
I just totally uninstalled formidable and added my license key again, and after I confirmed my license, I refreshed the page.

![Screen Shot 2020-09-18 at 2 15 32 PM](https://user-images.githubusercontent.com/9134515/93627022-b25e9e00-f9ba-11ea-9116-548130d676e4.png)
![Screen Shot 2020-09-18 at 2 15 35 PM](https://user-images.githubusercontent.com/9134515/93627014-af63ad80-f9ba-11ea-8270-6802bd41b9ed.png)

This update redirects the url so instead of dying on a 403 page, it goes to formidable.