### PR TITLE
add inline box shadow to autofill input

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -40,6 +40,10 @@ $important = empty( $defaults['important_style'] ) ? '' : ' !important';
 	text-align:var(--form-align)<?php echo esc_html( $important ); ?>;
 }
 
+input:-webkit-autofill {
+	-webkit-box-shadow: 0 0 0 30px white inset;
+}
+
 /* Form description */
 .with_frm_style .frm-show-form div.frm_description p{
 <?php if ( ! empty( $defaults['form_desc_size'] ) ) { ?>


### PR DESCRIPTION
This is a required part of the fix for https://github.com/Strategy11/formidable-pro/pull/2845

Without this, the autofilled field can't match the css check.