### PR TITLE
Do not pass the nonce referer for bulk actions

### DIFF
--- a/classes/helpers/FrmListHelper.php
+++ b/classes/helpers/FrmListHelper.php
@@ -1031,7 +1031,7 @@ class FrmListHelper {
 	 */
 	protected function display_tablenav( $which ) {
 		if ( 'top' == $which ) {
-			wp_nonce_field( 'bulk-' . $this->_args['plural'] );
+			wp_nonce_field( 'bulk-' . $this->_args['plural'], '_wpnonce', false );
 			if ( ! $this->has_min_items( 1 ) ) {
 				// Don't show bulk actions if no items.
 				return;


### PR DESCRIPTION
Fixes Strategy11/formidable-pro#2963

I don't think we can safely pass a nonce referer if we're passing the nonce through a $_GET request because the url will grow until it eventually hits a limit.

So I just don't pass it. It looks like we're not really checking for it, so everything still seems to work, just with a smaller URL.