### PR TITLE
remove unused var link in doaction listener

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -554,8 +554,7 @@ function frmAdminBuildJS() {
 		jQuery( '.frm_bstooltip, .frm_help' ).tooltip( );
 
 		jQuery( document ).on( 'click', '#doaction, #doaction2', function( event ) {
-			var link,
-				isTop = this.id === 'doaction',
+			var isTop = this.id === 'doaction',
 				suffix = isTop ? 'top' : 'bottom',
 				bulkActionSelector = document.getElementById( 'bulk-action-selector-' + suffix ),
 				confirmBulkDelete = document.getElementById( 'confirm-bulk-delete-' + suffix );


### PR DESCRIPTION
This isn't really anything crazy. I just noticed this `var link` was totally unused in this function. My syntax highlighter has it in another color, so it stands out a bit.

Doesn't hurt to clean up 🙂.