### PR TITLE
php warning when using fallback plugins fix

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -517,7 +517,8 @@ class FrmAddonsController {
 				} else {
 					$base_file = 'formidable-' . $slug;
 				}
-				$file_name = $base_file . '/' . $base_file . '.php';
+				$file_name       = $base_file . '/' . $base_file . '.php';
+				$addon['plugin'] = $file_name;
 			}
 
 			$addon['installed']    = self::is_installed( $file_name );

--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -518,7 +518,9 @@ class FrmAddonsController {
 					$base_file = 'formidable-' . $slug;
 				}
 				$file_name       = $base_file . '/' . $base_file . '.php';
-				$addon['plugin'] = $file_name;
+				if ( ! isset( $addon['plugin'] ) ) {
+					$addon['plugin'] = $file_name;
+				}
 			}
 
 			$addon['installed']    = self::is_installed( $file_name );

--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -517,7 +517,7 @@ class FrmAddonsController {
 				} else {
 					$base_file = 'formidable-' . $slug;
 				}
-				$file_name       = $base_file . '/' . $base_file . '.php';
+				$file_name = $base_file . '/' . $base_file . '.php';
 				if ( ! isset( $addon['plugin'] ) ) {
 					$addon['plugin'] = $file_name;
 				}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2667

The fallback's don't specify this value, but the prepare function figures it out and just never sets it.