### PR TITLE
addons typo when getting api info fix

### DIFF
--- a/classes/models/FrmAddon.php
+++ b/classes/models/FrmAddon.php
@@ -360,7 +360,7 @@ class FrmAddon {
 		// if there is no download url, this license does not apply to the addon
 		if ( isset( $addon['package'] ) ) {
 			$this->is_parent_licence = true;
-		} elseif ( isset( $addons['error'] ) ) {
+		} elseif ( isset( $addon['error'] ) ) {
 			// if the license is expired, we must assume all add-ons were packaged
 			$this->is_parent_licence = true;
 			$this->is_expired_addon  = true;


### PR DESCRIPTION
Caught this with psalm.

```
ERROR: UndefinedVariable - classes/models/FrmAddon.php:363:21 - Cannot find referenced variable $addons (see https://psalm.dev/024)
		} elseif ( isset( $addons['error'] ) ) {
```

This means that `is_expired_addon` was never really being flagged.
This might explain a lot of the weird license messages that people report.