### PR TITLE
Also call set_value_before_save for duplicate check

### DIFF
--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -131,6 +131,7 @@ class FrmEntry {
 		foreach ( $filter_vals as $field_id => $value ) {
 			$field                = FrmFieldFactory::get_field_object( $field_id );
 			$reduced[ $field_id ] = $field->get_value_to_save( $value, array( 'entry_id' => $entry_id ) );
+			$reduced[ $field_id ] = $field->set_value_before_save( $reduced[ $field_id ] );
 			if ( '' === $reduced[ $field_id ] || ( is_array( $reduced[ $field_id ] ) && 0 === count( $reduced[ $field_id ] ) ) ) {
 				unset( $reduced[ $field_id ] );
 			}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3013

These issues always mention the hook not working, but it's really just that the duplicate checks don't catch certain field types, so this is really just "duplicate checks don't work for date fields".

I missed that there are really two functions here.

`get_value_to_save` which I added in the last duplicate check, which caught signatures and some other fields.

But there is also a `set_value_before_save` that effects dates, numbers, times, credit cards.

I'm calling the new one afterward as it's meant for processing at the very end and the other function is intended for earlier in the processing.