### PR TITLE
Actually show error when ftp creds fail

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -865,9 +865,15 @@ class FrmAddonsController {
 		}
 
 		if ( $show_form ) {
-			//$form = ob_get_clean();
-			//TODO: test this: echo json_encode( array( 'form' => $form ) );
-			wp_send_json_error( __( 'Sorry, your site requires FTP authentication. Please download plugins from FormidableForms.com and install them manually.', 'formidable' ) );
+			$form     = ob_get_clean();
+			$message  = __( 'Sorry, your site requires FTP authentication. Please download plugins from FormidableForms.com and install them manually.', 'formidable' );
+			$data     = $form;
+			$response = array(
+				'success' => false,
+				'message' => $message,
+				'form'    => $form,
+			);
+			wp_send_json( $response );
 		}
 
 		ob_end_clean();

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5277,6 +5277,7 @@ function frmAdminBuildJS() {
 			success: function( response ) {
 				if ( typeof response !== 'string' && ! response.success ) {
 					addonError( response, el, button );
+					return;
 				}
 
 				afterAddonInstall( response, button, message, el );
@@ -5315,6 +5316,7 @@ function frmAdminBuildJS() {
 			success: function( response ) {
 				if ( typeof response !== 'string' && ! response.success ) {
 					addonError( response, el, proceed );
+					return;
 				}
 
 				afterAddonInstall( response, proceed, message, el );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5276,8 +5276,8 @@ function frmAdminBuildJS() {
 			},
 			success: function( response ) {
 				// If there is a WP Error instance, output it here and quit the script.
-				if ( response.error ) {
-					addonError( response, el, button );
+				if ( ! response.success ) {
+					addonError({ error: response.data }, el, button );
 					return;
 				}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5275,12 +5275,7 @@ function frmAdminBuildJS() {
 				plugin: plugin
 			},
 			success: function( response ) {
-				// If there is a WP Error instance, output it here and quit the script.
-				if ( ! response.success ) {
-					addonError({ error: response.data }, el, button );
-					return;
-				}
-
+				/*
 				// If we need more credentials, output the form sent back to us.
 				if ( response.form ) {
 					// Display the form to gather the users credentials.
@@ -5295,7 +5290,21 @@ function frmAdminBuildJS() {
 
 					// No need to move further if we need to enter our creds.
 					return;
+				}*/
+
+
+				if ( ! response.success ) {
+					addonError( response.message, el, button );
+
+					if ( response.form ) {
+						jQuery( '.frm-inline-error' ).remove();
+						button.closest( '.frm-card' )
+							.html( response.form )
+							.find( '#upgrade' ).click( installAddonWithCreds );
+					}
 				}
+
+
 
 				afterAddonInstall( response, button, message, el );
 			},
@@ -5306,6 +5315,8 @@ function frmAdminBuildJS() {
 	}
 
 	function installAddonWithCreds( e ) {
+		console.log( 'installAddonWithCreds' );
+
 		// Prevent the default action, let the user know we are attempting to install again and go with it.
 		e.preventDefault();
 
@@ -5314,6 +5325,8 @@ function frmAdminBuildJS() {
 		var el = proceed.parent().parent();
 
 		proceed.addClass( 'frm_loading_button' );
+
+		// TODO plugin is undefined
 
 		jQuery.ajax({
 			url: ajaxurl,
@@ -5330,18 +5343,14 @@ function frmAdminBuildJS() {
 				password: el.find( '#password' ).val()
 			},
 			success: function( response ) {
-				// If there is a WP Error instance, output it here and quit the script.
-				if ( response.error ) {
-					addonError( response, el, button );
-					return;
-				}
 
-				if ( response.form ) {
-					loader.hide();
-					jQuery( '.frm-inline-error' ).remove();
-					//proceed.val(admin.proceed);
-					//proceed.after('<span class="frm-inline-error">' + admin.connect_error + '</span>' );
-					return;
+				if ( ! response.success ) {
+					addonError( response.message, el, proceed );
+
+					if ( response.form ) {
+						jQuery( '.frm-inline-error' ).remove();
+						proceed.closest( '.frm-card' ).html( response.form );
+					}
 				}
 
 				afterAddonInstall( response, proceed, message, el );
@@ -5373,8 +5382,8 @@ function frmAdminBuildJS() {
 		}
 	}
 
-	function addonError( response, el, button ) {
-		el.append( '<div class="frm-addon-error frm_error_style"><p><strong>' + response.error + '</strong></p></div>' );
+	function addonError( errorMessage, el, button ) {
+		el.append( '<div class="frm-addon-error frm_error_style"><p><strong>' + errorMessage + '</strong></p></div>' );
 		button.removeClass( 'frm_loading_button' );
 		jQuery( '.frm-addon-error' ).delay( 4000 ).fadeOut();
 	}


### PR DESCRIPTION
When `define( 'FS_METHOD', 'ssh2' );` is defined:

I don't actually know how to connect to my local server with ftp so I don't actually know what happens if I submit this form successfully...

![Screen Shot 2020-10-08 at 2 32 17 PM](https://user-images.githubusercontent.com/9134515/95493700-33ce9e00-0973-11eb-9570-ba397f755874.png)

Since this is not supported right now, I think it might be better to just strip out all of the form code for now and revisit this next release?