### PR TITLE
Open an action before duplicate if it has not loaded yet

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -661,6 +661,7 @@ function frmAdminBuildJS() {
 						inside.html( html );
 						initiateMultiselect();
 						showInputIcon( '#' + cont.attr( 'id' ) );
+						jQuery( b ).trigger( 'frm-action-loaded' );
 					}
 				});
 			}
@@ -3734,7 +3735,10 @@ function frmAdminBuildJS() {
 	}
 
 	function copyFormAction() {
-		/*jshint validthis:true */
+		if ( waitForActionToLoadBeforeCopy( this ) ) {
+			return;
+		}
+
 		var action = jQuery( this ).closest( '.frm_form_action_settings' ).clone();
 		var currentID = action.attr( 'id' ).replace( 'frm_form_action_', '' );
 		var newID = newActionId( currentID );
@@ -3762,6 +3766,26 @@ function frmAdminBuildJS() {
 
 		jQuery( '#frm_notification_settings' ).append( div + html + '</div>' );
 		initiateMultiselect();
+	}
+
+	function waitForActionToLoadBeforeCopy( element ) {
+		return false;
+		var $trigger = jQuery( element ),
+			$original = $trigger.closest( '.frm_form_action_settings' ),
+			$inside = $original.find( '.widget-inside' ),
+			$top;
+
+		if ( $inside.find( 'p, div, table' ).length ) {
+			return false;
+		}
+
+		$top = $original.find( '.widget-top' );
+		$top.on( 'frm-action-loaded', function() {
+			$trigger.click();
+			$top.click();
+		});
+		$top.click();
+		return true;
 	}
 
 	function newActionId( currentID ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -634,10 +634,15 @@ function frmAdminBuildJS() {
 		popCalcFields( b, false );
 
 		var cont = jQuery( b ).closest( '.frm_form_action_settings' );
-		if ( cont.length && typeof target !== 'undefined' && ( target.parentElement.className.indexOf( 'frm_email_icons' ) > -1 || target.parentElement.className.indexOf( 'frm_toggle' ) > -1 ) ) {
-			// clicking on delete icon shouldn't open it
-			event.stopPropagation();
-			return;
+		if ( cont.length && typeof target !== 'undefined' ) {
+			var className = target.parentElement.className;
+			if ( 'string' === typeof className ) {
+				if ( className.indexOf( 'frm_email_icons' ) > -1 || className.indexOf( 'frm_toggle' ) > -1 ) {
+					// clicking on delete icon shouldn't open it
+					event.stopPropagation();
+					return;
+				}
+			}
 		}
 
 		var inside = cont.children( '.widget-inside' );
@@ -3769,7 +3774,6 @@ function frmAdminBuildJS() {
 	}
 
 	function waitForActionToLoadBeforeCopy( element ) {
-		return false;
 		var $trigger = jQuery( element ),
 			$original = $trigger.closest( '.frm_form_action_settings' ),
 			$inside = $original.find( '.widget-inside' ),
@@ -3782,7 +3786,8 @@ function frmAdminBuildJS() {
 		$top = $original.find( '.widget-top' );
 		$top.on( 'frm-action-loaded', function() {
 			$trigger.click();
-			$top.click();
+			$original.removeClass( 'open' );
+			$inside.hide();
 		});
 		$top.click();
 		return true;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3740,6 +3740,7 @@ function frmAdminBuildJS() {
 	}
 
 	function copyFormAction() {
+		/*jshint validthis:true */
 		if ( waitForActionToLoadBeforeCopy( this ) ) {
 			return;
 		}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2703

I also noticed that when the duplicate icon is clicked that it the value of `target.parentElement.className` is a [SVGAnimatedString](https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedString) which does not have an indexOf function. It throws a JavaScript error, so I'm checking for a string value first.