### PR TITLE
undefined key custom style when there are no fields fix

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1931,7 +1931,6 @@ class FrmFormsController {
 		$description = $args['description'];
 
 		if ( empty( $args['fields'] ) ) {
-			$frm_settings = FrmAppHelper::get_settings();
 			$values       = array(
 				'custom_style' => FrmAppHelper::custom_style_value( array() ),
 			);

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1931,7 +1931,10 @@ class FrmFormsController {
 		$description = $args['description'];
 
 		if ( empty( $args['fields'] ) ) {
-			$values = array();
+			$frm_settings = FrmAppHelper::get_settings();
+			$values       = array(
+				'custom_style' => FrmAppHelper::custom_style_value( array() ),
+			);
 		} else {
 			$values = FrmEntriesHelper::setup_new_vars( $args['fields'], $form, $args['reset'] );
 		}
@@ -1947,7 +1950,7 @@ class FrmFormsController {
 
 		$message_placement = self::message_placement( $form, $message );
 
-		include( FrmAppHelper::plugin_path() . '/classes/views/frm-entries/new.php' );
+		include FrmAppHelper::plugin_path() . '/classes/views/frm-entries/new.php';
 	}
 
 	/**

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1931,7 +1931,7 @@ class FrmFormsController {
 		$description = $args['description'];
 
 		if ( empty( $args['fields'] ) ) {
-			$values       = array(
+			$values = array(
 				'custom_style' => FrmAppHelper::custom_style_value( array() ),
 			);
 		} else {

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -48,9 +48,7 @@ class FrmEntriesHelper {
 			$values = array_merge( $values, $form->options );
 		}
 
-		$form_defaults = FrmFormsHelper::get_default_opts();
-		$frm_settings  = FrmAppHelper::get_settings();
-
+		$form_defaults                 = FrmFormsHelper::get_default_opts();
 		$form_defaults['custom_style'] = FrmAppHelper::custom_style_value( array() );
 
 		$values = array_merge( $form_defaults, $values );

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -51,7 +51,7 @@ class FrmEntriesHelper {
 		$form_defaults = FrmFormsHelper::get_default_opts();
 		$frm_settings  = FrmAppHelper::get_settings();
 
-		$form_defaults['custom_style'] = ( $frm_settings->load_style != 'none' );
+		$form_defaults['custom_style'] = FrmAppHelper::custom_style_value( array() );
 
 		$values = array_merge( $form_defaults, $values );
 


### PR DESCRIPTION
I noticed something in my error log when I tried to preview a form with no fields.

```
PHP Warning:  Undefined array key "custom_style" in /var/www/src/wp-content/plugins/formidable/classes/controllers/FrmFormsController.php on line 1946
```

I also refactored some other custom style code to make this more consistent across formidable. There was already a helper function in `FrmAppHelper` that had this same logic in it.