### PR TITLE
do not disable the screen options checkboxes

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6478,8 +6478,6 @@ function frmAdminBuildJS() {
 			});
 			clickTab( jQuery( '.starttab a' ), 'auto' );
 
-			jQuery( '.post-type-frm_display #screen-options-wrap:hidden input[type="checkbox"]' ).attr( 'disabled', true );
-
 			// submit the search form with dropdown
 			jQuery( '#frm-fid-search-menu a' ).click( function() {
 				var val = this.id.replace( 'fid-', '' );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-views/issues/46

I made a PR at one point to put this back but it had other updates. Meant to make another one with just this, didn't. Missed that this is also triggered from the listing page.

There's really no need for this line. I put it in here trying to fix the disappearing view sections issue, but this wasn't the final fix.