### PR TITLE
disable content checkbox in screen options

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5854,6 +5854,8 @@ function frmAdminBuildJS() {
 			});
 			clickTab( jQuery( '.starttab a' ), 'auto' );
 
+			jQuery( '.post-type-frm_display #screen-options-wrap:hidden input[type="checkbox"]' ).attr( 'disabled', true );
+
 			// submit the search form with dropdown
 			jQuery( '#frm-fid-search-menu a' ).click( function() {
 				var val = this.id.replace( 'fid-', '' );


### PR DESCRIPTION
I'm not totally sure what happened in https://github.com/Strategy11/formidable-pro/issues/2633 but I think he must've triggered the hidden checkbox.

This one liner makes sure that the screen options are disabled on the views editor.

Of course, this update would make it more difficult to actually fix the issue if you had it hidden before updating. I played with forcing the checkbox as checked, but it seemed to lead to issues of the checkbox being checked with the content still hidden as well.

My simple QA method was just running `jQuery('#frm_dyncontent-hide').click();` in the JavaScript console. Before this update, the content would disappear/appear with each call. Now it says visible.