### PR TITLE
dynamic field in repeater export fix

### DIFF
--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -444,8 +444,12 @@ class FrmCSVExportHelper {
 					$key   = substr( $k, 0, $start ++ );
 					$index = substr( $k, $start, strlen( $k ) - 1 - $start );
 
-					if ( isset( $rows[ $key ] ) && isset( $rows[ $key ][ $index ] ) ) {
-						$row = $rows[ $key ][ $index ];
+					if ( isset( $rows[ $key ] ) ) {
+						if ( is_string( $rows[ $key ] ) ) {
+							$row = $rows[ $key ];
+						} elseif ( is_array( $rows[ $key ] ) && isset( $rows[ $key ][ $index ] ) ) {
+							$row = $rows[ $key ][ $index ];
+						}
 					}
 
 					unset( $start, $key, $index );


### PR DESCRIPTION
Trying to fix https://github.com/Strategy11/formidable-pro/issues/2805

This is the problem area, but it's not actually the fix I want.

I'm noticing several issues:
- I've tried exporting 2 rows with one dynamic radio option selected in each and both columns included both values.
- I tried exporting a dynamic checkbox and the two selected values in my 1 row were left as ids.
- When I exported for a set of data that sometimes included 2 columns, the 2nd column was showing the first column's result even where there was only one repeater entry

The issue has to be higher up. It's coming through wrong. Probably similar to the fix for file uploads.