### PR TITLE
unique repeaters post check fix

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1082,13 +1082,70 @@ DEFAULT_HTML;
 		// Override in a child class.
 	}
 
+	/**
+	 * A field is not unique if it has already been passed to this function, or if it exists in meta for this field but another entry id
+	 *
+	 * @param mixed $value
+	 * @param int $entry_id
+	 * @return bool
+	 */
 	public function is_not_unique( $value, $entry_id ) {
-		$exists = false;
-		if ( FrmAppHelper::pro_is_installed() ) {
-			$exists = FrmProEntryMetaHelper::value_exists( $this->get_field_column( 'id' ), $value, $entry_id );
+		if ( $this->value_has_already_been_validated_as_unique( $value ) ) {
+			return true;
 		}
 
-		return $exists;
+		if ( $this->value_exists_in_meta_for_another_entry( $value, $entry_id ) ) {
+			return true;
+		}
+
+		$this->value_validated_as_unique( $value );
+		return false;
+	}
+
+	/**
+	 * @param mixed $value
+	 * @return bool
+	 */
+	private function value_has_already_been_validated_as_unique( $value ) {
+		global $frm_validated_unique_values;
+
+		if ( empty( $frm_validated_unique_values ) ) {
+			$frm_validated_unique_values = array();
+			return false;
+		}
+
+		$field_id = $this->get_field_column( 'id' );
+		if ( ! array_key_exists( $field_id, $frm_validated_unique_values ) ) {
+			$frm_validated_unique_values[ $field_id ] = array();
+			return false;
+		}
+
+		$already_validated_this_value = in_array( $value, $frm_validated_unique_values[ $field_id ], true );
+		return $already_validated_this_value;
+	}
+
+	/**
+	 * @param mixed $value
+	 * @param int $entry_id
+	 * @return bool
+	 */
+	private function value_exists_in_meta_for_another_entry( $value, $entry_id ) {
+		if ( ! FrmAppHelper::pro_is_installed() ) {
+			return false;
+		}
+		$field_id = $this->get_field_column( 'id' );
+		return FrmProEntryMetaHelper::value_exists( $field_id, $value, $entry_id );
+	}
+
+	/**
+	 * Track that a value has been flagged as unique so that no other iterations can be for the same value for this field
+	 *
+	 * @param mixed $value
+	 */
+	private function value_validated_as_unique( $value ) {
+		global $frm_validated_unique_values;
+		$field_id                                   = $this->get_field_column( 'id' );
+		$frm_validated_unique_values[ $field_id ][] = $value;
 	}
 
 	public function get_value_to_save( $value, $atts ) {

--- a/tests/fields/test_FrmFieldType.php
+++ b/tests/fields/test_FrmFieldType.php
@@ -153,4 +153,39 @@ class test_FrmFieldType extends FrmUnitTest {
 		$this->assertEquals( $checkbox->get_import_value( 'a,c' ), array( 'a', 'c' ) );
 		$this->assertEquals( $checkbox->get_import_value( 'a,b,c' ), 'a,b,c' );
 	}
+
+	/**
+	 * @covers FrmFieldType::is_not_unique
+	 */
+	public function test_is_not_unique() {
+
+		$form_id = $this->factory->form->create();
+		$field1 = $this->factory->field->create_and_get( array(
+			'type'    => 'number',
+			'form_id' => $form_id,
+		) );
+
+		$field_object1 = FrmFieldFactory::get_field_type( 'text', $field1 );
+		$entry_id     = 0;
+
+		$this->assertFalse( $field_object1->is_not_unique( 'First', $entry_id ), 'the first iteration of a new value should be flagged as okay' );
+		$this->assertTrue( $field_object1->is_not_unique( 'First', $entry_id ), 'the second iteration of a new value should should be flagged as a duplicate' );
+
+		$this->assertFalse( $field_object1->is_not_unique( 'Second', $entry_id ), 'the first iteration of a second new value should be flagged as okay' );
+		$this->assertFalse( $field_object1->is_not_unique( 'Third', $entry_id ), 'the first iteration of a third new value should be flagged as okay' );
+
+		$this->assertTrue( $field_object1->is_not_unique( 'Third', $entry_id ) );
+		$this->assertTrue( $field_object1->is_not_unique( 'Second', $entry_id ) );
+
+		$field_object2 = FrmFieldFactory::get_field_type( 'text', $field1 );
+		$this->assertTrue( $field_object2->is_not_unique( 'First', $entry_id ), 'another field object for the same field should also be flagging a duplicate' );
+
+		$field2 = $this->factory->field->create_and_get( array(
+			'type'    => 'number',
+			'form_id' => $form_id,
+		) );
+		$field_object3 = FrmFieldFactory::get_field_type( 'text', $field2 );
+
+		$this->assertFalse( $field_object3->is_not_unique( 'First', $entry_id ), 'a field object for another field should not flag a duplicate' );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/1913

I used a global variable as the validation seems to happen with different field object instances despite validating the same field, so storing the variables on the object didn't work. I made some unit tests to reflect that (that two different field objects for the same field still track duplicates between one another, and that another unrelated field object doesn't).