### PR TITLE
add a unit test to confirm that calculations do not get stripped when sanitized

### DIFF
--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -126,4 +126,22 @@ class test_FrmForm extends FrmUnitTest {
 	private function assert_form_is_hidden( $capability, $visibility, $message = '' ) {
 		$this->assertFalse( $this->form_is_visible( $capability, $visibility ), $message );
 	}
+
+	/**
+	 * @covers FrmForm::sanitize_field_opt
+	 */
+	public function test_sanitize_field_opt() {
+		$opt            = 'calc';
+		$original_value = '[189] > 1 && [189] < 5 ? 20 : [189] > 5 && [189] < 8 ? 21 : 0';
+		$value          = $original_value;
+		$this->sanitize_field_opt( $opt, $value );
+		$this->assertEquals( $original_value, $value, 'comparisons should not be detected as unsafe html tags' );
+	}
+
+	private function sanitize_field_opt( $opt, &$value ) {
+		return $this->run_private_method(
+			array( 'FrmForm', 'sanitize_field_opt' ),
+			array( $opt, &$value )
+		);
+	}
 }


### PR DESCRIPTION
Adds a unit test for https://github.com/Strategy11/formidable-pro/issues/2759

I don't actually think there's an issue in free after I've isolated this. But this function is where I started, and it deserves a unit test too.