### PR TITLE
Make duplicate check val filterable

### DIFF
--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -54,12 +54,13 @@ class FrmEntry {
 		$check_val                 = $new_values;
 		$check_val['created_at >'] = gmdate( 'Y-m-d H:i:s', ( strtotime( $new_values['created_at'] ) - absint( $duplicate_entry_time ) ) );
 
-		unset( $check_val['created_at'], $check_val['updated_at'] );
-		unset( $check_val['is_draft'], $check_val['id'], $check_val['item_key'] );
+		unset( $check_val['created_at'], $check_val['updated_at'], $check_val['is_draft'], $check_val['id'], $check_val['item_key'] );
 
 		if ( $new_values['item_key'] == $new_values['name'] ) {
 			unset( $check_val['name'] );
 		}
+
+		$check_val = apply_filters( 'frm_duplicate_check_val', $check_val );
 
 		global $wpdb;
 		$entry_exists = FrmDb::get_col( $wpdb->prefix . 'frm_items', $check_val, 'id', array( 'order_by' => 'created_at DESC' ) );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3037

Using a filter like:
```
add_filter(
	'frm_duplicate_check_val',
	function( $check_val ) {
		unset( $check_val['ip'] );
		return $check_val;
	}
);
```

or
```
add_filter(
	'frm_duplicate_check_val',
	function( $check_val ) {
                if ( 9 == $check_val['form_id'] ) { 
		    unset( $check_val['ip'] );
                }
		return $check_val;
	}
);
```

I'm not sure if we just want to take out IP by default so I'm leaving it for now.

Making it filterable makes this more customizable, and future-proof, and doesn't break anything in the process.