### PR TITLE
dropdown types should also update conditional logic on option change

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2366,7 +2366,7 @@ function frmAdminBuildJS() {
 	}
 
 	function resetOptionTextDetails() {
-		jQuery( '.frm-type-radio ul input[type="text"], .frm-type-checkbox ul input[type="text"]' ).filter( '[data-value-on-load]' ).removeAttr( 'data-value-on-load' );
+		jQuery( '.frm-single-settings ul input[type="text"][name^="field_options[options_"]' ).filter( '[data-value-on-load]' ).removeAttr( 'data-value-on-load' );
 		jQuery( 'input[type="hidden"][name^=optionmap]' ).remove();
 	}
 
@@ -6147,8 +6147,8 @@ function frmAdminBuildJS() {
 
 			jQuery( document ).on( 'change', '.frmjs_prod_data_type_opt', toggleProductType );
 
-			jQuery( document ).on( 'focus', '.frm-type-radio ul input[type="text"], .frm-type-checkbox ul input[type="text"]', onOptionTextFocus );
-			jQuery( document ).on( 'blur', '.frm-type-radio ul input[type="text"], .frm-type-checkbox ul input[type="text"]', onOptionTextBlur );
+			jQuery( document ).on( 'focus', '.frm-single-settings ul input[type="text"][name^="field_options[options_"]', onOptionTextFocus );
+			jQuery( document ).on( 'blur', '.frm-single-settings ul input[type="text"][name^="field_options[options_"]', onOptionTextBlur );
 
 			initBulkOptionsOverlay();
 			hideEmptyEle();


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/1025 again

Dropdowns just weren't in the scope of my update. I neglected that there were other types with options than radio and checkbox. I made it more generic, targeting the options themselves rather than specific types (it was hard coded to radios and checkboxes only, ignoring select).

I took out the hardcoding so this should catch anything else if there were another type I had missed.