### PR TITLE
do not remove ui-state-default from field when layout options open

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3541,7 +3541,7 @@ function frmAdminBuildJS() {
 			replace = ' frmstart  frmend ';
 			replaceWith = ' frmstart ' + replaceWith.trim() + ' frmend ';
 		} else {
-			replace = classes.trim();
+			replace = classes.trim().replace( 'ui-state-default', '' ); // make sure that we don't remove the ui-state-default class from input to keep event listeners.
 			replaceWith = replaceWith.trim();
 		}
 		field.className = field.className.replace( replace, replaceWith );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3537,11 +3537,17 @@ function frmAdminBuildJS() {
 		replaceWith = replaceWith.replace( ' block ', ' ' ).replace( ' inline ', ' horizontal_radio ' ).replace( ' frm_alignright ', ' ' );
 
 		classes = field.className.split( ' frmstart ' )[1].split( ' frmend ' )[0];
+
+		if ( 0 === classes.indexOf( 'frmend' ) ) {
+			classes = classes.split( 'frmend ' )[0].trim();
+			console.log({ classes });
+		}
+
 		if ( classes.trim() === '' ) {
 			replace = ' frmstart  frmend ';
 			replaceWith = ' frmstart ' + replaceWith.trim() + ' frmend ';
 		} else {
-			replace = classes.trim().replace( 'ui-state-default', '' ); // make sure that we don't remove the ui-state-default class from input to keep event listeners.
+			replace = classes.trim();
 			replaceWith = replaceWith.trim();
 		}
 		field.className = field.className.replace( replace, replaceWith );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3536,11 +3536,8 @@ function frmAdminBuildJS() {
 		// Allow for the column number dropdown.
 		replaceWith = replaceWith.replace( ' block ', ' ' ).replace( ' inline ', ' horizontal_radio ' ).replace( ' frm_alignright ', ' ' );
 
-		classes = field.className.split( ' frmstart ' )[1].split( ' frmend ' )[0];
-
-		if ( 0 === classes.indexOf( 'frmend ' ) ) {
-			classes = classes.split( 'frmend ' )[0].trim();
-		}
+		classes = field.className.split( ' frmstart ' )[1];
+		classes = 0 === classes.indexOf( 'frmend ' ) ? '' : classes.split( ' frmend ' )[0];
 
 		if ( classes.trim() === '' ) {
 			replace = ' frmstart  frmend ';

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3540,7 +3540,6 @@ function frmAdminBuildJS() {
 
 		if ( 0 === classes.indexOf( 'frmend' ) ) {
 			classes = classes.split( 'frmend ' )[0].trim();
-			console.log({ classes });
 		}
 
 		if ( classes.trim() === '' ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3538,7 +3538,7 @@ function frmAdminBuildJS() {
 
 		classes = field.className.split( ' frmstart ' )[1].split( ' frmend ' )[0];
 
-		if ( 0 === classes.indexOf( 'frmend' ) ) {
+		if ( 0 === classes.indexOf( 'frmend ' ) ) {
 			classes = classes.split( 'frmend ' )[0].trim();
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2952

The issue actually begins as soon as you open the "Add Layout Classes" pop up. It removes the `ui-state-default` class, which is necessary for the event listener to register the click event.

The issue comes down to the line above the fix `classes = field.className.split( ' frmstart ' )[1].split( ' frmend ' )[0];`.

`.split( ' frmend ' )` is not finding our class because there is no leading space before our `frmend` class.

I do an additional check, for if the string begins with `'frmend '`, and set it to an empty string if it is. This is the effectively equivalent of checking at [0] after the implode, for this specific case.