### PR TITLE
generate a new field key if the length is over 100

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1559,7 +1559,7 @@ class FrmAppHelper {
 			$key = sanitize_key( $name );
 		}
 
-		if ( empty( $key ) ) {
+		if ( empty( $key ) || strlen( $key ) >= 100 ) {
 			$max_slug_value = pow( 36, $num_chars );
 			$min_slug_value = 37; // we want to have at least 2 characters in the slug
 			$key            = base_convert( rand( $min_slug_value, $max_slug_value ), 10, 36 );
@@ -1575,7 +1575,7 @@ class FrmAppHelper {
 			'evenodd',
 		);
 
-		if ( is_numeric( $key ) || in_array( $key, $not_allowed ) ) {
+		if ( is_numeric( $key ) || in_array( $key, $not_allowed, true ) ) {
 			$key = $key . 'a';
 		}
 

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1555,18 +1555,14 @@ class FrmAppHelper {
 	public static function get_unique_key( $name, $table_name, $column, $id = 0, $num_chars = 5 ) {
 		$key = '';
 
-		if ( ! empty( $name ) ) {
+		if ( $name ) {
 			$key = sanitize_key( $name );
 		}
 
-		if ( 'field_key' === $column && strlen( $key ) >= 100 ) {
-			$key = '';
-		}
+		$key = self::maybe_clear_long_key( $key, $column );
 
-		if ( empty( $key ) ) {
-			$max_slug_value = pow( 36, $num_chars );
-			$min_slug_value = 37; // we want to have at least 2 characters in the slug
-			$key            = base_convert( rand( $min_slug_value, $max_slug_value ), 10, 36 );
+		if ( ! $key ) {
+			$key = self::generate_new_key( $num_chars );
 		}
 
 		$not_allowed = array(
@@ -1598,6 +1594,30 @@ class FrmAppHelper {
 		}
 
 		return $key;
+	}
+
+	/**
+	 * Possibly reset a key to avoid conflicts with column size limits.
+	 *
+	 * @param string $key
+	 * @param string $column
+	 * @return string either the original key value, or an empty string if the key was too long.
+	 */
+	private static function maybe_clear_long_key( $key, $column ) {
+		if ( 'field_key' === $column && strlen( $key ) >= 70 ) {
+			$key = '';
+		}
+		return $key;
+	}
+
+	/**
+	 * @param int $num_chars
+	 * @return string
+	 */
+	private static function generate_new_key( $num_chars ) {
+		$max_slug_value = pow( 36, $num_chars );
+		$min_slug_value = 37; // we want to have at least 2 characters in the slug
+		return base_convert( rand( $min_slug_value, $max_slug_value ), 10, 36 );
 	}
 
 	/**

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1559,7 +1559,11 @@ class FrmAppHelper {
 			$key = sanitize_key( $name );
 		}
 
-		if ( empty( $key ) || strlen( $key ) >= 100 ) {
+		if ( 'field_key' === $column && strlen( $key ) >= 100 ) {
+			$key = '';
+		}
+
+		if ( empty( $key ) ) {
 			$max_slug_value = pow( 36, $num_chars );
 			$min_slug_value = 37; // we want to have at least 2 characters in the slug
 			$key            = base_convert( rand( $min_slug_value, $max_slug_value ), 10, 36 );

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1554,30 +1554,16 @@ class FrmAppHelper {
 	 */
 	public static function get_unique_key( $name, $table_name, $column, $id = 0, $num_chars = 5 ) {
 		$key = '';
-
 		if ( $name ) {
 			$key = sanitize_key( $name );
+			$key = self::maybe_clear_long_key( $key, $column );
 		}
-
-		$key = self::maybe_clear_long_key( $key, $column );
 
 		if ( ! $key ) {
 			$key = self::generate_new_key( $num_chars );
 		}
 
-		$not_allowed = array(
-			'id',
-			'key',
-			'created-at',
-			'detaillink',
-			'editlink',
-			'siteurl',
-			'evenodd',
-		);
-
-		if ( is_numeric( $key ) || in_array( $key, $not_allowed, true ) ) {
-			$key = $key . 'a';
-		}
+		$key = self::prevent_numeric_and_reserved_keys( $key );
 
 		$key_check = FrmDb::get_var(
 			$table_name,
@@ -1618,6 +1604,30 @@ class FrmAppHelper {
 		$max_slug_value = pow( 36, $num_chars );
 		$min_slug_value = 37; // we want to have at least 2 characters in the slug
 		return base_convert( rand( $min_slug_value, $max_slug_value ), 10, 36 );
+	}
+
+	/**
+	 * @param string $key
+	 * @return string
+	 */
+	private static function prevent_numeric_and_reserved_keys( $key ) {
+		if ( is_numeric( $key ) ) {
+			$key .= 'a';
+		} else {
+			$not_allowed = array(
+				'id',
+				'key',
+				'created-at',
+				'detaillink',
+				'editlink',
+				'siteurl',
+				'evenodd',
+			);
+			if ( in_array( $key, $not_allowed, true ) ) {
+				$key .= 'a';
+			}
+		}
+		return $key;
 	}
 
 	/**

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -436,6 +436,9 @@ class test_FrmAppHelper extends FrmUnitTest {
 		$this->assertTrue( strpos( $output, $substring ) === false, $message );
 	}
 
+	/**
+	 * @covers FrmAppHelper::get_unique_key
+	 */
 	public function test_get_unique_key() {
 		global $wpdb;
 		$table_name = $wpdb->prefix . 'frm_fields';

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -451,5 +451,9 @@ class test_FrmAppHelper extends FrmUnitTest {
 		$name = 'key';
 		$key  = FrmAppHelper::get_unique_key( $name, $table_name, $column );
 		$this->assertTrue( 'key' !== $key, 'key is a reserved key so get_unique_key should never return it.' );
+
+		$name = 123;
+		$key  = FrmAppHelper::get_unique_key( $name, $table_name, $column );
+		$this->assertFalse( is_numeric( $key ), 'key should never be numeric.' );
 	}
 }

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -435,4 +435,18 @@ class test_FrmAppHelper extends FrmUnitTest {
 	private function assert_output_not_contains( $output, $substring, $message = '' ) {
 		$this->assertTrue( strpos( $output, $substring ) === false, $message );
 	}
+
+	public function test_get_unique_key() {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'frm_fields';
+		$column     = 'field_key';
+
+		$name = 'lrk2p3994ed7b17086290a2b7c3ca5e65c944451f9c2d457602cae34661ec7f32998cc21b037a67695662e4b9fb7e177a5b28a6c0f';
+		$key  = FrmAppHelper::get_unique_key( $name, $table_name, $column );
+		$this->assertTrue( strlen( $key ) < 100, 'field key length should never be over 100' );
+
+		$name = 'key';
+		$key  = FrmAppHelper::get_unique_key( $name, $table_name, $column );
+		$this->assertTrue( 'key' !== $key, 'key is a reserved key so get_unique_key should never return it.' );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2855 and I believe it fixes https://github.com/Strategy11/formidable-pro/issues/2741 as well.

You can't duplicate a field if the key is over 100 characters because we have a size limit in our database. If the key is over 100 characters in length, I treat it like it's empty and generate a new one from scratch.

I check specifically for the `$field_key` column value as I realize this might not be limited to 100 for other columns.

The other update is just to remove a phpcs warning.