### PR TITLE
fix php deprecation errors in csv export

### DIFF
--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -296,6 +296,11 @@ class FrmCSVExportHelper {
 					continue;
 				}
 
+				if ( ! isset( $entries[ self::$entry->parent_item_id ] ) ) {
+					$entries[ self::$entry->parent_item_id ]        = new stdClass();
+					$entries[ self::$entry->parent_item_id ]->metas = array();
+				}
+
 				if ( ! isset( $entries[ self::$entry->parent_item_id ]->metas[ $meta_id ] ) ) {
 					$entries[ self::$entry->parent_item_id ]->metas[ $meta_id ] = array();
 				} elseif ( ! is_array( $entries[ self::$entry->parent_item_id ]->metas[ $meta_id ] ) ) {
@@ -503,8 +508,14 @@ class FrmCSVExportHelper {
 	 * Escape a " in a csv with another "
 	 *
 	 * @since 2.0
+	 * @param mixed $value
+	 * @return mixed
 	 */
 	public static function escape_csv( $value ) {
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+
 		if ( '=' === $value[0] ) {
 			// escape the = to prevent vulnerability
 			$value = "'" . $value;


### PR DESCRIPTION
Fixes 3 errors I was seeing in my pro unit tests on PHP 7.4:

1) test_FrmCSVExportHelper::test_prepare_csv_row
Trying to access array offset on value of type bool
/tmp/wordpress/src/wp-content/plugins/formidable/classes/helpers/FrmCSVExportHelper.php:508

2) test_FrmCSVExportHelper::test_prepare_csv_row_empty_fields_in_repeaters
Trying to access array offset on value of type bool
/tmp/wordpress/src/wp-content/plugins/formidable/classes/helpers/FrmCSVExportHelper.php:508

3) test_FrmCSVExportHelper::test_add_repeat_field_values_to_csv
Creating default object from empty value
/tmp/wordpress/src/wp-content/plugins/formidable/classes/helpers/FrmCSVExportHelper.php:300