### PR TITLE
honeypot setting appears basic when off fix

### DIFF
--- a/classes/views/frm-forms/spam-settings/honeypot.php
+++ b/classes/views/frm-forms/spam-settings/honeypot.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<label for="honeypot"><?php esc_html_e( 'Use Honeypot to check entries for spam', 'formidable' ); ?></label>
 		<select id="honeypot" name="options[honeypot]">
 			<option value="off" <?php selected( $values['honeypot'], 'off' ); ?>><?php esc_html_e( 'Off', 'formidable' ); ?></option>
-			<option value="basic" <?php selected( ! empty( $values['honeypot'] ) && 'strict' !== $values['honeypot'], true ); ?>><?php esc_html_e( 'Basic', 'formidable' ); ?></option>
+			<option value="basic" <?php selected( $values['honeypot'], 'basic' ); ?>><?php esc_html_e( 'Basic', 'formidable' ); ?></option>
 			<option value="strict" <?php selected( $values['honeypot'], 'strict' ); ?>><?php esc_html_e( 'Strict', 'formidable' ); ?></option>
 		</select>
 	</td>


### PR DESCRIPTION
Fixes the issue Guga posted [here](https://strategy11.slack.com/archives/CJFQ599V5/p1621876733054200).

The honeypot option was working fine but the basic option would appear as selected if it was off. And then a subsequent save would likely turn it back on as a result.

My logic for the basic option was too much of a catch-all.

I don't think any of it the extra logic I had is really necessary now. The default is basic.