### PR TITLE
Preparation for issue 61 of pro version

### DIFF
--- a/classes/controllers/FrmSettingsController.php
+++ b/classes/controllers/FrmSettingsController.php
@@ -318,10 +318,11 @@ class FrmSettingsController {
 		global $wpdb;
 
 		$term = FrmAppHelper::get_param( 'term', '', 'get', 'sanitize_text_field' );
+		$post_type = FrmAppHelper::get_param( 'post_type', 'page', 'get', 'sanitize_text_field' );
 
 		$where = array(
 			'post_status'     => 'publish',
-			'post_type'       => 'page',
+			'post_type'       => $post_type,
 			'post_title LIKE' => $term,
 		);
 

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1014,9 +1014,17 @@ class FrmAppHelper {
 		return ( true === $value || 1 == $value || 'true' == $value || 'yes' == $value );
 	}
 
-	public static function get_pages() {
+	/**
+	 * Gets all post from a specific post type.
+	 *
+	 * @since 4.10.01 Add `$post_type` argument.
+	 *
+	 * @param string $post_type Post type to query. Default is `page`.
+	 * @return WP_Post[]
+	 */
+	public static function get_pages( $post_type = 'page' ) {
 		$query = array(
-			'post_type'   => 'page',
+			'post_type'   => $post_type,
 			'post_status' => array( 'publish', 'private' ),
 			'numberposts' => - 1,
 			'orderby'     => 'title',
@@ -1031,11 +1039,14 @@ class FrmAppHelper {
 	 * the total page count
 	 *
 	 * @since 4.03.06
+	 * @since 4.10.01 Added `post_type` and `autocomplete_placeholder` to the arguments array.
+	 *
+	 * @param array $args Selection arguments.
 	 */
 	public static function maybe_autocomplete_pages_options( $args ) {
 		$args = self::preformat_selection_args( $args );
 
-		$pages_count = wp_count_posts( 'page' );
+		$pages_count = wp_count_posts( $args['post_type'] );
 
 		if ( $pages_count->publish <= 50 ) {
 			self::wp_pages_dropdown( $args );
@@ -1053,7 +1064,8 @@ class FrmAppHelper {
 
 		?>
 		<input type="text" class="frm-page-search"
-			placeholder="<?php esc_html_e( 'Select a Page', 'formidable' ); ?>"
+			data-post-type="<?php echo esc_attr( $args['post_type'] ); ?>"
+			placeholder="<?php echo esc_html( $args['autocomplete_placeholder'] ); ?>"
 			value="<?php echo esc_attr( $title ); ?>" />
 		<input type="hidden" name="<?php echo esc_attr( $args['field_name'] ); ?>"
 			value="<?php echo esc_attr( $selected ); ?>" />
@@ -1068,7 +1080,7 @@ class FrmAppHelper {
 	public static function wp_pages_dropdown( $args = array(), $page_id = '', $truncate = false ) {
 		self::prep_page_dropdown_params( $page_id, $truncate, $args );
 
-		$pages    = self::get_pages();
+		$pages    = self::get_pages( $args['post_type'] );
 		$selected = self::get_post_param( $args['field_name'], $args['page_id'], 'absint' );
 
 		?>
@@ -1105,6 +1117,7 @@ class FrmAppHelper {
 	 * Filter to format args for page dropdown or autocomplete
 	 *
 	 * @since 4.03.06
+	 * @since 4.10.01 Added `post_type` and `autocomplete_placeholder` to the arguments array.
 	 */
 	private static function preformat_selection_args( $args ) {
 		$defaults = array(
@@ -1112,6 +1125,8 @@ class FrmAppHelper {
 			'placeholder' => ' ',
 			'field_name'  => '',
 			'page_id'     => '',
+			'post_type'   => 'page',
+			'autocomplete_placeholder' => __( 'Select a Page', 'formidable' ),
 		);
 
 		return array_merge( $defaults, $args );

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1068,6 +1068,7 @@ class FrmAppHelper {
 			placeholder="<?php echo esc_html( $args['autocomplete_placeholder'] ); ?>"
 			value="<?php echo esc_attr( $title ); ?>" />
 		<input type="hidden" name="<?php echo esc_attr( $args['field_name'] ); ?>"
+			class="frm_autocomplete_value_input"
 			value="<?php echo esc_attr( $selected ); ?>" />
 		<?php
 	}

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1065,7 +1065,7 @@ class FrmAppHelper {
 		?>
 		<input type="text" class="frm-page-search"
 			data-post-type="<?php echo esc_attr( $args['post_type'] ); ?>"
-			placeholder="<?php echo esc_html( $args['autocomplete_placeholder'] ); ?>"
+			placeholder="<?php echo esc_attr( $args['autocomplete_placeholder'] ); ?>"
 			value="<?php echo esc_attr( $title ); ?>" />
 		<input type="hidden" name="<?php echo esc_attr( $args['field_name'] ); ?>"
 			class="frm_autocomplete_value_input"

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -1317,6 +1317,7 @@ class FrmXMLHelper {
 			'post_status',
 			'post_custom_fields',
 			'post_password',
+			'post_parent',
 		);
 
 		foreach ( $post_settings as $post_setting ) {
@@ -1337,6 +1338,7 @@ class FrmXMLHelper {
 				'post_password',
 				'post_date',
 				'post_status',
+				'post_parent',
 			);
 
 			// Fields with arrays saved.

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -702,6 +702,7 @@ function frmAdminBuildJS() {
 						inside.html( html );
 						initiateMultiselect();
 						showInputIcon( '#' + cont.attr( 'id' ) );
+						initAutocomplete( 'page', inside );
 						jQuery( b ).trigger( 'frm-action-loaded' );
 					}
 				});
@@ -4289,6 +4290,7 @@ function frmAdminBuildJS() {
 		// update all rows of categories/taxonomies
 		var curSelect, newSelect,
 			catRows = document.getElementById( 'frm_posttax_rows' ).childNodes,
+			postParentField = document.querySelector( '.frm_post_parent_field' ),
 			postType = this.value;
 
 		// Get new category/taxonomy options
@@ -4323,6 +4325,40 @@ function frmAdminBuildJS() {
 				}
 			}
 		});
+
+		// Get new post parent option.
+		if ( postParentField ) {
+			const postParentOpt     = postParentField.querySelector( '.frm_autocomplete_value_input' ) || postParentField.querySelector( 'select' );
+			const postParentOptName = postParentOpt.getAttribute( 'name' );
+
+			jQuery.ajax( {
+				url: ajaxurl,
+				method: 'POST',
+				data: {
+					action: 'frm_get_post_parent_option',
+					post_type: postType,
+					_wpnonce: frmGlobal.nonce
+				},
+				success: response => {
+					if ( 'string' !== typeof response ) {
+						console.error( response );
+						return;
+					}
+
+					// Post type is not hierarchical.
+					if ( '0' === response ) {
+						postParentField.classList.add( 'frm_hidden' );
+						postParentOpt.value = '';
+						return;
+					}
+
+					postParentField.classList.remove( 'frm_hidden' );
+					postParentField.querySelector( '.frm_post_parent_opt_wrapper' ).innerHTML = response.replaceAll( 'REPLACETHISNAME', postParentOptName );
+					initAutocomplete( 'page', postParentField );
+				},
+				error: response => console.error( response )
+			});
+		}
 	}
 
 	function addPosttaxRow() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4331,7 +4331,7 @@ function frmAdminBuildJS() {
 			const postParentOpt     = postParentField.querySelector( '.frm_autocomplete_value_input' ) || postParentField.querySelector( 'select' );
 			const postParentOptName = postParentOpt.getAttribute( 'name' );
 
-			jQuery.ajax( {
+			jQuery.ajax({
 				url: ajaxurl,
 				method: 'POST',
 				data: {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6048,39 +6048,50 @@ function frmAdminBuildJS() {
 			return;
 		}
 
-		jQuery( '.frm-' + type + '-search' ).autocomplete({
-			delay: 100,
-			minLength: 0,
-			source: ajaxurl + '?action=frm_' + type + '_search&nonce=' + frmGlobal.nonce,
-			change: autoCompleteSelectBlank,
-			select: autoCompleteSelectFromResults,
-			focus: autoCompleteFocus,
-			position: {
-				my: 'left top',
-				at: 'left bottom',
-				collision: 'flip'
-			},
-			response: function( event, ui ) {
-				if ( ! ui.content.length ) {
-					var noResult = { value: '', label: frm_admin_js.no_items_found };
-					ui.content.push( noResult );
-				}
-			},
-			create: function() {
-				var $container = jQuery( this ).parent();
+		const basedUrlParams = '?action=frm_' + type + '_search&nonce=' + frmGlobal.nonce;
+		const elements = jQuery( '.frm-' + type + '-search' );
+		elements.each( function() {
+			let urlParams = basedUrlParams;
+			const element = jQuery( this );
 
-				if ( $container.length === 0 ) {
-					$container = 'body';
-				}
+			// Check if a custom post type is specific.
+			if ( element.attr( 'data-post-type' ) ) {
+				urlParams += '&post_type=' + element.attr( 'data-post-type' );
+			}
+			element.autocomplete({
+				delay: 100,
+				minLength: 0,
+				source: ajaxurl + urlParams,
+				change: autoCompleteSelectBlank,
+				select: autoCompleteSelectFromResults,
+				focus: autoCompleteFocus,
+				position: {
+					my: 'left top',
+					at: 'left bottom',
+					collision: 'flip'
+				},
+				response: function( event, ui ) {
+					if ( ! ui.content.length ) {
+						var noResult = { value: '', label: frm_admin_js.no_items_found };
+						ui.content.push( noResult );
+					}
+				},
+				create: function() {
+					var $container = jQuery( this ).parent();
 
-				jQuery( this ).autocomplete( 'option', 'appendTo', $container );
-			}
-		})
-		.on( 'focus', function() {
-			// Show options on click to make it work more like a dropdown.
-			if ( this.value === '' || this.nextElementSibling.value < 1 ) {
-				jQuery( this ).autocomplete( 'search', this.value );
-			}
+					if ( $container.length === 0 ) {
+						$container = 'body';
+					}
+
+					jQuery( this ).autocomplete( 'option', 'appendTo', $container );
+				}
+			})
+			.on( 'focus', function() {
+				// Show options on click to make it work more like a dropdown.
+				if ( this.value === '' || this.nextElementSibling.value < 1 ) {
+					jQuery( this ).autocomplete( 'search', this.value );
+				}
+			});
 		});
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4353,6 +4353,7 @@ function frmAdminBuildJS() {
 					}
 
 					postParentField.classList.remove( 'frm_hidden' );
+					// The replaced string is declared in FrmProFormActionController::ajax_get_post_parent_option() in the pro version.
 					postParentField.querySelector( '.frm_post_parent_opt_wrapper' ).innerHTML = response.replaceAll( 'REPLACETHISNAME', postParentOptName );
 					initAutocomplete( 'page', postParentField );
 				},

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6043,13 +6043,18 @@ function frmAdminBuildJS() {
 		}
 	}
 
-	function initAutocomplete( type ) {
-		if ( jQuery( '.frm-' + type + '-search' ).length < 1 ) {
-			return;
-		}
-
+	/**
+	 * Init autocomplete.
+	 *
+	 * @since 4.10.01 Add container param to init autocomplete elements inside an element.
+	 *
+	 * @param {String} type Type of data. Accepts `page` or `user`.
+	 * @param {String|Object} container Container class or element. Default is null.
+	 */
+	function initAutocomplete( type, container ) {
 		const basedUrlParams = '?action=frm_' + type + '_search&nonce=' + frmGlobal.nonce;
-		const elements = jQuery( '.frm-' + type + '-search' );
+		const elements       = ! container ? jQuery( '.frm-' + type + '-search' ) : jQuery( container ).find( '.frm-' + type + '-search' );
+
 		elements.each( function() {
 			let urlParams = basedUrlParams;
 			const element = jQuery( this );


### PR DESCRIPTION
This PR is prepared for this issue: https://github.com/Strategy11/formidable-pro/issues/61

What I did in this PR:

- Add `post_type` and `autocomplete_placeholder` to the arguments array of FrmAppHelper::maybe_autocomplete_pages_options() method
- Add container as second param to initAutocomplete() JS function
- Add JS code to dynamic load the post parent option in pro version

There are 3 main things needed to test here:
- Test if it does not break the current page select or autocomplete options
- Test if `post_type` and `autocomplete_placeholder` work as expected. Example code to test:
```
FrmAppHelper::maybe_autocomplete_pages_options(
	array(
		'field_name'  => 'options[success_page_id]',
		'page_id'     => isset( $values['success_page_id'] ) ? $values['success_page_id'] : '',
		'placeholder' => __( 'Select a Post', 'formidable' ),
		'post_type'                             => 'post',
		'autocomplete_placeholder' => __( 'Select a Post', 'formidable' ),
	)
);
```
- Test with the pull request for issue 61 of pro version. It will be mentioned soon.