### PR TITLE
fix string values if an array was expected when exporting

### DIFF
--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -315,6 +315,10 @@ class FrmCSVExportHelper {
 				)
 			);
 
+			if ( $col->form_id !== self::$form_id && ! is_array( $field_value ) ) {
+				$field_value = array( $field_value );
+			}
+
 			if ( ! empty( $col->field_options['separate_value'] ) ) {
 				$sep_value = FrmEntriesHelper::display_value(
 					$field_value,

--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -305,6 +305,7 @@ class FrmCSVExportHelper {
 			FrmAppHelper::unserialize_or_decode( $field_value );
 			self::add_array_values_to_columns( $row, compact( 'col', 'field_value' ) );
 
+			$was_array   = is_array( $field_value );
 			$field_value = apply_filters(
 				'frm_csv_value',
 				$field_value,
@@ -315,8 +316,8 @@ class FrmCSVExportHelper {
 				)
 			);
 
-			if ( $col->form_id !== self::$form_id && ! is_array( $field_value ) ) {
-				$field_value = array( $field_value );
+			if ( $was_array && is_string( $field_value ) ) {
+				$field_value = explode( ', ', $field_value );
 			}
 
 			if ( ! empty( $col->field_options['separate_value'] ) ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2682

I think that after the file ids go into `frm_csv_value` they're coming out differently and it was treating the string as an array, picking the first item, which was just the letter h from http.

I just check if we're expecting an array (the form ids don't match) and we have a string when it should be an array.

Still seems to struggle with exporting more than one file though per field though...