### PR TITLE
use conditional addon button on views upsell page

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -1140,6 +1140,13 @@ class FrmAddonsController {
 		);
 	}
 
+	/**
+	 * Render a conditional action button for a specified plugin
+	 *
+	 * @param string $plugin
+	 * @param array|string $upgrade_link_args
+	 * @since 4.09
+	 */
 	public static function conditional_action_button( $plugin, $upgrade_link_args ) {
 		$addon         = self::get_addon( $plugin );
 		$license_type  = self::get_license_type();

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -168,8 +168,9 @@ class FrmAppController {
 			),
 		);
 
-		// Let people know reports and views exist.
-		if ( ! FrmAppHelper::pro_is_installed() ) {
+		$views_installed = is_callable( 'FrmProAppHelper::views_is_installed' ) ? FrmProAppHelper::views_is_installed() : FrmAppHelper::pro_is_installed();
+
+		if ( ! $views_installed ) {
 			$nav_items[] = array(
 				'link'    => admin_url( 'admin.php?page=formidable-views&frm-full=1&form=' . absint( $id ) ),
 				'label'   => __( 'Views', 'formidable' ),
@@ -180,6 +181,10 @@ class FrmAppController {
 					'class' => 'frm_noallow',
 				),
 			);
+		}
+
+		// Let people know reports and views exist.
+		if ( ! FrmAppHelper::pro_is_installed() ) {
 			$nav_items[] = array(
 				'link'    => admin_url( 'admin.php?page=formidable&frm_action=lite-reports&frm-full=1&form=' . absint( $id ) ),
 				'label'   => __( 'Reports', 'formidable' ),

--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -10,7 +10,8 @@ class FrmEntriesController {
 
 		add_submenu_page( 'formidable', 'Formidable | ' . __( 'Entries', 'formidable' ), __( 'Entries', 'formidable' ), 'frm_view_entries', 'formidable-entries', 'FrmEntriesController::route' );
 
-		if ( ! FrmAppHelper::pro_is_installed() ) {
+		$views_installed = is_callable( 'FrmProAppHelper::views_is_installed' ) ? FrmProAppHelper::views_is_installed() : FrmAppHelper::pro_is_installed();
+		if ( ! $views_installed ) {
 			add_submenu_page( 'formidable', 'Formidable | ' . __( 'Views', 'formidable' ), __( 'Views', 'formidable' ), 'frm_view_entries', 'formidable-views', 'FrmFormsController::no_views' );
 		}
 

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -74,6 +74,47 @@ class FrmAppHelper {
 	}
 
 	/**
+	 * Render a conditional action button for an add on
+	 *
+	 * @since 4.09
+	 * @param array $addon
+	 * @param string|false $license_type
+	 * @param string $plan_required
+	 * @param string $upgrade_link
+	 */
+	public static function conditional_action_button( $addon, $license_type, $plan_required, $upgrade_link ) {
+		if ( $addon['status']['type'] === 'installed' ) {
+			?>
+			<a rel="<?php echo esc_attr( $addon['plugin'] ); ?>" class="button button-primary frm-button-primary frm-activate-addon <?php echo esc_attr( empty( $addon['activate_url'] ) ? 'frm_hidden' : '' ); ?>">
+				<?php esc_html_e( 'Activate', 'formidable' ); ?>
+			</a>
+			<?php
+		} elseif ( ! empty( $addon['url'] ) ) {
+			?>
+			<a class="frm-install-addon button button-primary frm-button-primary" rel="<?php echo esc_attr( $addon['url'] ); ?>" aria-label="<?php esc_attr_e( 'Install', 'formidable' ); ?>">
+				<?php esc_html_e( 'Install', 'formidable' ); ?>
+			</a>
+			<?php
+		} elseif ( $license_type && $license_type === strtolower( $plan_required ) ) {
+			?>
+			<a class="install-now button button-secondary frm-button-secondary" href="<?php echo esc_url( self::admin_upgrade_link( 'addons', 'account/downloads/' ) . '&utm_content=' . $addon['slug'] ); ?>" target="_blank" aria-label="<?php esc_attr_e( 'Upgrade Now', 'formidable' ); ?>">
+				<?php esc_html_e( 'Renew Now', 'formidable' ); ?>
+			</a>
+			<?php
+		} else {
+			if ( isset( $addon['categories'] ) && in_array( 'Solution', $addon['categories'], true ) ) {
+				// Solutions will go to a separate page.
+				$upgrade_link = self::admin_upgrade_link( 'addons', $addon['link'] );
+			}
+			?>
+			<a class="install-now button button-secondary frm-button-secondary" href="<?php echo esc_url( $upgrade_link . '&utm_content=' . $addon['slug'] ); ?>" target="_blank" rel="noopener" aria-label="<?php esc_attr_e( 'Upgrade Now', 'formidable' ); ?>">
+				<?php esc_html_e( 'Upgrade Now', 'formidable' ); ?>
+			</a>
+			<?php
+		}
+	}
+
+	/**
 	 * @since 3.04.02
 	 * @param array|string $args
 	 * @param string       $page

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -83,6 +83,15 @@ class FrmAppHelper {
 	 * @param string $upgrade_link
 	 */
 	public static function conditional_action_button( $addon, $license_type, $plan_required, $upgrade_link ) {
+		if ( ! $addon ) {
+			?>
+			<a class="install-now button button-secondary frm-button-secondary" href="<?php echo esc_url( $upgrade_link ); ?>" target="_blank" rel="noopener" aria-label="<?php esc_attr_e( 'Upgrade Now', 'formidable' ); ?>">
+				<?php esc_html_e( 'Upgrade Now', 'formidable' ); ?>
+			</a>
+			<?php
+			return;
+		}
+
 		if ( $addon['status']['type'] === 'installed' ) {
 			?>
 			<a rel="<?php echo esc_attr( $addon['plugin'] ); ?>" class="button button-primary frm-button-primary frm-activate-addon <?php echo esc_attr( empty( $addon['activate_url'] ) ? 'frm_hidden' : '' ); ?>">

--- a/classes/views/addons/list.php
+++ b/classes/views/addons/list.php
@@ -77,29 +77,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						);
 						?>
 					</span>
-					<?php if ( $addon['status']['type'] === 'installed' ) { ?>
-						<a rel="<?php echo esc_attr( $addon['plugin'] ); ?>" class="button button-primary frm-button-primary frm-activate-addon <?php echo esc_attr( empty( $addon['activate_url'] ) ? 'frm_hidden' : '' ); ?>">
-							<?php esc_html_e( 'Activate', 'formidable' ); ?>
-						</a>
-					<?php } elseif ( isset( $addon['url'] ) && ! empty( $addon['url'] ) ) { ?>
-						<a class="frm-install-addon button button-primary frm-button-primary" rel="<?php echo esc_attr( $addon['url'] ); ?>" aria-label="<?php esc_attr_e( 'Install', 'formidable' ); ?>">
-							<?php esc_html_e( 'Install', 'formidable' ); ?>
-						</a>
-					<?php } elseif ( ! empty( $license_type ) && $license_type === strtolower( $plan_required ) ) { ?>
-						<a class="install-now button button-secondary frm-button-secondary" href="<?php echo esc_url( FrmAppHelper::admin_upgrade_link( 'addons', 'account/downloads/' ) . '&utm_content=' . $addon['slug'] ); ?>" target="_blank" aria-label="<?php esc_attr_e( 'Upgrade Now', 'formidable' ); ?>">
-							<?php esc_html_e( 'Renew Now', 'formidable' ); ?>
-						</a>
-					<?php } else { ?>
-						<?php
-						if ( isset( $addon['categories'] ) && in_array( 'Solution', $addon['categories'] ) ) {
-							// Solutions will go to a separate page.
-							$pricing = FrmAppHelper::admin_upgrade_link( 'addons', $addon['link'] );
-						}
-						?>
-						<a class="install-now button button-secondary frm-button-secondary" href="<?php echo esc_url( $pricing . '&utm_content=' . $addon['slug'] ); ?>" target="_blank" rel="noopener" aria-label="<?php esc_attr_e( 'Upgrade Now', 'formidable' ); ?>">
-							<?php esc_html_e( 'Upgrade Now', 'formidable' ); ?>
-						</a>
-					<?php } ?>
+					<?php FrmAppHelper::conditional_action_button( $addon, ! empty( $license_type ) ? $license_type : false, $plan_required, $pricing ); ?>
 				</div>
 			</div>
 		<?php } ?>

--- a/classes/views/shared/views-info.php
+++ b/classes/views/shared/views-info.php
@@ -20,9 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<p style="max-width:400px;margin:20px auto">
 				<?php esc_html_e( 'Bring entries to the front-end of your site for full-featured applications or just to show the content.', 'formidable' ); ?>
 			</p>
-			<a class="button button-primary frm-button-primary" href="<?php echo esc_url( FrmAppHelper::admin_upgrade_link( 'views-info' ) ); ?>" target="_blank" rel="noopener">
-				<?php esc_html_e( 'Upgrade Now', 'formidable' ); ?>
-			</a>
+			<?php FrmAddonsController::conditional_action_button( 'views', 'views-info' ); ?>
 		</div>
 	</div>
 </div>

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1530,7 +1530,7 @@ div.frm_updated_message {
 	text-align: center;
 }
 
-#frm_top_bar + .wrap > .frm_updated_message {
+#frm_top_bar + .wrap > .frm_updated_message, #frm_top_bar + .wrap > .frm_warning_style {
 	display: inline-block;
 	width: 100%;
 	box-sizing: border-box;


### PR DESCRIPTION
- [x] Views upsell page should use the conditional Install/Activate/Upgrade link used on the Add-ons page instead of the static Upgrade link

The new upsell updates for views require some tweaks in the free plugin

- Adds views to the fallback plugin list
- Add a few helper functions to make it easier to access certain API details when just looking for a single thing
- The views upsell page now uses the same button logic as the addons list page (which is now moved into two different helper functions, one that manages the rendering and one that connects the addon to the rendering function without exposing the whole addon api)
- Do the same css adjustment for the messages warning that I did in an earlier update to add padding for errors