### PR TITLE
esc attr fix in mb adv info view

### DIFF
--- a/classes/views/shared/mb_adv_info.php
+++ b/classes/views/shared/mb_adv_info.php
@@ -163,7 +163,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</h3>
 			<ul class="frm_code_list frm-full-hover frmcenter">
 				<li>
-					<a href="#" id="frm-insert-condition" class="frm_insert_code" data-code="if x equals='']<?php echo esc_attr( 'Conditional content here', 'formidable' ); ?>[/if x">
+					<a href="#" id="frm-insert-condition" class="frm_insert_code" data-code="if x equals='']<?php esc_attr_e( 'Conditional content here', 'formidable' ); ?>[/if x">
 						[if x equals=""][/if x]
 					</a>
 				</li>


### PR DESCRIPTION
Playing with scanning our PHP code and caught this.

It's specifying a text domain but calling esc_attr which doesn't support that.