### PR TITLE
use unique ids when dragging a field to avoid replacement conflicts

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1170,7 +1170,6 @@ function frmAdminBuildJS() {
 			success: function( msg ) {
 				document.getElementById( 'frm_form_editor_container' ).classList.add( 'frm-has-fields' );
 				$newFields.append( msg );
-
 				afterAddField( msg, true );
 			},
 			error: function( jqXHR, textStatus, errorThrown ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -324,6 +324,7 @@ function frmAdminBuildJS() {
 		copyHelper = false,
 		fieldsUpdated = 0,
 		thisFormId = 0,
+		autoId = 0,
 		optionMap = {};
 
 	if ( thisForm !== null ) {
@@ -994,23 +995,25 @@ function frmAdminBuildJS() {
 	 * @param {object} opts
 	 */
 	function insertNewFieldByDragging( selectedItem, fieldButton ) {
-		var fieldType = fieldButton.attr( 'id' );
+		var fieldType, addBtn, currentItem, section, formId, sectionId, loadingID, hasBreak;
+
+		fieldType = fieldButton.attr( 'id' );
 
 		// We'll optimistically disable the button now. We'll re-enable if AJAX fails
 		if ( 'summary' === fieldType ) {
-			var addBtn = fieldButton.children( '.frm_add_field' );
+			addBtn = fieldButton.children( '.frm_add_field' );
 			disableSummaryBtnBeforeAJAX( addBtn, fieldButton );
 		}
 
-		var currentItem = jQuery( selectedItem ).data().uiSortable.currentItem;
-		var section = getSectionForFieldPlacement( currentItem );
-		var formId = getFormIdForFieldPlacement( section );
-		var sectionId = getSectionIdForFieldPlacement( section );
+		currentItem = jQuery( selectedItem ).data().uiSortable.currentItem;
+		section = getSectionForFieldPlacement( currentItem );
+		formId = getFormIdForFieldPlacement( section );
+		sectionId = getSectionIdForFieldPlacement( section );
 
-		var loadingID = fieldType.replace( '|', '-' );
+		loadingID = fieldType.replace( '|', '-' ) + '_' + getAutoId();
 		currentItem.replaceWith( '<li class="frm-wait frmbutton_loadingnow" id="' + loadingID + '" ></li>' );
 
-		var hasBreak = 0;
+		hasBreak = 0;
 		if ( 'summary' === fieldType ) {
 			// see if we need to insert a page break before this newly-added summary field. Check for at least 1 page break
 			hasBreak = jQuery( '.frmbutton_loadingnow#' + loadingID ).prevAll( 'li[data-type="break"]' ).length ? 1 : 0;
@@ -1037,6 +1040,17 @@ function frmAdminBuildJS() {
 				maybeReenableSummaryBtnAfterAJAX( fieldType, addBtn, fieldButton, errorThrown );
 			}
 		});
+	}
+
+	/**
+	 * Get a unique id that automatically increments with every function call.
+	 * Can be used for any UI that requires a unique id.
+	 * Not to be used in data.
+	 *
+	 * @returns {integer}
+	 */
+	function getAutoId() {
+		return ++autoId;
 	}
 
 	// don't allow page break, embed form, captcha, summary, or section inside section field
@@ -1156,6 +1170,7 @@ function frmAdminBuildJS() {
 			success: function( msg ) {
 				document.getElementById( 'frm_form_editor_container' ).classList.add( 'frm-has-fields' );
 				$newFields.append( msg );
+
 				afterAddField( msg, true );
 			},
 			error: function( jqXHR, textStatus, errorThrown ) {


### PR DESCRIPTION
I was trying to push the editor to its limits to see if anything would break, and something did 😱

It turns out, that if you drag the same type of field really fast (which can happen from just barely dragging it as well, if you were clicking and moving around your mouse a lot like I was), it will break when it replaces the temporary loading spinner because the two fields that are being dragged have the same id. The value of `loadingID` is just the field type: "select", or "text", etc.

```
Uncaught TypeError: field is null
    afterAddField http://localhost:8889/wp-content/plugins/formidable/js/formidable_admin.js?ver=4.10:1259
    success http://localhost:8889/wp-content/plugins/formidable/js/formidable_admin.js?ver=4.10:1034
    jQuery 4
```

To fix this, I'm adding a function that just returns an id it didn't return before, to make sure that the value of `loadingID` is always unique.

I also bumped all of the variable declarations for this function to the top while I was at it, to remove a few of our linting warnings.

I also tested this in Chrome and there is a different error,

![Screen Shot 2021-03-26 at 1 40 33 PM](https://user-images.githubusercontent.com/9134515/112665178-8a546980-8e39-11eb-9849-828e42199065.png)