### PR TITLE
Make an ajax request for menu order field

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4381,73 +4381,47 @@ function frmAdminBuildJS() {
 
 		// Get new post parent option.
 		if ( postParentField ) {
-			const postParentOpt     = postParentField.querySelector( '.frm_autocomplete_value_input' ) || postParentField.querySelector( 'select' );
-			const postParentOptName = postParentOpt.getAttribute( 'name' );
-
-			jQuery.ajax({
-				url: ajaxurl,
-				method: 'POST',
-				data: {
-					action: 'frm_get_post_parent_option',
-					post_type: postType,
-					_wpnonce: frmGlobal.nonce
-				},
-				success: response => {
-					if ( 'string' !== typeof response ) {
-						console.error( response );
-						return;
-					}
-
-					// Post type is not hierarchical.
-					if ( '0' === response ) {
-						postParentField.classList.add( 'frm_hidden' );
-						postParentOpt.value = '';
-						return;
-					}
-
-					postParentField.classList.remove( 'frm_hidden' );
-					// The replaced string is declared in FrmProFormActionController::ajax_get_post_parent_option() in the pro version.
-					postParentField.querySelector( '.frm_post_parent_opt_wrapper' ).innerHTML = response.replaceAll( 'REPLACETHISNAME', postParentOptName );
-					initAutocomplete( 'page', postParentField );
-				},
-				error: response => console.error( response )
-			});
+			getActionOption( postParentField, postType, 'frm_get_post_parent_option', 'frm_post_parent_opt_wrapper' );
 		}
 
 		if ( postMenuOrderField ) {
-			const postMenuOrderOpt     = postMenuOrderField.querySelector( '.frm_autocomplete_value_input' ) || postMenuOrderField.querySelector( 'select' );
-			const postMenuOrderOptName = postMenuOrderOpt.getAttribute( 'name' );
-
-			jQuery.ajax({
-				url: ajaxurl,
-				method: 'POST',
-				data: {
-					action: 'frm_get_post_menu_order_option',
-					post_type: postType,
-					_wpnonce: frmGlobal.nonce,
-					form_id: thisFormId
-				},
-				success: response => {
-					if ( 'string' !== typeof response ) {
-						console.error( response );
-						return;
-					}
-
-					// Post type is not a page.
-					if ( '0' === response ) {
-						postMenuOrderField.classList.add( 'frm_hidden' );
-						postMenuOrderField.value = '';
-						return;
-					}
-
-					postMenuOrderField.classList.remove( 'frm_hidden' );
-					// The replaced string is declared in FrmProFormActionController::ajax_get_post_menu_order_option() in the pro version.
-					postMenuOrderField.querySelector( '.frm_post_menu_order_opt_wrapper' ).innerHTML = response.replaceAll( 'REPLACETHISNAME', postMenuOrderOptName );
-					initAutocomplete( 'page', postMenuOrderField );
-				},
-				error: response => console.error( response )
-			});
+			getActionOption( postMenuOrderField, postType, 'frm_get_post_menu_order_option', 'frm_post_menu_order_opt_wrapper' );
 		}
+	}
+
+	function getActionOption( field, postType, action, wrapperClass ) {
+		const opt = field.querySelector( '.frm_autocomplete_value_input' ) || field.querySelector( 'select' ),
+			optName = opt.getAttribute( 'name' );
+
+		jQuery.ajax({
+			url: ajaxurl,
+			method: 'POST',
+			data: {
+				action: action,
+				post_type: postType,
+				_wpnonce: frmGlobal.nonce,
+				form_id: thisFormId
+			},
+			success: response => {
+				if ( 'string' !== typeof response ) {
+					console.error( response );
+					return;
+				}
+
+				// Post type is not a page.
+				if ( '0' === response ) {
+					field.classList.add( 'frm_hidden' );
+					field.value = '';
+					return;
+				}
+
+				field.classList.remove( 'frm_hidden' );
+				// The replaced string is declared in FrmProFormActionController::ajax_get_post_menu_order_option() in the pro version.
+				field.querySelector( '.' + wrapperClass ).innerHTML = response.replaceAll( 'REPLACETHISNAME', optName );
+				initAutocomplete( 'page', field );
+			},
+			error: response => console.error( response )
+		});
 	}
 
 	function addPosttaxRow() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4381,15 +4381,24 @@ function frmAdminBuildJS() {
 
 		// Get new post parent option.
 		if ( postParentField ) {
-			getActionOption( postParentField, postType, 'frm_get_post_parent_option', 'frm_post_parent_opt_wrapper' );
+			getActionOption(
+				postParentField,
+				postType,
+				'frm_get_post_parent_option',
+				function( response, optName ) {
+					// The replaced string is declared in FrmProFormActionController::ajax_get_post_menu_order_option() in the pro version.
+					postParentField.querySelector( '.frm_post_parent_opt_wrapper' ).innerHTML = response.replaceAll( 'REPLACETHISNAME', optName );
+					initAutocomplete( 'page', postParentField );
+				}
+			);
 		}
 
 		if ( postMenuOrderField ) {
-			getActionOption( postMenuOrderField, postType, 'frm_get_post_menu_order_option', 'frm_post_menu_order_opt_wrapper' );
+			getActionOption( postMenuOrderField, postType, 'frm_get_post_menu_order_option' );
 		}
 	}
 
-	function getActionOption( field, postType, action, wrapperClass ) {
+	function getActionOption( field, postType, action, successHandler ) {
 		const opt = field.querySelector( '.frm_autocomplete_value_input' ) || field.querySelector( 'select' ),
 			optName = opt.getAttribute( 'name' );
 
@@ -4399,8 +4408,7 @@ function frmAdminBuildJS() {
 			data: {
 				action: action,
 				post_type: postType,
-				_wpnonce: frmGlobal.nonce,
-				form_id: thisFormId
+				_wpnonce: frmGlobal.nonce
 			},
 			success: response => {
 				if ( 'string' !== typeof response ) {
@@ -4416,9 +4424,10 @@ function frmAdminBuildJS() {
 				}
 
 				field.classList.remove( 'frm_hidden' );
-				// The replaced string is declared in FrmProFormActionController::ajax_get_post_menu_order_option() in the pro version.
-				field.querySelector( '.' + wrapperClass ).innerHTML = response.replaceAll( 'REPLACETHISNAME', optName );
-				initAutocomplete( 'page', field );
+
+				if ( 'function' === typeof successHandler ) {
+					successHandler( response, optName );
+				}
 			},
 			error: response => console.error( response )
 		});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4343,6 +4343,7 @@ function frmAdminBuildJS() {
 		var curSelect, newSelect,
 			catRows = document.getElementById( 'frm_posttax_rows' ).childNodes,
 			postParentField = document.querySelector( '.frm_post_parent_field' ),
+			postMenuOrderField = document.querySelector( '.frm_post_menu_order_field' ),
 			postType = this.value;
 
 		// Get new category/taxonomy options
@@ -4408,6 +4409,41 @@ function frmAdminBuildJS() {
 					// The replaced string is declared in FrmProFormActionController::ajax_get_post_parent_option() in the pro version.
 					postParentField.querySelector( '.frm_post_parent_opt_wrapper' ).innerHTML = response.replaceAll( 'REPLACETHISNAME', postParentOptName );
 					initAutocomplete( 'page', postParentField );
+				},
+				error: response => console.error( response )
+			});
+		}
+
+		if ( postMenuOrderField ) {
+			const postMenuOrderOpt     = postMenuOrderField.querySelector( '.frm_autocomplete_value_input' ) || postMenuOrderField.querySelector( 'select' );
+			const postMenuOrderOptName = postMenuOrderOpt.getAttribute( 'name' );
+
+			jQuery.ajax({
+				url: ajaxurl,
+				method: 'POST',
+				data: {
+					action: 'frm_get_post_menu_order_option',
+					post_type: postType,
+					_wpnonce: frmGlobal.nonce,
+					form_id: thisFormId
+				},
+				success: response => {
+					if ( 'string' !== typeof response ) {
+						console.error( response );
+						return;
+					}
+
+					// Post type is not a page.
+					if ( '0' === response ) {
+						postMenuOrderField.classList.add( 'frm_hidden' );
+						postMenuOrderField.value = '';
+						return;
+					}
+
+					postMenuOrderField.classList.remove( 'frm_hidden' );
+					// The replaced string is declared in FrmProFormActionController::ajax_get_post_menu_order_option() in the pro version.
+					postMenuOrderField.querySelector( '.frm_post_menu_order_opt_wrapper' ).innerHTML = response.replaceAll( 'REPLACETHISNAME', postMenuOrderOptName );
+					initAutocomplete( 'page', postMenuOrderField );
 				},
 				error: response => console.error( response )
 			});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4394,7 +4394,7 @@ function frmAdminBuildJS() {
 		}
 
 		if ( postMenuOrderField ) {
-			getActionOption( postMenuOrderField, postType, 'frm_get_post_menu_order_option' );
+			getActionOption( postMenuOrderField, postType, 'frm_should_use_post_menu_order_option' );
 		}
 	}
 
@@ -4416,8 +4416,8 @@ function frmAdminBuildJS() {
 					return;
 				}
 
-				// Post type is not a page.
 				if ( '0' === response ) {
+					// This post type does not support this field.
 					field.classList.add( 'frm_hidden' );
 					field.value = '';
 					return;


### PR DESCRIPTION
Testing the new menu_order setting, I feel like it has to be dynamic like the post_parent options.

I refactored the post_parent logic as well since these both use almost entirely the same logic.

I wonder if we might want to use one action instead, but that might be weird with backward compatibility and having this in free and pro.

Also requires the AJAX action logic in the pro plugin [here](https://github.com/Strategy11/formidable-pro/pull/3089).