### PR TITLE
check the actual value that would be saved to the database when checking for duplicates

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -583,12 +583,17 @@ class FrmFieldsController {
 		}
 	}
 
+	/**
+	 * @param array $field
+	 * @return string
+	 */
 	private static function prepare_placeholder( $field ) {
+		$placeholder          = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
+		$placeholder_is_blank = empty( $placeholder ) && '0' !== $placeholder;
 		$is_placeholder_field = FrmFieldsHelper::is_placeholder_field_type( $field['type'] );
-		$is_combo_field       = in_array( $field['type'], array( 'address', 'credit_card' ) );
+		$is_combo_field       = in_array( $field['type'], array( 'address', 'credit_card' ), true );
 
-		$placeholder = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
-		if ( empty( $placeholder ) && $is_placeholder_field && ! $is_combo_field ) {
+		if ( $placeholder_is_blank && $is_placeholder_field && ! $is_combo_field ) {
 			$placeholder = self::get_default_value_from_name( $field );
 		}
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1931,7 +1931,9 @@ class FrmFormsController {
 		$description = $args['description'];
 
 		if ( empty( $args['fields'] ) ) {
-			$values = array();
+			$values = array(
+				'custom_style' => FrmAppHelper::custom_style_value( array() ),
+			);
 		} else {
 			$values = FrmEntriesHelper::setup_new_vars( $args['fields'], $form, $args['reset'] );
 		}
@@ -1947,7 +1949,7 @@ class FrmFormsController {
 
 		$message_placement = self::message_placement( $form, $message );
 
-		include( FrmAppHelper::plugin_path() . '/classes/views/frm-entries/new.php' );
+		include FrmAppHelper::plugin_path() . '/classes/views/frm-entries/new.php';
 	}
 
 	/**

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -48,10 +48,8 @@ class FrmEntriesHelper {
 			$values = array_merge( $values, $form->options );
 		}
 
-		$form_defaults = FrmFormsHelper::get_default_opts();
-		$frm_settings  = FrmAppHelper::get_settings();
-
-		$form_defaults['custom_style'] = ( $frm_settings->load_style != 'none' );
+		$form_defaults                 = FrmFormsHelper::get_default_opts();
+		$form_defaults['custom_style'] = FrmAppHelper::custom_style_value( array() );
 
 		$values = array_merge( $form_defaults, $values );
 

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -392,9 +392,11 @@ class FrmFieldsHelper {
 	 * Check if this field type allows placeholders
 	 *
 	 * @since 2.05
+	 * @param string $type
+	 * @return bool
 	 */
 	public static function is_placeholder_field_type( $type ) {
-		return ! in_array( $type, array( 'radio', 'checkbox', 'hidden', 'file' ) );
+		return ! in_array( $type, array( 'radio', 'checkbox', 'hidden', 'file' ), true );
 	}
 
 	public static function get_checkbox_id( $field, $opt_key, $type = 'checkbox' ) {

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -79,9 +79,11 @@ class FrmEntry {
 				$field_metas[ $meta->field_id ] = $meta->meta_value;
 			}
 
-			// If prev entry is empty and current entry is not, they are not duplicates
 			$filtered_vals = array_filter( $values['item_meta'] );
+			$filtered_vals = self::convert_values_to_their_saved_value( $filtered_vals, $entry_exist );
 			$field_metas   = array_filter( $field_metas );
+
+			// If prev entry is empty and current entry is not, they are not duplicates
 			if ( empty( $field_metas ) && ! empty( $filtered_vals ) ) {
 				return false;
 			}
@@ -114,6 +116,26 @@ class FrmEntry {
 		}
 
 		return $is_duplicate;
+	}
+
+	/**
+	 * Convert form data to the actual value that would be saved into the database.
+	 * This is important for the duplicate check as something like 'a:2:{s:5:"typed";s:0:"";s:6:"output";s:0:"";}' (a signature value) is actually an empty string and does not get saved.
+	 *
+	 * @param array $filter_vals
+	 * @param int   $entry_id
+	 * @return array
+	 */
+	private static function convert_values_to_their_saved_value( $filter_vals, $entry_id ) {
+		$reduced = array();
+		foreach ( $filter_vals as $field_id => $value ) {
+			$field                = FrmFieldFactory::get_field_object( $field_id );
+			$reduced[ $field_id ] = $field->get_value_to_save( $value, array( 'entry_id' => $entry_id ) );
+			if ( '' === $reduced[ $field_id ] || ( is_array( $reduced[ $field_id ] ) && 0 === count( $reduced[ $field_id ] ) ) ) {
+				unset( $reduced[ $field_id ] );
+			}
+		}
+		return $reduced;
 	}
 
 	/**

--- a/tests/fields/test_FrmFieldsController.php
+++ b/tests/fields/test_FrmFieldsController.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @group fields
+ */
+class test_FrmFieldsController extends FrmUnitTest {
+
+	/**
+	 * @covers FrmFieldsController::prepare_placeholder
+	 */
+	public function test_prepare_placeholder() {
+		$name        = 'Number';
+		$field       = array(
+			'type'        => 'number',
+			'placeholder' => '',
+			'label'       => 'inside',
+			'name'        => $name,
+			'required'    => 0,
+		);
+		$placeholder = $this->prepare_placeholder( $field );
+		$this->assertEquals( $name, $placeholder, 'an empty string should be replaced by the label inside of an input.' );
+
+		$field['placeholder'] = '0';
+		$placeholder          = $this->prepare_placeholder( $field );
+		$this->assertEquals( '0', $placeholder, '0 is a valid placeholder value.' );
+
+		$field['placeholder'] = '';
+		$field['type']        = 'hidden';
+		$placeholder          = $this->prepare_placeholder( $field );
+		$this->assertEquals( '', $placeholder, 'some types of fields are not "is_placeholder_field_type" and should be left empty.' );
+	}
+
+	private function prepare_placeholder( $field ) {
+		return $this->run_private_method( array( 'FrmFieldsController', 'prepare_placeholder' ), array( $field ) );
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2872

The issue title is a little misleading. The hook works fine. This is really just an issue that signatures, and some other fields, don't get flagged as duplicates even when they are.

Two empty or identical signatures never get flagged as duplicated. Likely anything that might change its value afterward (files and tags appear to as well) as the comparison check is checking the before-values against after-values.

This just changes those before-values to after-values so we're not comparing two different things against each other.

An example before-value (serialized) `a:2:{s:5:"typed";s:0:"";s:6:"output";s:0:"";}`
Eventually becomes an empty string and never gets saved.