### PR TITLE
Add more exceptions to zip plugin file

### DIFF
--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -58,8 +58,8 @@ zip -r $zipname $destination \
 	-x "*/vendor/*" \
 	-x "formidable-pro/views/*" \
 	-x "formidable-views/js/dom.js" \
-    -x "formidable-views/js/editor.js" \
-    -x "formidable-views/js/index.js" \
+	-x "formidable-views/js/editor.js" \
+	-x "formidable-views/js/index.js" \
 	-x "*/webpack.config.js" \
 	-x "*.zip"
 

--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -39,6 +39,7 @@ zip -r $zipname $destination \
 	-x "*/bin/*" \
 	-x "*/changelog.txt" \
 	-x "*/composer.json" \
+	-x "*/composer.lock" \
 	-x "*/formidableforms.css" \
 	-x "*/js/src/*" \
 	-x "*/js/frm.min.js" \
@@ -56,6 +57,9 @@ zip -r $zipname $destination \
 	-x "*/tests/*" \
 	-x "*/vendor/*" \
 	-x "formidable-pro/views/*" \
+	-x "formidable-views/js/dom.js" \
+    -x "formidable-views/js/editor.js" \
+    -x "formidable-views/js/index.js" \
 	-x "*/webpack.config.js" \
 	-x "*.zip"
 


### PR DESCRIPTION
Excluding the unminified JavaScript from views here. And also the composer.lock file, which I guess I committed into views when I did the separation.

I'm not sure how important that even is, but the exception is good to have here since we're doing the same for the other `composer.json` file.