### PR TITLE
drop php52

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
 	"type": "wordpress-plugin",
 	"require": {
 		"composer/installers": "~1.0",
-		"xrstf/composer-php52": "^1.0.19",
 		"phpmailer/phpmailer": ">=5.2.25"
 	},
 	"autoload": {
@@ -32,16 +31,5 @@
 	},
     "require-dev": {
         "phpunit/phpunit": "6.*"
-    },
-	"scripts": {
-		"post-install-cmd": [
-			"xrstf\\Composer52\\Generator::onPostInstallCmd"
-		],
-		"post-update-cmd": [
-			"xrstf\\Composer52\\Generator::onPostInstallCmd"
-		],
-		"post-autoload-dump": [
-			"xrstf\\Composer52\\Generator::onPostInstallCmd"
-		]
-	}
+    }
 }


### PR DESCRIPTION
Same issue on free as in pro, dropping php52 support as it's legacy and no longer necessary for anything, and breaking Travis builds.

Causing multiple of my recent pull requests to fail, as well as the latest master merge.

I've already merged it into those broken branches so that they can pass testing.