### PR TITLE
use trailingslash it to avoid formidableimages path issue

### DIFF
--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -469,7 +469,7 @@ class FrmStylesController {
 	 * @return string
 	 */
 	public static function replace_relative_url( $css ) {
-		$plugin_url = FrmAppHelper::plugin_url();
+		$plugin_url = trailingslashit( FrmAppHelper::plugin_url() );
 		return str_replace(
 			array(
 				'url(../',


### PR DESCRIPTION
I was seeing a bug with my css trying to load at a path missing a slash in it (http://example.org/wp-content/plugins/formidableimages/ajax_loader.gif)

Looks like we missed a slash with https://github.com/Strategy11/formidable-forms/pull/393

I think this is fine. Just running this by you @truongwp.