### PR TITLE
force jquery ui 1.11.4

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1500,6 +1500,10 @@ class FrmAppHelper {
 			$ver = $query->ver;
 		}
 
+		if ( version_compare( $ver, '1.12.1', '>=' ) ) {
+			$ver = '1.11.4';
+		}
+
 		return $ver;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2811 since the latest jQuery ui doesn't seem to include i18n files.

I think WordPress 5.6 uses jQuery 1.12.1 by default.

Going forward we don't want everyone to need to add a workaround.

I tested this and date localizations don't work without this fix in the new WordPress.

The alternative might be trying to support 1.12.1 with the old i18n files, but I feel like we're at risk of a conflict with that. I think the best plan moving forward would be replacing datepicker with something that isn't jQuery based, possibly https://flatpickr.js.org/