### PR TITLE
better confirm field validation for embedded forms

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -151,7 +151,7 @@ function frmFrontFormJS() {
 	}
 
 	function validateForm( object ) {
-		var r, rl, n, nl, emailFields, passwordFields, fields, field, value, requiredFields,
+		var r, rl, n, nl, fields, field, value, requiredFields,
 			errors = [];
 
 		// Make sure required text field is filled in
@@ -164,8 +164,6 @@ function frmFrontFormJS() {
 			}
 		}
 
-		emailFields = jQuery( object ).find( 'input[type=email]' ).filter( ':visible' );
-		passwordFields = jQuery( object ).find( 'input[type=password]' ).filter( ':visible' );
 		fields = jQuery( object ).find( 'input,select,textarea' );
 		if ( fields.length ) {
 			for ( n = 0, nl = fields.length; n < nl; n++ ) {
@@ -177,9 +175,9 @@ function frmFrontFormJS() {
 					} else if ( field.type === 'number' ) {
 						errors = checkNumberField( field, errors );
 					} else if ( field.type === 'email' ) {
-						errors = checkEmailField( field, errors, emailFields );
+						errors = checkEmailField( field, errors );
 					} else if ( field.type === 'password' ) {
-						errors = checkPasswordField( field, errors, passwordFields );
+						errors = checkPasswordField( field, errors );
 					} else if ( field.type === 'url' ) {
 						errors = checkUrlField( field, errors );
 					} else if ( field.pattern !== null ) {
@@ -213,8 +211,6 @@ function frmFrontFormJS() {
 
 	function validateField( fieldId, field ) {
 		var key,
-			emailFields,
-			passwordFields,
 			errors = [];
 
 		var $fieldCont = jQuery( field ).closest( '.frm_form_field' );
@@ -224,11 +220,9 @@ function frmFrontFormJS() {
 
 		if ( errors.length < 1 ) {
 			if ( field.type === 'email' ) {
-				emailFields = jQuery( field ).closest( 'form' ).find( 'input[type=email]' );
-				errors = checkEmailField( field, errors, emailFields );
+				errors = checkEmailField( field, errors );
 			} else if ( field.type === 'password' ) {
-				passwordFields = jQuery( field ).closest( 'form' ).find( 'input[type=password]' );
-				errors = checkPasswordField( field, errors, passwordFields );
+				errors = checkPasswordField( field, errors );
 			} else if ( field.type === 'number' ) {
 				errors = checkNumberField( field, errors );
 			} else if ( field.type === 'url' ) {
@@ -345,7 +339,7 @@ function frmFrontFormJS() {
 		return errors;
 	}
 
-	function checkEmailField( field, errors, $emailFields ) {
+	function checkEmailField( field, errors ) {
 		var fieldID = getFieldId( field, true ),
 			pattern = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/i;
 
@@ -354,36 +348,36 @@ function frmFrontFormJS() {
 			errors[ fieldID ] = getFieldValidationMessage( field, 'data-invmsg' );
 		}
 
-		confirmField( field, errors, $emailFields );
+		confirmField( field, errors );
 		return errors;
 	}
 
-	function checkPasswordField( field, errors, $passwordFields ) {
-		confirmField( field, errors, $passwordFields );
+	function checkPasswordField( field, errors ) {
+		confirmField( field, errors );
 		return errors;
 	}
 
-	function confirmField( field, errors, $fields ) {
-		var fieldID = getFieldId( field, true ),
+	function confirmField( field, errors ) {
+		var value, confirmValue,
+			fieldID = getFieldId( field, true ),
+			id = field.id,
+			strippedId = id.replace( 'conf_', '' ),
 			strippedFieldID = fieldID.replace( 'conf_', '' ),
-			$confirmField = $fields.filter( '[name="item_meta[conf_' + strippedFieldID + ']"]' ),
-			$firstField,
-			value,
-			confirmValue;
+			firstField = document.getElementById( strippedId ),
+			confirmField = document.getElementById( strippedId.replace( 'field_', 'field_conf_' ) );
 
-		if ( ! $confirmField.length || typeof errors[ 'conf_' + strippedFieldID ] !== 'undefined' ) {
+		if ( confirmField === null || typeof errors[ 'conf_' + strippedFieldID ] !== 'undefined' ) {
 			return;
 		}
 
 		if ( fieldID !== strippedFieldID ) {
-			$firstField = $fields.filter( '[name="item_meta[' + strippedFieldID + ']"]' );
-			value = $firstField.val();
-			confirmValue = $confirmField.val();
+			value = firstField.value;
+			confirmValue = confirmField.value;
 			if ( '' !== value && '' !== confirmValue && value !== confirmValue ) {
-				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( $confirmField.get( 0 ), 'data-confmsg' );
+				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( confirmField, 'data-confmsg' );
 			}
 		} else {
-			validateField( 'conf_' + strippedFieldID, $confirmField.get( 0 ) );
+			validateField( 'conf_' + strippedFieldID, confirmField );
 		}
 	}
 

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -360,8 +360,7 @@ function frmFrontFormJS() {
 	function confirmField( field, errors ) {
 		var value, confirmValue, firstField,
 			fieldID = getFieldId( field, true ),
-			id = field.id,
-			strippedId = id.replace( 'conf_', '' ),
+			strippedId = field.id.replace( 'conf_', '' ),
 			strippedFieldID = fieldID.replace( 'conf_', '' ),
 			confirmField = document.getElementById( strippedId.replace( 'field_', 'field_conf_' ) );
 

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -358,12 +358,11 @@ function frmFrontFormJS() {
 	}
 
 	function confirmField( field, errors ) {
-		var value, confirmValue,
+		var value, confirmValue, firstField,
 			fieldID = getFieldId( field, true ),
 			id = field.id,
 			strippedId = id.replace( 'conf_', '' ),
 			strippedFieldID = fieldID.replace( 'conf_', '' ),
-			firstField = document.getElementById( strippedId ),
 			confirmField = document.getElementById( strippedId.replace( 'field_', 'field_conf_' ) );
 
 		if ( confirmField === null || typeof errors[ 'conf_' + strippedFieldID ] !== 'undefined' ) {
@@ -371,6 +370,7 @@ function frmFrontFormJS() {
 		}
 
 		if ( fieldID !== strippedFieldID ) {
+			firstField = document.getElementById( strippedId );
 			value = firstField.value;
 			confirmValue = confirmField.value;
 			if ( '' !== value && '' !== confirmValue && value !== confirmValue ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/1392 for embedded forms

The issue was that the name didn't match the `'conf_' + strippedFieldID` pattern in embedded fields.

I've figured out how to improve the process a bit. I removed the requirement to pass along fields, and I check for exact expected field id values. Uses fewer variables, less jQuery, and it works for embedded forms no problem.