### PR TITLE
do not display upgrade modal if option is not disabled

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1725,14 +1725,15 @@ class FrmFieldsHelper {
 		$field_label .= ' <span>' . $field_name . '</span>';
 
 		// If the individual field isn't allowed, disable it.
-		$run_filter      = true;
-		$single_no_allow = ' ';
-		$install_data    = '';
-		$requires        = '';
-		$link            = isset( $field_type['link'] ) ? esc_url_raw( $field_type['link'] ) : '';
-		$show_upgrade    = strpos( $field_type['icon'], ' frm_show_upgrade' );
+		$run_filter             = true;
+		$single_no_allow        = ' ';
+		$install_data           = '';
+		$requires               = '';
+		$link                   = isset( $field_type['link'] ) ? esc_url_raw( $field_type['link'] ) : '';
+		$has_show_upgrade_class = strpos( $field_type['icon'], ' frm_show_upgrade' );
+		$show_upgrade           = ! FrmAppHelper::pro_is_installed() || $has_show_upgrade_class;
 
-		if ( $show_upgrade ) {
+		if ( $has_show_upgrade_class ) {
 			$single_no_allow   .= 'frm_show_upgrade';
 			$field_type['icon'] = str_replace( ' frm_show_upgrade', '', $field_type['icon'] );
 			$run_filter         = false;

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1715,25 +1715,24 @@ class FrmFieldsHelper {
 
 	/**
 	 * @since 4.04
+	 * @param array $args
 	 */
 	public static function show_add_field_buttons( $args ) {
-		$field_key      = $args['field_key'];
-		$field_type     = $args['field_type'];
-		$field_label    = FrmAppHelper::icon_by_class( FrmFormsHelper::get_field_link_icon( $field_type ), array( 'echo' => false ) );
-		$field_name     = FrmFormsHelper::get_field_link_name( $field_type );
-		$field_label   .= ' <span>' . $field_name . '</span>';
-
-		/* translators: %s: Field name */
-		$upgrade_label = sprintf( esc_html__( '%s fields', 'formidable' ), $field_name );
+		$field_key    = $args['field_key'];
+		$field_type   = $args['field_type'];
+		$field_label  = FrmAppHelper::icon_by_class( FrmFormsHelper::get_field_link_icon( $field_type ), array( 'echo' => false ) );
+		$field_name   = FrmFormsHelper::get_field_link_name( $field_type );
+		$field_label .= ' <span>' . $field_name . '</span>';
 
 		// If the individual field isn't allowed, disable it.
 		$run_filter      = true;
 		$single_no_allow = ' ';
 		$install_data    = '';
 		$requires        = '';
-		$upgrade_message = '';
 		$link            = isset( $field_type['link'] ) ? esc_url_raw( $field_type['link'] ) : '';
-		if ( strpos( $field_type['icon'], ' frm_show_upgrade' ) ) {
+		$show_upgrade    = strpos( $field_type['icon'], ' frm_show_upgrade' );
+
+		if ( $show_upgrade ) {
 			$single_no_allow   .= 'frm_show_upgrade';
 			$field_type['icon'] = str_replace( ' frm_show_upgrade', '', $field_type['icon'] );
 			$run_filter         = false;
@@ -1748,8 +1747,15 @@ class FrmFieldsHelper {
 			}
 		}
 
-		if ( isset( $field_type['message'] ) ) {
-			$upgrade_message = FrmAppHelper::kses( $field_type['message'], array( 'a', 'img' ) );
+		$upgrade_label   = '';
+		$upgrade_message = '';
+		if ( $show_upgrade ) {
+			/* translators: %s: Field name */
+			$upgrade_label = sprintf( esc_html__( '%s fields', 'formidable' ), $field_name );
+
+			if ( isset( $field_type['message'] ) ) {
+				$upgrade_message = FrmAppHelper::kses( $field_type['message'], array( 'a', 'img' ) );
+			}
 		}
 
 		?>

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1731,7 +1731,7 @@ class FrmFieldsHelper {
 		$requires               = '';
 		$link                   = isset( $field_type['link'] ) ? esc_url_raw( $field_type['link'] ) : '';
 		$has_show_upgrade_class = strpos( $field_type['icon'], ' frm_show_upgrade' );
-		$show_upgrade           = ! FrmAppHelper::pro_is_installed() || $has_show_upgrade_class;
+		$show_upgrade           = $has_show_upgrade_class || false !== strpos( $args['no_allow_class'], 'frm_show_upgrade' );
 
 		if ( $has_show_upgrade_class ) {
 			$single_no_allow   .= 'frm_show_upgrade';

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3745,11 +3745,20 @@ function frmAdminBuildJS() {
 		}
 
 		jQuery( document ).on( 'click', '[data-upgrade]', function( event ) {
+			var upgradeLabel, requires, button, link, content;
+
 			event.preventDefault();
+			upgradeLabel = this.getAttribute( 'data-upgrade' );
+
+			if ( '' === upgradeLabel ) {
+				// if the upgrade level is empty, it's because this upgrade is already active.
+				return;
+			}
+
 			jQuery( '#frm_upgrade_modal .frm_lock_icon' ).removeClass( 'frm_lock_open_icon' );
 			jQuery( '#frm_upgrade_modal .frm_lock_icon use' ).attr( 'xlink:href', '#frm_lock_icon' );
 
-			var requires = this.getAttribute( 'data-requires' );
+			requires = this.getAttribute( 'data-requires' );
 			if ( typeof requires === 'undefined' || requires === null || requires === '' ) {
 				requires = 'Pro';
 			}
@@ -3758,15 +3767,15 @@ function frmAdminBuildJS() {
 			// If one click upgrade, hide other content
 			addOneClickModal( this );
 
-			jQuery( '.frm_feature_label' ).text( this.getAttribute( 'data-upgrade' ) );
+			jQuery( '.frm_feature_label' ).text( upgradeLabel );
 			jQuery( '#frm_upgrade_modal h2' ).show();
 
 			$info.dialog( 'open' );
 
 			// set the utm medium
-			var button = $info.find( '.button-primary:not(#frm-oneclick-button)' );
-			var link = button.attr( 'href' ).replace( /(medium=)[a-z_-]+/ig, '$1' + this.getAttribute( 'data-medium' ) );
-			var content = this.getAttribute( 'data-content' );
+			button = $info.find( '.button-primary:not(#frm-oneclick-button)' );
+			link = button.attr( 'href' ).replace( /(medium=)[a-z_-]+/ig, '$1' + this.getAttribute( 'data-medium' ) );
+			content = this.getAttribute( 'data-content' );
 			if ( content === undefined ) {
 				content = '';
 			}


### PR DESCRIPTION
Another thing I noticed when trying to push the form editor, is that you can actually trigger the upgrade modals for fields that are not locked, by clicking in the corners where the `[data-upgrade]` listener is happening, where the inner `.frm_add_field` is not touching because of its border radius.

![Screen Shot 2021-03-25 at 5 13 15 PM](https://user-images.githubusercontent.com/9134515/112645271-127c4400-8e25-11eb-882a-5772f2b6ddfb.png)

To fix this, I'm checking the value of `show_upgrade` now, and actually avoiding some of the upgrade message logic and page HTML, hopefully improving performance a bit in the process for people who are on pro.

And I also refactored the JavaScript a bit, moving any variable declarations to the top of the function. And aligned some spaces in PHP.