### PR TITLE
undefined variable entry metas fix

### DIFF
--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -405,7 +405,7 @@ class FrmEntry {
 			}
 
 			// include sub entries in an array
-			if ( ! isset( $entry_metas[ $meta_val->field_id ] ) ) {
+			if ( ! isset( $entry->metas[ $meta_val->field_id ] ) ) {
 				$entry->metas[ $meta_val->field_id ] = array();
 			}
 


### PR DESCRIPTION
Caught with psalm.

```
ERROR: UndefinedVariable - classes/models/FrmEntry.php:408:18 - Cannot find referenced variable $entry_metas (see https://psalm.dev/024)
			if ( ! isset( $entry_metas[ $meta_val->field_id ] ) ) {
```

I tried testing around this and couldn't see anything breaking as a result.

Since `entry_metas` should never be set it's possible there's a bug here that was overwriting the value of `$entry->metas[ $meta_val->field_id ]`.