### PR TITLE
add -label to single option label input id in order to make it unique

### DIFF
--- a/classes/views/frm-fields/single-option.php
+++ b/classes/views/frm-fields/single-option.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php FrmAppHelper::icon_by_class( 'frmfont frm_drag_icon frm-drag' ); ?>
 	<input type="<?php echo esc_attr( $default_type ); ?>" name="<?php echo esc_attr( $field_name ); ?>" <?php echo ( isset( $checked ) && $checked ? 'checked="checked"' : '' ); ?> value="<?php echo esc_attr( $field_val ); ?>"/>
 
-	<input type="text" name="field_options[options_<?php echo esc_attr( $field['id'] ); ?>][<?php echo esc_attr( $opt_key ); ?>][label]" value="<?php echo esc_attr( $opt ); ?>" class="field_<?php echo esc_attr( $field['id'] ); ?>_option <?php echo esc_attr( $field['separate_value'] ? 'frm_with_key' : '' ); ?>" id="<?php echo esc_attr( $html_id . '-' . $opt_key ); ?>" data-frmchange="trim,updateOption" />
+	<input type="text" name="field_options[options_<?php echo esc_attr( $field['id'] ); ?>][<?php echo esc_attr( $opt_key ); ?>][label]" value="<?php echo esc_attr( $opt ); ?>" class="field_<?php echo esc_attr( $field['id'] ); ?>_option <?php echo esc_attr( $field['separate_value'] ? 'frm_with_key' : '' ); ?>" id="<?php echo esc_attr( $html_id . '-' . $opt_key . '-label' ); ?>" data-frmchange="trim,updateOption" />
 
 	<a href="javascript:void(0)" class="frm_icon_font frm_remove_tag" data-fid="<?php echo esc_attr( $field['id'] ); ?>" data-removeid="frm_delete_field_<?php echo esc_attr( $field['id'] . '-' . $opt_key ); ?>_container" data-removemore="#frm_<?php echo esc_attr( $default_type . '_' . $field['id'] . '-' . $opt_key ); ?>" data-showlast="#frm_add_opt_<?php echo esc_attr( $field['id'] ); ?>"></a>
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2878

I mention in my comment there more about the conflict.

This field needs a unique id. Adding `-label` makes sense to me, as the input targets the label, but maybe that's misleading, since it's not actually a label either.

I don't believe this id for the input label is actually used anywhere in particular. If it was relying on id before, it likely wouldn't have worked since it wasn't unique anyway.