### PR TITLE
validate message data before rendering it

### DIFF
--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -109,6 +109,11 @@ class FrmInbox extends FrmFormApi {
 		}
 
 		$this->fill_message( $message );
+
+		if ( ! $this->validate_message_data( $message ) ) {
+			return;
+		}
+
 		$this->messages[ $message['key'] ] = $message;
 
 		$this->update_list();

--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -49,16 +49,31 @@ class FrmInbox extends FrmFormApi {
 	 */
 	public function set_messages() {
 		$this->messages = get_option( $this->option );
-		if ( empty( $this->messages ) ) {
+		if ( ! empty( $this->messages ) ) {
+			foreach ( $this->messages as $key => $message ) {
+				if ( ! $this->validate_message_data( $message ) ) {
+					unset( $this->messages[ $key ] );
+				}
+			}
+		} else {
 			$this->messages = array();
 		}
-
 		$this->add_api_messages();
 
 		/**
 		 * Messages are in an array.
 		 */
 		$this->messages = apply_filters( 'frm_inbox', $this->messages );
+	}
+
+	/**
+	 * Check that message data is not missing required information.
+	 *
+	 * @param array $message
+	 * @return bool true if the messages contains the required keys to display a message properly.
+	 */
+	private function validate_message_data( $message ) {
+		return isset( $message['subject'] ) && isset( $message['message'] ) && isset( $message['cta'] ) && ! empty( $message['created'] );
 	}
 
 	/**

--- a/tests/misc/test_FrmInbox.php
+++ b/tests/misc/test_FrmInbox.php
@@ -1,0 +1,29 @@
+<?php
+
+class test_FrmInbox extends FrmUnitTest {
+
+	/**
+	 * @covers FrmInbox::validate_message_data
+	 */
+	public function test_validate_message_data() {
+		$valid_message = array(
+			'message' => 'This is a test message',
+			'subject' => 'Test message subject',
+			'icon'    => 'frm_report_problem_icon',
+			'cta'     => '',
+			'created' => time(),
+			'key'     => 'test_message',
+		);
+		$valid         = $this->validate_message_data( $valid_message );
+		$this->assertTrue( $valid );
+
+		$invalid_message = array();
+		$valid           = $this->validate_message_data( $invalid_message );
+		$this->assertFalse( $valid );
+	}
+
+	private function validate_message_data( $message ) {
+		$inbox = new FrmInbox();
+		return $this->run_private_method( array( $inbox, 'validate_message_data' ), array( $message ) );
+	}
+}


### PR DESCRIPTION
I'm working toward a solution for https://github.com/Strategy11/formidable-pro/issues/2879

This at least avoids all of the errors that happen when you load the inbox.