### PR TITLE
clear values on placeholder match only if not required

### DIFF
--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -113,21 +113,29 @@ class FrmEntryValidate {
 		$errors = apply_filters( 'frm_validate_field_entry', $errors, $posted_field, $value, $args );
 	}
 
+	/**
+	 * Set $value to an empty string if it matches the placeholder or its label
+	 *
+	 * @param object $field
+	 * @param string $value
+	 */
 	private static function maybe_clear_value_for_default_blank_setting( $field, &$value ) {
-		$placeholder = FrmField::get_option( $field, 'placeholder' );
-		$is_default  = ( ! empty( $placeholder ) && $value == $placeholder );
-		$is_label    = false;
-
-		if ( ! $is_default ) {
-			$position = FrmField::get_option( $field, 'label' );
-			if ( empty( $position ) ) {
-				$position = FrmStylesController::get_style_val( 'position', $field->form_id );
+		// check for placeholder matches for fields that are not required
+		if ( ! $field->required ) {
+			$placeholder = FrmField::get_option( $field, 'placeholder' );
+			if ( $placeholder && $value === $placeholder ) {
+				$value = '';
+				return;
 			}
-
-			$is_label = ( $position == 'inside' && FrmFieldsHelper::is_placeholder_field_type( $field->type ) && $value == $field->name );
 		}
 
-		if ( $is_label || $is_default ) {
+		// check if it matches the name of its inside label
+		$position = FrmField::get_option( $field, 'label' );
+		if ( ! $position ) {
+			$position = FrmStylesController::get_style_val( 'position', $field->form_id );
+		}
+
+		if ( 'inside' === $position && FrmFieldsHelper::is_placeholder_field_type( $field->type ) && $field->name === $value ) {
 			$value = '';
 		}
 	}


### PR DESCRIPTION
My go at fixing https://github.com/Strategy11/formidable-pro/issues/2636

I understand that we're probably stripping the placeholder because of issues with IE interpreting placeholders as values and sending data that we don't want.

I think it makes sense to keep that if the field isn't required to avoid a ton of junk data in the database, but I don't think we should stop people if they're legitimately trying to enter data into a required field and it matches the placeholder. Of course this means that we might still lose Jim's name if it's not required, so maybe we want add an option.

I also refactored the function a bit as it was a little funny to follow. I think it's fine to just handle it in pieces, with fewer variables and more comments.