### PR TITLE
fix add on error handling

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1731,6 +1731,10 @@ h2.frm-h2 + .howto {
 }
 
 /* Add-on tiles */
+.frm-addons .frm-card.frm-addon-not-installed {
+	position: relative;
+}
+
 .frm-addons .plugin-card-top {
 	height: 140px;
 	padding-top: 30px;
@@ -1783,13 +1787,11 @@ h2.frm-h2 + .howto {
 
 .frm-addon-error {
 	position: absolute;
-	width: 100%;
+	top: 55px;
+	left: 10px;
+	right: 10px;
 	font-weight: bold;
 	text-align: center;
-	max-width: 291px;
-	margin: 0;
-	margin-top: -205px;
-	margin-left: -17px;
 }
 
 /* Form Templates */

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5286,10 +5286,8 @@ function frmAdminBuildJS() {
 					// Display the form to gather the users credentials.
 
 					addonError(
-						{
-							error: response.form
-						},
-						button.parent(),
+						{ error: response.form },
+						el,
 						button
 					);
 					// Add a disabled attribute the install button if the creds are needed.
@@ -5342,9 +5340,7 @@ function frmAdminBuildJS() {
 
 				if ( response.form ) {
 					addonError(
-						{
-							error: response.form
-						},
+						{ error: response.form },
 						el,
 						button
 					);

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5285,7 +5285,7 @@ function frmAdminBuildJS() {
 				if ( response.form ) {
 					// Display the form to gather the users credentials.
 
-					addonError( { error: response.form }, button.parent(), button );
+					addonError( {error: response.form}, button.parent(), button );
 					// Add a disabled attribute the install button if the creds are needed.
 					button.attr( 'disabled', true );
 
@@ -5335,7 +5335,7 @@ function frmAdminBuildJS() {
 				}
 
 				if ( response.form ) {
-					addonError( { error: response.form }, el, button );
+					addonError( {error: response.form}, el, button );
 					return;
 				}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5285,7 +5285,13 @@ function frmAdminBuildJS() {
 				if ( response.form ) {
 					// Display the form to gather the users credentials.
 
-					addonError( {error: response.form}, button.parent(), button );
+					addonError(
+						{
+							error: response.form
+						},
+						button.parent(),
+						button
+					);
 					// Add a disabled attribute the install button if the creds are needed.
 					button.attr( 'disabled', true );
 
@@ -5335,7 +5341,13 @@ function frmAdminBuildJS() {
 				}
 
 				if ( response.form ) {
-					addonError( {error: response.form}, el, button );
+					addonError(
+						{
+							error: response.form
+						},
+						el,
+						button
+					);
 					return;
 				}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5285,9 +5285,7 @@ function frmAdminBuildJS() {
 				if ( response.form ) {
 					// Display the form to gather the users credentials.
 
-					button.append( '<div class="frm-addon-error frm_error_style">' + response.form + '</div>' );
-					loader.hide();
-
+					addonError( { error: response.form }, button.parent(), button );
 					// Add a disabled attribute the install button if the creds are needed.
 					button.attr( 'disabled', true );
 
@@ -5337,10 +5335,7 @@ function frmAdminBuildJS() {
 				}
 
 				if ( response.form ) {
-					loader.hide();
-					jQuery( '.frm-inline-error' ).remove();
-					//proceed.val(admin.proceed);
-					//proceed.after('<span class="frm-inline-error">' + admin.connect_error + '</span>' );
+					addonError( { error: response.form }, el, button );
 					return;
 				}
 


### PR DESCRIPTION
I noticed a lot of stuff breaks when you get an add on error.

<img width="726" alt="Screen Shot 2020-10-08 at 9 20 31 AM" src="https://user-images.githubusercontent.com/9134515/95457787-c48f8480-0947-11eb-9d3b-e9432fbd0223.png">

There is no loader variable in this file outside of these two places. I think old code was left behind.

After I cleaned that up and tried removing the loading class from the button, the error message looks totally broken as well.
![Screen Shot 2020-10-08 at 9 27 37 AM](https://user-images.githubusercontent.com/9134515/95458433-86df2b80-0948-11eb-869c-abd51680cf65.png)

I changed a lot of the styling to make it simpler. Does this look good?
![Screen Shot 2020-10-08 at 9 23 19 AM](https://user-images.githubusercontent.com/9134515/95458481-99596500-0948-11eb-88c3-d4760ad08426.png)
