### PR TITLE
Maybe add wp site health before calling rest_do_request

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -586,7 +586,7 @@ class FrmAppController {
 		if ( ! class_exists( 'WP_Site_Health' ) ) {
 			$wp_site_health_path = ABSPATH . 'wp-admin/includes/class-wp-site-health.php';
 			if ( file_exists( $wp_site_health_path ) ) {
-				require_once ABSPATH . 'wp-admin/includes/class-wp-site-health.php';
+				require_once $wp_site_health_path;
 			}
 		}
 	}

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -562,6 +562,8 @@ class FrmAppController {
 		set_transient( 'frm_updating_api', true, MINUTE_IN_SECONDS );
 		$request = new WP_REST_Request( 'GET', '/frm-admin/v1/install' );
 
+		self::maybe_add_wp_site_health();
+
 		if ( $blog_id ) {
 			switch_to_blog( $blog_id );
 			$response = rest_do_request( $request );
@@ -573,6 +575,19 @@ class FrmAppController {
 		if ( $response->is_error() ) {
 			// if the remove post fails, use javascript instead
 			add_action( 'admin_notices', 'FrmAppController::install_js_fallback' );
+		}
+	}
+
+	/**
+	 * Make sure WP_Site_Health has been included because it is required when calling rest_do_request.
+	 * Check first that the file exists because WP_Site_Health was only introduced in WordPress 5.2.
+	 */
+	private static function maybe_add_wp_site_health() {
+		if ( ! class_exists( 'WP_Site_Health' ) ) {
+			$wp_site_health_path = ABSPATH . 'wp-admin/includes/class-wp-site-health.php';
+			if ( file_exists( $wp_site_health_path ) ) {
+				require_once ABSPATH . 'wp-admin/includes/class-wp-site-health.php';
+			}
 		}
 	}
 

--- a/tests/misc/test_FrmAppController.php
+++ b/tests/misc/test_FrmAppController.php
@@ -183,4 +183,12 @@ class test_FrmAppController extends FrmUnitTest {
 		$new_db = get_option( 'frm_db_version' );
 		$this->assertSame( $current_db, $new_db, 'The DB did not update correctly' );
 	}
+
+	/**
+	 * @covers FrmAppController::network_upgrade_site
+	 */
+	public function test_network_upgrade_site() {
+		FrmAppController::network_upgrade_site();
+		$this->addToAssertionCount( 1 );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2865

I don't really think there's anything you can actually test for with this function. It doesn't return anything. But having the test here catches any errors, so I just bumped the assertion count.

I see that `network_upgrade_site` is called from 3 different places, and it's not very clear which one is the issue here.

I see some of the calls wrapped in conditions like `if ( ! FrmAppHelper::doing_ajax() && self::needs_update() ) {`. Maybe we need to put more of these conditions into the function itself?
