### PR TITLE
check that field options is an array before checking count

### DIFF
--- a/classes/views/frm-fields/back-end/field-options.php
+++ b/classes/views/frm-fields/back-end/field-options.php
@@ -2,6 +2,8 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
+
+$field_option_count = is_array( $args['field']['options'] ) ? count( $args['field']['options'] ) : 0;
 ?>
 <span class="frm-bulk-edit-link <?php echo empty( FrmField::get_option( $args['field'], 'image_options' ) ) ? '' : 'frm_hidden'; ?> ">
 	<a href="#" title="<?php echo esc_attr( $option_title ); ?>" class="frm-bulk-edit-link">
@@ -11,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <?php do_action( 'frm_add_multiple_opts_labels', $args['field'] ); ?>
 
-<ul id="frm_field_<?php echo esc_attr( $args['field']['id'] ); ?>_opts" class="frm_sortable_field_opts frm_clear<?php echo ( count( $args['field']['options'] ) > 10 ) ? ' frm_field_opts_list' : ''; ?> frm_add_remove" data-key="<?php echo esc_attr( $args['field']['field_key'] ); ?>">
+<ul id="frm_field_<?php echo esc_attr( $args['field']['id'] ); ?>_opts" class="frm_sortable_field_opts frm_clear<?php echo ( $field_option_count > 10 ) ? ' frm_field_opts_list' : ''; ?> frm_add_remove" data-key="<?php echo esc_attr( $args['field']['field_key'] ); ?>">
 	<?php $this->show_single_option( $args ); ?>
 </ul>
 


### PR DESCRIPTION
I was playing with lookup radio fields, saw this error. It was causing some stuff not to load in the back end of the form editor.

Without this I never see the submit button in the form editor's preview.

And it logs this huge error statement.

```
PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($var) must be of type Countable|array, string given in /var/www/src/wp-content/plugins/formidable/classes/views/frm-fields/back-end/field-options.php:14
Stack trace:
#0 /var/www/src/wp-content/plugins/formidable/classes/models/fields/FrmFieldType.php(397): include()
#1 /var/www/src/wp-content/plugins/formidable/classes/views/frm-fields/back-end/field-choices.php(13): FrmFieldType->show_field_options(Array)
#2 /var/www/src/wp-content/plugins/formidable/classes/models/fields/FrmFieldType.php(378): include('/var/www/src/wp...')
#3 /var/www/src/wp-content/plugins/formidable/classes/views/frm-fields/back-end/settings.php(97): FrmFieldType->show_field_choices(Array)
#4 /var/www/src/wp-content/plugins/formidable/classes/controllers/FrmFieldsController.php(330): include('/var/www/src/wp...')
#5 /var/www/src/wp-content/plugins/formidable/classes/views/frm-forms/add_field.php(72): FrmFieldsController::load_single_field_settings(NULL)
#6 /var/www/src/wp-content/plugins/formidable/classes/controllers/FrmFieldsController.php(187): require('/var/www/src/wp...')
#7 /var/www/src/wp-content/plugins/formidable/classes/views/frm-forms/form.php(33): FrmFieldsController::load_single_field(Object(stdClass), Array)
#8 /var/www/src/wp-content/plugins/formidable/classes/views/frm-forms/edit.php(33): require('/var/www/src/wp...')
#9 /var/www/src/wp-content/plugins/formidable/classes/controllers/FrmFormsController.php(993): require('/var/www/src/wp...')
#10 /var/www/src/wp-content/plugins/formidable/classes/controllers/FrmFormsController.php(112): FrmFormsController::get_edit_vars(11)
#11 /var/www/src/wp-content/plugins/formidable/classes/controllers/FrmFormsController.php(1480): FrmFormsController::edit(Array)
```

I think this is happening because my lookup has no options.
I think this might be a PHP8-specific error. Not sure.