### PR TITLE
Avoid XSS from data-verify / data-caution attributes

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3751,7 +3751,7 @@ function frmAdminBuildJS() {
 			if ( typeof requires === 'undefined' || requires === null || requires === '' ) {
 				requires = 'Pro';
 			}
-			jQuery( '.license-level' ).html( requires );
+			jQuery( '.license-level' ).text( requires );
 
 			// If one click upgrade, hide other content
 			addOneClickModal( this );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -375,18 +375,28 @@ function frmAdminBuildJS() {
 	}
 
 	function confirmModal( link ) {
-		var i, dataAtts,
+		var caution, verify, $confirmMessage, frmCaution, i, dataAtts,
 			$info = initModal( '#frm_confirm_modal', '400px' ),
 			continueButton = document.getElementById( 'frm-confirmed-click' );
-
+	
 		if ( $info === false ) {
 			return false;
 		}
-
-		var caution = link.getAttribute( 'data-frmcaution' );
-		var cautionHtml = caution ? '<span class="frm-caution">' + caution + '</span> ' : '';
-
-		jQuery( '.frm-confirm-msg' ).html( cautionHtml + link.getAttribute( 'data-frmverify' ) );
+	
+		caution = link.getAttribute( 'data-frmcaution' );
+		verify = link.getAttribute( 'data-frmverify' );
+		$confirmMessage = jQuery( '.frm-confirm-msg' );
+	
+		if ( caution ) {
+			frmCaution = document.createElement( 'span' );
+			frmCaution.classList.add( 'frm-caution' );
+			frmCaution.appendChild( document.createTextNode( caution ) );
+			$confirmMessage.append( frmCaution );
+		}
+		
+		if ( verify ) {
+			$confirmMessage.append( document.createTextNode( verify ) );
+		}
 
 		removeAtts = continueButton.dataset;
 		for ( i in dataAtts ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3756,7 +3756,7 @@ function frmAdminBuildJS() {
 			// If one click upgrade, hide other content
 			addOneClickModal( this );
 
-			jQuery( '.frm_feature_label' ).html( this.getAttribute( 'data-upgrade' ) );
+			jQuery( '.frm_feature_label' ).text( this.getAttribute( 'data-upgrade' ) );
 			jQuery( '#frm_upgrade_modal h2' ).show();
 
 			$info.dialog( 'open' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -378,22 +378,22 @@ function frmAdminBuildJS() {
 		var caution, verify, $confirmMessage, frmCaution, i, dataAtts,
 			$info = initModal( '#frm_confirm_modal', '400px' ),
 			continueButton = document.getElementById( 'frm-confirmed-click' );
-	
+
 		if ( $info === false ) {
 			return false;
 		}
-	
+
 		caution = link.getAttribute( 'data-frmcaution' );
 		verify = link.getAttribute( 'data-frmverify' );
 		$confirmMessage = jQuery( '.frm-confirm-msg' );
-	
+
 		if ( caution ) {
 			frmCaution = document.createElement( 'span' );
 			frmCaution.classList.add( 'frm-caution' );
 			frmCaution.appendChild( document.createTextNode( caution ) );
 			$confirmMessage.append( frmCaution );
 		}
-		
+
 		if ( verify ) {
 			$confirmMessage.append( document.createTextNode( verify ) );
 		}


### PR DESCRIPTION
Fixes a vulnerability Steph mentions in https://github.com/Strategy11/formidable-pro/issues/2827#issuecomment-762478526

This can be exploited when someone creates an anchor tag that matches our expected attribute.

Also fixes https://github.com/Strategy11/formidable-pro/issues/2846