### PR TITLE
prepend option to select inside loop fix

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3010,11 +3010,11 @@ function frmAdminBuildJS() {
 
 				valueSelect.prepend( optionMatch );
 			}
-		}
 
-		optionMatch = valueSelect.querySelector( 'option[value=""]' );
-		if ( optionMatch !== null ) {
-			valueSelect.prepend( optionMatch );
+			optionMatch = valueSelect.querySelector( 'option[value=""]' );
+			if ( optionMatch !== null ) {
+				valueSelect.prepend( optionMatch );
+			}
 		}
 	}
 


### PR DESCRIPTION
Got the scope of this logic wrong.

I was seeing `valueSelect is undefined` which would happen in there were no rows. It shouldn't be accessing a variable that gets created in the loop from outside of the loop.

This doesn't seem to be breaking JavaScript but it still logs an error to the console and it's likely missing rows where it is.