### PR TITLE
edit link not working if submission user was not logged in fix

### DIFF
--- a/classes/helpers/FrmEntriesListHelper.php
+++ b/classes/helpers/FrmEntriesListHelper.php
@@ -268,12 +268,16 @@ class FrmEntriesListHelper extends FrmListHelper {
 				$val = empty( $item->is_draft ) ? esc_html__( 'No', 'formidable' ) : esc_html__( 'Yes', 'formidable' );
 				break;
 			case 'form_id':
-				$form_id             = $item->form_id;
-				$user_can_edit_forms = false === FrmAppHelper::permission_nonce_error( 'frm_edit_forms' );
-				if ( $user_can_edit_forms ) {
+				$form_id = $item->form_id;
+				if ( FrmAppHelper::is_admin_page( 'formidable-entries' ) ) {
+					$user_can_edit_forms = false === FrmAppHelper::permission_nonce_error( 'frm_edit_forms' );
+					if ( ! $user_can_edit_forms ) {
+						$val = FrmFormsHelper::edit_form_link_label( $form_id );
+					}
+				}
+
+				if ( ! isset( $val ) ) {
 					$val = FrmFormsHelper::edit_form_link( $form_id );
-				} else {
-					$val = FrmFormsHelper::edit_form_link_label( $form_id );
 				}
 				break;
 			case 'post_id':

--- a/tests/entries/test_FrmEntriesListHelper.php
+++ b/tests/entries/test_FrmEntriesListHelper.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @group entries
+ */
+class test_FrmEntriesListHelper extends FrmUnitTest {
+
+	private $form_id;
+	private $helper;
+
+	/**
+	 * @covers FrmEntriesListHelper::column_value
+	 */
+	public function test_column_value() {
+		$some_form_id  = 63334;
+		$this->form_id = $some_form_id;
+		$this->helper  = $this->get_new_helper_instance();
+
+		$this->set_private_property( $this->helper, 'column_name', 'form_id' );
+
+		$link  = FrmFormsHelper::edit_form_link( $this->form_id );
+		$label = FrmFormsHelper::edit_form_link_label( $this->form_id );
+
+		wp_set_current_user( null );
+		$this->assert_value_equals( $link );
+
+		wp_set_current_user( 1 );
+		$this->assert_value_equals( $link );
+
+		$this->switch_to_entries_listing_page();
+		$this->assert_value_equals( $link );
+
+		wp_set_current_user( null );
+		$this->assert_value_equals( $label );
+	}
+
+	private function switch_to_entries_listing_page() {
+		global $pagenow;
+		$pagenow = 'admin.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		if ( ! defined( 'WP_ADMIN' ) ) {
+			define( 'WP_ADMIN', true );
+		}
+		$_GET['page'] = 'formidable-entries';
+	}
+
+	private function assert_value_equals( $expected ) {
+		$value = $this->column_value( $this->get_an_item_object() );
+		$this->assertEquals( $expected, $value );
+	}
+
+	private function get_new_helper_instance() {
+		$GLOBALS['hook_suffix'] = 'post'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$args                   = array(
+			'screen' => '',
+		);
+		return new FrmEntriesListHelper( $args );
+	}
+
+	private function get_an_item_object() {
+		$item          = new stdClass();
+		$item->form_id = $this->form_id;
+		return $item;
+	}
+
+	private function column_value( $item ) {
+		return $this->run_private_method(
+			array( $this->helper, 'column_value' ),
+			array( $item )
+		);
+	}
+}

--- a/tests/entries/test_FrmEntriesListHelper.php
+++ b/tests/entries/test_FrmEntriesListHelper.php
@@ -9,9 +9,9 @@ class test_FrmEntriesListHelper extends FrmUnitTest {
 	private $helper;
 
 	/**
-	 * @covers FrmEntriesListHelper::column_value
+	 * @covers FrmEntriesListHelper::column_value form_id
 	 */
-	public function test_column_value() {
+	public function test_column_value_form_id() {
 		$some_form_id  = 63334;
 		$this->form_id = $some_form_id;
 		$this->helper  = $this->get_new_helper_instance();


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2771

This is an accidental regression from https://github.com/Strategy11/formidable-forms/pull/299 the scope of this function call was bigger than I was thinking. I've made it so this only happens on the entries page now.