### PR TITLE
remove jquery blur and focus shorthand

### DIFF
--- a/js/bootstrap-multiselect.js
+++ b/js/bootstrap-multiselect.js
@@ -708,7 +708,7 @@
                     this.lastToggledInput = $target;
                 }
 
-                $target.blur();
+                $target.trigger( 'blur' );
             }, this));
 
             // Keyboard support.
@@ -742,7 +742,7 @@
                     }
 
                     var $current = $items.eq(index);
-                    $current.focus();
+                    $current.trigger( 'focus' );
 
                     if (event.keyCode === 32 || event.keyCode === 13) {
                         var $checkbox = $current.find('input');

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -987,13 +987,13 @@ function frmFrontFormJS() {
 
 			jQuery( '.frm-show-form input[onblur], .frm-show-form textarea[onblur]' ).each( function() {
 				if ( jQuery( this ).val() === '' ) {
-					jQuery( this ).blur();
+					jQuery( this ).trigger( 'blur' );
 				}
 			});
 
 			jQuery( document ).on( 'focus', '.frm_toggle_default', clearDefault );
 			jQuery( document ).on( 'blur', '.frm_toggle_default', replaceDefault );
-			jQuery( '.frm_toggle_default' ).blur();
+			jQuery( '.frm_toggle_default' ).trigger( 'blur' );
 
 			jQuery( document.getElementById( 'frm_resend_email' ) ).on( 'click', resendEmail );
 
@@ -1202,7 +1202,7 @@ function frmFrontFormJS() {
 				scrollObj = id;
 			}
 
-			scrollObj.focus();
+			jQuery( scrollObj ).trigger( 'focus' );
 			newPos = scrollObj.offset().top;
 			if ( ! newPos || frm_js.offset === '-1' ) {
 				return;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6041,7 +6041,7 @@ function frmAdminBuildJS() {
 				jQuery( this ).autocomplete( 'option', 'appendTo', $container );
 			}
 		})
-		.focus( function() {
+		.on( 'focus', function() {
 			// Show options on click to make it work more like a dropdown.
 			if ( this.value === '' || this.nextElementSibling.value < 1 ) {
 				jQuery( this ).autocomplete( 'search', this.value );
@@ -6598,7 +6598,7 @@ function frmAdminBuildJS() {
 			});
 
 			jQuery( '.frm_form_builder form' ).first().on( 'submit', function() {
-				jQuery( '.inplace_field' ).blur();
+				jQuery( '.inplace_field' ).trigger( 'blur' );
 			});
 
 			initiateMultiselect();
@@ -7043,7 +7043,7 @@ function frmAdminBuildJS() {
 					target.parent().addClass( 'tabs' );
 
 					// select the search bar
-					jQuery( '.quick-search', wrapper ).focus();
+					jQuery( '.quick-search', wrapper ).trigger( 'focus' );
 
 					e.preventDefault();
 				}


### PR DESCRIPTION
We had a support ticket come in asking about some left behind shorthand warnings from jQuery migrate. I don't think these would ever actually be removed from jQuery, but we might as well change everything to drop the deprecation warnings.

Similar to some of the earlier deprecation updates made in https://github.com/Strategy11/formidable-forms/pull/315