### PR TITLE
update readme for 4.10

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 == Changelog ==
+= 4.10 =
+* Fix: Some fields, including signatures, were not properly detecting duplicate entries.
+* Fix: Zeros were not appearing when used as a placeholder value.
+* Fix: Prevent a warning when previewing a form with no fields.
+
 = 4.09.08 =
 * New: If you add or remove an action from a form and try to leave the page without saving, there will be a warning.
 * Fix: The style editor save button was hidden in WordPress 5.7.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: forms, contact form, form builder, survey, form maker, form creator, paypa
 Requires at least: 4.7
 Tested up to: 5.7
 Requires PHP: 5.6
-Stable tag: 4.09.08
+Stable tag: 4.10
 
 The most advanced WordPress forms plugin. Go beyond contact forms with our drag & drop form builder for surveys, quizzes, and more.
 
@@ -435,6 +435,11 @@ Using our Zapier integration, you can easily connect Formidable with over 1000+ 
 See all <a href="https://zapier.com/apps/formidable/integrations">Formidable Zapier Integrations</a>.
 
 == Changelog ==
+= 4.10 =
+* Fix: Some fields, including signatures, were not properly detecting duplicate entries.
+* Fix: Zeros were not appearing when used as a placeholder value.
+* Fix: Prevent a warning when previewing a form with no fields.
+
 = 4.09.08 =
 * New: If you add or remove an action from a form and try to leave the page without saving, there will be a warning.
 * Fix: The style editor save button was hidden in WordPress 5.7.
@@ -465,9 +470,5 @@ See all <a href="https://zapier.com/apps/formidable/integrations">Formidable Zap
 * Fix: dropdown fields were cut off in the admin area in WordPress 5.6.
 * Fix: Update a few deprecated jQuery functions.
 * Fix: Prevent some duplicate database queries on the back end.
-
-= 4.09.02 =
-* Show a warning when leaving the settings page with unsaved changes.
-* Make the process for using free templates more clear.
 
 <a href="https://raw.githubusercontent.com/Strategy11/formidable-forms/master/changelog.txt">See changelog for all versions</a>


### PR DESCRIPTION
I plan to do a release tomorrow. I have everything in the free plugin already merged that I intend to include in this release.

Since there is a migration in pro, I'm bumping up to a new `4.10` version.