### PR TITLE
cs fix, do not exclude extract rule

### DIFF
--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -416,7 +416,7 @@ class FrmStylesController {
 	}
 
 	public static function include_style_section( $atts, $sec ) {
-		extract( $atts );
+		extract( $atts ); // phpcs:ignore WordPress.PHP.DontExtract
 		$style = $atts['style'];
 		FrmStylesHelper::prepare_color_output( $style->post_content, false );
 

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1584,7 +1584,7 @@ class FrmAppHelper {
 			return false;
 		}
 
-		extract( $atts );
+		extract( $atts ); // phpcs:ignore WordPress.PHP.DontExtract
 		ob_start();
 		include( $filename );
 		$contents = ob_get_contents();

--- a/classes/views/frm-form-actions/email_action.php
+++ b/classes/views/frm-form-actions/email_action.php
@@ -20,7 +20,7 @@ class FrmEmailAction extends FrmFormAction {
 	}
 
 	public function form( $form_action, $args = array() ) {
-		extract( $args );
+		extract( $args ); // phpcs:ignore WordPress.PHP.DontExtract
 
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-form-actions/_email_settings.php';
 	}

--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $settings = FrmStylesHelper::get_settings_for_output( $style );
-extract( $settings );
+extract( $settings ); // phpcs:ignore WordPress.PHP.DontExtract
 
 $important = empty( $important_style ) ? '' : ' !important';
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -28,12 +28,10 @@
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
 		<exclude name="Generic.Files.LowercasedFilename.NotFound" />
-		<exclude name="WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid" />
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid" />
 		<exclude name="WordPress.Classes.ValidClassName.NotCamelCaps" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" /><!-- Some WP globals break the rule -->
-		<exclude name="WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid" />
 		<exclude name="WordPress.PHP.YodaConditions"/>
 	</rule>
 	<rule ref="WordPress.WP.I18n">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -21,8 +21,6 @@
 		<exclude name="WordPress.WP.GlobalVariablesOverride" />
 
 		<!-- Enable these rules right away -->
-		<exclude name="WordPress.Functions.DontExtract.extract_extract" />
-		<exclude name="WordPress.PHP.DontExtract.extract_extract" />
 		<exclude name="WordPress.Security.NonceVerification.Missing" />
 
 		<!-- These give issues with the current code base. -->


### PR DESCRIPTION
Trying to slowly remove exclusions from our code sniffing. Extract only appears 4 times, and I figure it'd better to put the ignore on each of the 4 instances than to allow more in without the flag.

I looked at all 4 instances. I don't think any are too easy to write the extract out from.

Technically removes two rules because it seemed to have duplicates under different namespaces.

There were also duplicate exclusions for `WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid` which happens to be valid already, so I'm removing both.