### PR TITLE
add code styling rules to free unit tests

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,16 +11,12 @@
 	<arg value="nsp" />
 
 	<rule ref="WordPress">
-
 		<!-- Temporary exclusions. Enable these when we have time to address them -->
 		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeOpen" />
 		<exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterEnd" />
 		<exclude name="Squiz.Commenting" />
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 		<exclude name="WordPress.WP.GlobalVariablesOverride" />
-
-		<!-- Enable these rules right away -->
-		<exclude name="WordPress.Security.NonceVerification.Missing" />
 
 		<!-- These give issues with the current code base. -->
 		<exclude name="WordPress.Files.FileName.UnderscoresNotAllowed" />
@@ -41,6 +37,23 @@
 		</properties>
 	</rule>
 	<rule ref="Squiz.Scope.StaticThisUsage" />
+
+	<!-- Enable these rules right away -->
+	<rule ref="WordPress.Security.NonceVerification.Missing">
+		<exclude-pattern>classes/models/fields/FrmFieldCaptcha.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmFormAction.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmStyle.php</exclude-pattern>
+		<exclude-pattern>classes/controllers/FrmStylesController.php</exclude-pattern>
+		<exclude-pattern>classes/controllers/FrmFormsController.php</exclude-pattern>
+		<exclude-pattern>classes/controllers/FrmEntriesController.php</exclude-pattern>
+		<exclude-pattern>classes/helpers/FrmFieldsHelper.php</exclude-pattern>
+		<exclude-pattern>classes/helpers/FrmStylesHelper.php</exclude-pattern>
+		<exclude-pattern>classes/helpers/FrmEntriesHelper.php</exclude-pattern>
+		<exclude-pattern>classes/helpers/FrmFormsHelper.php</exclude-pattern>
+		<exclude-pattern>classes/helpers/FrmCSVExportHelper.php</exclude-pattern>
+		<exclude-pattern>classes/helpers/FrmAppHelper.php</exclude-pattern>
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
 
 	<!-- Exclude specific rules for unit tests -->
 	<rule ref="PEAR.NamingConventions.ValidClassName.StartWithCapital">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,7 +2,6 @@
 <ruleset name="Formidable Forms">
 	<description>Formidable Forms rules for PHP_CodeSniffer</description>
 
-	<exclude-pattern>tests/*</exclude-pattern>
 	<exclude-pattern>vendor/*</exclude-pattern>
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>deprecated/*</exclude-pattern>
@@ -19,6 +18,7 @@
 		<exclude name="Squiz.Commenting" />
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 		<exclude name="WordPress.WP.GlobalVariablesOverride" />
+		<exclude name="Generic.Files.LineEndings.InvalidEOLChar" />
 
 		<!-- Enable these rules right away -->
 		<exclude name="WordPress.Security.NonceVerification.Missing" />
@@ -40,5 +40,32 @@
 				<element value="formidable"/>
 			</property>
 		</properties>
+	</rule>
+	<rule ref="Squiz.Scope.StaticThisUsage" />
+
+	<!-- Exclude specific rules for unit tests -->
+	<rule ref="PEAR.NamingConventions.ValidClassName.StartWithCapital">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.DB.PreparedSQL.NotPrepared">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.DB.PreparedSQL.InterpolatedNotPrepared">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.Security.ValidatedSanitizedInput.InputNotValidated">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.Security.ValidatedSanitizedInput.MissingUnslash">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized">
+		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,7 +18,6 @@
 		<exclude name="Squiz.Commenting" />
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 		<exclude name="WordPress.WP.GlobalVariablesOverride" />
-		<exclude name="Generic.Files.LineEndings.InvalidEOLChar" />
 
 		<!-- Enable these rules right away -->
 		<exclude name="WordPress.Security.NonceVerification.Missing" />

--- a/tests/base/FrmAjaxUnitTest.php
+++ b/tests/base/FrmAjaxUnitTest.php
@@ -32,19 +32,19 @@ class FrmAjaxUnitTest extends WP_Ajax_UnitTestCase {
 		$this->factory->entry = new Entry_Factory( $this );
 	}
 
-    function set_as_user_role( $role ) {
-        // create user
-        $user_id = $this->factory->user->create( array( 'role' => $role ) );
-		$user = new WP_User($user_id);
+	public function set_as_user_role( $role ) {
+		// create user
+		$user_id = $this->factory->user->create( array( 'role' => $role ) );
+		$user = new WP_User( $user_id );
 		$this->assertTrue( $user->exists(), 'Problem getting user ' . $user_id );
 
-        // log in as user
-        wp_set_current_user($user_id);
-        $this->$user_id = $user_id;
+		// log in as user
+		wp_set_current_user( $user_id );
+		$this->$user_id = $user_id;
 		$this->assertTrue( current_user_can( $role ) );
-    }
+	}
 
-	function trigger_action( $action ) {
+	public function trigger_action( $action ) {
 		$response = '';
 		try {
 			$this->_handleAjax( $action );

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -34,7 +34,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 		self::empty_tables();
 	}
 
-	function setUp() {
+	public function setUp() {
 		parent::setUp();
 
 		$this->is_pro_active = get_option( 'frmpro-authorized' );
@@ -59,7 +59,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 	protected static function empty_tables() {
 		global $wpdb;
 		$tables = self::get_table_names();
-		foreach ( $tables as $table ){
+		foreach ( $tables as $table ) {
 			$exists = $wpdb->get_var( 'DESCRIBE ' . $table );
 			if ( $exists ) {
 				$wpdb->query( "TRUNCATE $table" );
@@ -88,8 +88,10 @@ class FrmUnitTest extends WP_UnitTestCase {
 		global $wpdb;
 
 		$tables = array(
-			$wpdb->prefix . 'frm_fields', $wpdb->prefix . 'frm_forms',
-			$wpdb->prefix . 'frm_items',  $wpdb->prefix . 'frm_item_metas',
+			$wpdb->prefix . 'frm_fields',
+			$wpdb->prefix . 'frm_forms',
+			$wpdb->prefix . 'frm_items',
+			$wpdb->prefix . 'frm_item_metas',
 		);
 		if ( is_multisite() && is_callable( 'FrmProCopy::table_name' ) ) {
 			$tables[] = FrmProCopy::table_name();
@@ -182,10 +184,10 @@ class FrmUnitTest extends WP_UnitTestCase {
 			$media_ids = FrmProFileImport::import_attachment( $values['val'], $values['field'] );
 
 			if ( is_array( $values['val'] ) ) {
-				$media_ids = explode(',', $media_ids );
+				$media_ids = explode( ',', $media_ids );
 			} else {
 				$is_file_val = is_numeric( $media_ids ) || strpos( $media_ids, ',' );
-				self::assertTrue( $is_file_val, 'The following file is not importing correctly: ' . $values[ 'val' ] );
+				self::assertTrue( $is_file_val, 'The following file is not importing correctly: ' . $values['val'] );
 			}
 
 			// Insert into entries
@@ -194,12 +196,12 @@ class FrmUnitTest extends WP_UnitTestCase {
 		}
 	}
 
-	function get_all_fields_for_form_key( $form_key ) {
+	public function get_all_fields_for_form_key( $form_key ) {
 		$field_totals = array(
 			$this->all_fields_form_key => $this->is_pro_active ? $this->all_field_types_count : ( $this->all_field_types_count - 3 ),
 			$this->create_post_form_key => 10,
 			$this->contact_form_key => $this->contact_form_field_count,
-			$this->repeat_sec_form_key => 3
+			$this->repeat_sec_form_key => 3,
 		);
 		$expected_field_num = isset( $field_totals[ $form_key ] ) ? $field_totals[ $form_key ] : 0;
 
@@ -207,7 +209,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 		$fields = FrmField::get_all_for_form( $form_id, '', 'include' );
 
 		$actual_field_num = count( $fields );
-		$this->assertEquals( $actual_field_num, $expected_field_num, $actual_field_num . ' fields were retrieved for ' . $form_key . ' form, but ' . $expected_field_num . ' were expected. This could mean that certain fields were not imported correctly.');
+		$this->assertEquals( $actual_field_num, $expected_field_num, $actual_field_num . ' fields were retrieved for ' . $form_key . ' form, but ' . $expected_field_num . ' were expected. This could mean that certain fields were not imported correctly.' );
 
 		return $fields;
 	}
@@ -215,11 +217,11 @@ class FrmUnitTest extends WP_UnitTestCase {
 	/**
 	* Set the current user to 1
 	*/
-	function set_current_user_to_1( ) {
+	public function set_current_user_to_1() {
 		$this->set_user_by_role( 'administrator' );
 	}
 
-	function set_current_user_to_username( $login ) {
+	public function set_current_user_to_username( $login ) {
 		$user = get_user_by( 'login', $login );
 
 		if ( $user ) {
@@ -234,16 +236,16 @@ class FrmUnitTest extends WP_UnitTestCase {
 	 *
 	 * @return WP_User
 	 */
-    function set_user_by_role( $role ) {
-	    $user = $this->get_user_by_role( $role );
-	    wp_set_current_user( $user->ID );
+	public function set_user_by_role( $role ) {
+		$user = $this->get_user_by_role( $role );
+		wp_set_current_user( $user->ID );
 
-	    $this->assertTrue( current_user_can( $role ), 'Failed setting the current user role' );
+		$this->assertTrue( current_user_can( $role ), 'Failed setting the current user role' );
 
-	    FrmAppHelper::maybe_add_permissions();
+		FrmAppHelper::maybe_add_permissions();
 
 		return $user->ID;
-    }
+	}
 
 	/**
 	 * Get a user of a specific role
@@ -253,7 +255,12 @@ class FrmUnitTest extends WP_UnitTestCase {
 	 * @return WP_User
 	 */
 	public function get_user_by_role( $role ) {
-		$users = get_users( array( 'role' => $role, 'number' => 1 ) );
+		$users = get_users(
+			array(
+				'role' => $role,
+				'number' => 1,
+			)
+		);
 		if ( empty( $users ) ) {
 			$this->fail( 'No users with this role currently exist.' );
 			$user = null;
@@ -264,7 +271,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 		return $user;
 	}
 
-	function go_to_new_post() {
+	public function go_to_new_post() {
 		$new_post = $this->factory->post->create_and_get();
 		$page = get_permalink( $new_post->ID );
 
@@ -272,7 +279,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 		return $new_post->ID;
 	}
 
-	function set_front_end( $page = '' ) {
+	public function set_front_end( $page = '' ) {
 		if ( $page == '' ) {
 			$page = home_url( '/' );
 		}
@@ -282,12 +289,18 @@ class FrmUnitTest extends WP_UnitTestCase {
 		$this->assertFalse( is_admin(), 'Failed to switch to the front-end' );
 	}
 
-	function set_admin_screen( $page = 'index.php' ) {
+	public function set_admin_screen( $page = 'index.php' ) {
 		global $current_screen;
 
 		$screens = array(
-			'index.php' => array( 'base' => 'dashboard', 'id' => 'dashboard' ),
-			'admin.php?page=formidable' => array( 'base' => 'admin', 'id' => 'toplevel_page_formidable' ),
+			'index.php' => array(
+				'base' => 'dashboard',
+				'id' => 'dashboard',
+			),
+			'admin.php?page=formidable' => array(
+				'base' => 'admin',
+				'id' => 'toplevel_page_formidable',
+			),
 		);
 
 		if ( $page == 'formidable-edit' ) {
@@ -299,10 +312,13 @@ class FrmUnitTest extends WP_UnitTestCase {
 			$screens[ $page ] = array( 'base' => reset( $base ) );
 		}
 
-		$_GET = $_POST = $_REQUEST = array();
-		$GLOBALS['taxnow'] = $GLOBALS['typenow'] = '';
-		$screen = (object) $screens[ $page ];
-		$hook = parse_url( $page );
+		$_GET               = array();
+		$_POST              = array();
+		$_REQUEST           = array();
+		$GLOBALS['taxnow']  = '';
+		$GLOBALS['typenow'] = '';
+		$screen             = (object) $screens[ $page ];
+		$hook               = parse_url( $page );
 
 		$GLOBALS['hook_suffix'] = $hook['path'];
 		set_current_screen();
@@ -317,6 +333,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 
 	/**
 	 * Set the admin page parameters for the later code to use
+	 *
 	 * @since 3.0
 	 */
 	protected function set_get_params( $url ) {
@@ -346,7 +363,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 		}
 	}
 
-	function clean_up_global_scope() {
+	public function clean_up_global_scope() {
 		parent::clean_up_global_scope();
 		if ( isset( $GLOBALS['current_screen'] ) ) {
 			unset( $GLOBALS['current_screen'] );
@@ -368,42 +385,42 @@ class FrmUnitTest extends WP_UnitTestCase {
 		}
 	}
 
-	function get_footer_output() {
-        ob_start();
-        do_action( 'wp_footer' );
-        $output = ob_get_contents();
-        ob_end_clean();
+	public function get_footer_output() {
+		ob_start();
+		do_action( 'wp_footer' );
+		$output = ob_get_contents();
+		ob_end_clean();
 
 		return $output;
 	}
 
-    public static function install_data() {
-        return array(
-        	dirname( __FILE__ ) . '/testdata.xml',
+	public static function install_data() {
+		return array(
+			dirname( __FILE__ ) . '/testdata.xml',
 			dirname( __FILE__ ) . '/free-form.xml',
-	        dirname( __FILE__ ) . '/editform.xml',
+			dirname( __FILE__ ) . '/editform.xml',
 			dirname( __FILE__ ) . '/file-upload.xml',
-        );
-    }
+		);
+	}
 
 	static function generate_xml( $type, $xml_args ) {
 		// Code copied from FrmXMLController::generate_xml
 		global $wpdb;
 
 		$type = (array) $type;
-		if ( in_array( 'items', $type) && ! in_array( 'forms', $type) ) {
+		if ( in_array( 'items', $type ) && ! in_array( 'forms', $type ) ) {
 			// make sure the form is included if there are entries
 			$type[] = 'forms';
 		}
 
-		if ( in_array( 'forms', $type) ) {
+		if ( in_array( 'forms', $type ) ) {
 			// include actions with forms
 			$type[] = 'actions';
 		}
 
 		$tables = array(
-			'items'     => $wpdb->prefix .'frm_items',
-			'forms'     => $wpdb->prefix .'frm_forms',
+			'items'     => $wpdb->prefix . 'frm_items',
+			'forms'     => $wpdb->prefix . 'frm_forms',
 			'posts'     => $wpdb->posts,
 			'styles'    => $wpdb->posts,
 			'actions'   => $wpdb->posts,
@@ -424,81 +441,85 @@ class FrmUnitTest extends WP_UnitTestCase {
 			$join = '';
 			$table = $tables[ $tb_type ];
 
-			$select = $table .'.id';
+			$select = $table . '.id';
 			$query_vars = array();
 
 			switch ( $tb_type ) {
-                case 'forms':
-                    //add forms
-                    if ( $args['ids'] ) {
-						$where[] = array( 'or' => 1, $table . '.id' => $args['ids'], $table .'.parent_form_id' => $args['ids'] );
-                	} else {
+				case 'forms':
+					//add forms
+					if ( $args['ids'] ) {
+						$where[] = array(
+							'or' => 1,
+							$table . '.id' => $args['ids'],
+							$table . '.parent_form_id' => $args['ids'],
+						);
+					} else {
 						$where[ $table . '.status !' ] = 'draft';
-                	}
-                break;
-                case 'actions':
-                    $select = $table .'.ID';
+					}
+					break;
+				case 'actions':
+					$select = $table . '.ID';
 					$where['post_type'] = FrmFormActionsController::$action_post_type;
-                    if ( ! empty($args['ids']) ) {
+					if ( ! empty( $args['ids'] ) ) {
 						$where['menu_order'] = $args['ids'];
-                    }
-                break;
-                case 'items':
-                    //$join = "INNER JOIN {$wpdb->prefix}frm_item_metas im ON ($table.id = im.item_id)";
-                    if ( $args['ids'] ) {
+					}
+					break;
+				case 'items':
+					//$join = "INNER JOIN {$wpdb->prefix}frm_item_metas im ON ($table.id = im.item_id)";
+					if ( $args['ids'] ) {
 						$where[ $table . '.form_id' ] = $args['ids'];
-                    }
-                break;
-                case 'styles':
-                    // Loop through all exported forms and get their selected style IDs
-                    $form_ids = $args['ids'];
-                    $style_ids = array();
-                    foreach ( $form_ids as $form_id ) {
-                        $form_data = FrmForm::getOne( $form_id );
-                        // For forms that have not been updated while running 2.0, check if custom_style is set
-                        if ( isset( $form_data->options['custom_style'] ) ) {
-                            $style_ids[] = $form_data->options['custom_style'];
-                        }
-                        unset( $form_id, $form_data );
-                    }
-                    $select = $table .'.ID';
-                    $where['post_type'] = 'frm_styles';
+					}
+					break;
+				case 'styles':
+					// Loop through all exported forms and get their selected style IDs
+					$form_ids = $args['ids'];
+					$style_ids = array();
+					foreach ( $form_ids as $form_id ) {
+						$form_data = FrmForm::getOne( $form_id );
+						// For forms that have not been updated while running 2.0, check if custom_style is set
+						if ( isset( $form_data->options['custom_style'] ) ) {
+							$style_ids[] = $form_data->options['custom_style'];
+						}
+						unset( $form_id, $form_data );
+					}
+					$select = $table . '.ID';
+					$where['post_type'] = 'frm_styles';
 
-                    // Only export selected styles
-                    if ( ! empty( $style_ids ) ) {
-                        $where['ID'] = $style_ids;
-                    }
-                break;
-                default:
-                    $select = $table .'.ID';
-                    $join = ' INNER JOIN ' . $wpdb->postmeta . ' pm ON (pm.post_id=' . $table . '.ID)';
-                    $where['pm.meta_key'] = 'frm_form_id';
+					// Only export selected styles
+					if ( ! empty( $style_ids ) ) {
+						$where['ID'] = $style_ids;
+					}
+					break;
+				default:
+					$select = $table . '.ID';
+					$join = ' INNER JOIN ' . $wpdb->postmeta . ' pm ON (pm.post_id=' . $table . '.ID)';
+					$where['pm.meta_key'] = 'frm_form_id';
 
-                    if ( empty($args['ids']) ) {
-                        $where['pm.meta_value >'] = 1;
-                    } else {
-                        $where['pm.meta_value'] = $args['ids'];
-                    }
-                break;
+					if ( empty( $args['ids'] ) ) {
+						$where['pm.meta_value >'] = 1;
+					} else {
+						$where['pm.meta_value'] = $args['ids'];
+					}
+					break;
 			}
 
 			$records[ $tb_type ] = FrmDb::get_col( $table . $join, $where, $select );
-			unset($tb_type);
+			unset( $tb_type );
 		}
 
-		$xml_header = '<?xml version="1.0" encoding="' . esc_attr( get_bloginfo('charset') ) . "\" ?>\n";
+		$xml_header = '<?xml version="1.0" encoding="' . esc_attr( get_bloginfo( 'charset' ) ) . "\" ?>\n";
 		ob_start();
-		include(FrmAppHelper::plugin_path() .'/classes/views/xml/xml.php');
+		include( FrmAppHelper::plugin_path() . '/classes/views/xml/xml.php' );
 		$xml_body = ob_get_contents();
 		ob_end_clean();
 
 		$xml = $xml_header . $xml_body;
 
-		$cwd = getcwd();
-		$path = "$cwd" .'/'. "temp.xml";
-		@chmod( $path,0755 );
-		$fw = fopen( $path, "w" );
-		fputs( $fw,$xml, strlen( $xml ) );
+		$cwd  = getcwd();
+		$path = "{$cwd}/temp.xml";
+		@chmod( $path, 0755 );
+		$fw = fopen( $path, 'w' );
+		fputs( $fw, $xml, strlen( $xml ) );
 		fclose( $fw );
 
 		return $path;
@@ -516,7 +537,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 		}
 
 		$admin_args = array(
-			'user_login'  =>  'admin',
+			'user_login'  => 'admin',
 			'user_email' => 'admin@mail.com',
 			'user_pass' => 'admin',
 			'role' => 'administrator',
@@ -525,7 +546,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 		$this->assertNotEmpty( $admin );
 
 		$editor_args = array(
-			'user_login'  =>  'editor',
+			'user_login'  => 'editor',
 			'user_email' => 'editor@mail.com',
 			'user_pass' => 'editor',
 			'role' => 'editor',
@@ -534,7 +555,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 		$this->assertNotEmpty( $editor );
 
 		$subscriber_args = array(
-			'user_login'  =>  'subscriber',
+			'user_login'  => 'subscriber',
 			'user_email' => 'subscriber@mail.com',
 			'user_pass' => 'subscriber',
 			'role' => 'subscriber',
@@ -595,7 +616,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 				$user = wp_get_current_user();
 
 				// remove any standard roles to make room for a custom one
-				foreach( array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' ) as $role ) {
+				foreach ( array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' ) as $role ) {
 					$user->remove_role( $role );
 				}
 

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -403,7 +403,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 		);
 	}
 
-	static function generate_xml( $type, $xml_args ) {
+	public static function generate_xml( $type, $xml_args ) {
 		// Code copied from FrmXMLController::generate_xml
 		global $wpdb;
 

--- a/tests/base/frm_factory.php
+++ b/tests/base/frm_factory.php
@@ -2,7 +2,7 @@
 
 class Form_Factory extends WP_UnitTest_Factory_For_Thing {
 
-	function __construct( $factory = null ) {
+	public function __construct( $factory = null ) {
 		parent::__construct( $factory );
 
 		$defaults = FrmFormsHelper::setup_new_vars( false );
@@ -18,7 +18,7 @@ class Form_Factory extends WP_UnitTest_Factory_For_Thing {
 		$this->default_generation_definitions['protect_files_role'] = '';
 	}
 
-	function create_object( $args ) {
+	public function create_object( $args ) {
 		$form = FrmForm::create( $args );
 
 		$field_values = FrmFieldsHelper::setup_new_vars( 'text', $form );
@@ -30,21 +30,21 @@ class Form_Factory extends WP_UnitTest_Factory_For_Thing {
 		return $form;
 	}
 
-	function update_object( $form_id, $fields ) {
+	public function update_object( $form_id, $fields ) {
 		return FrmForm::update( $form_id, $fields );
 	}
 
-	function get_id_by_key( $form_key ) {
+	public function get_id_by_key( $form_key ) {
 		return FrmForm::get_id_by_key( $form_key );
 	}
 
-	function get_object_by_id( $form_id ) {
+	public function get_object_by_id( $form_id ) {
 		return FrmForm::getOne( $form_id );
 	}
 }
 
 class Field_Factory extends WP_UnitTest_Factory_For_Thing {
-	function __construct( $factory = null ) {
+	public function __construct( $factory = null ) {
 		parent::__construct( $factory );
 
 		global $wpdb;
@@ -57,7 +57,7 @@ class Field_Factory extends WP_UnitTest_Factory_For_Thing {
 
 	}
 
-	function create_object( $args ) {
+	public function create_object( $args ) {
 		$field_values = FrmFieldsHelper::setup_new_vars( $args['type'], $args['form_id'] );
 		unset( $args['type'], $args['form_id'] );
 
@@ -74,15 +74,15 @@ class Field_Factory extends WP_UnitTest_Factory_For_Thing {
 		return FrmField::create( $field_values );
 	}
 
-	function update_object( $field_id, $values ) {
+	public function update_object( $field_id, $values ) {
 		return FrmField::update( $field_id, $values );
 	}
 
-	function get_object_by_id( $field_id ) {
+	public function get_object_by_id( $field_id ) {
 		return FrmField::getOne( $field_id );
 	}
 
-	function generate_entry_array( $form ) {
+	public function generate_entry_array( $form ) {
 		$form_id = is_object( $form ) ? $form->id : $form;
 		$entry_data = array(
 			'form_id'   => $form_id,
@@ -99,14 +99,14 @@ class Field_Factory extends WP_UnitTest_Factory_For_Thing {
 	/**
 	 * Get all fields in a form
 	 */
-	function get_fields_from_form( $form_id ) {
+	public function get_fields_from_form( $form_id ) {
 		return FrmField::get_all_for_form( $form_id );
 	}
 
 	/**
 	 * When creating an entry, set the correct data formats
 	 */
-	function set_field_value( $field ) {
+	public function set_field_value( $field ) {
 		$value = rand_str();
 		$field_values = array(
 			'email'  => 'admin@example.org',
@@ -128,14 +128,14 @@ class Field_Factory extends WP_UnitTest_Factory_For_Thing {
 		return $value;
 	}
 
-	function get_id_by_key( $field_key ) {
+	public function get_id_by_key( $field_key ) {
 		return FrmField::get_id_by_key( $field_key );
 	}
 }
 
 class Entry_Factory extends WP_UnitTest_Factory_For_Thing {
 
-	function __construct( $factory = null ) {
+	public function __construct( $factory = null ) {
 		parent::__construct( $factory );
 
 		global $wpdb;
@@ -146,24 +146,24 @@ class Entry_Factory extends WP_UnitTest_Factory_For_Thing {
 
 	}
 
-	function create_object( $args ) {
-        $default_values = array(
-            'form_id'   => $args['form_id'],
-            'item_meta' => array(),
-        );
+	public function create_object( $args ) {
+		$default_values = array(
+			'form_id'   => $args['form_id'],
+			'item_meta' => array(),
+		);
 		$args = array_merge( $default_values, $args );
 		return FrmEntry::create( $args );
 	}
 
-	function update_object( $entry_id, $fields ) {
+	public function update_object( $entry_id, $fields ) {
 		return FrmEntry::update( $entry_id, $fields );
 	}
 
-	function get_object_by_id( $entry_id ) {
+	public function get_object_by_id( $entry_id ) {
 		return FrmEntry::getOne( $entry_id );
 	}
 
-	function get_id_by_key( $entry_key ) {
+	public function get_id_by_key( $entry_key ) {
 		return FrmEntry::get_id_by_key( $entry_key );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,11 +22,11 @@ if ( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 	require '../../../../tests/phpunit/includes/bootstrap.php';
 }
 
-if ( file_exists( dirname( __FILE__ )  . '/../vendor/autoload_52.php' ) ) {
-	include( dirname( __FILE__ )  . '/../vendor/autoload_52.php' );
+if ( file_exists( dirname( __FILE__ ) . '/../vendor/autoload_52.php' ) ) {
+	include( dirname( __FILE__ ) . '/../vendor/autoload_52.php' );
 }
 
-if ( version_compare( phpversion(), '5.3', '>=' ) && file_exists( dirname( __FILE__ )  . '/../vendor/autoload.php' ) ) {
+if ( version_compare( phpversion(), '5.3', '>=' ) && file_exists( dirname( __FILE__ ) . '/../vendor/autoload.php' ) ) {
 	include( dirname( __FILE__ ) . '/../vendor/autoload.php' );
 }
 

--- a/tests/database/test_FrmMigrate.php
+++ b/tests/database/test_FrmMigrate.php
@@ -9,7 +9,7 @@ class test_FrmMigrate extends FrmUnitTest {
 	 * @covers FrmMigrate::upgrade
 	 * @todo Check if style was created
 	 */
-	public function test_upgrade( ) {
+	public function test_upgrade() {
 		$frmdb = new FrmMigrate();
 		$frmdb->upgrade();
 
@@ -22,7 +22,7 @@ class test_FrmMigrate extends FrmUnitTest {
 	/**
 	 * @covers FrmMigrate::maybe_create_contact_form
 	 */
-	public function test_maybe_create_contact_form( ) {
+	public function test_maybe_create_contact_form() {
 		delete_option( 'frm_db_version' );
 		$frmdb = new FrmMigrate();
 		$frmdb->upgrade();
@@ -47,13 +47,15 @@ class test_FrmMigrate extends FrmUnitTest {
 	 */
 	public function test_migrate_to_17() {
 		$form_id = $this->factory->form->create();
-		$field = $this->factory->field->create_and_get( array(
-			'type' => 'text',
-			'form_id' => $form_id,
-			'field_options' => array(
-				'size' => '10', // the old size in characters
-			),
-		) );
+		$field = $this->factory->field->create_and_get(
+			array(
+				'type' => 'text',
+				'form_id' => $form_id,
+				'field_options' => array(
+					'size' => '10', // the old size in characters
+				),
+			)
+		);
 		$this->assertNotEmpty( $field );
 		$field_id = $field->id;
 
@@ -104,13 +106,15 @@ class test_FrmMigrate extends FrmUnitTest {
 		);
 		$field_ids = array();
 		foreach ( $sizes as $start_size => $new_size ) {
-			$field_id = $this->factory->field->create( array(
-				'type' => 'text',
-				'form_id' => $form_id,
-				'field_options' => array(
-					'size' => $start_size,
-				),
-			) );
+			$field_id = $this->factory->field->create(
+				array(
+					'type' => 'text',
+					'form_id' => $form_id,
+					'field_options' => array(
+						'size' => $start_size,
+					),
+				)
+			);
 			$field_ids[ $start_size ] = $field_id;
 		}
 
@@ -282,7 +286,7 @@ class test_FrmMigrate extends FrmUnitTest {
 			$field = $this->factory->field->get_object_by_id( $field_ids[ $key ] );
 			$this->assertNotEmpty( $field );
 
-			$this->assertEquals( $setting['expected']['default_value'], $field->default_value, print_r( $setting['start'], 1 ) . ' did not result in "' . $setting['expected']['default_value'] . '" in test ' . $key  );
+			$this->assertEquals( $setting['expected']['default_value'], $field->default_value, print_r( $setting['start'], 1 ) . ' did not result in "' . $setting['expected']['default_value'] . '" in test ' . $key );
 			$this->assertEquals( $setting['expected']['placeholder'], $field->field_options['placeholder'], print_r( $setting['start'], 1 ) . ' did not result in "' . $setting['expected']['placeholder'] . '" in test ' . $key );
 
 			if ( isset( $setting['start']['options'] ) ) {
@@ -318,7 +322,7 @@ class test_FrmMigrate extends FrmUnitTest {
 	/**
 	 * @covers FrmMigrate::migrate_to_16
 	 */
-	function test_migrate_from_12_to_current() {
+	public function test_migrate_from_12_to_current() {
 		self::frm_install();
 
 		update_option( 'frm_db_version', 12 );
@@ -376,8 +380,8 @@ class test_FrmMigrate extends FrmUnitTest {
 		$this->markTestIncomplete( 'Make sure uninstall is complete' );
 		self::do_tables_exist( false );
 
-		$this->assertEmpty( get_option('frm_db_version', true ) );
-		$this->assertEmpty( get_option('frm_options', true ) );
+		$this->assertEmpty( get_option( 'frm_db_version', true ) );
+		$this->assertEmpty( get_option( 'frm_options', true ) );
 
 		// TODO: Check if roles exist FrmAppHelper::frm_capabilities()
 		// TODO: Check if any posts exist for extra types

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -58,17 +58,22 @@ class test_FrmEmail extends FrmUnitTest {
 	 *
 	 * @covers FrmNotification::trigger_email
 	 */
-	public function test_trigger_email_one(){
+	public function test_trigger_email_one() {
 		$pass_entry = clone $this->entry;
 
 		$expected = array(
 			'to' => array( array( $this->email_action->post_content['email_to'], '' ) ),
 			'cc' => array(),
 			'bcc' => array(),
-			'from' => FrmAppHelper::site_name() . ' <' . get_option('admin_email') . '>',
-			'reply_to' => get_option('admin_email'),
+			'from' => FrmAppHelper::site_name() . ' <' . get_option( 'admin_email' ) . '>',
+			'reply_to' => get_option( 'admin_email' ),
 			'subject' => self::prepare_subject( $this->contact_form->name . ' Form submitted on ' . FrmAppHelper::site_name() ),
-			'body' =>  FrmEntriesController::show_entry_shortcode( array( 'id' => $this->entry->id, 'entry' => $pass_entry ) ),
+			'body' => FrmEntriesController::show_entry_shortcode(
+				array(
+					'id' => $this->entry->id,
+					'entry' => $pass_entry,
+				)
+			),
 			'content_type' => 'Content-Type: text/html; charset=UTF-8',
 		);
 
@@ -102,7 +107,7 @@ class test_FrmEmail extends FrmUnitTest {
 	public function test_trigger_email_two() {
 		$entry_clone = clone $this->entry;
 		$expected = array();
-		$admin_email = get_option('admin_email');
+		$admin_email = get_option( 'admin_email' );
 
 		// Adjust entry values
 		$name_id = FrmField::get_id_by_key( $this->name_field_key );
@@ -130,11 +135,17 @@ class test_FrmEmail extends FrmUnitTest {
 
 		// Reply to
 		$this->email_action->post_content['reply_to'] = 'Reply Name';
-		$expected['reply_to'] = 'Reply Name <' . get_option('admin_email') . '>';
+		$expected['reply_to'] = 'Reply Name <' . get_option( 'admin_email' ) . '>';
 
 		// Body - set plain text to true
 		$this->email_action->post_content['plain_text'] = true;
-		$expected['body'] = FrmEntriesController::show_entry_shortcode( array( 'id' => $entry_clone->id, 'entry' => $entry_clone, 'plain_text' => true ) );
+		$expected['body'] = FrmEntriesController::show_entry_shortcode(
+			array(
+				'id' => $entry_clone->id,
+				'entry' => $entry_clone,
+				'plain_text' => true,
+			)
+		);
 
 		// Content type
 		$expected['content_type'] = 'Content-Type: text/plain; charset=UTF-8';
@@ -179,7 +190,7 @@ class test_FrmEmail extends FrmUnitTest {
 		// To
 		$this->email_action->post_content['email_to'] = 'Name test1@mail.com, Name2<test2@mail.com>';
 		$expected['to'] = array( array( 'test1@mail.com', 'Name' ), array( 'test2@mail.com', 'Name2' ), array( 'test3@mail.com', '' ) );
-		add_filter('frm_to_email', array( $this, 'add_to_emails' ), 10, 4 );
+		add_filter( 'frm_to_email', array( $this, 'add_to_emails' ), 10, 4 );
 
 		// CC
 		$this->email_action->post_content['cc'] = '"Jamie Wahlin" <testcc1@mail.com>,';
@@ -197,7 +208,7 @@ class test_FrmEmail extends FrmUnitTest {
 
 		// From
 		$this->email_action->post_content['from'] = 'Name';
-		$expected['from'] = 'Name <' . get_option('admin_email') . '>';
+		$expected['from'] = 'Name <' . get_option( 'admin_email' ) . '>';
 
 		// Reply to
 		$this->email_action->post_content['reply_to'] = '"Reply To" <[' . $this->email_field_key . ']>';
@@ -205,7 +216,13 @@ class test_FrmEmail extends FrmUnitTest {
 
 		// Body - set inc_user_info to true
 		$this->email_action->post_content['inc_user_info'] = true;
-		$expected['body'] = FrmEntriesController::show_entry_shortcode( array( 'id' => $entry_clone->id, 'entry' => $entry_clone, 'user_info' => true ) );
+		$expected['body'] = FrmEntriesController::show_entry_shortcode(
+			array(
+				'id' => $entry_clone->id,
+				'entry' => $entry_clone,
+				'user_info' => true,
+			)
+		);
 
 		// Content type
 		$expected['content_type'] = 'Content-Type: text/html; charset=UTF-8';
@@ -213,7 +230,7 @@ class test_FrmEmail extends FrmUnitTest {
 		FrmNotification::trigger_email( $this->email_action, $entry_clone, $this->contact_form );
 
 		// Remove filters so they don't interfere with subsequent tests
-		remove_filter('frm_to_email', array( $this, 'add_to_emails' ), 10 );
+		remove_filter( 'frm_to_email', array( $this, 'add_to_emails' ), 10 );
 		remove_filter( 'frm_email_subject', array( $this, 'change_email_subject' ), 10 );
 
 		$mock_email = end( $GLOBALS['phpmailer']->mock_sent );
@@ -272,7 +289,13 @@ class test_FrmEmail extends FrmUnitTest {
 
 		// Body - set plain text to true
 		$this->email_action->post_content['plain_text'] = true;
-		$expected['body'] = FrmEntriesController::show_entry_shortcode( array( 'id' => $entry_clone->id, 'entry' => $entry_clone, 'plain_text' => true ) );
+		$expected['body'] = FrmEntriesController::show_entry_shortcode(
+			array(
+				'id' => $entry_clone->id,
+				'entry' => $entry_clone,
+				'plain_text' => true,
+			)
+		);
 
 		// Content type
 		$expected['content_type'] = 'Content-Type: text/plain; charset=UTF-8';
@@ -314,7 +337,7 @@ class test_FrmEmail extends FrmUnitTest {
 	public function test_trigger_email_five() {
 		$entry_clone = clone $this->entry;
 		$expected = array();
-		$admin_email = get_option('admin_email');
+		$admin_email = get_option( 'admin_email' );
 
 		// Update entry values
 		$name_id = FrmField::get_id_by_key( $this->name_field_key );
@@ -342,14 +365,20 @@ class test_FrmEmail extends FrmUnitTest {
 		if ( substr( $sitename, 0, 4 ) == 'www.' ) {
 			$sitename = substr( $sitename, 4 );
 		}
-		$expected['from'] = 'Yahoo <wordpress@' . $sitename. '>';
+		$expected['from'] = 'Yahoo <wordpress@' . $sitename . '>';
 
 		// Reply to
 		$expected['reply_to'] = $admin_email;
 
 		// Body - set plain text to true
 		$this->email_action->post_content['plain_text'] = true;
-		$expected['body'] = FrmEntriesController::show_entry_shortcode( array( 'id' => $entry_clone->id, 'entry' => $entry_clone, 'plain_text' => true ) );
+		$expected['body'] = FrmEntriesController::show_entry_shortcode(
+			array(
+				'id' => $entry_clone->id,
+				'entry' => $entry_clone,
+				'plain_text' => true,
+			)
+		);
 
 		// Content type
 		$expected['content_type'] = 'Content-Type: text/plain; charset=UTF-8';
@@ -400,7 +429,7 @@ class test_FrmEmail extends FrmUnitTest {
 		return $subject;
 
 		// TODO: Run this with the frm_encode_subject filter.
-		$charset = get_option('blog_charset');
+		$charset = get_option( 'blog_charset' );
 		return '=?' . $charset . '?B?' . base64_encode( $subject ) . '?=';
 	}
 
@@ -444,14 +473,14 @@ class test_FrmEmail extends FrmUnitTest {
 
 	protected function check_subject( $expected, $mock_email ) {
 		if ( isset( $mock_email['subject'] ) ) {
-			$this->assertSame( $expected[ 'subject' ], $mock_email[ 'subject' ], 'Subject does not match expected.' );
+			$this->assertSame( $expected['subject'], $mock_email['subject'], 'Subject does not match expected.' );
 		}
 	}
 
 	protected function check_message_body( $expected, $mock_email ) {
 		// Remove line breaks from body for comparison
-		$expected['body'] = preg_replace( "/\r|\n/", "", $expected['body'] );
-		$mock_email['body'] = preg_replace( "/\r|\n/", "", $mock_email['body'] );
+		$expected['body'] = preg_replace( "/\r|\n/", '', $expected['body'] );
+		$mock_email['body'] = preg_replace( "/\r|\n/", '', $mock_email['body'] );
 
 		$this->assertSame( $expected['body'], $mock_email['body'], 'Message body does not match expected.' );
 	}
@@ -468,13 +497,13 @@ class test_FrmEmail extends FrmUnitTest {
 		$this->assertNotContains( 'Bcc:', $mock_email['header'], 'BCC is included when it should not be.' );
 	}
 
-	public function add_to_emails(  $to_emails, $values, $form_id, $args ) {
+	public function add_to_emails( $to_emails, $values, $form_id, $args ) {
 		$to_emails[] = 'test3@mail.com';
 		$to_emails[] = '1231231234';
 		return $to_emails;
 	}
 
-	public function change_email_subject(  $subject, $args ) {
+	public function change_email_subject( $subject, $args ) {
 		$subject = 'New subject';
 		return $subject;
 	}
@@ -568,12 +597,15 @@ class test_FrmEmail extends FrmUnitTest {
 	 */
 	public function test_set_message() {
 		$name_id = FrmField::get_id_by_key( $this->name_field_key );
-		$default = FrmEntriesHelper::replace_default_message( '[default-message]', array(
-			'id'         => $this->entry->id,
-			'entry'      => $this->entry,
-			'plain_text' => $this->email_action->post_content['plain_text'],
-			'user_info'  => $this->email_action->post_content['inc_user_info'],
-		) );
+		$default = FrmEntriesHelper::replace_default_message(
+			'[default-message]',
+			array(
+				'id'         => $this->entry->id,
+				'entry'      => $this->entry,
+				'plain_text' => $this->email_action->post_content['plain_text'],
+				'user_info'  => $this->email_action->post_content['inc_user_info'],
+			)
+		);
 
 		$settings = array(
 			''                   => $default,

--- a/tests/entries/test_FrmEntriesController.php
+++ b/tests/entries/test_FrmEntriesController.php
@@ -10,7 +10,7 @@ class test_FrmEntriesController extends FrmUnitTest {
 	 * @covers FrmEntriesController::_delete_entry
 	 * @covers FrmEntriesController::unlink_post
 	 */
-	function test_delete_entry_after_save() {
+	public function test_delete_entry_after_save() {
 		$save_form = $this->create_form();
 		$this->assertEmpty( $save_form->options['no_save'] );
 
@@ -35,9 +35,11 @@ class test_FrmEntriesController extends FrmUnitTest {
 	}
 
 	private function create_form( $options = array() ) {
-		return $this->factory->form->create_and_get( array(
-			'options' => $options,
-		) );
+		return $this->factory->form->create_and_get(
+			array(
+				'options' => $options,
+			)
+		);
 	}
 
 	private function create_post_entry( $form, $entry_key ) {

--- a/tests/entries/test_FrmEntry.php
+++ b/tests/entries/test_FrmEntry.php
@@ -9,7 +9,7 @@ class test_FrmEntry extends FrmUnitTest {
 	 * @covers FrmEntry::create
 	 * @covers FrmEntry::is_duplicate
 	 */
-	function test_is_duplicate() {
+	public function test_is_duplicate() {
 		$form = $this->factory->form->get_object_by_id( $this->contact_form_key );
 		$this->assertNotEmpty( $form, 'Form not found with id ' . $this->contact_form_key );
 		$entry_data = $this->factory->field->generate_entry_array( $form );
@@ -44,12 +44,12 @@ class test_FrmEntry extends FrmUnitTest {
 	/**
 	 * @covers FrmEntry::getAll
 	 */
-    function test_getAll() {
+	public function test_getAll() {
 		$form = $this->factory->form->get_object_by_id( $this->contact_form_key );
 		$entry_data = $this->factory->field->generate_entry_array( $form );
 		$this->factory->entry->create_many( 10, $entry_data );
 
-        $items = FrmEntry::getAll( array( 'it.form_id' => $form->id ) );
-        $this->assertTrue( count( $items ) >= 10, 'There are no entries in form ' . $form->id );
-    }
+		$items = FrmEntry::getAll( array( 'it.form_id' => $form->id ) );
+		$this->assertTrue( count( $items ) >= 10, 'There are no entries in form ' . $form->id );
+	}
 }

--- a/tests/entries/test_FrmEntryValidate.php
+++ b/tests/entries/test_FrmEntryValidate.php
@@ -3,7 +3,6 @@
 /**
  * @group entries
  * @group free
- *
  */
 class test_FrmEntryValidate extends FrmUnitTest {
 
@@ -23,7 +22,7 @@ class test_FrmEntryValidate extends FrmUnitTest {
 				$made_up_name_field_id  => $test_name,
 				$made_up_email_field_id => $test_email,
 				$made_up_url_field_id   => $test_url,
-			)
+			),
 		);
 
 		wp_set_current_user( null );
@@ -32,7 +31,7 @@ class test_FrmEntryValidate extends FrmUnitTest {
 		$this->assertTrue( empty( $check['user_id'] ) );
 		$this->assertEquals( $test_name, $check['comment_author'] );
 		$this->assertEquals( $test_email, $check['comment_author_email'] );
-		$this->assertEquals( $test_url, $check['comment_author_url'] );		
+		$this->assertEquals( $test_url, $check['comment_author_url'] );
 
 		wp_set_current_user( 1 );
 		$user  = wp_get_current_user();

--- a/tests/entries/test_FrmShowEntryShortcode.php
+++ b/tests/entries/test_FrmShowEntryShortcode.php
@@ -7,7 +7,6 @@
  * @group entries
  * @group show-entry-shortcode
  * @group free
- *
  */
 class test_FrmShowEntryShortcode extends FrmUnitTest {
 
@@ -196,7 +195,7 @@ class test_FrmShowEntryShortcode extends FrmUnitTest {
 	public function test_default_message_with_specific_field_ids_included() {
 		$entry = $this->get_test_entry( true );
 
-		$this->set_included_fields( 'id ');
+		$this->set_included_fields( 'id ' );
 
 		$atts = array(
 			'id' => $entry->id,
@@ -717,7 +716,7 @@ class test_FrmShowEntryShortcode extends FrmUnitTest {
 		return array(
 			FrmField::get_id_by_key( 'free-text-field' ) => 'Test Testerson',
 			FrmField::get_id_by_key( 'free-paragraph-field' ) => "Test\r\nMiddle\r\nTesterson",
-			FrmField::get_id_by_key( 'free-checkboxes' ) => array ( 'Red', 'Green' ),
+			FrmField::get_id_by_key( 'free-checkboxes' ) => array( 'Red', 'Green' ),
 			FrmField::get_id_by_key( 'free-radio-button-field' ) => 'cookies',
 			FrmField::get_id_by_key( 'free-dropdown-field' ) => 'Ace Ventura',
 			FrmField::get_id_by_key( 'free-email-field' ) => 'jamie@mail.com',
@@ -862,7 +861,7 @@ class test_FrmShowEntryShortcode extends FrmUnitTest {
 		if ( isset( $atts['direction'] ) && $atts['direction'] == 'rtl' ) {
 			$content = $field_value . ': ' . $field->name;
 		} else {
-			$content = $field->name .': ' . $field_value;
+			$content = $field->name . ': ' . $field_value;
 		}
 
 		$content .= "\r\n";
@@ -1057,7 +1056,7 @@ class test_FrmShowEntryShortcode extends FrmUnitTest {
 	protected function get_expected_default_shortcodes( $type, $atts ) {
 		$content = '';
 
-		$fields = FrmField::get_all_for_form( $atts[ 'form_id' ], '', 'include' );
+		$fields = FrmField::get_all_for_form( $atts['form_id'], '', 'include' );
 
 		if ( $type === 'html' ) {
 			$content .= $this->table_header( $atts );
@@ -1151,7 +1150,7 @@ class test_FrmShowEntryShortcode extends FrmUnitTest {
 		$expected = array(
 			'free-text-field' => 'Test Testerson',
 			'free-paragraph-field' => "Test\r\nMiddle\r\nTesterson",
-			'free-checkboxes' => array ( 'Red', 'Green' ),
+			'free-checkboxes' => array( 'Red', 'Green' ),
 			'free-radio-button-field' => 'cookies',
 			'free-dropdown-field' => 'Ace Ventura',
 			'free-email-field' => 'jamie@mail.com',

--- a/tests/entries/test_FrmTableHTMLGenerator.php
+++ b/tests/entries/test_FrmTableHTMLGenerator.php
@@ -5,7 +5,6 @@
  *
  * @group entries
  * @group free
- *
  */
 class test_FrmTableHTMLGenerator extends FrmUnitTest {
 
@@ -13,7 +12,7 @@ class test_FrmTableHTMLGenerator extends FrmUnitTest {
 	 * @covers FrmTableHTMLGenerator::init_style_settings
 	 * @covers FrmTableHTMLGenerator::get_color_markup
 	 */
-	function test_init_style_settings() {
+	public function test_init_style_settings() {
 		$colors = $this->_get_colors();
 		$table_generator = new FrmTableHTMLGenerator( 'entry', $colors['start'] );
 
@@ -28,7 +27,7 @@ class test_FrmTableHTMLGenerator extends FrmUnitTest {
 	/**
 	 * @covers FrmTableHTMLGenerator::is_color_setting
 	 */
-	function test_is_color_setting() {
+	public function test_is_color_setting() {
 		$table_generator = new FrmTableHTMLGenerator( 'entry' );
 
 		$colors = array( 'border_color', 'bg_color', 'text_color', 'alt_bg_color' );
@@ -44,7 +43,7 @@ class test_FrmTableHTMLGenerator extends FrmUnitTest {
 		}
 	}
 
-	function _get_colors() {
+	private function _get_colors() {
 		$atts = array(
 			'border_color' => 'ffffff',
 			'bg_color'     => 'red',
@@ -59,6 +58,9 @@ class test_FrmTableHTMLGenerator extends FrmUnitTest {
 			'alt_bg_color' => '#fff',
 		);
 
-		return array( 'start' => $atts, 'expected' => $expected );
+		return array(
+			'start' => $atts,
+			'expected' => $expected,
+		);
 	}
 }

--- a/tests/fields/test_FrmField.php
+++ b/tests/fields/test_FrmField.php
@@ -4,20 +4,25 @@
  * @group fields
  */
 class test_FrmField extends FrmUnitTest {
-	function test_create() {
+	public function test_create() {
 		$form_id = $this->factory->form->get_id_by_key( 'contact-db12' );
 		$field_types = array_merge( FrmField::field_selection(), FrmField::pro_field_selection() );
 		foreach ( $field_types as $field_type => $field_info ) {
-			$field_id = $this->factory->field->create( array( 'type' => $field_type, 'form_id' => $form_id ) );
-            $this->assertTrue( is_numeric( $field_id ) );
-            $this->assertTrue( $field_id > 0 );
+			$field_id = $this->factory->field->create(
+				array(
+					'type' => $field_type,
+					'form_id' => $form_id,
+				)
+			);
+			$this->assertTrue( is_numeric( $field_id ) );
+			$this->assertTrue( $field_id > 0 );
 		}
 	}
 
 	/**
 	* @covers FrmField::getAll
 	*/
-	function test_getAll() {
+	public function test_getAll() {
 		$forms = array(
 			$this->contact_form_key => $this->contact_form_field_count,
 			$this->all_fields_form_key => $this->all_field_types_count - $this->contact_form_field_count - 3,
@@ -34,7 +39,7 @@ class test_FrmField extends FrmUnitTest {
 	/**
 	 * @covers FrmField::get_all_for_form
 	 */
-	function test_get_all_for_form() {
+	public function test_get_all_for_form() {
 		$forms = array(
 			'basic_test' => array(
 				'form_key' => $this->contact_form_key,

--- a/tests/fields/test_FrmFieldType.php
+++ b/tests/fields/test_FrmFieldType.php
@@ -8,22 +8,26 @@ class test_FrmFieldType extends FrmUnitTest {
 	/**
 	 * @covers FrmFieldNumber::add_min_max
 	 */
-	function test_html_min_number() {
+	public function test_html_min_number() {
 		$form_id = $this->factory->form->create();
-		$field = $this->factory->field->create_and_get( array(
-			'type'    => 'number',
-			'form_id' => $form_id,
-			'field_options' => array(
-				'minnum' => 10,
-				'maxnum' => 999,
-				'step'   => 'any',
-			),
-		) );
+		$field = $this->factory->field->create_and_get(
+			array(
+				'type'    => 'number',
+				'form_id' => $form_id,
+				'field_options' => array(
+					'minnum' => 10,
+					'maxnum' => 999,
+					'step'   => 'any',
+				),
+			)
+		);
 		$this->assertNotEmpty( $field );
-		
-		$form = FrmFormsController::get_form_shortcode( array(
-			'id' => $form_id,
-		) );
+
+		$form = FrmFormsController::get_form_shortcode(
+			array(
+				'id' => $form_id,
+			)
+		);
 		$this->assertContains( ' min="10"', $form );
 		$this->assertContains( ' max="999"', $form );
 		$this->assertContains( ' step="any"', $form );
@@ -32,7 +36,7 @@ class test_FrmFieldType extends FrmUnitTest {
 	/**
 	 * @covers FrmFieldType::sanitize_value
 	 */
-	function test_sanitize_value() {
+	public function test_sanitize_value() {
 		$frm_field_type = new FrmFieldDefault();
 
 		$values = array(
@@ -116,12 +120,12 @@ class test_FrmFieldType extends FrmUnitTest {
 				'value'    => array(
 					'6',
 					'2a',
-					'a1'
+					'a1',
 				),
 				'expected' => array(
 					'6',
 					'2',
-					'0'
+					'0',
 				),
 			),
 		);
@@ -136,15 +140,33 @@ class test_FrmFieldType extends FrmUnitTest {
 	 * @covers FrmFieldType::get_import_value
 	 */
 	public function test_get_import_value() {
-		$field = new stdClass;
+		$field = new stdClass();
 		$field->type = 'checkbox';
 		$field->options = array(
-			array( 'value' => 'a', 'label' => 'A' ),
-			array( 'value' => 'b', 'label' => 'B' ),
-			array( 'value' => 'c', 'label' => 'C' ),
-			array( 'value' => 'a,b', 'label' => 'A, B' ),
-			array( 'value' => 'a,b,c', 'label' => 'A, B, C' ),
-			array( 'value' => 'a, b, c', 'label' => 'A, B, C' ),
+			array(
+				'value' => 'a',
+				'label' => 'A',
+			),
+			array(
+				'value' => 'b',
+				'label' => 'B',
+			),
+			array(
+				'value' => 'c',
+				'label' => 'C',
+			),
+			array(
+				'value' => 'a,b',
+				'label' => 'A, B',
+			),
+			array(
+				'value' => 'a,b,c',
+				'label' => 'A, B, C',
+			),
+			array(
+				'value' => 'a, b, c',
+				'label' => 'A, B, C',
+			),
 		);
 
 		$checkbox = FrmFieldFactory::get_field_type( 'checkbox', $field );

--- a/tests/fields/test_FrmFieldValidate.php
+++ b/tests/fields/test_FrmFieldValidate.php
@@ -17,11 +17,13 @@ class test_FrmFieldValidate extends FrmUnitTest {
 		$this->form = $this->factory->form->create_and_get();
 		$field_types = $this->get_all_fields();
 		foreach ( $field_types as $field_type ) {
-			$this->factory->field->create( array(
-				'type'      => $field_type,
-				'form_id'   => $this->form->id,
-				'field_key' => $this->get_field_key( $field_type ),
-			) );
+			$this->factory->field->create(
+				array(
+					'type'      => $field_type,
+					'form_id'   => $this->form->id,
+					'field_key' => $this->get_field_key( $field_type ),
+				)
+			);
 		}
 	}
 
@@ -70,9 +72,9 @@ class test_FrmFieldValidate extends FrmUnitTest {
 			$errors = $this->check_single_value( array( $field_id => $test_format['value'] ) );
 
 			if ( $test_format['invalid'] ) {
-				$this->assertNotEmpty( $errors, $test_format['type'] .' value ' . $test_format['value'] .' passed validation'  );
+				$this->assertNotEmpty( $errors, $test_format['type'] . ' value ' . $test_format['value'] . ' passed validation' );
 			} else {
-				$this->assertEmpty( $errors, $test_format['type'] .' value ' . $test_format['value'] .' did not pass validation'  );
+				$this->assertEmpty( $errors, $test_format['type'] . ' value ' . $test_format['value'] . ' did not pass validation' );
 			}
 		}
 	}
@@ -137,7 +139,7 @@ class test_FrmFieldValidate extends FrmUnitTest {
 		if ( ! empty( $errors ) ) {
 			$error_field_ids = array_keys( $errors );
 			foreach ( $fields as $field ) {
-				if ( ! isset( $errors[ 'field'. $field->id ] ) ) {
+				if ( ! isset( $errors[ 'field' . $field->id ] ) ) {
 					$error_fields[] = $field->type;
 				}
 			}
@@ -166,6 +168,7 @@ class test_FrmFieldValidate extends FrmUnitTest {
 
 	/**
 	 * When a url field is required, http:// should not pass
+	 *
 	 * @covers FrmFieldUrl::validate
 	 */
 	public function test_url_value() {
@@ -175,7 +178,7 @@ class test_FrmFieldValidate extends FrmUnitTest {
 		$this->set_required_field( $field );
 
 		$errors = $this->check_single_value( array( $field->id => 'http://' ) );
-		$this->assertTrue( isset( $errors[ 'field'. $field->id ] ), 'http:// passed required validation '. print_r($errors,1) );
+		$this->assertTrue( isset( $errors[ 'field' . $field->id ] ), 'http:// passed required validation ' . print_r( $errors, 1 ) );
 	}
 
 	/**
@@ -187,13 +190,13 @@ class test_FrmFieldValidate extends FrmUnitTest {
 		$this->set_required_field( $field );
 
 		$errors = $this->check_single_value( array( $field->id => 'notemail@' ) );
-		$this->assertTrue( isset( $errors[ 'field'. $field->id ] ), 'Poorly formatted email passed validation '. print_r($errors,1) );
+		$this->assertTrue( isset( $errors[ 'field' . $field->id ] ), 'Poorly formatted email passed validation ' . print_r( $errors, 1 ) );
 
 		$errors = $this->check_single_value( array( $field->id => '' ) );
-		$this->assertTrue( isset( $errors[ 'field'. $field->id ] ), 'Email email passed required validation '. print_r($errors,1) );
+		$this->assertTrue( isset( $errors[ 'field' . $field->id ] ), 'Email email passed required validation ' . print_r( $errors, 1 ) );
 
 		$errors = $this->check_single_value( array( $field->id => 'email@example.com' ) );
-		$this->assertFalse( isset( $errors[ 'field'. $field->id ] ), 'Properly formatted email did not pass validation '. print_r($errors,1) );
+		$this->assertFalse( isset( $errors[ 'field' . $field->id ] ), 'Properly formatted email did not pass validation ' . print_r( $errors, 1 ) );
 	}
 
 	/**
@@ -202,29 +205,31 @@ class test_FrmFieldValidate extends FrmUnitTest {
 	public function test_number_validation() {
 		$field = $this->factory->field->get_object_by_id( $this->get_field_key( 'number' ) );
 		$errors = $this->check_single_value( array( $field->id => '10.5' ) );
-		$this->assertFalse( isset( $errors[ 'field'. $field->id ] ), 'Number failed validation '. print_r( $errors, 1 ) );
+		$this->assertFalse( isset( $errors[ 'field' . $field->id ] ), 'Number failed validation ' . print_r( $errors, 1 ) );
 
-		$field = $this->factory->field->create_and_get( array(
-			'type'    => 'number',
-			'form_id' => $this->form->id,
-			'field_options' => array(
-				'minnum' => 0,
-				'maxnum' => 20,
-			),
-		) );
+		$field = $this->factory->field->create_and_get(
+			array(
+				'type'    => 'number',
+				'form_id' => $this->form->id,
+				'field_options' => array(
+					'minnum' => 0,
+					'maxnum' => 20,
+				),
+			)
+		);
 		$this->assertEquals( 20, $field->field_options['maxnum'] );
 
 		$errors = $this->check_single_value( array( $field->id => '10.5' ) );
-		$this->assertFalse( isset( $errors[ 'field'. $field->id ] ), 'Number failed range validation '. print_r( $errors, 1 ) );
+		$this->assertFalse( isset( $errors[ 'field' . $field->id ] ), 'Number failed range validation ' . print_r( $errors, 1 ) );
 
 		$errors = $this->check_single_value( array( $field->id => 'not numeric' ) );
-		$this->assertTrue( isset( $errors[ 'field'. $field->id ] ), 'Number failed numeric validation' );
+		$this->assertTrue( isset( $errors[ 'field' . $field->id ] ), 'Number failed numeric validation' );
 
 		$errors = $this->check_single_value( array( $field->id => '25' ) );
-		$this->assertTrue( isset( $errors[ 'field'. $field->id ] ), 'Number failed max range validation' );
+		$this->assertTrue( isset( $errors[ 'field' . $field->id ] ), 'Number failed max range validation' );
 
 		$errors = $this->check_single_value( array( $field->id => '-25' ) );
-		$this->assertTrue( isset( $errors[ 'field'. $field->id ] ), 'Number failed min range validation' );
+		$this->assertTrue( isset( $errors[ 'field' . $field->id ] ), 'Number failed min range validation' );
 	}
 
 	protected function set_required_fields( $fields ) {
@@ -237,7 +242,7 @@ class test_FrmFieldValidate extends FrmUnitTest {
 		global $wpdb;
 		$query_results = $wpdb->update( $wpdb->prefix . 'frm_fields', array( 'required' => 1 ), array( 'id' => $field->id ) );
 		if ( $query_results ) {
-            wp_cache_delete( $field->id, 'frm_field' );
+			wp_cache_delete( $field->id, 'frm_field' );
 			FrmField::delete_form_transient( $this->form->id );
 
 			$field = FrmField::getOne( $field->id );
@@ -282,14 +287,16 @@ class test_FrmFieldValidate extends FrmUnitTest {
 		);
 
 		foreach ( $check_formats as $check_it ) {
-			$field = $this->factory->field->create_and_get( array(
-				'type'      => 'phone',
-				'form_id'   => $this->form->id,
-				'field_key' => $check_it['field_key'],
-				'field_options' => array(
-					'format' => $check_it['format'],
-				),
-			) );
+			$field = $this->factory->field->create_and_get(
+				array(
+					'type'      => 'phone',
+					'form_id'   => $this->form->id,
+					'field_key' => $check_it['field_key'],
+					'field_options' => array(
+						'format' => $check_it['format'],
+					),
+				)
+			);
 			$this->assertEquals( $check_it['format'], $field->field_options['format'] );
 
 			$format = FrmEntryValidate::phone_format( $field );
@@ -323,20 +330,24 @@ class test_FrmFieldValidate extends FrmUnitTest {
 		$enabled = $this->run_private_method( array( 'FrmEntryValidate', 'is_akismet_enabled_for_user' ), array( $this->form->id ) );
 		$this->assertFalse( $enabled );
 
-		$akismet_for_everyone = $this->factory->form->create_and_get( array(
-			'options' => array(
-				'akismet' => '1',
-			),
-		) );
+		$akismet_for_everyone = $this->factory->form->create_and_get(
+			array(
+				'options' => array(
+					'akismet' => '1',
+				),
+			)
+		);
 		$this->assertNotEmpty( $akismet_for_everyone->options['akismet'] );
 		$enabled = $this->run_private_method( array( 'FrmEntryValidate', 'is_akismet_enabled_for_user' ), array( $akismet_for_everyone->id ) );
 		$this->assertTrue( $enabled );
 
-		$akismet_logged = $this->factory->form->create_and_get( array(
-			'options' => array(
-				'akismet' => 'logged',
-			),
-		) );
+		$akismet_logged = $this->factory->form->create_and_get(
+			array(
+				'options' => array(
+					'akismet' => 'logged',
+				),
+			)
+		);
 		$this->assertEquals( 'logged', $akismet_logged->options['akismet'] );
 
 		wp_set_current_user( 0 );
@@ -402,6 +413,6 @@ class test_FrmFieldValidate extends FrmUnitTest {
 	private function get_disallowed_option_name() {
 		$keys = get_option( 'disallowed_keys' );
 		// Fallback for WP < 5.5.
-		return $name = ( false === $keys ) ? 'blacklist_keys' : 'disallowed_keys';
+		return false === $keys ? 'blacklist_keys' : 'disallowed_keys';
 	}
 }

--- a/tests/fields/test_FrmFieldsAjax.php
+++ b/tests/fields/test_FrmFieldsAjax.php
@@ -9,7 +9,7 @@ class test_FrmFieldsAjax extends FrmAjaxUnitTest {
 	protected $form_id = 0;
 
 	protected $user_id = 0;
-	
+
 	public function setUp() {
 		parent::setUp();
 
@@ -27,12 +27,12 @@ class test_FrmFieldsAjax extends FrmAjaxUnitTest {
 	/**
 	 * @covers FrmFieldsController::create
 	 */
-    public function test_create() {
+	public function test_create() {
 		$_POST = array(
 			'action'    => 'frm_insert_field',
-            'nonce'     => wp_create_nonce('frm_ajax'),
+			'nonce'     => wp_create_nonce( 'frm_ajax' ),
 			'form_id'   => $this->form_id,
-            'field_type'     => 'text', //create text field
+			'field_type'     => 'text', //create text field
 		);
 
 		try {
@@ -41,16 +41,16 @@ class test_FrmFieldsAjax extends FrmAjaxUnitTest {
 			unset( $e );
 		}
 
-        global $wpdb;
-        $this->field_id = $wpdb->insert_id;
+		global $wpdb;
+		$this->field_id = $wpdb->insert_id;
 
-        $this->assertTrue( is_numeric( $this->field_id ) );
-        $this->assertNotEmpty( $this->field_id );
+		$this->assertTrue( is_numeric( $this->field_id ) );
+		$this->assertNotEmpty( $this->field_id );
 
-        // make sure the field exists
+		// make sure the field exists
 		$field = FrmField::getOne( $this->field_id );
-        $this->assertTrue( is_object( $field ) );
-    }
+		$this->assertTrue( is_object( $field ) );
+	}
 
 	/**
 	 * Test duplicating a text field
@@ -62,20 +62,22 @@ class test_FrmFieldsAjax extends FrmAjaxUnitTest {
 		$this->assertTrue( current_user_can( 'frm_edit_forms' ), 'User does not have permission' );
 
 		$format = '^([a-zA-Z]\d{4})$';
-		$original_field = $this->factory->field->create_and_get( array(
-			'form_id'       => $this->form_id,
-			'type'          => 'text',
-			'field_options' => array(
-				'format'    => $format,
-				'in_section' => 0,
-			),
-		) );
+		$original_field = $this->factory->field->create_and_get(
+			array(
+				'form_id'       => $this->form_id,
+				'type'          => 'text',
+				'field_options' => array(
+					'format'    => $format,
+					'in_section' => 0,
+				),
+			)
+		);
 		$this->assertNotEmpty( $original_field->id );
 		$this->assertEquals( $format, $original_field->field_options['format'] );
 
 		$_POST = array(
 			'action'   => 'frm_duplicate_field',
-			'nonce'    => wp_create_nonce('frm_ajax'),
+			'nonce'    => wp_create_nonce( 'frm_ajax' ),
 			'field_id' => $original_field->id,
 			'form_id'  => $original_field->form_id,
 		);
@@ -97,7 +99,7 @@ class test_FrmFieldsAjax extends FrmAjaxUnitTest {
 	}
 
 	// Get a field object by key
-	protected function get_field_by_key( $field_key ){
+	protected function get_field_by_key( $field_key ) {
 		$divider_field_id = FrmField::get_id_by_key( $field_key );
 		$field = FrmField::getOne( $divider_field_id );
 		self::check_field_prior_to_duplication( $field );
@@ -108,7 +110,7 @@ class test_FrmFieldsAjax extends FrmAjaxUnitTest {
 
 	// Check in_section variable prior to duplication
 	protected function check_field_prior_to_duplication( $field ) {
-		$this->assertTrue( isset( $field->field_options[ 'in_section' ] ), 'The in_section variable is not set correctly on import.' );
+		$this->assertTrue( isset( $field->field_options['in_section'] ), 'The in_section variable is not set correctly on import.' );
 	}
 
 	// Check if a field is created correctly

--- a/tests/fields/test_FrmFieldsHelper.php
+++ b/tests/fields/test_FrmFieldsHelper.php
@@ -12,7 +12,7 @@ class test_FrmFieldsHelper extends FrmUnitTest {
 	 *
 	 * @covers FrmFieldsHelper::value_meets_condition
 	 */
-	function test_value_meets_condition() {
+	public function test_value_meets_condition() {
 		$tests = array(
 			array(
 				'observed_value' => 6,

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -30,7 +30,7 @@ class test_FrmForm extends FrmUnitTest {
 		$this->assertEquals( count( $original_actions ), count( $new_actions ) );
 	}
 
-	private function _check_if_child_fields_duplicate( $old_child_forms, $new_child_forms ) {
+	protected function _check_if_child_fields_duplicate( $old_child_forms, $new_child_forms ) {
 		// Just check the first form
 		$old_child_form = reset( $old_child_forms );
 		$new_child_form = reset( $new_child_forms );

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -7,7 +7,7 @@ class test_FrmForm extends FrmUnitTest {
 	/**
 	 * @covers FrmForm::create
 	 */
-	function test_create() {
+	public function test_create() {
 		$values = FrmFormsHelper::setup_new_vars( false );
 		$form_id = FrmForm::create( $values );
 		$this->assertTrue( is_numeric( $form_id ) );
@@ -17,7 +17,7 @@ class test_FrmForm extends FrmUnitTest {
 	/**
 	 * @covers FrmForm::duplicate
 	 */
-	function test_duplicate(){
+	public function test_duplicate() {
 		$form = $this->factory->form->get_object_by_id( $this->all_fields_form_key );
 
 		$id = FrmForm::duplicate( $form->id );
@@ -30,7 +30,7 @@ class test_FrmForm extends FrmUnitTest {
 		$this->assertEquals( count( $original_actions ), count( $new_actions ) );
 	}
 
-	function _check_if_child_fields_duplicate( $old_child_forms, $new_child_forms ) {
+	private function _check_if_child_fields_duplicate( $old_child_forms, $new_child_forms ) {
 		// Just check the first form
 		$old_child_form = reset( $old_child_forms );
 		$new_child_form = reset( $new_child_forms );
@@ -46,7 +46,7 @@ class test_FrmForm extends FrmUnitTest {
 	/**
 	 * @covers FrmForm::destroy
 	 */
-	function test_destroy(){
+	public function test_destroy() {
 		$forms = FrmForm::getAll();
 		$this->assertNotEmpty( count( $forms ) );
 

--- a/tests/forms/test_FrmFormActionsController.php
+++ b/tests/forms/test_FrmFormActionsController.php
@@ -7,10 +7,11 @@ class test_FrmFormActionsController extends FrmUnitTest {
 
 	/**
 	 * Make sure the form action post type exists
+	 *
 	 * @todo check for taxonomies and other settings
 	 * @todo create an action and get_post and check for expected values $this->factory->post->create
 	 */
-	function test_register_post_types() {
+	public function test_register_post_types() {
 		$post_types = get_post_types();
 		$action_post_type = FrmFormActionsController::$action_post_type;
 		$this->assertTrue( in_array( $action_post_type, $post_types ), 'The ' . $action_post_type . ' is missing' );

--- a/tests/forms/test_FrmFormsController.php
+++ b/tests/forms/test_FrmFormsController.php
@@ -5,12 +5,12 @@
  */
 class test_FrmFormsController extends FrmUnitTest {
 
-	function test_register_widgets() {
+	public function test_register_widgets() {
 		global $wp_widget_factory;
 		$this->assertTrue( isset( $wp_widget_factory->widgets['FrmShowForm'] ) );
 	}
 
-	function test_head() {
+	public function test_head() {
 		$this->set_front_end();
 		$edit_in_place = wp_script_is( 'formidable-editinplace', 'enqueued' );
 		$this->assertFalse( $edit_in_place, 'The edit-in-place script should not be enqueued' );
@@ -28,7 +28,7 @@ class test_FrmFormsController extends FrmUnitTest {
 		*/
 	}
 
-	function test_get_form_shortcode() {
+	public function test_get_form_shortcode() {
 		$form = FrmFormsController::get_form_shortcode( array( 'id' => $this->contact_form_key ) );
 		$this->assertNotEmpty( strpos( $form, '<form ' ), 'The form is missing' );
 	}
@@ -37,7 +37,7 @@ class test_FrmFormsController extends FrmUnitTest {
 	* @covers FrmFormsController::update
 	* without ajax
 	*/
-	function test_form_update_no_ajax() {
+	public function test_form_update_no_ajax() {
 		if ( FrmAppHelper::doing_ajax() ) {
 			$this->markTestSkipped( 'Run with --filter test_form_update_no_ajax' );
 		}
@@ -55,7 +55,7 @@ class test_FrmFormsController extends FrmUnitTest {
 		self::_check_updated_values( $form_id );
 	}
 
-	function _setup_post_values( $form_id ){
+	private function _setup_post_values( $form_id ) {
 		$fields = FrmField::get_all_for_form( $form_id );
 
 		$form = FrmForm::getOne( $form_id );
@@ -72,7 +72,7 @@ class test_FrmFormsController extends FrmUnitTest {
 			'name' => $form->name,
 			'frm_fields_submitted' => array(),
 			'item_meta' => array(),
-			'field_options' => array()
+			'field_options' => array(),
 		);
 
 		foreach ( $fields as $field ) {
@@ -105,7 +105,7 @@ class test_FrmFormsController extends FrmUnitTest {
 	}
 
 	// Make sure DOING_AJAX is false
-	function _check_doing_ajax() {
+	private function _check_doing_ajax() {
 		if ( defined( 'DOING_AJAX' ) ) {
 			$doing_ajax = true;
 		} else {
@@ -115,7 +115,7 @@ class test_FrmFormsController extends FrmUnitTest {
 		$this->assertFalse( $doing_ajax, 'DOING_AJAX must be false for this test to work. Maybe run this test individually to make sure DOING_AJAX is false.' );
 	}
 
-	function _check_updated_values( $form_id ) {
+	private function _check_updated_values( $form_id ) {
 		$fields = FrmField::get_all_for_form( $form_id );
 
 		// Compare to posted values
@@ -130,7 +130,7 @@ class test_FrmFormsController extends FrmUnitTest {
 	/**
 	 * @covers FrmFormsController::front_head
 	 */
-	function test_front_head() {
+	public function test_front_head() {
 		$this->assertTrue( FrmFormsController::has_combo_js_file(), 'The combo file was not created' );
 
 		FrmFormsController::front_head();
@@ -152,15 +152,18 @@ class test_FrmFormsController extends FrmUnitTest {
 
 	/**
 	 * Test redirect after create
+	 *
 	 * @covers FrmFormsController::redirect_after_submit
 	 */
-	function test_redirect_after_create() {
-		$form = $this->factory->form->create_and_get( array(
-			'options' => array(
-				'success_action' => 'redirect',
-				'success_url'    => 'http://example.com',
-			),
-		) );
+	public function test_redirect_after_create() {
+		$form = $this->factory->form->create_and_get(
+			array(
+				'options' => array(
+					'success_action' => 'redirect',
+					'success_url'    => 'http://example.com',
+				),
+			)
+		);
 		$this->assertEquals( $form->options['success_action'], 'redirect' );
 
 		$entry_key = 'submit-redirect';
@@ -181,25 +184,27 @@ class test_FrmFormsController extends FrmUnitTest {
 	/**
 	 * @covers FrmFormsController::show_message_after_save
 	 */
-	function test_message_after_create() {
+	public function test_message_after_create() {
 		$this->run_message_after_create( 0 );
 	}
 
 	/**
 	 * @covers FrmFormsController::show_message_after_save
 	 */
-	function test_message_with_form_after_create() {
+	public function test_message_with_form_after_create() {
 		$this->run_message_after_create( 1 );
 	}
 
-	function run_message_after_create( $show_form = 0 ) {
-		$form = $this->factory->form->create_and_get( array(
-			'options' => array(
-				'success_action' => 'message',
-				'success_msg'    => 'Done!',
-				'show_form'      => $show_form,
-			),
-		) );
+	public function run_message_after_create( $show_form = 0 ) {
+		$form = $this->factory->form->create_and_get(
+			array(
+				'options' => array(
+					'success_action' => 'message',
+					'success_msg'    => 'Done!',
+					'show_form'      => $show_form,
+				),
+			)
+		);
 		$this->assertEquals( $form->options['success_action'], 'message' );
 
 		$entry_key = 'submit-message';

--- a/tests/forms/test_FrmFormsControllerAjax.php
+++ b/tests/forms/test_FrmFormsControllerAjax.php
@@ -17,7 +17,7 @@ class test_FrmFormsControllerAjax extends FrmAjaxUnitTest {
 	* @covers FrmFormsController::update
 	* with ajax
 	*/
-	function test_form_update_with_ajax() {
+	public function test_form_update_with_ajax() {
 		$form_id = $this->factory->form->get_id_by_key( $this->contact_form_key );
 		$this->assertNotEmpty( $form_id, 'Form not found with key ' . $this->contact_form_key );
 
@@ -35,7 +35,7 @@ class test_FrmFormsControllerAjax extends FrmAjaxUnitTest {
 		self::_check_updated_values( $form_id );
 	}
 
-	function _setup_post_values( $form_id ){
+	private function _setup_post_values( $form_id ) {
 		$fields = FrmField::get_all_for_form( $form_id );
 
 		$form = FrmForm::getOne( $form_id );
@@ -53,7 +53,7 @@ class test_FrmFormsControllerAjax extends FrmAjaxUnitTest {
 			'name' => $form->name,
 			'frm_fields_submitted' => array(),
 			'item_meta' => array(),
-			'field_options' => array()
+			'field_options' => array(),
 		);
 
 		foreach ( $fields as $field ) {
@@ -85,7 +85,7 @@ class test_FrmFormsControllerAjax extends FrmAjaxUnitTest {
 		}
 	}
 
-	function _check_updated_values( $form_id ) {
+	private function _check_updated_values( $form_id ) {
 		$fields = FrmField::get_all_for_form( $form_id );
 
 		// Compare to posted values

--- a/tests/misc/test_FrmAddon.php
+++ b/tests/misc/test_FrmAddon.php
@@ -68,7 +68,7 @@ class test_FrmAddon extends FrmUnitTest {
 			array(
 				'time'     => strtotime( '-2 hours' ),
 				'expected' => false,
-			)
+			),
 		);
 
 		$this->run_private_method( array( $this->addon, 'set_auto_activate_time' ) );

--- a/tests/misc/test_FrmAppController.php
+++ b/tests/misc/test_FrmAppController.php
@@ -15,10 +15,10 @@ class test_FrmAppController extends FrmUnitTest {
 
 		$this->markTestIncomplete( 'Needs work' );
 
-        ob_start();
-        require( ABSPATH . 'wp-admin/menu.php' );
-        $menu = ob_get_contents();
-        ob_end_clean();
+		ob_start();
+		require( ABSPATH . 'wp-admin/menu.php' );
+		$menu = ob_get_contents();
+		ob_end_clean();
 		echo $menu;
 		$this->assertTrue( current_user_can( 'frm_view_forms' ), 'The user cannot frm_view_forms' );
 
@@ -42,7 +42,7 @@ class test_FrmAppController extends FrmUnitTest {
 
 		foreach ( $expected as $name => $value ) {
 			$menu_page = menu_page_url( $name, false );
-			if ( $allow == 'allow' ){
+			if ( $allow == 'allow' ) {
 				$this->assertEquals( $value, $menu_page );
 			} else {
 				$this->assertNotEquals( $value, $menu_page );
@@ -74,11 +74,11 @@ class test_FrmAppController extends FrmUnitTest {
 	public function test_load_wp_admin_style() {
 		$this->set_admin_screen();
 
-        ob_start();
+		ob_start();
 		do_action( 'admin_enqueue_scripts' );
-        do_action( 'admin_print_styles' );
-        $styles = ob_get_contents();
-        ob_end_clean();
+		do_action( 'admin_print_styles' );
+		$styles = ob_get_contents();
+		ob_end_clean();
 
 		$this->assertNotEmpty( $styles );
 		$this->assertTrue( strpos( $styles, FrmAppHelper::plugin_url() . '/css/frm_fonts.css' ) !== false, 'The frm_fonts stylesheet is missing' );
@@ -157,12 +157,14 @@ class test_FrmAppController extends FrmUnitTest {
 			$option = get_option( 'frm_db_version' );
 			$this->assertSame( $current, $option );
 
-			$upgrade = FrmAppController::compare_for_update( array(
-				'option'             => 'frm_db_version',
-				'new_db_version'     => FrmAppHelper::$db_version,
-				'new_plugin_version' => FrmAppHelper::plugin_version(),
-			) );
-			$this->assertEquals( $test['expected'], $upgrade, $test['version'] .' db: '. $test['db'] . ' => ' . $current . ( $upgrade ? ' needs no update ' : ' needs an update' ) . ' from ' . $option );
+			$upgrade = FrmAppController::compare_for_update(
+				array(
+					'option'             => 'frm_db_version',
+					'new_db_version'     => FrmAppHelper::$db_version,
+					'new_plugin_version' => FrmAppHelper::plugin_version(),
+				)
+			);
+			$this->assertEquals( $test['expected'], $upgrade, $test['version'] . ' db: ' . $test['db'] . ' => ' . $current . ( $upgrade ? ' needs no update ' : ' needs an update' ) . ' from ' . $option );
 		}
 	}
 

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -7,7 +7,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::plugin_version
 	 */
-	function test_plugin_version() {
+	public function test_plugin_version() {
 		$version = FrmAppHelper::plugin_version();
 		$this->assertNotEmpty( $version );
 
@@ -19,7 +19,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::plugin_folder
 	 */
-	function test_plugin_folder() {
+	public function test_plugin_folder() {
 		$folder = FrmAppHelper::plugin_folder();
 		$expected = array( 'formidable', 'formidable-forms' );
 		$this->assertTrue( in_array( $folder, $expected ) );
@@ -28,7 +28,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::plugin_path
 	 */
-	function test_plugin_path() {
+	public function test_plugin_path() {
 		$path = FrmAppHelper::plugin_path();
 		$expected_file = $path . '/formidable.php';
 		$this->assertTrue( file_exists( $expected_file ) );
@@ -36,9 +36,10 @@ class test_FrmAppHelper extends FrmUnitTest {
 
 	/**
 	 * The path is relative if it starts with /
+	 *
 	 * @covers FrmAppHelper::relative_plugin_url
 	 */
-	function test_relative_plugin_url() {
+	public function test_relative_plugin_url() {
 		$path = FrmAppHelper::relative_plugin_url();
 		$this->assertEquals( strpos( $path, '/' ), 0 );
 	}
@@ -46,7 +47,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::site_url
 	 */
-	function test_site_url() {
+	public function test_site_url() {
 		$url = FrmAppHelper::site_url();
 		$this->assertEquals( 'http://example.org', $url );
 	}
@@ -54,7 +55,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::plugin_url
 	 */
-	function test_plugin_url() {
+	public function test_plugin_url() {
 		$url = FrmAppHelper::plugin_url();
 		$this->assertNotEmpty( $url );
 	}
@@ -62,7 +63,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::make_affiliate_url
 	 */
-	function test_make_affiliate_url() {
+	public function test_make_affiliate_url() {
 		add_filter( 'frm_affiliate_id', '__return_false' );
 		$urls = array( 'http://site.com', 'https://site.com/page/' );
 		foreach ( $urls as $url ) {
@@ -85,7 +86,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::get_settings
 	 */
-	function test_get_settings() {
+	public function test_get_settings() {
 		$settings = FrmAppHelper::get_settings();
 		$this->assertNotEmpty( $settings );
 		$this->assertTrue( is_object( $settings ) );
@@ -95,7 +96,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::pro_is_installed
 	 */
-	function test_pro_is_installed() {
+	public function test_pro_is_installed() {
 		$active = FrmAppHelper::pro_is_installed();
 		if ( is_callable( 'FrmProEddController::pro_is_authorized' ) ) {
 			$this->assertTrue( $active );
@@ -107,7 +108,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::is_formidable_admin
 	 */
-	function test_is_formidable_admin() {
+	public function test_is_formidable_admin() {
 		$page_names = array(
 			'nope'               => false,
 			'formidable'         => true,
@@ -142,7 +143,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::is_empty_value
 	 */
-	function test_is_empty_value() {
+	public function test_is_empty_value() {
 		$empty_value = FrmAppHelper::is_empty_value( '' );
 		$this->assertTrue( $empty_value );
 
@@ -159,7 +160,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::get_server_value
 	 */
-	function test_get_server_value() {
+	public function test_get_server_value() {
 		$url = FrmAppHelper::get_server_value( 'HTTP_HOST' );
 		$this->assertEquals( $url, 'example.org' );
 
@@ -171,10 +172,12 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::get_param
 	 */
-	function test_get_param() {
-		$set_value = '<script></script>test';
-		$expected_value = 'test';
-		$_GET['test'] = $_POST['test2'] = $_POST['item_meta'][25] = $set_value;
+	public function test_get_param() {
+		$set_value              = '<script></script>test';
+		$expected_value         = 'test';
+		$_GET['test']           = $set_value;
+		$_POST['test2']         = $set_value;
+		$_POST['item_meta'][25] = $set_value;
 
 		$result = FrmAppHelper::get_param( 'test', '', 'get', 'sanitize_text_field' );
 		$this->assertEquals( $result, $expected_value );
@@ -190,7 +193,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	 * @covers FrmAppHelper::get_post_param
 	 * @covers FrmAppHelper::get_simple_request
 	 */
-	function test_get_post_param() {
+	public function test_get_post_param() {
 		$set_value = '<script></script>test';
 		$expected_value = 'test';
 		$_POST['test3'] = $set_value;
@@ -202,7 +205,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::sanitize_value
 	 */
-	function test_sanitize_value() {
+	public function test_sanitize_value() {
 		$values = array(
 			array(
 				'value'    => '<script></script>test',
@@ -229,7 +232,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	 * @covers FrmAppHelper::simple_get
 	 * @covers FrmAppHelper::get_simple_request
 	 */
-	function test_simple_get() {
+	public function test_simple_get() {
 		$set_value = '<script></script>test';
 		$expected_value = 'test';
 		$_GET['test4'] = $set_value;
@@ -241,43 +244,47 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::get_simple_request
 	 */
-	function test_get_simple_request() {
-		$result = FrmAppHelper::get_simple_request( array(
-			'type'  => 'request',
-			'param' => 'test5',
-		) );
+	public function test_get_simple_request() {
+		$result = FrmAppHelper::get_simple_request(
+			array(
+				'type'  => 'request',
+				'param' => 'test5',
+			)
+		);
 		$this->assertEquals( '', $result );
 
 		$set_value = '<script></script>test';
 		$expected = 'test';
 		$_REQUEST['test5'] = $set_value;
 
-		$result = FrmAppHelper::get_simple_request( array(
-			'type'  => 'request',
-			'param' => 'test5',
-		) );
+		$result = FrmAppHelper::get_simple_request(
+			array(
+				'type'  => 'request',
+				'param' => 'test5',
+			)
+		);
 		$this->assertEquals( $expected, $result );
 	}
 
 	/**
 	 * @covers FrmAppHelper::sanitize_request
 	 */
-	function test_sanitize_request() {
+	public function test_sanitize_request() {
 		$values = array(
 			'form_id' => '<script></script>12',
-            'frm_action' => '<script></script>create me',
-            'form_key'   => '<script></script>This is a <b>text</b> field',
+			'frm_action' => '<script></script>create me',
+			'form_key'   => '<script></script>This is a <b>text</b> field',
 			'content'    => '<script></script>This is a <b>text</b> field',
 		);
 
-        $sanitize_method = array(
-            'form_id'    => 'absint',
-            'frm_action' => 'sanitize_title',
-            'form_key'   => 'sanitize_text_field',
+		$sanitize_method = array(
+			'form_id'    => 'absint',
+			'frm_action' => 'sanitize_title',
+			'form_key'   => 'sanitize_text_field',
 			'content'    => 'wp_kses_post',
-        );
+		);
 
-        FrmAppHelper::sanitize_request( $sanitize_method, $values );
+		FrmAppHelper::sanitize_request( $sanitize_method, $values );
 
 		$this->assertEquals( $values['form_id'], absint( $values['form_id'] ) );
 		$this->assertEquals( $values['frm_action'], sanitize_title( $values['frm_action'] ) );
@@ -288,7 +295,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::kses
 	 */
-	function test_kses() {
+	public function test_kses() {
 		$start_value = '<script><script>';
 		$safe_value = 'Hello, <a href="/test">click here</a>';
 		$start_value .= $safe_value;
@@ -303,9 +310,10 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::remove_get_action
 	 */
-	function test_remove_get_action() {
-		$_GET['action'] = 'bulk_trash';
-		$start_url = $_SERVER['REQUEST_URI'] = admin_url( 'admin.php?page=formidable&action=bulk_trash' );
+	public function test_remove_get_action() {
+		$_GET['action']         = 'bulk_trash';
+		$start_url              = admin_url( 'admin.php?page=formidable&action=bulk_trash' );
+		$_SERVER['REQUEST_URI'] = $start_url;
 		FrmAppHelper::remove_get_action();
 		$new_url = FrmAppHelper::get_server_value( 'REQUEST_URI' );
 		$this->assertNotEquals( $new_url, $start_url );
@@ -314,16 +322,16 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::get_query_var
 	 */
-    function test_get_query_var() {
+	public function test_get_query_var() {
 		$new_post_id = $this->go_to_new_post();
 		$get_post_id = FrmAppHelper::get_query_var( '', 'p' );
 		$this->assertEquals( $new_post_id, $get_post_id );
-    }
+	}
 
 	/**
 	 * @covers FrmAppHelper::allowed_html
 	 */
-	function test_allowed_html() {
+	public function test_allowed_html() {
 		$safe_html = $this->run_private_method( array( 'FrmAppHelper', 'safe_html' ), array() );
 		$tests = array(
 			array(
@@ -353,23 +361,23 @@ class test_FrmAppHelper extends FrmUnitTest {
 	/**
 	 * @covers FrmAppHelper::maybe_add_permissions
 	 */
-    function test_maybe_add_permissions() {
+	public function test_maybe_add_permissions() {
 		$this->set_user_by_role( 'subscriber' );
 		$this->assertFalse( current_user_can( 'frm_view_forms' ), 'Subscriber can frm_view_forms' );
 		$this->assertFalse( current_user_can( 'frm_edit_forms' ), 'Subscriber can frm_edit_forms' );
 
 		$this->set_user_by_role( 'administrator' );
-        $frm_roles = FrmAppHelper::frm_capabilities();
-        foreach ( $frm_roles as $frm_role => $frm_role_description ) {
+		$frm_roles = FrmAppHelper::frm_capabilities();
+		foreach ( $frm_roles as $frm_role => $frm_role_description ) {
 			$this->assertTrue( current_user_can( $frm_role ), 'Admin cannot ' . $frm_role );
-        }
+		}
 	}
-	
+
 	/**
 	 * @group visibility
 	 * @covers FrmAppHelper::wp_roles_dropdown (single)
 	 */
-	function test_wp_roles_dropdown() {
+	public function test_wp_roles_dropdown() {
 		ob_start();
 		FrmAppHelper::wp_roles_dropdown( 'field_options', 'administrator' );
 		$output = ob_get_contents();
@@ -377,7 +385,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 
 		$this->assert_output_contains( $output, 'name="field_options"' );
 		$this->assert_output_contains( $output, 'id="field_options"' );
-		$this->assert_output_not_contains( $output. 'multiple="multiple"', 'default is single' );
+		$this->assert_output_not_contains( $output . 'multiple="multiple"', 'default is single' );
 		$this->assert_output_contains( $output, '>Administrator' );
 	}
 
@@ -385,7 +393,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	 * @group visibility
 	 * @covers FrmAppHelper::roles_options ($public = 'private')
 	 */
-	function test_roles_options() {
+	public function test_roles_options() {
 		ob_start();
 		FrmAppHelper::roles_options( 'editor' );
 		$output = ob_get_contents();
@@ -402,7 +410,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 	 * @group visibility
 	 * @covers FrmAppHelper::roles_options
 	 */
-	function test_roles_options_empty_string_option() {
+	public function test_roles_options_empty_string_option() {
 		ob_start();
 		FrmAppHelper::roles_options( '' );
 		$output = ob_get_contents();

--- a/tests/misc/test_FrmCSVExportHelper.php
+++ b/tests/misc/test_FrmCSVExportHelper.php
@@ -78,28 +78,34 @@ class test_FrmCSVExportHelper extends FrmUnitTest {
 		$this->check_php_version( '5.3' );
 
 		$embedded_form = $this->factory->form->create_and_get();
-		$section       = $this->factory->field->create_and_get( array( 
-			'form_id' => $embedded_form->id,
-			'type'    => 'divider',
-			'name'    => 'Section',
-		) );
-		$field_in_section = $this->factory->field->create_and_get( array(
-			'form_id' => $embedded_form->id,
-			'type'    => 'text',
-			'name'    => 'Text',
-			'field_options' => array(
-				'in_section' => $section->id,
-			),
-		) );
+		$section       = $this->factory->field->create_and_get(
+			array(
+				'form_id' => $embedded_form->id,
+				'type'    => 'divider',
+				'name'    => 'Section',
+			)
+		);
+		$field_in_section = $this->factory->field->create_and_get(
+			array(
+				'form_id' => $embedded_form->id,
+				'type'    => 'text',
+				'name'    => 'Text',
+				'field_options' => array(
+					'in_section' => $section->id,
+				),
+			)
+		);
 
 		$parent_form = $this->factory->form->create_and_get();
-		$embed_field = $this->factory->field->create_and_get( array(
-			'form_id' => $parent_form->id,
-			'type'    => 'embed',
-			'field_options' => array(
-				'form_select' => $embedded_form->id,
-			),
-		) );
+		$embed_field = $this->factory->field->create_and_get(
+			array(
+				'form_id' => $parent_form->id,
+				'type'    => 'embed',
+				'field_options' => array(
+					'form_select' => $embedded_form->id,
+				),
+			)
+		);
 
 		$this->set_form( $parent_form );
 

--- a/tests/misc/test_FrmDirectFileAccess.php
+++ b/tests/misc/test_FrmDirectFileAccess.php
@@ -14,7 +14,7 @@ class test_FrmDirectFileAccess extends FrmUnitTest {
 		}
 
 		$files = scandir( $dir );
-	
+
 		foreach ( $files as $key => $value ) {
 			$path = realpath( $dir . DIRECTORY_SEPARATOR . $value );
 			if ( ! is_dir( $path ) ) {
@@ -32,12 +32,12 @@ class test_FrmDirectFileAccess extends FrmUnitTest {
 				}
 			}
 		}
-	
+
 		return $results;
 	}
 
 	private function check_for_abspath_check( $path ) {
-		return strpos( file_get_contents( $path ), "! defined( 'ABSPATH' )" ) !== FALSE;
+		return strpos( file_get_contents( $path ), "! defined( 'ABSPATH' )" ) !== false;
 	}
 
 	public function test_direct_file_access() {

--- a/tests/misc/test_FrmHooksController.php
+++ b/tests/misc/test_FrmHooksController.php
@@ -5,7 +5,7 @@
  */
 class test_FrmHooksController extends FrmUnitTest {
 
-	function test_trigger_load_form_hooks() {
+	public function test_trigger_load_form_hooks() {
 		FrmHooksController::trigger_load_form_hooks();
 		$expected_hooks = array(
 			'frm_field_type' => 'FrmFieldsController::change_type',
@@ -15,7 +15,7 @@ class test_FrmHooksController extends FrmUnitTest {
 
 		foreach ( $expected_hooks as $tag => $function ) {
 			$has_filter = has_filter( $tag, $function );
-			$this->assertTrue( $has_filter !== false, 'The ' . $tag .' hook is not loaded' );
+			$this->assertTrue( $has_filter !== false, 'The ' . $tag . ' hook is not loaded' );
 		}
 	}
 }

--- a/tests/test_ajax.php
+++ b/tests/test_ajax.php
@@ -4,14 +4,14 @@
  */
 class Tests_Frm_Ajax extends FrmAjaxUnitTest {
 
-	function test_plugin_activated() {
+	public function test_plugin_activated() {
 		$this->assertTrue( is_plugin_active( 'formidable/formidable.php' ) );
 	}
 
-    /**
+	/**
 	 * Prevent unauthorized user from uninstalling
 	 */
-	function test_block_uninstall() {
+	public function test_block_uninstall() {
 		// log in as user
 		$role = 'editor';
 		$user_id = $this->factory->user->create( compact( 'role' ) );
@@ -30,8 +30,8 @@ class Tests_Frm_Ajax extends FrmAjaxUnitTest {
 
 		$this->assertSame( $expected, $response );
 
-        global $wpdb;
-        $exists = $wpdb->query( 'DESCRIBE '. $wpdb->prefix . 'frm_fields' );
-        $this->assertNotEmpty( $exists );
+		global $wpdb;
+		$exists = $wpdb->query( 'DESCRIBE ' . $wpdb->prefix . 'frm_fields' );
+		$this->assertNotEmpty( $exists );
 	}
 }

--- a/tests/test_wordpress_plugin_tests.php
+++ b/tests/test_wordpress_plugin_tests.php
@@ -2,16 +2,16 @@
 
 class WP_Test_WordPress_Plugin_Tests extends FrmUnitTest {
 
-	function test_plugin_activated() {
+	public function test_plugin_activated() {
 		$this->assertTrue( is_plugin_active( 'formidable/formidable.php' ) );
 	}
 
-	function test_wpml_install(){
-        if ( is_callable('FrmProCopy::install') ) {
-	        $copy = new FrmProCopy();
-	        $copy->install();
+	public function test_wpml_install() {
+		if ( is_callable( 'FrmProCopy::install' ) ) {
+			$copy = new FrmProCopy();
+			$copy->install();
 			self::do_tables_exist( true );
-        }
+		}
 	}
 
 }
@@ -19,9 +19,8 @@ class WP_Test_WordPress_Plugin_Tests extends FrmUnitTest {
 /**
 *
 * Namespacing allows more flexibility
-* 	- Mock objects without real data
+*   - Mock objects without real data
 * Check out PHPUnit test doubles, PHPunit data providers, Test-driven development (TDD)
 * qunit/phantomjs for js unit testing
 * See: "Browser Eyeballing != Javascript testing" by Jordna Kaspar
-*
 */

--- a/tests/views/shortcodes/test_FrmFieldShortcodes.php
+++ b/tests/views/shortcodes/test_FrmFieldShortcodes.php
@@ -59,7 +59,7 @@ class test_FrmFieldShortcodes extends FrmUnitTest {
 		return array(
 			FrmField::get_id_by_key( 'free-text-field' ) => 'Test Testerson',
 			FrmField::get_id_by_key( 'free-paragraph-field' ) => "Test\r\nMiddle\r\nTesterson",
-			FrmField::get_id_by_key( 'free-checkboxes' ) => array ( 'Red', 'Green' ),
+			FrmField::get_id_by_key( 'free-checkboxes' ) => array( 'Red', 'Green' ),
 			FrmField::get_id_by_key( 'free-radio-button-field' ) => 'cookies',
 			FrmField::get_id_by_key( 'free-dropdown-field' ) => 'Ace Ventura',
 			FrmField::get_id_by_key( 'free-email-field' ) => 'jamie@mail.com',
@@ -89,6 +89,6 @@ class test_FrmFieldShortcodes extends FrmUnitTest {
 	}
 
 	protected function get_actual_value( $value ) {
-		return apply_filters('frm_content', $value, $this->test_form, $this->test_entry );
+		return apply_filters( 'frm_content', $value, $this->test_form, $this->test_entry );
 	}
 }


### PR DESCRIPTION
Removing the full exclusion for code styling in our free unit tests. I think all of the actual code styling should be enforced still. My IDE uses these files to show me warnings or not, and I like the consistency.

I left several of the rules that can't be fixed automatically or easily, that relate to security and naming convention rather than code cleanliness. It adds some bulk to the cs rules but it's easy to follow.

As this only effects code styling in unit tests and none of the actual packages code I feel confident that it won't break anything. I've ran the pro unit tests against this branch and they were a success so it shouldn't break anything in Travis.

Also added a rule for `Squiz.Scope.StaticThisUsage` on everything we're checking as it doesn't hurt to check for that. We had no instances of it, but I figure more code coverage is better.