### PR TITLE
fix product price input width

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5876,7 +5876,7 @@ tr.frm_options_heading td {
 	float: left;
 }
 
-#new_fields .frm_product_price_wrapper input:last-child {
+#new_fields .frm_product_price_wrapper input:nth-child(2) {
 	width: 37%;
 	float: right;
 }


### PR DESCRIPTION
I noticed this was weird for a while, but never really knew when the issue was introduced.

The issue with the `:last-child` selector is because I introduced a hidden `optionmap` input on text focus in v4.08 (https://github.com/Strategy11/formidable-forms/commit/a35ac7848d9d6ee47c1c41efa8e19d52ae27abdc) for updating radio option conditional logic. This seems to somewhat apply to products as well, although I also noticed this small issue - https://github.com/Strategy11/formidable-pro/issues/2909

**Before**
![Screen Shot 2021-03-04 at 4 15 52 PM](https://user-images.githubusercontent.com/9134515/110024800-ecbbbd80-7d04-11eb-948b-1eff1fb3b3f9.png)

**After**
![Screen Shot 2021-03-04 at 4 15 37 PM](https://user-images.githubusercontent.com/9134515/110024814-f1807180-7d04-11eb-9949-9bb97352884b.png)