### PR TITLE
force content checkbox for view settings

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5953,7 +5953,7 @@ function frmAdminBuildJS() {
 		}
 
 		$contentCheckbox = $checkboxes.filter( '[name="frm_dyncontent-hide"]' );
-		if ( ! $contentCheckbox.is( ':checked') ) {
+		if ( ! $contentCheckbox.is( ':checked' ) ) {
 			setTimeout(
 				function() {
 					$contentCheckbox.click();

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5944,6 +5944,28 @@ function frmAdminBuildJS() {
 		return object;
 	}
 
+	function adjustScreenOptionsCheckboxesForViews() {
+		var $checkboxes = jQuery( '.post-type-frm_display #screen-options-wrap:hidden input[type="checkbox"]' ),
+			$contentCheckbox;
+
+		if ( ! $checkboxes.length ) {
+			return;
+		}
+
+		$contentCheckbox = $checkboxes.filter( '[name="frm_dyncontent-hide"]' );
+		if ( ! $contentCheckbox.is( ':checked') ) {
+			setTimeout(
+				function() {
+					$contentCheckbox.click();
+					$checkboxes.attr( 'disabled', true );
+				},
+				0
+			);
+		} else {
+			$checkboxes.attr( 'disabled', true );
+		}
+	}
+
 	return {
 		init: function() {
 			s = {};
@@ -6039,7 +6061,7 @@ function frmAdminBuildJS() {
 			});
 			clickTab( jQuery( '.starttab a' ), 'auto' );
 
-			jQuery( '.post-type-frm_display #screen-options-wrap:hidden input[type="checkbox"]' ).attr( 'disabled', true );
+			adjustScreenOptionsCheckboxesForViews();
 
 			// submit the search form with dropdown
 			jQuery( '#frm-fid-search-menu a' ).click( function() {


### PR DESCRIPTION
Should fix https://github.com/Strategy11/formidable-pro/issues/2633

I'm still not sure how it's getting triggered for people. There are these `hide-if-js` and `hide-if-no-js` classes that get added depending on the state of the checkbox, that might have a plugin conflict. Nat had mentioned a plugin conflict, could be the same for Kristine.

I played with unchecking the box and refreshing the page, seeing if I could recover from that. I need to do a 0 second timeout so that it happens after WordPress initializes their event listeners. Otherwise, I'd have to do some hacky interpretation of what happens when the checkbox is toggled.

But who knows. I haven't gotten enough detail from anyone experiencing the issue to know IF the checkbox is even the issue. Maybe something is just hiding the container directly with css.