### PR TITLE
remove undefined variables from unset in FrmFormsController.php

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -973,7 +973,7 @@ class FrmFormsController {
 			$fields = FrmField::get_all_for_form( $form->id, '', 'exclude' );
 		}
 
-		unset( $end_section_values, $last_order, $open, $reset_fields );
+		unset( $reset_fields );
 
 		$args             = array( 'parent_form_id' => $form->id );
 		$values           = FrmAppHelper::setup_edit_vars( $form, 'forms', '', true, array(), $args );


### PR DESCRIPTION
```
ERROR: UndefinedVariable - classes/controllers/FrmFormsController.php:976:31 - Cannot find referenced variable $last_order (see https://psalm.dev/024)
		unset( $end_section_values, $last_order, $open, $reset_fields );

ERROR: UndefinedVariable - classes/controllers/FrmFormsController.php:976:44 - Cannot find referenced variable $open (see https://psalm.dev/024)
		unset( $end_section_values, $last_order, $open, $reset_fields );

ERROR: UndefinedVariable - classes/controllers/FrmFormsController.php:976:10 - Cannot find referenced variable $end_section_values (see https://psalm.dev/024)
		unset( $end_section_values, $last_order, $open, $reset_fields );
```

Caught when running psalm.

Really not an issue since unsetting an undefined variable does nothing, but there's no reason to have this code here.