### PR TITLE
Fix ribbon position for new add-ons

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1631,6 +1631,11 @@ div.frm_updated_message {
 	size: 11px;
 }
 
+.plugin-card-top .frm_ribbon {
+	right: -33px;
+	top: -28px;
+}
+
 .frm_ribbon span {
 	position: absolute;
 	left: 25px;


### PR DESCRIPTION
The "new" ribbon was hidden on the add-ons page.
<img width="410" alt="Screen Shot 2021-06-17 at 9 45 08 AM" src="https://user-images.githubusercontent.com/1116876/122430347-c25adc80-cf50-11eb-8dc6-0dc5818e4101.png">

After:
<img width="409" alt="Screen Shot 2021-06-17 at 9 45 46 AM" src="https://user-images.githubusercontent.com/1116876/122430456-dacaf700-cf50-11eb-94a7-5a8f14c79f1f.png">
