### PR TITLE
better action conditional logic call to action

### DIFF
--- a/classes/models/FrmFormAction.php
+++ b/classes/models/FrmFormAction.php
@@ -834,4 +834,18 @@ class FrmFormAction {
 
 		return apply_filters( 'frm_action_triggers', $triggers );
 	}
+
+	public function render_conditional_logic_call_to_action() {
+		?>
+			<h3>
+				<a href="javascript:void(0)" class="frm_show_upgrade frm_noallow" data-upgrade="<?php echo esc_attr( $this->get_upgrade_text() ); ?>" data-medium="conditional-<?php echo esc_attr( $this->id_base ); ?>">
+					<?php esc_html_e( 'Use Conditional Logic', 'formidable' ); ?>
+				</a>
+			</h3>
+		<?php
+	}
+
+	protected function get_upgrade_text() {
+		return __( 'Conditional form actions', 'formidable' );
+	}
 }

--- a/classes/views/frm-form-actions/_action_inside.php
+++ b/classes/views/frm-form-actions/_action_inside.php
@@ -65,18 +65,17 @@ do_action( 'frm_additional_action_settings', $form_action, $pass_args );
 
 // Show Conditional logic indicator.
 if ( ! FrmAppHelper::pro_is_installed() ) {
-	?>
-	<h3>
-		<a href="javascript:void(0)" class="frm_show_upgrade frm_noallow" data-upgrade="<?php esc_attr_e( 'Email attachments', 'formidable' ); ?>" data-medium="email-attachment">
-			<?php esc_html_e( 'Attachment', 'formidable' ); ?>
-		</a>
-	</h3>
-	<h3>
-		<a href="javascript:void(0)" class="frm_show_upgrade frm_noallow" data-upgrade="<?php esc_attr_e( 'Conditional emails', 'formidable' ); ?>" data-medium="conditional-email">
-			<?php esc_html_e( 'Use Conditional Logic', 'formidable' ); ?>
-		</a>
-	</h3>
-	<?php
+	if ( 'email' === $form_action->post_excerpt ) {
+		?>
+		<h3>
+			<a href="javascript:void(0)" class="frm_show_upgrade frm_noallow" data-upgrade="<?php esc_attr_e( 'Email attachments', 'formidable' ); ?>" data-medium="email-attachment">
+				<?php esc_html_e( 'Attachment', 'formidable' ); ?>
+			</a>
+		</h3>
+		<?php
+	}
+
+	$action_control->render_conditional_logic_call_to_action();
 }
 
 // Show Form Action Automation indicator.

--- a/classes/views/frm-form-actions/email_action.php
+++ b/classes/views/frm-form-actions/email_action.php
@@ -39,4 +39,8 @@ class FrmEmailAction extends FrmFormAction {
 			'event'         => array( 'create' ),
 		);
 	}
+
+	protected function get_upgrade_text() {
+		return __( 'Conditional emails', 'formidable' );
+	}
 }


### PR DESCRIPTION
I noticed in the aweber notes that you can use the plugin without pro.

I tried this out and there are some UI items that show up for emails for all of the other action types as well. It looks sort of messy, since none of the other types really support Attachments.

I made it so we can extend our FrmFormActions to handle custom text but for now most of the plugins will read as `Conditional form actions` instead of `Conditional emails` which is still a nice step up. I already extended email so it still says Condtional emails :)

This update also extends `data-medium` a bit, someone could click through now on `conditional-zapier` and `conditional-aweber` rather than all being marked as `conditional-email`. I figured this was useful to distinguish.

![Screen Shot 2020-10-14 at 1 07 57 PM](https://user-images.githubusercontent.com/9134515/96016557-450a2580-0e1f-11eb-9301-91ab53541e42.png)

Otherwise the aweber plugin does work well without pro.