### PR TITLE
hide formidable button on form pages fix

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -613,14 +613,28 @@ class FrmFormsController {
 	 * @since 2.0.15
 	 */
 	public static function insert_form_button() {
-		if ( current_user_can( 'frm_view_forms' ) ) {
-			FrmAppHelper::load_admin_wide_js();
-			$menu_name = FrmAppHelper::get_menu_name();
-			$icon      = apply_filters( 'frm_media_icon', FrmAppHelper::svg_logo() );
-			echo '<a href="#TB_inline?width=50&height=50&inlineId=frm_insert_form" class="thickbox button add_media frm_insert_form" title="' . esc_attr__( 'Add forms and content', 'formidable' ) . '">' .
-				FrmAppHelper::kses( $icon, 'all' ) .
-				' ' . esc_html( $menu_name ) . '</a>'; // WPCS: XSS ok.
+		if ( ! self::should_include_formidable_button_in_media_buttons() ) {
+			return;
 		}
+
+		FrmAppHelper::load_admin_wide_js();
+		$menu_name = FrmAppHelper::get_menu_name();
+		$icon      = apply_filters( 'frm_media_icon', FrmAppHelper::svg_logo() );
+		echo '<a href="#TB_inline?width=50&height=50&inlineId=frm_insert_form" class="thickbox button add_media frm_insert_form" title="' . esc_attr__( 'Add forms and content', 'formidable' ) . '">' .
+			FrmAppHelper::kses( $icon, 'all' ) .
+			' ' . esc_html( $menu_name ) . '</a>'; // WPCS: XSS ok.
+	}
+
+	/**
+	 * @return bool
+	 */
+	private static function should_include_formidable_button_in_media_buttons() {
+		if ( ! current_user_can( 'frm_view_forms' ) || ! is_admin() ) {
+			return false;
+		}
+
+		$action = FrmAppHelper::get_param( 'action', '', 'get', 'sanitize_key' );
+		return ! in_array( $action, array( 'frm_add_form_row', 'frm_forms_preview' ), true );
 	}
 
 	public static function insert_form_popup() {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2780

I believe this is a good fix. I don't think we ever want to show the formidable buttons on actual formidable forms. I've moved the permission check out into another function and extended the logic. There are no changes in the original function outside of just outdenting all of the logic.

This fixes a few things. The ajax action that loads new repeater rows was always including the formidable button, even on front end forms. Front end forms were not showing the button by default, but preview forms were.