### PR TITLE
add repeat icon color to style settings

### DIFF
--- a/classes/models/FrmStyle.php
+++ b/classes/models/FrmStyle.php
@@ -416,6 +416,7 @@ class FrmStyle {
 			'collapse_icon'        => '6',
 			'collapse_pos'         => 'after',
 			'repeat_icon'          => '1',
+			'repeat_icon_color'    => 'ffffff',
 
 			'submit_style'               => false,
 			'submit_font_size'           => '15px',

--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -444,4 +444,8 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 	padding:0<?php echo esc_html( $important ); ?>;
 }
 
+.frm_repeat_sec .frm_icon_font::before {
+	color: <?php echo esc_html( $repeat_icon_color ); ?> !important;
+}
+
 <?php do_action( 'frm_output_single_style', $settings ); ?>

--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -444,8 +444,10 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 	padding:0<?php echo esc_html( $important ); ?>;
 }
 
-.frm_repeat_sec .frm_icon_font::before {
-	color: <?php echo esc_html( $repeat_icon_color ); ?> !important;
-}
+<?php if ( ! empty( $repeat_icon_color ) ) { ?>
+	.frm_repeat_sec .frm_icon_font::before {
+		color: <?php echo esc_html( $repeat_icon_color ); ?> !important;
+	}
+<?php } ?>
 
 <?php do_action( 'frm_output_single_style', $settings ); ?>

--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -444,10 +444,4 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 	padding:0<?php echo esc_html( $important ); ?>;
 }
 
-<?php if ( ! empty( $repeat_icon_color ) ) { ?>
-	.frm_repeat_sec .frm_icon_font::before {
-		color: <?php echo esc_html( $repeat_icon_color ); ?> !important;
-	}
-<?php } ?>
-
 <?php do_action( 'frm_output_single_style', $settings ); ?>

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -1429,7 +1429,7 @@ select.frm_loading_lookup{
 }
 
 .frm_repeat_sec .frm_icon_font::before {
-    color: <?php echo esc_html( $defaults['repeat_icon_color'] ); ?> !important;
+	color: <?php echo esc_html( $defaults['repeat_icon_color'] ); ?> !important;
 }
 
 /* Fonts */

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -1428,7 +1428,7 @@ select.frm_loading_lookup{
 	display:block;
 }
 
-.with_frm_style .frm_repeat_sec .frm_form_field i.frm_icon_font::before {
+.with_frm_style .frm_repeat_sec .frm_form_field .frm_icon_font::before {
 	color:<?php echo esc_html( $defaults['repeat_icon_color'] . $important ); ?>;
 	color:var(--repeat-icon-color)<?php echo esc_html( $important ); ?>;
 }

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -1428,7 +1428,7 @@ select.frm_loading_lookup{
 	display:block;
 }
 
-.frm_repeat_sec .frm_icon_font::before {
+.frm_repeat_sec .frm_form_field i.frm_icon_font::before {
 	color: <?php echo esc_html( $defaults['repeat_icon_color'] ); ?> !important;
 }
 

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -1428,8 +1428,9 @@ select.frm_loading_lookup{
 	display:block;
 }
 
-.frm_repeat_sec .frm_form_field i.frm_icon_font::before {
-	color: <?php echo esc_html( $defaults['repeat_icon_color'] ); ?> !important;
+.with_frm_style .frm_repeat_sec .frm_form_field i.frm_icon_font::before {
+	color:<?php echo esc_html( $defaults['repeat_icon_color'] . $important ); ?>;
+	color:var(--repeat-icon-color)<?php echo esc_html( $important ); ?>;
 }
 
 /* Fonts */

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -1428,6 +1428,10 @@ select.frm_loading_lookup{
 	display:block;
 }
 
+.frm_repeat_sec .frm_icon_font::before {
+    color: <?php echo esc_html( $defaults['repeat_icon_color'] ); ?> !important;
+}
+
 /* Fonts */
 <?php readfile( FrmAppHelper::plugin_path() . '/css/font_icons.css' ); ?>
 <?php do_action( 'frm_include_front_css', compact( 'defaults' ) ); ?>


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2944 alongside https://github.com/Strategy11/formidable-pro/pull/2964

I played with the preview stuff in the editor, which seems to require single_theme. I'm a little confused by the differences between the single and custom theme files. I don't want to add too much, so I left out the changes I had in single_theme. The preview doesn't update in real time, but it does work after save, which seems to be consistent with some of the things in the style editor and not others.