### PR TITLE
fix select padding issue in WordPress 5.6

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7330,19 +7330,9 @@ button.frm_choose_image_box,
 	width: 100%;
 }
 
-/** TODO: After 5.5, remove the branch clases **/
-.branch-5-6 #postbox-container-2 select,
-.branch-5-6.wp-admin .frm_wrap select,
-.branch-5-6 .frm_wrap .frm_form_builder select,
-.branch-5-5 #postbox-container-2 select,
-.branch-5-5.wp-admin .frm_wrap select,
-.branch-5-5 .frm_wrap .frm_form_builder select,
-.branch-5-4 #postbox-container-2 select,
-.branch-5-4.wp-admin .frm_wrap select,
-.branch-5-4 .frm_wrap .frm_form_builder select,
-.branch-5-3 #postbox-container-2 select,
-.branch-5-3.wp-admin .frm_wrap select,
-.branch-5-3 .frm_wrap .frm_form_builder select {
+#postbox-container-2 select,
+.wp-admin .frm_wrap select,
+.frm_wrap .frm_form_builder select {
 	height: auto;
 	padding: 0 24px 0 12px;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7331,6 +7331,9 @@ button.frm_choose_image_box,
 }
 
 /** TODO: After 5.5, remove the branch clases **/
+.branch-5-6 #postbox-container-2 select,
+.branch-5-6.wp-admin .frm_wrap select,
+.branch-5-6 .frm_wrap .frm_form_builder select,
 .branch-5-5 #postbox-container-2 select,
 .branch-5-5.wp-admin .frm_wrap select,
 .branch-5-5 .frm_wrap .frm_form_builder select,


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2814

I listened to the TODO comment and removed the `.branch` prefixes that were avoiding the new `branch-5-6`

This will possibly mean some funny padding in WordPress < 5.3 but I imagine we're okay with that.