### PR TITLE
Guarantee unique action id

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -325,7 +325,8 @@ function frmAdminBuildJS() {
 		fieldsUpdated = 0,
 		thisFormId = 0,
 		autoId = 0,
-		optionMap = {};
+		optionMap = {},
+		lastNewActionIdReturned = 0;
 
 	if ( thisForm !== null ) {
 		thisFormId = thisForm.value;
@@ -3950,10 +3951,9 @@ function frmAdminBuildJS() {
 	}
 
 	function addFormAction() {
-		/*jshint validthis:true */
-		var actionId = getNewActionId();
-		var type = jQuery( this ).data( 'actiontype' );
-		var formId = thisFormId;
+		var actionId = getNewActionId(),
+			type = jQuery( this ).data( 'actiontype' ),
+			formId = thisFormId;
 
 		jQuery.ajax({
 			type: 'POST', url: ajaxurl,
@@ -4014,6 +4014,10 @@ function frmAdminBuildJS() {
 		if ( typeof document.getElementById( 'frm_form_action_' + len ) !== 'undefined' ) {
 			len = len + 100;
 		}
+		if ( lastNewActionIdReturned >= len ) {
+			len = lastNewActionIdReturned + 1;
+		}
+		lastNewActionIdReturned = len;
 		return len;
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3951,6 +3951,7 @@ function frmAdminBuildJS() {
 	}
 
 	function addFormAction() {
+		/*jshint validthis:true */
 		var actionId = getNewActionId(),
 			type = jQuery( this ).data( 'actiontype' ),
 			formId = thisFormId;


### PR DESCRIPTION
I noticed a bug the other day when my AJAX request to create an action took a moment, and I clicked it again.

It ended up creating two action elements with the same `actionId` value. Then causes some weird behaviours, like when I go to delete the bottom action, it actually goes and deletes the top one instead.

I'm adding an extra tracked variable here that makes sure that the value returned is always higher than the value previously returned.

I also refactored the js slightly so that the variables are all in one declaration in the addFormAction function.