### PR TITLE
Undefined variable repeat icon fix

### DIFF
--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -379,6 +379,10 @@ class FrmStylesHelper {
 		$settings['auto_width']   = $settings['auto_width'] ? 'auto' : $settings['field_width'];
 		$settings['box_shadow']   = ( isset( $settings['remove_box_shadow'] ) && $settings['remove_box_shadow'] ) ? 'none' : '0 1px 1px rgba(0, 0, 0, 0.075) inset';
 
+		if ( ! isset( $settings['repeat_icon'] ) ) {
+			$settings['repeat_icon'] = 1;
+		}
+
 		return $settings;
 	}
 


### PR DESCRIPTION
I'm playing around with the style editor and caught this undefined variable warning every time it tries to preview the theme.

```
[30-Apr-2021 01:08:20 UTC] PHP Warning:  Undefined variable $repeat_icon in /var/www/src/wp-content/plugins/formidable/css/_single_theme.css.php on line 43
[30-Apr-2021 01:08:20 UTC] PHP Warning:  Undefined variable $repeat_icon in /var/www/src/wp-content/plugins/formidable/css/_single_theme.css.php on line 47
```

It looks like it doesn't effect functionality as it's just a warning.