### PR TITLE
include data-requires="Elite" for automation call to action

### DIFF
--- a/classes/views/frm-form-actions/_action_inside.php
+++ b/classes/views/frm-form-actions/_action_inside.php
@@ -89,7 +89,7 @@ if ( ! function_exists( 'load_frm_autoresponder' ) ) {
 	}
 	?>
 	<h3>
-		<a href="javascript:void(0)" class="frm_show_upgrade<?php echo esc_attr( $class ); ?>" data-upgrade="<?php esc_attr_e( 'Form action automations', 'formidable' ); ?>" data-medium="action-automation" data-oneclick="<?php echo esc_attr( $install_data ); ?>">
+		<a href="javascript:void(0)" class="frm_show_upgrade<?php echo esc_attr( $class ); ?>" data-upgrade="<?php esc_attr_e( 'Form action automations', 'formidable' ); ?>" data-requires="Elite" data-medium="action-automation" data-oneclick="<?php echo esc_attr( $install_data ); ?>">
 			<?php esc_html_e( 'Setup Automation', 'formidable' ); ?>
 		</a>
 	</h3>


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2989

It looks like all three issues are just about the automation requiring Elite.

This is already a supported attribute, so changing the text didn't take much.

![Screen Shot 2021-05-07 at 4 58 41 PM](https://user-images.githubusercontent.com/9134515/117502651-31a6df00-af56-11eb-9275-5c7ea7685a5a.png)