### PR TITLE
change deprecated jquery keyup trigger event

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ on:
 name: PHPUnit
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     strategy:
       matrix:
         include:

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6558,7 +6558,7 @@ function frmAdminBuildJS() {
 			jQuery( document ).on( 'focusin click', '.frm-auto-search', stopPropagation );
 			var autoSearch = jQuery( '.frm-auto-search' );
 			if ( autoSearch.val() !== '' ) {
-				autoSearch.keyup();
+				autoSearch.trigger( 'keyup' );
 			}
 
 			// Initialize Formidable Connection.


### PR DESCRIPTION
Noticed another jQuery deprecation warning coming from formidable.

`jQuery.fn.keyup() event shorthand is deprecated`

Also, using `ubuntu-latest` has finally caught up with formidable lite as well and no longer works for several versions of PHP we're testing so I'm forcing ubuntu 16.04 for now because it works with all of our tests.