### PR TITLE
Fix class name replace issue for fields without classes already set

### DIFF
--- a/classes/views/frm-forms/form.php
+++ b/classes/views/frm-forms/form.php
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 	</div>
 
-	<ul id="frm-show-fields" class="frm_sorting inside">
+	<ul id="frm-show-fields" class="frm_sorting inside frm_grid_container">
 		<?php
 		if ( isset( $values['fields'] ) && ! empty( $values['fields'] ) ) {
 			$values['count'] = 0;

--- a/classes/views/frm-forms/form.php
+++ b/classes/views/frm-forms/form.php
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 	</div>
 
-	<ul id="frm-show-fields" class="frm_sorting inside frm_grid_container">
+	<ul id="frm-show-fields" class="frm_sorting inside">
 		<?php
 		if ( isset( $values['fields'] ) && ! empty( $values['fields'] ) ) {
 			$values['count'] = 0;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3555,9 +3555,8 @@ function frmAdminBuildJS() {
 		classes = 0 === classes.indexOf( 'frmend ' ) ? '' : classes.split( ' frmend ' )[0];
 
 		if ( classes.trim() === '' ) {
-			if ( -1 !== field.className.indexOf( ' frmstart  frmend ' ) ) {
-				replace = ' frmstart  frmend ';
-			} else {
+			replace = ' frmstart  frmend ';
+			if ( -1 === field.className.indexOf( replace ) ) {
 				replace = ' frmstart frmend ';
 			}
 			replaceWith = ' frmstart ' + replaceWith.trim() + ' frmend ';

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3555,12 +3555,17 @@ function frmAdminBuildJS() {
 		classes = 0 === classes.indexOf( 'frmend ' ) ? '' : classes.split( ' frmend ' )[0];
 
 		if ( classes.trim() === '' ) {
-			replace = ' frmstart  frmend ';
+			if ( -1 !== field.className.indexOf( ' frmstart  frmend ' ) ) {
+				replace = ' frmstart  frmend ';
+			} else {
+				replace = ' frmstart frmend ';
+			}
 			replaceWith = ' frmstart ' + replaceWith.trim() + ' frmend ';
 		} else {
 			replace = classes.trim();
 			replaceWith = replaceWith.trim();
 		}
+
 		field.className = field.className.replace( replace, replaceWith );
 	}
 


### PR DESCRIPTION
I'm starting to get into the side-by-side form editor requirements here, and I'm noticing some funny things with the current ways that the editor is adding stuff.

The replace here is not working when there are no classes because it looks like this double space check is being trimmed now.

I check first if the previous string exists, and if it doesn't, I do my replace instead to fix this issue.

There was that other layout class error happening here that I think probably broke for the same reason.