### PR TITLE
actually show error when ftp creds fail

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5276,8 +5276,8 @@ function frmAdminBuildJS() {
 			},
 			success: function( response ) {
 				// If there is a WP Error instance, output it here and quit the script.
-				if ( response.error ) {
-					addonError( response, el, button );
+				if ( ! response.success ) {
+					addonError({ error: response.data }, el, button );
 					return;
 				}
 


### PR DESCRIPTION
I'm not sure how much I totally know this whole new process or what is actually still missing in https://github.com/Strategy11/formidable-pro/issues/2649 but I see some issues at the moment with some old code.

I'd like to know, are we planning to ever actually support this ftp credentials form, or does it make sense to remove, at least temporarily for the readability of the code.

There are `loader.hide();` lines referring to a loader variable that does not exist anymore. Clearly this code is outdated.

This PR is into `develop` not master. I saw that in some of new updates the `'form' =>` key was dropped [here](https://github.com/Strategy11/formidable-forms/commit/d5ae8315f24177b5cd3fc6053da16113fd4dfa82#diff-3f0754e59a2323f0f79b3b84d882f2b2L863) in favour of `wp_send_json_error` but the js logic was checking for a `.error`, which is not what you get when you call wp_send_json_error this way.
<img width="710" alt="Screen Shot 2020-10-08 at 10 07 19 AM" src="https://user-images.githubusercontent.com/9134515/95462919-88135700-094e-11eb-9643-d51edf5456ea.png">

Does the alert look fine? It goes beyond the borders of the box its in.
![Screen Shot 2020-10-08 at 10 14 13 AM](https://user-images.githubusercontent.com/9134515/95463357-0a038000-094f-11eb-8057-a12f93aca9bf.png)
