### PR TITLE
clean confirm message before appending text fix

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -386,6 +386,7 @@ function frmAdminBuildJS() {
 		caution = link.getAttribute( 'data-frmcaution' );
 		verify = link.getAttribute( 'data-frmverify' );
 		$confirmMessage = jQuery( '.frm-confirm-msg' );
+		$confirmMessage.empty();
 
 		if ( caution ) {
 			frmCaution = document.createElement( 'span' );


### PR DESCRIPTION
Nat just caught a bug from a recent update here - https://github.com/Strategy11/formidable-pro/issues/2878#issuecomment-779339042

The modal wasn't clearing, so the pop up could include old messages as well in it.

Best to slip this fix into the release as well 🚀 