### PR TITLE
only show expiring message if days is greater than 0

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -192,7 +192,7 @@ class FrmAppHelper {
 	 */
 	public static function expiring_message() {
 		$expiring = FrmAddonsController::is_license_expiring();
-		if ( ! $expiring ) {
+		if ( ! $expiring || $expiring < 0 ) {
 			return;
 		}
 		?>


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2721

Since `FrmAppHelper::renewal_message` covers any actual expirations, the expiration warning has no need to ever remind about anything negative.

It's possible this should also be fixed at a server level but I don't believe anything actually relies on this for functionality. It is just so we can show a message, so this should really be enough.

Or, maybe for consistency we want to do a similar approach to this:
```
if ( $days_left > 30 ) {
	return false;
}
```

Change it to
```
if ( $days_left > 30 || $days_left < 0 ) {
	return false;
}
```

But maybe it's nice to know the difference here.