### PR TITLE
unlock all templates on free code verification

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -299,7 +299,7 @@ class FrmAppController {
 		if ( ! FrmAppHelper::pro_is_installed() ) {
 			// avoid rendering the email and code blocks for users who have upgraded or have a free license already
 			$api = new FrmFormTemplateApi();
-			if ( ! $api->get_free_license() ) {
+			if ( ! $api->has_free_access() ) {
 				array_push( $blocks_to_render, 'email', 'code' );
 			}
 		}

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -1406,7 +1406,7 @@ BEFORE_HTML;
 
 				if ( $category === 'Personal' ) {
 					// Show the current package name.
-					$category = 'Basic';
+					$category = 'Plus';
 				}
 
 				return $category;

--- a/classes/models/FrmFormTemplateApi.php
+++ b/classes/models/FrmFormTemplateApi.php
@@ -124,31 +124,28 @@ class FrmFormTemplateApi extends FrmFormApi {
 		self::$free_license = $code;
 		update_option( self::$code_option_name, $code, 'no' );
 
-		$data = array(
-			'url_by_key' => array(),
-		);
+		$data = array();
 		$key  = FrmAppHelper::get_param( 'key', '', 'post', 'sanitize_key' );
 
 		if ( $key ) {
-			$api       = new self();
-			$templates = $api->get_api_info();
+			$data['url_by_key'] = array();
+			$api                = new self();
+			$templates          = $api->get_api_info();
 
 			foreach ( $templates as $template ) {
 				if ( ! isset( $template['url'] ) || ! in_array( 'free', $template['categories'], true ) ) {
 					continue;
 				}
 
-				if ( $key === $template['key'] ) {
-					$data['url'] = $template['url'];
-				}
-
 				$data['url_by_key'][ $template['key'] ] = $template['url'];
 			}
-		}
 
-		if ( ! isset( $data['url'] ) ) {
-			$error = new WP_Error( 400, 'We were unable to retrieve the template' );
-			wp_send_json_error( $error );
+			if ( ! isset( $data['url_by_key'][ $key ] ) ) {
+				$error = new WP_Error( 400, 'We were unable to retrieve the template' );
+				wp_send_json_error( $error );
+			}
+
+			$data['url'] = $data['url_by_key'][ $key ];
 		}
 
 		wp_send_json_success( $data );

--- a/classes/models/FrmFormTemplateApi.php
+++ b/classes/models/FrmFormTemplateApi.php
@@ -83,8 +83,6 @@ class FrmFormTemplateApi extends FrmFormApi {
 	 * @param string $code the code from the email sent for the API
 	 */
 	private static function verify_code( $code ) {
-		self::clear_template_cache_before_free_code_verification();
-
 		$base64_code = base64_encode( $code );
 		$api_url     = self::$base_api_url . 'code?l=' . urlencode( $base64_code );
 		$response    = wp_remote_get( $api_url );
@@ -95,13 +93,14 @@ class FrmFormTemplateApi extends FrmFormApi {
 		$successful = ! empty( $decoded->response );
 
 		if ( $successful ) {
+			self::clear_template_cache_before_getting_free_templates();
 			self::on_api_verify_code_success( $code );
 		} else {
 			wp_send_json_error( new WP_Error( $decoded->code, $decoded->message ) );
 		}
 	}
 
-	private static function clear_template_cache_before_free_code_verification() {
+	private static function clear_template_cache_before_getting_free_templates() {
 		delete_option( 'frm_form_templates_l' );
 	}
 

--- a/classes/models/FrmFormTemplateApi.php
+++ b/classes/models/FrmFormTemplateApi.php
@@ -93,7 +93,6 @@ class FrmFormTemplateApi extends FrmFormApi {
 		$successful = ! empty( $decoded->response );
 
 		if ( $successful ) {
-			self::clear_template_cache_before_getting_free_templates();
 			self::on_api_verify_code_success( $code );
 		} else {
 			wp_send_json_error( new WP_Error( $decoded->code, $decoded->message ) );
@@ -128,6 +127,8 @@ class FrmFormTemplateApi extends FrmFormApi {
 		$key  = FrmAppHelper::get_param( 'key', '', 'post', 'sanitize_key' );
 
 		if ( $key ) {
+			self::clear_template_cache_before_getting_free_templates();
+
 			$data['urlByKey'] = array();
 			$api              = new self();
 			$templates        = $api->get_api_info();

--- a/classes/models/FrmFormTemplateApi.php
+++ b/classes/models/FrmFormTemplateApi.php
@@ -128,24 +128,24 @@ class FrmFormTemplateApi extends FrmFormApi {
 		$key  = FrmAppHelper::get_param( 'key', '', 'post', 'sanitize_key' );
 
 		if ( $key ) {
-			$data['url_by_key'] = array();
-			$api                = new self();
-			$templates          = $api->get_api_info();
+			$data['urlByKey'] = array();
+			$api              = new self();
+			$templates        = $api->get_api_info();
 
 			foreach ( $templates as $template ) {
 				if ( ! isset( $template['url'] ) || ! in_array( 'free', $template['categories'], true ) ) {
 					continue;
 				}
 
-				$data['url_by_key'][ $template['key'] ] = $template['url'];
+				$data['urlByKey'][ $template['key'] ] = $template['url'];
 			}
 
-			if ( ! isset( $data['url_by_key'][ $key ] ) ) {
+			if ( ! isset( $data['urlByKey'][ $key ] ) ) {
 				$error = new WP_Error( 400, 'We were unable to retrieve the template' );
 				wp_send_json_error( $error );
 			}
 
-			$data['url'] = $data['url_by_key'][ $key ];
+			$data['url'] = $data['urlByKey'][ $key ];
 		}
 
 		wp_send_json_success( $data );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5571,7 +5571,6 @@ function frmAdminBuildJS() {
 	function initNewFormModal() {
 		var installFormTrigger,
 			activeHoverIcons,
-			activeTemplateKey,
 			$modal,
 			handleError,
 			handleEmailAddressError,
@@ -5713,7 +5712,7 @@ function frmAdminBuildJS() {
 				});
 
 				activePage = 'email';
-				activeTemplateKey = $li.attr( 'data-key' );
+				$modal.attr( 'frm-this-form', $li.attr( 'data-key' ) );
 				$li.append( installFormTrigger );
 			} else if ( $modal.hasClass( 'frm-expired' ) ) {
 				activePage = 'renew';
@@ -5817,7 +5816,7 @@ function frmAdminBuildJS() {
 					action: 'template_api_signup',
 					nonce: frmGlobal.nonce,
 					code: code,
-					key: activeTemplateKey
+					key: $modal.attr( 'frm-this-form' )
 				},
 				success: function( response ) {
 					if ( response.success ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5906,10 +5906,10 @@ function frmAdminBuildJS() {
 		jQuery( '#frm_new_form_modal' ).find( '.frm-selectable[data-key]' ).each( function() {
 			var $template = jQuery( this ),
 				key = $template.attr( 'data-key' );
-			if ( 'undefined' !== typeof urlByKey[ key ] ) {
+			if ( 'undefined' !== typeof urlByKey[ key ]) {
 				$template.removeClass( 'frm-locked-template' );
 				$template.find( 'h3 svg' ).remove(); // remove the lock from the title
-				$template.attr( 'data-rel', urlByKey[ key ] );
+				$template.attr( 'data-rel', urlByKey[ key ]);
 			}
 		});
 	}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5825,6 +5825,10 @@ function frmAdminBuildJS() {
 							installFormTrigger.click();
 							$modal.attr( 'frm-page', 'details' );
 							document.getElementById( 'frm_action_type' ).value = 'frm_install_template';
+
+							if ( typeof response.data.url_by_key !== 'undefined' ) {
+								updateTemplateModalFreeUrls( response.data.url_by_key );
+							}
 						}
 					} else {
 						if ( Array.isArray( response.data ) && response.data.length ) {
@@ -5896,6 +5900,18 @@ function frmAdminBuildJS() {
 		if ( urlParams.get( 'triggerNewFormModal' ) ) {
 			triggerNewFormModal();
 		}
+	}
+
+	function updateTemplateModalFreeUrls( url_by_key ) {
+		jQuery( '#frm_new_form_modal' ).find( '.frm-selectable[data-key]' ).each( function() {
+			var $template = jQuery( this ),
+				key = $template.attr( 'data-key' );
+			if ( 'undefined' !== typeof url_by_key[ key ] ) {
+				$template.removeClass( 'frm-locked-template' );
+				$template.find( 'h3 svg' ).remove(); // remove the lock from the title
+				$template.attr( 'data-rel', url_by_key[ key ] );
+			}
+		});
 	}
 
 	function transitionToAddDetails( $modal, name, link, action ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5826,8 +5826,8 @@ function frmAdminBuildJS() {
 							$modal.attr( 'frm-page', 'details' );
 							document.getElementById( 'frm_action_type' ).value = 'frm_install_template';
 
-							if ( typeof response.data.url_by_key !== 'undefined' ) {
-								updateTemplateModalFreeUrls( response.data.url_by_key );
+							if ( typeof response.data.urlByKey !== 'undefined' ) {
+								updateTemplateModalFreeUrls( response.data.urlByKey );
 							}
 						}
 					} else {
@@ -5902,14 +5902,14 @@ function frmAdminBuildJS() {
 		}
 	}
 
-	function updateTemplateModalFreeUrls( url_by_key ) {
+	function updateTemplateModalFreeUrls( urlByKey ) {
 		jQuery( '#frm_new_form_modal' ).find( '.frm-selectable[data-key]' ).each( function() {
 			var $template = jQuery( this ),
 				key = $template.attr( 'data-key' );
-			if ( 'undefined' !== typeof url_by_key[ key ] ) {
+			if ( 'undefined' !== typeof urlByKey[ key ] ) {
 				$template.removeClass( 'frm-locked-template' );
 				$template.find( 'h3 svg' ).remove(); // remove the lock from the title
-				$template.attr( 'data-rel', url_by_key[ key ] );
+				$template.attr( 'data-rel', urlByKey[ key ] );
 			}
 		});
 	}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2774

I was getting some pretty odd behaviour before also clearing the caches. I noticed that the cache key wasn't accounting for the free license either.

But the main thing is the new `updateTemplateModalFreeUrls` function that updates every free template, setting the urls that we can get. I dropped the break from the template loop and set everything to an array if it's free and has a url. Then I check that array for the specific key. Since we require these urls, there's a bit involved but nothing too crazy.

One thing though, in this new update, the license getting saved isn't base 64 encoded in the options anymore. This would mean that any previous option would no longer work. Is that fine? Do we want to revert that?