### PR TITLE
add strict option for honeypot, default to text, add new frm_process_honeypot filter

### DIFF
--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -229,7 +229,7 @@ class FrmEntryValidate {
 			return;
 		}
 
-		if ( self::is_honeypot_spam() || self::is_spam_bot() ) {
+		if ( self::is_honeypot_spam( $values['form_id'] ) || self::is_spam_bot() ) {
 			$errors['spam'] = __( 'Your entry appears to be spam!', 'formidable' );
 		}
 
@@ -244,10 +244,24 @@ class FrmEntryValidate {
 		}
 	}
 
-	private static function is_honeypot_spam() {
-		$honeypot_value = FrmAppHelper::get_param( 'frm_verify', '', 'get', 'sanitize_text_field' );
+	/**
+	 * @param int $form_id
+	 * @return boolean
+	 */
+	private static function is_honeypot_spam( $form_id ) {
+		$form     = FrmForm::getOne( $form_id );
+		$atts     = compact( 'form' );
+		$honeypot = apply_filters( 'frm_run_honeypot', true, $atts );
 
-		return ( $honeypot_value !== '' );
+		if ( ! $honeypot ) {
+			// never flag as honeypot spam if disabled.
+			return false;
+		}
+
+		$honeypot_value   = FrmAppHelper::get_param( 'frm_verify', '', 'get', 'sanitize_text_field' );
+		$is_honeypot_spam = $honeypot_value !== '';
+
+		return apply_filters( 'frm_process_honeypot', $is_honeypot_spam, $atts );
 	}
 
 	private static function is_spam_bot() {

--- a/classes/views/frm-entries/form.php
+++ b/classes/views/frm-entries/form.php
@@ -60,11 +60,11 @@ if ( FrmAppHelper::is_admin() ) {
 	$honeypot = apply_filters( 'frm_run_honeypot', true, compact( 'form' ) );
 	if ( $honeypot ) {
 		?>
-<div class="frm_verify" <?php echo ( $honeypot === true ) ? '' : 'aria-hidden="true"'; ?>>
+<div class="frm_verify" <?php echo in_array( $honeypot, array( true, 'strict' ), true ) ? '' : 'aria-hidden="true"'; ?>>
 	<label for="frm_email_<?php echo esc_attr( $form->id ); ?>">
 		<?php esc_html_e( 'If you are human, leave this field blank.', 'formidable' ); ?>
 	</label>
-	<input type="email" class="frm_verify" id="frm_email_<?php echo esc_attr( $form->id ); ?>" name="frm_verify" value="<?php echo esc_attr( FrmAppHelper::get_param( 'frm_verify', '', 'get', 'wp_kses_post' ) ); ?>" <?php FrmFormsHelper::maybe_hide_inline(); ?> />
+	<input type="<?php echo esc_attr( 'strict' === $honeypot ? 'email' : 'text' ); ?>" class="frm_verify" id="frm_email_<?php echo esc_attr( $form->id ); ?>" name="frm_verify" value="<?php echo esc_attr( FrmAppHelper::get_param( 'frm_verify', '', 'get', 'wp_kses_post' ) ); ?>" <?php FrmFormsHelper::maybe_hide_inline(); ?> />
 </div>
 		<?php
 	}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2993

Updated functionality of `frm_run_honeypot`.
```
add_filter(
	'frm_run_honeypot',
	function( $honeypot, $atts ) {
		// default value of $honeypot is true (spam is more likely than "strict" but false positives are also lower)
		$form = $atts['form'];
		return 'strict';
	},
	10,
	2
);
```

New filter `frm_process_honeypot`.

```
add_filter(
	'frm_process_honeypot',
	function( $is_honeypot_spam, $atts ) {
		$form = $atts['form'];
		if ( $is_honeypot_spam ) {
			// handle honeypot spam.
		}
		// validate as not spam so the form still submits.
		return false;
	},
	10,
	2
);
```