### PR TITLE
make sure the style editor update button is not hidden (css fix)

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8007,3 +8007,7 @@ Responsive Design
 		width: 100%;
 	}
 }
+
+.frm-admin-page-styles #frm-publishing #save_menu_header {
+	display: inline-block;
+}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2914

It looks like WordPress 5.7 adds a new css rule in `wp-admin/css/nav-menus.css`:

```
#save_menu_header {
    display: none;
}
```

Our update button on the views page has this id so it disappeared.

I'm just applying a style on top to undo this on our button.