### PR TITLE
Deprecate the old grid css setting

### DIFF
--- a/classes/controllers/FrmInboxController.php
+++ b/classes/controllers/FrmInboxController.php
@@ -13,23 +13,9 @@ class FrmInboxController {
 	 */
 	public static function menu() {
 		$unread = self::get_notice_count();
-
-		$frm_settings = FrmAppHelper::get_settings();
-		if ( $frm_settings->old_css ) {
-			$inbox = new FrmInbox();
-			$inbox->add_message(
-				array(
-					'key'     => 'old_css',
-					'subject' => 'The option to not use CSS Grids for form layouts is being removed.',
-					'message' => 'New formidable features will require the CSS Grid. We recommend enabling the CSS Grid in Global Settings and testing that your forms still look good with updated layouts.',
-					'cta'     => '<a href="' . esc_url( admin_url( 'admin.php?page=formidable-settings' ) ) . '" class="button-primary frm-button-primary">' . esc_html__( 'Go to Global Settings', 'formidable' ) . '</a>',
-					'icon'    => 'frm_report_problem_icon',
-					'type'    => 'news',
-				)
-			);
-		}
-
 		add_submenu_page( 'formidable', 'Formidable | ' . __( 'Inbox', 'formidable' ), __( 'Inbox', 'formidable' ) . $unread, 'frm_change_settings', 'formidable-inbox', 'FrmInboxController::inbox' );
+
+		self::maybe_add_old_css_message();
 	}
 
 	/**
@@ -38,8 +24,25 @@ class FrmInboxController {
 	private static function get_notice_count() {
 		FrmFormMigratorsHelper::maybe_add_to_inbox();
 
-		$inbox  = new FrmInbox();
+		$inbox = new FrmInbox();
 		return $inbox->unread_html();
+	}
+
+	private static function maybe_add_old_css_message() {
+		$frm_settings = FrmAppHelper::get_settings();
+		if ( $frm_settings->old_css ) {
+			$inbox = new FrmInbox();
+			$inbox->add_message(
+				array(
+					'key'     => 'old_css',
+					'subject' => 'The option to disable CSS Grids for form layouts is being removed.',
+					'message' => 'We\'ve got some awesome form layout features coming soon. These new layouts will require CSS grids, and will not be supported in Internet Explorer. If a visitor views your forms in IE, a single field will show in each row.<br><br>We recommend enabling CSS Grids in Global Settings and then checking your form layouts.',
+					'cta'     => '<a href="' . esc_url( admin_url( 'admin.php?page=formidable-settings' ) ) . '" class="button-primary frm-button-primary">' . esc_html__( 'Go to Global Settings', 'formidable' ) . '</a>',
+					'icon'    => 'frm_report_problem_icon',
+					'type'    => 'news',
+				)
+			);
+		}
 	}
 
 	/**

--- a/classes/controllers/FrmInboxController.php
+++ b/classes/controllers/FrmInboxController.php
@@ -14,6 +14,21 @@ class FrmInboxController {
 	public static function menu() {
 		$unread = self::get_notice_count();
 
+		$frm_settings = FrmAppHelper::get_settings();
+		if ( $frm_settings->old_css ) {
+			$inbox = new FrmInbox();
+			$inbox->add_message(
+				array(
+					'key'     => 'old_css',
+					'subject' => 'The option to not use CSS Grids for form layouts is being removed.',
+					'message' => 'New formidable features will require the CSS Grid. We recommend enabling the CSS Grid in Global Settings and testing that your forms still look good with updated layouts.',
+					'cta'     => '<a href="' . esc_url( admin_url( 'admin.php?page=formidable-settings' ) ) . '" class="button-primary frm-button-primary">' . esc_html__( 'Go to Global Settings', 'formidable' ) . '</a>',
+					'icon'    => 'frm_report_problem_icon',
+					'type'    => 'news',
+				)
+			);
+		}
+
 		add_submenu_page( 'formidable', 'Formidable | ' . __( 'Inbox', 'formidable' ), __( 'Inbox', 'formidable' ) . $unread, 'frm_change_settings', 'formidable-inbox', 'FrmInboxController::inbox' );
 	}
 

--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -245,16 +245,27 @@ class FrmSettings {
 	}
 
 	private function update_settings( $params ) {
-		$this->pubkey   = trim( $params['frm_pubkey'] );
-		$this->privkey  = $params['frm_privkey'];
-		$this->re_type  = $params['frm_re_type'];
-		$this->re_lang  = $params['frm_re_lang'];
-
+		$this->pubkey     = trim( $params['frm_pubkey'] );
+		$this->privkey    = $params['frm_privkey'];
+		$this->re_type    = $params['frm_re_type'];
+		$this->re_lang    = $params['frm_re_lang'];
 		$this->load_style = $params['frm_load_style'];
+
+		$previous_old_css_setting = $this->old_css;
 
 		$checkboxes = array( 'mu_menu', 're_multi', 'use_html', 'jquery_css', 'accordion_js', 'fade_form', 'old_css', 'no_ips', 'tracking', 'admin_bar' );
 		foreach ( $checkboxes as $set ) {
 			$this->$set = isset( $params[ 'frm_' . $set ] ) ? $params[ 'frm_' . $set ] : 0;
+		}
+
+		$this->maybe_remove_old_css_inbox_message( $previous_old_css_setting, $this->old_css );
+	}
+
+	private function maybe_remove_old_css_inbox_message( $previous_setting, $new_setting ) {
+		$enabled_css_grid = $previous_setting && ! $new_setting;
+		if ( $enabled_css_grid ) {
+			$inbox = new FrmInbox();
+			$inbox->remove( 'old_css' );
 		}
 	}
 

--- a/classes/views/frm-settings/general.php
+++ b/classes/views/frm-settings/general.php
@@ -31,13 +31,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</select>
 </p>
 
-<p>
-	<label for="frm_old_css">
-		<input type="checkbox" id="frm_old_css" name="frm_old_css" value="1" <?php checked( $frm_settings->old_css, 1 ); ?> />
-		<?php esc_html_e( 'Do not use CSS Grids for form layouts', 'formidable' ); ?>
-		<span class="frm_help frm_icon_font frm_tooltip_icon" title="<?php esc_attr_e( 'Form layouts built using CSS grids that are not fully supported by older browsers like Internet Explorer. Leave this box unchecked for your layouts to look best in current browsers, but show in a single column in older browsers.', 'formidable' ); ?>"></span>
-	</label>
-</p>
+<?php if ( $frm_settings->old_css ) { ?>
+	<p>
+		<label for="frm_old_css">
+			<input type="checkbox" id="frm_old_css" name="frm_old_css" value="1" <?php checked( $frm_settings->old_css, 1 ); ?> />
+			<?php esc_html_e( 'Do not use CSS Grids for form layouts', 'formidable' ); ?>
+			<span class="frm_help frm_icon_font frm_tooltip_icon" title="<?php esc_attr_e( 'Form layouts built using CSS grids that are not fully supported by older browsers like Internet Explorer. Leave this box unchecked for your layouts to look best in current browsers, but show in a single column in older browsers.', 'formidable' ); ?>"></span>
+		</label>
+	</p>
+<?php } ?>
 
 <?php do_action( 'frm_style_general_settings', $frm_settings ); ?>
 

--- a/classes/views/frm-settings/general.php
+++ b/classes/views/frm-settings/general.php
@@ -37,6 +37,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<input type="checkbox" id="frm_old_css" name="frm_old_css" value="1" <?php checked( $frm_settings->old_css, 1 ); ?> />
 			<?php esc_html_e( 'Do not use CSS Grids for form layouts', 'formidable' ); ?>
 			<span class="frm_help frm_icon_font frm_tooltip_icon" title="<?php esc_attr_e( 'Form layouts built using CSS grids that are not fully supported by older browsers like Internet Explorer. Leave this box unchecked for your layouts to look best in current browsers, but show in a single column in older browsers.', 'formidable' ); ?>"></span>
+			&nbsp;
+			<span class="frm_warning_style" role="alert">
+				<?php FrmAppHelper::icon_by_class( 'frmfont frm_alert_icon' ); ?>
+				<?php esc_html_e( 'Warning: This setting is deprecated. It will be removed when it is turned off.', 'formidable' ); ?>
+			</span>
 		</label>
 	</p>
 <?php } ?>


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3034

<img width="1199" alt="Screen Shot 2021-06-28 at 12 10 35 PM" src="https://user-images.githubusercontent.com/9134515/123661596-0e3c3a00-d80b-11eb-95b4-0e1655ae29ac.png">

Do we want to change the wording? The double negative is a little funny.

And do we want to mention more about why we're doing this? Mention internet explorer? Should we refer to the upcoming WordPress deprecation?