### PR TITLE
mark fields updated to 0 on publish button click

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7066,6 +7066,7 @@ function frmAdminBuildJS() {
 
 			// Show loading indicator.
 			jQuery( '#publish' ).on( 'mousedown', function() {
+				fieldsUpdated = 0;
 				this.classList.add( 'frm_loading_button' );
 			});
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-views/issues/116 by resetting the fieldsUpdated flag when the update button is clicked.

This was something I missed when I did https://github.com/Strategy11/formidable-forms/pull/357 as I didn't catch that the fade out logic was happening for multiple types of elements on various pages, not just actions on the settings page.

This page still doesn't really support the unsaved changes pop ups, but it might not be worth it since we're replacing this soon.