### PR TITLE
Make icons clickable in new form modal

### DIFF
--- a/classes/views/frm-forms/list-template.php
+++ b/classes/views/frm-forms/list-template.php
@@ -34,7 +34,7 @@ if ( ! empty( $template['custom'] ) ) {
 	<div class="frm-featured-form">
 		<?php
 		if ( $render_icon ) {
-			?><div class="frm-category-icon">
+			?><div class="frm-category-icon" role="button">
 				<?php FrmFormsHelper::template_icon( $template['categories'] ); ?>
 			</div><?php
 		}

--- a/classes/views/frm-forms/list-templates.php
+++ b/classes/views/frm-forms/list-templates.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <ul class="frm-templates-list frm-featured-forms">
 	<li class="frm-add-blank-form frm-selectable">
 		<div class="frm-featured-form">
-			<div class="frm-category-icon" style="background-color: #F4AD3D;">
+			<div class="frm-category-icon" role="button" style="background-color: #F4AD3D;">
 				<?php FrmAppHelper::icon_by_class( 'frmfont frm_plus_icon' ); ?>
 			</div><div>
 				<h3 role="button"><?php esc_html_e( 'Blank Form', 'formidable' ); ?></h3>
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 	?><li class="frm-selectable" data-href="<?php echo esc_url( admin_url( 'admin.php?page=formidable-import' ) ); ?>">
 		<div class="frm-featured-form">
-			<div class="frm-category-icon" style="background-color: #805EF6;">
+			<div class="frm-category-icon" role="button" style="background-color: #805EF6;">
 				<?php FrmAppHelper::icon_by_class( 'frmfont frm_upload_icon' ); ?>
 			</div><div>
 				<h3 role="button"><?php esc_html_e( 'Import', 'formidable' ); ?></h3>
@@ -51,7 +51,7 @@ FrmAppHelper::show_search_box(
 			?>
 			<li class="control-section accordion-section">
 				<div class="frm-featured-form">
-					<div class="frm-category-icon" style="background-color: #805EF6;">
+					<div class="frm-category-icon" role="button" style="background-color: #805EF6;">
 						<?php FrmFormsHelper::template_icon( array( $category ) ); ?>
 					</div><div>
 						<div role="button" class="accordion-section-title">

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5974,8 +5974,8 @@ function frmAdminBuildJS() {
 		document.getElementById( 'frm_template_name' ).value = name;
 		document.getElementById( 'frm_link' ).value = link;
 		document.getElementById( 'frm_action_type' ).value = action;
-		nameLabel.innerHTML = nameLabel.getAttribute( 'data-' + type );
-		descLabel.innerHTML = descLabel.getAttribute( 'data-' + type );
+		nameLabel.textContent = nameLabel.getAttribute( 'data-' + type );
+		descLabel.textContent = descLabel.getAttribute( 'data-' + type );
 
 		document.getElementById( 'frm-create-title' ).setAttribute( 'frm-type', type );
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5969,9 +5969,10 @@ function frmAdminBuildJS() {
 	function transitionToAddDetails( $modal, name, link, action ) {
 		var nameLabel = document.getElementById( 'frm_new_name' ),
 			descLabel = document.getElementById( 'frm_new_desc' ),
-			type = [ 'frm_install_template', 'frm_install_form' ].indexOf( action ) >= 0 ? 'form' : 'template';
+			type = [ 'frm_install_template', 'frm_install_form' ].indexOf( action ) >= 0 ? 'form' : 'template',
+			templateNameInput = document.getElementById( 'frm_template_name' );
 
-		document.getElementById( 'frm_template_name' ).value = name;
+		templateNameInput.value = name;
 		document.getElementById( 'frm_link' ).value = link;
 		document.getElementById( 'frm_action_type' ).value = action;
 		nameLabel.textContent = nameLabel.getAttribute( 'data-' + type );
@@ -5980,6 +5981,10 @@ function frmAdminBuildJS() {
 		document.getElementById( 'frm-create-title' ).setAttribute( 'frm-type', type );
 
 		$modal.attr( 'frm-page', 'details' );
+
+		if ( '' === name ) {
+			templateNameInput.focus();
+		}
 	}
 
 	function getStrippedTemplateName( $li ) {


### PR DESCRIPTION
I noticed in the new view modal that clicking the icons was not triggering the new form events because they were missing the `role="button"` code. Same applies to the new form modal, so I'm making an update here too.

I'm also auto-focusing the template name input if you're creating one with an empty name because I think there should be one. I've tried to type a name a few times and had to focus first. Just makes it easier.

And I'm changing a couple of label updates to use `textContent` since they come from data attributes and this could ultimately be manipulated a bit (though that would take a lot of hoops to jump through).