### PR TITLE
do not fill frm_verify field when autofilling for free templates

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5806,7 +5806,7 @@ function frmAdminBuildJS() {
 			}
 
 			$hiddenForm = jQuery( '#frmapi-email-form' ).find( 'form' );
-			$hiddenEmailField = $hiddenForm.find( '[type="email"]' );
+			$hiddenEmailField = $hiddenForm.find( '[type="email"]' ).not( '.frm_verify' );
 			if ( ! $hiddenEmailField.length ) {
 				return;
 			}


### PR DESCRIPTION
This fixes the issue with the free templates form flagging emails as invalid.