### PR TITLE
check if message is array before adding it fix

### DIFF
--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -76,9 +76,14 @@ class FrmInbox extends FrmFormApi {
 	}
 
 	/**
-	 * @param array $message
+	 * @param array|string $message
 	 */
 	public function add_message( $message ) {
+		if ( ! is_array( $message ) ) {
+			// if the API response is invalid, $message may not be an array.
+			return;
+		}
+
 		if ( isset( $this->messages[ $message['key'] ] ) && ! isset( $message['force'] ) ) {
 			// Don't replace messages unless required.
 			return;

--- a/tests/misc/test_FrmInbox.php
+++ b/tests/misc/test_FrmInbox.php
@@ -1,0 +1,33 @@
+<?php
+
+class test_FrmInbox extends FrmUnitTest {
+
+	private $inbox;
+
+	public function test_add_message() {
+		$this->inbox   = new FrmInbox();
+		$initial_count = $this->get_message_count();
+		$message       = array(
+			'key'     => 'sale-20201108',
+			'subject' => 'Want a Free 27-inch iMac?',
+			'message' => 'Do you write code? Edit videos? Create podcasts? Play online games? Want a free 27” iMac to do it? We want you to have one.',
+			'cta'     => 'Win a Free iMac',
+			'icon'    => 'frm_price_tags_icon',
+			'type'    => 'promo',
+		);
+		$this->inbox->add_message( $message );
+		$this->assert_message_count( $initial_count + 1, 'Message count should go up after a valid message is added.' );
+
+		$invalid_message = $message['message'];
+		$this->inbox->add_message( $invalid_message );
+		$this->assert_message_count( $initial_count + 1, 'Message count should not go up after an invalid message is added.' );
+	}
+
+	private function assert_message_count( $count, $message ) {
+		$this->assertEquals( $count, $this->get_message_count(), $message );
+	}
+
+	private function get_message_count() {
+		return count( $this->inbox->get_messages() );
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2873

I didn't realize we were initially given much of the original error from the ticket.

It's cut off, but the first error is `Illegal string offset 'key'`.

Which points out the obvious issue that `$message` was coming through as a string, not an array at all.

We already cleaned up after the fact, but this prevents the issue from happening in the first place.