### PR TITLE
allow 0 as a placeholder value

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -588,7 +588,7 @@ class FrmFieldsController {
 		$is_combo_field       = in_array( $field['type'], array( 'address', 'credit_card' ) );
 
 		$placeholder = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
-		if ( empty( $placeholder ) && $is_placeholder_field && ! $is_combo_field ) {
+		if ( empty( $placeholder ) && '0' !== $placeholder && $is_placeholder_field && ! $is_combo_field ) {
 			$placeholder = self::get_default_value_from_name( $field );
 		}
 

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -583,12 +583,17 @@ class FrmFieldsController {
 		}
 	}
 
+	/**
+	 * @param array $field
+	 * @return string
+	 */
 	private static function prepare_placeholder( $field ) {
+		$placeholder          = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
+		$placeholder_is_blank = empty( $placeholder ) && '0' !== $placeholder;
 		$is_placeholder_field = FrmFieldsHelper::is_placeholder_field_type( $field['type'] );
-		$is_combo_field       = in_array( $field['type'], array( 'address', 'credit_card' ) );
+		$is_combo_field       = in_array( $field['type'], array( 'address', 'credit_card' ), true );
 
-		$placeholder = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
-		if ( empty( $placeholder ) && '0' !== $placeholder && $is_placeholder_field && ! $is_combo_field ) {
+		if ( $placeholder_is_blank && $is_placeholder_field && ! $is_combo_field ) {
 			$placeholder = self::get_default_value_from_name( $field );
 		}
 

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -392,9 +392,11 @@ class FrmFieldsHelper {
 	 * Check if this field type allows placeholders
 	 *
 	 * @since 2.05
+	 * @param string $type
+	 * @return bool
 	 */
 	public static function is_placeholder_field_type( $type ) {
-		return ! in_array( $type, array( 'radio', 'checkbox', 'hidden', 'file' ) );
+		return ! in_array( $type, array( 'radio', 'checkbox', 'hidden', 'file' ), true );
 	}
 
 	public static function get_checkbox_id( $field, $opt_key, $type = 'checkbox' ) {

--- a/tests/fields/test_FrmFieldsController.php
+++ b/tests/fields/test_FrmFieldsController.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @group fields
+ */
+class test_FrmFieldsController extends FrmUnitTest {
+
+	/**
+	 * @covers FrmFieldsController::prepare_placeholder
+	 */
+	public function test_prepare_placeholder() {
+		$name        = 'Number';
+		$field       = array(
+			'type'        => 'number',
+			'placeholder' => '',
+			'label'       => 'inside',
+			'name'        => $name,
+			'required'    => 0,
+		);
+		$placeholder = $this->prepare_placeholder( $field );
+		$this->assertEquals( $name, $placeholder, 'an empty string should be replaced by the label inside of an input.' );
+
+		$field['placeholder'] = '0';
+		$placeholder          = $this->prepare_placeholder( $field );
+		$this->assertEquals( '0', $placeholder, '0 is a valid placeholder value.' );
+
+		$field['placeholder'] = '';
+		$field['type']        = 'hidden';
+		$placeholder          = $this->prepare_placeholder( $field );
+		$this->assertEquals( '', $placeholder, 'some types of fields are not "is_placeholder_field_type" and should be left empty.' );
+	}
+
+	private function prepare_placeholder( $field ) {
+		return $this->run_private_method( array( 'FrmFieldsController', 'prepare_placeholder' ), array( $field ) );
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2916

To replicate, add a number field, set 0 as the placeholder (not the default value, the placeholder).

When you preview the form, the 0 does not appear without this fix.