### PR TITLE
add a fallback for the_content if get_template_part does not support page

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -314,7 +314,21 @@ class FrmFormsController {
 		add_action( 'loop_no_results', 'FrmFormsController::show_page_preview' );
 		add_filter( 'is_active_sidebar', '__return_false' );
 		FrmStylesController::enqueue_css( 'enqueue', true );
-		get_template_part( 'page' );
+
+		if ( false === get_template_part( 'page' ) ) {
+			self::fallback_when_page_template_part_is_not_supported_by_theme();
+		}
+	}
+
+	/**
+	 * Not every theme supports get_template_part( 'page' ).
+	 * When this is not supported, false is returned, and we can handle a fallback.
+	 */
+	private static function fallback_when_page_template_part_is_not_supported_by_theme() {
+		if ( have_posts() ) {
+			the_post();
+			the_content();
+		}
 	}
 
 	/**

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -328,7 +328,12 @@ class FrmFormsController {
 		if ( have_posts() ) {
 			the_post();
 			get_header( '' );
+			// add some generic class names to the container to add some natural padding to the content.
+			// .entry-content catches the WordPress TwentyTwenty theme.
+			// .container catches Customizr content.
+			echo '<div class="container entry-content">';
 			the_content();
+			echo '</div>';
 			get_footer();
 		}
 	}

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -327,7 +327,9 @@ class FrmFormsController {
 	private static function fallback_when_page_template_part_is_not_supported_by_theme() {
 		if ( have_posts() ) {
 			the_post();
+			get_header( '' );
 			the_content();
+			get_footer();
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/1880

I tried this out with Customizr only as the other plugins all seem to be paid ones that I don't have access to.

When there is no support a template part `get_template_part` actually returns `false`, so we can try calling a fallback method for rendering our form.

I skimmed over the customizr code quite a bit, and I think the right option is to just call `the_content()` to trigger the render event. I also added `get_header()` and `get_footer()` calls as well, to make it a little more page-like. But it still feels pretty ugly with Customizr.

Since this fix is so generic and simple, I think it should really work with every conflicting plugin.

Instead of nothing, I get a pretty plain, not-very-styled form, but it's better than nothing - it works!

![Screen Shot 2021-04-26 at 1 46 28 PM](https://user-images.githubusercontent.com/9134515/116120363-d6433a00-a695-11eb-8899-ef48c9fb2296.png)

Maybe there's a way to get some theme styling in here, but I couldn't really figure out what hook would work.

@stephywells do you think this is an acceptable solution? I couldn't really figure out how to get better theme support without writing really custom code specific for the themes.

Without the header/footer calls, it looks more like:
![Screen Shot 2021-04-26 at 1 25 30 PM](https://user-images.githubusercontent.com/9134515/116117667-e1489b00-a692-11eb-9bde-aaf396fa98e5.png)