### PR TITLE
clean up phpcs more on free

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,8 +13,6 @@
 	<rule ref="WordPress">
 		<exclude name="Squiz.Commenting" />
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
-		<exclude name="WordPress.WP.GlobalVariablesOverride" />
-		<exclude name="WordPress.PHP.YodaConditions"/>
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
 	</rule>
@@ -44,27 +42,30 @@
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid">
-		<!-- the getOne and getAll functions all break this rule -->
-		<exclude-pattern>classes/models/FrmField.php</exclude-pattern>
-		<exclude-pattern>classes/models/FrmForm.php</exclude-pattern>
-		<exclude-pattern>classes/models/FrmEntry.php</exclude-pattern>
-		<exclude-pattern>classes/models/FrmEntryMeta.php</exclude-pattern>
-	</rule>
-	<rule ref="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase">
-		<!-- wpmuBaseTablePrefix breaks this rule -->
-		<exclude-pattern>classes/models/FrmField.php</exclude-pattern>
-		<exclude-pattern>classes/models/FrmForm.php</exclude-pattern>
-		<exclude-pattern>classes/models/FrmDb.php</exclude-pattern>
-	</rule>
+	<!-- MEDIUM PRIORITY ITEMS TO FIX -->
 	<rule ref="Squiz.PHP.EmbeddedPhp.ContentBeforeOpen">
 		<exclude-pattern>classes/views/*</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.PHP.EmbeddedPhp.ContentAfterEnd">
 		<exclude-pattern>classes/views/*</exclude-pattern>
 	</rule>
+	<rule ref="WordPress.WP.GlobalVariablesOverride">
+		<exclude-pattern>css/_single_theme.css.php</exclude-pattern>
+		<exclude-pattern>classes/views/*</exclude-pattern>
+		<exclude-pattern>classes/models/FrmDb.php</exclude-pattern>
+		<exclude-pattern>classes/controllers/FrmFormsController.php</exclude-pattern>
+		<exclude-pattern>classes/helpers/FrmEntriesListHelper.php</exclude-pattern>
+		<exclude-pattern>classes/helpers/FrmFormsListHelper.php</exclude-pattern>
+	</rule>
 
-	<!-- Exclude specific rules for unit tests -->
+	<!-- LOW PRIORITY ITEMS TO FIX -->
+	<rule ref="WordPress.PHP.YodaConditions">
+		<exclude-pattern>classes/*</exclude-pattern>
+		<exclude-pattern>tests/*</exclude-pattern>
+		<exclude-pattern>css/_single_theme.css.php</exclude-pattern>
+	</rule>
+
+	<!-- Exclude specific rules for unit tests (fix when possible) -->
 	<rule ref="PEAR.NamingConventions.ValidClassName.StartWithCapital">
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
@@ -88,5 +89,20 @@
 	</rule>
 	<rule ref="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized">
 		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+
+	<!-- These rules likely won't see any changes for compatibility -->
+	<rule ref="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid">
+		<!-- the getOne and getAll functions all break this rule -->
+		<exclude-pattern>classes/models/FrmField.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmForm.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmEntry.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmEntryMeta.php</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase">
+		<!-- wpmuBaseTablePrefix breaks this rule -->
+		<exclude-pattern>classes/models/FrmField.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmForm.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmDb.php</exclude-pattern>
 	</rule>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,7 +11,6 @@
 	<arg value="nsp" />
 
 	<rule ref="WordPress">
-		<exclude name="Generic.Files.LineEndings.InvalidEOLChar" />
 		<exclude name="Squiz.Commenting" />
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 		<exclude name="WordPress.WP.GlobalVariablesOverride" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,23 +11,13 @@
 	<arg value="nsp" />
 
 	<rule ref="WordPress">
-		<!-- Temporary exclusions. Enable these when we have time to address them -->
-		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeOpen" />
-		<exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterEnd" />
+		<exclude name="Generic.Files.LineEndings.InvalidEOLChar" />
 		<exclude name="Squiz.Commenting" />
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 		<exclude name="WordPress.WP.GlobalVariablesOverride" />
-
-		<!-- These give issues with the current code base. -->
-		<exclude name="WordPress.Files.FileName.UnderscoresNotAllowed" />
+		<exclude name="WordPress.PHP.YodaConditions"/>
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
-		<exclude name="Generic.Files.LowercasedFilename.NotFound" />
-		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid" />
-		<exclude name="WordPress.Classes.ValidClassName.NotCamelCaps" />
-		<exclude name="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase" />
-		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" /><!-- Some WP globals break the rule -->
-		<exclude name="WordPress.PHP.YodaConditions"/>
 	</rule>
 	<rule ref="WordPress.WP.I18n">
 		<properties>
@@ -38,7 +28,7 @@
 	</rule>
 	<rule ref="Squiz.Scope.StaticThisUsage" />
 
-	<!-- Enable these rules right away -->
+	<!-- HIGH PRIORITY ITEMS TO FIX -->
 	<rule ref="WordPress.Security.NonceVerification.Missing">
 		<exclude-pattern>classes/models/fields/FrmFieldCaptcha.php</exclude-pattern>
 		<exclude-pattern>classes/models/FrmFormAction.php</exclude-pattern>
@@ -53,6 +43,26 @@
 		<exclude-pattern>classes/helpers/FrmCSVExportHelper.php</exclude-pattern>
 		<exclude-pattern>classes/helpers/FrmAppHelper.php</exclude-pattern>
 		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid">
+		<!-- the getOne and getAll functions all break this rule -->
+		<exclude-pattern>classes/models/FrmField.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmForm.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmEntry.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmEntryMeta.php</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase">
+		<!-- wpmuBaseTablePrefix breaks this rule -->
+		<exclude-pattern>classes/models/FrmField.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmForm.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmDb.php</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.PHP.EmbeddedPhp.ContentBeforeOpen">
+		<exclude-pattern>classes/views/*</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.PHP.EmbeddedPhp.ContentAfterEnd">
+		<exclude-pattern>classes/views/*</exclude-pattern>
 	</rule>
 
 	<!-- Exclude specific rules for unit tests -->

--- a/tests/fields/test_FrmFieldType.php
+++ b/tests/fields/test_FrmFieldType.php
@@ -182,10 +182,12 @@ class test_FrmFieldType extends FrmUnitTest {
 	public function test_is_not_unique() {
 
 		$form_id = $this->factory->form->create();
-		$field1 = $this->factory->field->create_and_get( array(
-			'type'    => 'number',
-			'form_id' => $form_id,
-		) );
+		$field1 = $this->factory->field->create_and_get(
+			array(
+				'type'    => 'number',
+				'form_id' => $form_id,
+			)
+		);
 
 		$field_object1 = FrmFieldFactory::get_field_type( 'text', $field1 );
 		$entry_id     = 0;
@@ -202,10 +204,12 @@ class test_FrmFieldType extends FrmUnitTest {
 		$field_object2 = FrmFieldFactory::get_field_type( 'text', $field1 );
 		$this->assertTrue( $field_object2->is_not_unique( 'First', $entry_id ), 'another field object for the same field should also be flagging a duplicate' );
 
-		$field2 = $this->factory->field->create_and_get( array(
-			'type'    => 'number',
-			'form_id' => $form_id,
-		) );
+		$field2 = $this->factory->field->create_and_get(
+			array(
+				'type'    => 'number',
+				'form_id' => $form_id,
+			)
+		);
 		$field_object3 = FrmFieldFactory::get_field_type( 'text', $field2 );
 
 		$this->assertFalse( $field_object3->is_not_unique( 'First', $entry_id ), 'a field object for another field should not flag a duplicate' );


### PR DESCRIPTION
After a little extra phpcs QA in free, I found a few rules that we don't need, and I was able to isolate a few exclusions to just a few small files.

And I had to update a new unit test that was added after the unit test standardization.

Looks pretty good now.