### PR TITLE
Add condition to avoid js warnings for a null property

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1054,8 +1054,9 @@ function frmAdminBuildJS() {
 
 		addHtmlToField = function( element ) {
 			element.classList.add( 'frm_load_now' );
-			if ( element.querySelector( '.frm_hidden_fdata' ) !== null ) {
-			    field.push( element.querySelector( '.frm_hidden_fdata' ).innerHTML );
+			var frmHiddenFdata = element.querySelector( '.frm_hidden_fdata' );
+			if ( frmHiddenFdata !== null ) {
+			    field.push( frmHiddenFdata.innerHTML );
 			}   
 		};
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1053,8 +1053,8 @@ function frmAdminBuildJS() {
 			field = [];
 
 		addHtmlToField = function( element ) {
-			element.classList.add( 'frm_load_now' );
 			var frmHiddenFdata = element.querySelector( '.frm_hidden_fdata' );
+			element.classList.add( 'frm_load_now' );
 			if ( frmHiddenFdata !== null ) {
 				field.push( frmHiddenFdata.innerHTML );
 			}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1056,7 +1056,7 @@ function frmAdminBuildJS() {
 			element.classList.add( 'frm_load_now' );
 			var frmHiddenFdata = element.querySelector( '.frm_hidden_fdata' );
 			if ( frmHiddenFdata !== null ) {
-			    field.push( frmHiddenFdata.innerHTML );
+				field.push( frmHiddenFdata.innerHTML );
 			}   
 		};
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1054,7 +1054,9 @@ function frmAdminBuildJS() {
 
 		addHtmlToField = function( element ) {
 			element.classList.add( 'frm_load_now' );
-			field.push( element.querySelector( '.frm_hidden_fdata' ).innerHTML );
+			if ( element.querySelector( '.frm_hidden_fdata' ) !== null ) {
+			    field.push( element.querySelector( '.frm_hidden_fdata' ).innerHTML );
+			}   
 		};
 
 		nextElement = thisField;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1057,7 +1057,7 @@ function frmAdminBuildJS() {
 			var frmHiddenFdata = element.querySelector( '.frm_hidden_fdata' );
 			if ( frmHiddenFdata !== null ) {
 				field.push( frmHiddenFdata.innerHTML );
-			}   
+			}
 		};
 
 		nextElement = thisField;


### PR DESCRIPTION
This PR should do the trick to fix the JS error reported by @altoin 
![download - 2021-01-05T105636 519](https://user-images.githubusercontent.com/16246503/103650079-daf0b080-4f35-11eb-8258-ad64fec93b3f.png)

https://sandbox.formidableforms.com/toyin/wp-admin/admin.php?page=formidable&frm_action=edit&id=936
