### PR TITLE
adjust message for single day in license expiry reminder

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -151,9 +151,16 @@ class FrmAppHelper {
 			&nbsp;
 			<?php
 			printf(
-				/* translators: %1$s: start HTML tag, %2$s: end HTML tag */
-				esc_html__( 'Your form subscription expires in %1$s days%2$s.', 'formidable' ),
-				'<strong>' . esc_html( $expiring ),
+				esc_html(
+					/* translators: %1$s: start HTML tag, %2$s: end HTML tag */
+					_n(
+						'Your form subscription expires in %1$s day%2$s.',
+						'Your form subscription expires in %1$s days%2$s.',
+						$expiring,
+						'formidable'
+					)
+				),
+				'<strong>' . esc_html( number_format_i18n( $expiring ) ),
 				'</strong>'
 			);
 			?>


### PR DESCRIPTION
Before
<img width="394" alt="Screen Shot 2020-09-27 at 2 04 39 PM" src="https://user-images.githubusercontent.com/9134515/94371116-67374000-00ca-11eb-8654-b48e9aeb1f35.png">

After
<img width="395" alt="Screen Shot 2020-09-27 at 2 04 02 PM" src="https://user-images.githubusercontent.com/9134515/94371105-54247000-00ca-11eb-9195-de8dc9c336ef.png">