### PR TITLE
Better email confirmation js validation (and password js validation)

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -375,11 +375,11 @@ function frmFrontFormJS() {
 			return;
 		}
 
-		if ( fieldID !== strippedFieldID ) {
+		if ( fieldID !== strippedFieldID && typeof errors[ 'conf_' + strippedFieldID ] === 'undefined' ) {
 			$firstField = $fields.filter( '[name="item_meta[' + strippedFieldID + ']"]' );
 			value = $firstField.val();
 			confirmValue = $confirmField.val();
-			if ( typeof errors[ 'conf_' + strippedFieldID ] === 'undefined' && '' !== value && '' !== confirmValue && value !== confirmValue ) {
+			if ( '' !== value && '' !== confirmValue && value !== confirmValue ) {
 				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( $confirmField.get( 0 ), 'data-confmsg' );
 			}
 		} else {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -384,7 +384,7 @@ function frmFrontFormJS() {
 			value = $firstField.val();
 			confirmValue = $confirmField.val();
 			if ( typeof errors[ 'conf_' + strippedFieldID ] === 'undefined' && '' !== value && '' !== confirmValue && value !== confirmValue ) {
-				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( $confirmField.get( 0 ), 'data-nomatch' );
+				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( $confirmField.get( 0 ), 'data-confmsg' );
 			}
 		} else {
 			validateField( 'conf_' + strippedFieldID, $confirmField.get( 0 ) );

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -371,11 +371,11 @@ function frmFrontFormJS() {
 			value,
 			confirmValue;
 
-		if ( ! $confirmField.length ) {
+		if ( ! $confirmField.length || typeof errors[ 'conf_' + strippedFieldID ] !== 'undefined' ) {
 			return;
 		}
 
-		if ( fieldID !== strippedFieldID && typeof errors[ 'conf_' + strippedFieldID ] === 'undefined' ) {
+		if ( fieldID !== strippedFieldID ) {
 			$firstField = $fields.filter( '[name="item_meta[' + strippedFieldID + ']"]' );
 			value = $firstField.val();
 			confirmValue = $confirmField.val();
@@ -385,8 +385,6 @@ function frmFrontFormJS() {
 		} else {
 			validateField( 'conf_' + strippedFieldID, $confirmField.get( 0 ) );
 		}
-
-		return errors;
 	}
 
 	function checkNumberField( field, errors ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -367,7 +367,6 @@ function frmFrontFormJS() {
 		var fieldID = getFieldId( field, true ),
 			strippedFieldID = fieldID.replace( 'conf_', '' ),
 			$confirmField = $fields.filter( '[name="item_meta[conf_' + strippedFieldID + ']"]' ),
-			isConfirmation,
 			$firstField,
 			value,
 			confirmValue;
@@ -376,10 +375,8 @@ function frmFrontFormJS() {
 			return;
 		}
 
-		isConfirmation = fieldID !== strippedFieldID;
-		$firstField = $fields.filter( '[name="item_meta[' + strippedFieldID + ']"]' );
-
-		if ( isConfirmation ) {
+		if ( fieldID !== strippedFieldID ) {
+			$firstField = $fields.filter( '[name="item_meta[' + strippedFieldID + ']"]' );
 			value = $firstField.val();
 			confirmValue = $confirmField.val();
 			if ( typeof errors[ 'conf_' + strippedFieldID ] === 'undefined' && '' !== value && '' !== confirmValue && value !== confirmValue ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -337,35 +337,35 @@ function frmFrontFormJS() {
 		return errors;
 	}
 
-	function checkEmailField( field, errors, emailFields ) {
-		var isConf, re, invalidMsg, confName, match,
-			emailAddress = field.value,
-			fieldID = getFieldId( field, true );
+	function checkEmailField( field, errors, $emailFields ) {
+		var fieldID = getFieldId( field, true ),
+			strippedFieldID = fieldID.replace( 'conf_', '' ),
+			isConfirmation = fieldID !== strippedFieldID,
+			$emailField = $emailFields.filter( '[name="item_meta[' + strippedFieldID + ']"]' ),
+			$confirmField = $emailFields.filter( '[name="item_meta[conf_' + strippedFieldID + ']"]' ),
+			pattern = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/i;
 
-		if ( fieldID in errors ) {
+		// validate the current field we're editing first
+		if ( '' !== field.value && pattern.test( field.value ) === false ) {
+			errors[ fieldID ] = getFieldValidationMessage( field, 'data-invmsg' );
+		}
+
+		if ( ! $confirmField.length ) {
 			return errors;
 		}
 
-		isConf = ( fieldID.indexOf( 'conf_' ) === 0 );
-		if ( emailAddress !== '' || isConf ) {
-			re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/i;
-			invalidMsg = getFieldValidationMessage( field, 'data-invmsg' );
-			if ( emailAddress !== '' && re.test( emailAddress ) === false ) {
-				errors[ fieldID ] = invalidMsg;
-				if ( isConf ) {
-					errors[ fieldID.replace( 'conf_', '' ) ] = '';
-				}
-			} else if ( isConf ) {
-				confName = field.name.replace( 'conf_', '' );
-				match = emailFields.filter( '[name="' + confName + '"]' ).val();
-				if ( match !== emailAddress ) {
-					errors[ fieldID ] = '';
-					errors[ fieldID.replace( 'conf_', '' ) ] = '';
-				}
+		// if both fields are valid emails, check that they match
+		if ( isConfirmation ) {
+			if ( 'false' === $emailField.attr( 'aria-invalid' ) && 'false' === $confirmField.attr( 'aria-invalid' ) && '' !== $emailField.val() && '' !== $confirmField.val() && $emailField.val() !== $confirmField.val() ) {
+				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( $confirmField.get(0), 'data-nomatch' );
 			}
+		} else {
+			validateField( 'conf_' + strippedFieldID, $confirmField.get(0) );
 		}
+
 		return errors;
 	}
+
 
 	function checkNumberField( field, errors ) {
 		var fieldID,

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -347,51 +347,43 @@ function frmFrontFormJS() {
 
 	function checkEmailField( field, errors, $emailFields ) {
 		var fieldID = getFieldId( field, true ),
-			strippedFieldID = fieldID.replace( 'conf_', '' ),
-			isConfirmation = fieldID !== strippedFieldID,
-			$emailField = $emailFields.filter( '[name="item_meta[' + strippedFieldID + ']"]' ),
-			$confirmField = $emailFields.filter( '[name="item_meta[conf_' + strippedFieldID + ']"]' ),
-			pattern = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/i,
-			email,
-			confirmEmail;
+			pattern = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/i;
 
 		// validate the current field we're editing first
 		if ( '' !== field.value && pattern.test( field.value ) === false ) {
 			errors[ fieldID ] = getFieldValidationMessage( field, 'data-invmsg' );
 		}
 
-		if ( ! $confirmField.length ) {
-			return errors;
-		}
-
-		// if both fields are valid emails, check that they match
-		if ( isConfirmation ) {
-			email = $emailField.val();
-			confirmEmail = $confirmField.val();
-			if ( 'false' === $emailField.attr( 'aria-invalid' ) && 'false' === $confirmField.attr( 'aria-invalid' ) && '' !== email && '' !== confirmEmail && email !== confirmEmail ) {
-				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( $confirmField.get( 0 ), 'data-nomatch' );
-			}
-		} else {
-			validateField( 'conf_' + strippedFieldID, $confirmField.get( 0 ) );
-		}
-
+		confirmField( field, errors, $emailFields );
 		return errors;
 	}
 
 	function checkPasswordField( field, errors, $passwordFields ) {
+		confirmField( field, errors, $passwordFields );
+		return errors;
+	}
+
+	function confirmField( field, errors, $fields ) {
 		var fieldID = getFieldId( field, true ),
 			strippedFieldID = fieldID.replace( 'conf_', '' ),
-			isConfirmation = fieldID !== strippedFieldID,
-			$passwordField = $passwordFields.filter( '[name="item_meta[' + strippedFieldID + ']"]' ),
-			$confirmField = $passwordFields.filter( '[name="item_meta[conf_' + strippedFieldID + ']"]' ),
-			password,
-			confirmPassword;
+			$confirmField = $fields.filter( '[name="item_meta[conf_' + strippedFieldID + ']"]' ),
+			isConfirmation,
+			$firstField,
+			value,
+			confirmValue;
+
+		if ( ! $confirmField.length ) {
+			return;
+		}
+
+		isConfirmation = fieldID !== strippedFieldID;
+		$firstField = $fields.filter( '[name="item_meta[' + strippedFieldID + ']"]' );
 
 		// if both fields are valid emails, check that they match
 		if ( isConfirmation ) {
-			password = $passwordField.val();
-			confirmPassword = $confirmField.val();
-			if ( 'false' === $passwordField.attr( 'aria-invalid' ) && 'false' === $confirmField.attr( 'aria-invalid' ) && '' !== password && '' !== confirmPassword && password !== confirmPassword ) {
+			value = $firstField.val();
+			confirmValue = $confirmField.val();
+			if ( 'false' === $firstField.attr( 'aria-invalid' ) && 'false' === $confirmField.attr( 'aria-invalid' ) && '' !== value && '' !== confirmValue && value !== confirmValue ) {
 				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( $confirmField.get( 0 ), 'data-nomatch' );
 			}
 		} else {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -357,10 +357,10 @@ function frmFrontFormJS() {
 		// if both fields are valid emails, check that they match
 		if ( isConfirmation ) {
 			if ( 'false' === $emailField.attr( 'aria-invalid' ) && 'false' === $confirmField.attr( 'aria-invalid' ) && '' !== $emailField.val() && '' !== $confirmField.val() && $emailField.val() !== $confirmField.val() ) {
-				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( $confirmField.get(0), 'data-nomatch' );
+				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( $confirmField.get( 0 ), 'data-nomatch' );
 			}
 		} else {
-			validateField( 'conf_' + strippedFieldID, $confirmField.get(0) );
+			validateField( 'conf_' + strippedFieldID, $confirmField.get( 0 ) );
 		}
 
 		return errors;

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -366,7 +366,6 @@ function frmFrontFormJS() {
 		return errors;
 	}
 
-
 	function checkNumberField( field, errors ) {
 		var fieldID,
 			number = field.value;

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -151,7 +151,7 @@ function frmFrontFormJS() {
 	}
 
 	function validateForm( object ) {
-		var r, rl, n, nl, emailFields, fields, field, value, requiredFields,
+		var r, rl, n, nl, emailFields, passwordFields, fields, field, value, requiredFields,
 			errors = [];
 
 		// Make sure required text field is filled in
@@ -165,6 +165,7 @@ function frmFrontFormJS() {
 		}
 
 		emailFields = jQuery( object ).find( 'input[type=email]' ).filter( ':visible' );
+		passwordFields = jQuery( object ).find( 'input[type=password]' ).filter( ':visible' );
 		fields = jQuery( object ).find( 'input,select,textarea' );
 		if ( fields.length ) {
 			for ( n = 0, nl = fields.length; n < nl; n++ ) {
@@ -177,6 +178,8 @@ function frmFrontFormJS() {
 						errors = checkNumberField( field, errors );
 					} else if ( field.type === 'email' ) {
 						errors = checkEmailField( field, errors, emailFields );
+					} else if ( field.type === 'password' ) {
+						errors = checkPasswordField( field, errors, passwordFields );
 					} else if ( field.type === 'url' ) {
 						errors = checkUrlField( field, errors );
 					} else if ( field.pattern !== null ) {
@@ -209,7 +212,9 @@ function frmFrontFormJS() {
 	}
 
 	function validateField( fieldId, field ) {
-		var key, emailFields,
+		var key,
+			emailFields,
+			passwordFields,
 			errors = [];
 
 		var $fieldCont = jQuery( field ).closest( '.frm_form_field' );
@@ -221,6 +226,9 @@ function frmFrontFormJS() {
 			if ( field.type === 'email' ) {
 				emailFields = jQuery( field ).closest( 'form' ).find( 'input[type=email]' );
 				errors = checkEmailField( field, errors, emailFields );
+			} else if ( field.type === 'password' ) {
+				passwordFields = jQuery( field ).closest( 'form' ).find( 'input[type=password]' );
+				errors = checkPasswordField( field, errors, passwordFields );
 			} else if ( field.type === 'number' ) {
 				errors = checkNumberField( field, errors );
 			} else if ( field.type === 'url' ) {
@@ -343,7 +351,9 @@ function frmFrontFormJS() {
 			isConfirmation = fieldID !== strippedFieldID,
 			$emailField = $emailFields.filter( '[name="item_meta[' + strippedFieldID + ']"]' ),
 			$confirmField = $emailFields.filter( '[name="item_meta[conf_' + strippedFieldID + ']"]' ),
-			pattern = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/i;
+			pattern = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/i,
+			email,
+			confirmEmail;
 
 		// validate the current field we're editing first
 		if ( '' !== field.value && pattern.test( field.value ) === false ) {
@@ -356,7 +366,32 @@ function frmFrontFormJS() {
 
 		// if both fields are valid emails, check that they match
 		if ( isConfirmation ) {
-			if ( 'false' === $emailField.attr( 'aria-invalid' ) && 'false' === $confirmField.attr( 'aria-invalid' ) && '' !== $emailField.val() && '' !== $confirmField.val() && $emailField.val() !== $confirmField.val() ) {
+			email = $emailField.val();
+			confirmEmail = $confirmField.val();
+			if ( 'false' === $emailField.attr( 'aria-invalid' ) && 'false' === $confirmField.attr( 'aria-invalid' ) && '' !== email && '' !== confirmEmail && email !== confirmEmail ) {
+				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( $confirmField.get( 0 ), 'data-nomatch' );
+			}
+		} else {
+			validateField( 'conf_' + strippedFieldID, $confirmField.get( 0 ) );
+		}
+
+		return errors;
+	}
+
+	function checkPasswordField( field, errors, $passwordFields ) {
+		var fieldID = getFieldId( field, true ),
+			strippedFieldID = fieldID.replace( 'conf_', '' ),
+			isConfirmation = fieldID !== strippedFieldID,
+			$passwordField = $passwordFields.filter( '[name="item_meta[' + strippedFieldID + ']"]' ),
+			$confirmField = $passwordFields.filter( '[name="item_meta[conf_' + strippedFieldID + ']"]' ),
+			password,
+			confirmPassword;
+
+		// if both fields are valid emails, check that they match
+		if ( isConfirmation ) {
+			password = $passwordField.val();
+			confirmPassword = $confirmField.val();
+			if ( 'false' === $passwordField.attr( 'aria-invalid' ) && 'false' === $confirmField.attr( 'aria-invalid' ) && '' !== password && '' !== confirmPassword && password !== confirmPassword ) {
 				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( $confirmField.get( 0 ), 'data-nomatch' );
 			}
 		} else {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -383,7 +383,7 @@ function frmFrontFormJS() {
 		if ( isConfirmation ) {
 			value = $firstField.val();
 			confirmValue = $confirmField.val();
-			if ( 'false' === $firstField.attr( 'aria-invalid' ) && 'false' === $confirmField.attr( 'aria-invalid' ) && '' !== value && '' !== confirmValue && value !== confirmValue ) {
+			if ( typeof errors[ 'conf_' + strippedFieldID ] === 'undefined' && '' !== value && '' !== confirmValue && value !== confirmValue ) {
 				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( $confirmField.get( 0 ), 'data-nomatch' );
 			}
 		} else {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -379,7 +379,6 @@ function frmFrontFormJS() {
 		isConfirmation = fieldID !== strippedFieldID;
 		$firstField = $fields.filter( '[name="item_meta[' + strippedFieldID + ']"]' );
 
-		// if both fields are valid emails, check that they match
 		if ( isConfirmation ) {
 			value = $firstField.val();
 			confirmValue = $confirmField.val();


### PR DESCRIPTION
Tackling the checklist items `Email confirmation fields don't show error message` and `Validate password confirmation fields` from https://github.com/Strategy11/formidable-pro/issues/1392

It requires the message as well, which comes from pro code [here](https://github.com/Strategy11/formidable-pro/pull/2634)

Without it, it just won't display still.

This update also fixes some inconsistencies with the email validation. I tried to make the logic easier to follow/more consistent for the both fields.

Previously, if the confirm field was invalid, it wouldn't become valid if you changed the original email address only to match the confirmation address.

As for the last item on the list, I'm not familiar with the option (`Default value will NOT pass validation`). I see it's defined in FrmAppHelper.php as `'no_valid_default'  => __( 'Default value will NOT pass form validation', 'formidable' ),` but I don't see references to no_valid_default. It looks like that support doesn't exist on the PHP side either.

https://github.com/search?q=org%3AStrategy11+no_valid_default&type=Code