### PR TITLE
Confirm before leaving a page with unsaved changes when a form action is added or removed

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3940,6 +3940,8 @@ function frmAdminBuildJS() {
 				nonce: frmGlobal.nonce
 			},
 			success: function( html ) {
+				fieldUpdated();
+
 				// Close any open actions first.
 				jQuery( '.frm_form_action_settings.open' ).removeClass( 'open' );
 
@@ -5160,7 +5162,6 @@ function frmAdminBuildJS() {
 				success: function( msg ) {
 					jQuery( '.frm_uninstall' ).fadeOut( 'slow' );
 					window.location = msg;
-					fieldsUpdated = 1;
 				}
 			});
 		}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -628,6 +628,7 @@ function frmAdminBuildJS() {
 		var $fadeEle = jQuery( document.getElementById( id ) );
 		$fadeEle.fadeOut( 400, function() {
 			$fadeEle.remove();
+			fieldUpdated();
 
 			if ( hide !== '' ) {
 				jQuery( hide ).hide();
@@ -5159,6 +5160,7 @@ function frmAdminBuildJS() {
 				success: function( msg ) {
 					jQuery( '.frm_uninstall' ).fadeOut( 'slow' );
 					window.location = msg;
+					fieldsUpdated = 1;
 				}
 			});
 		}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2907

I usually just check for changed fields, but that doesn't work to detect new or deleted actions.

I also noticed in my testing that the same issue applied to creating the action (add an action, leave the page, no warning).