### PR TITLE
Put back the watch lookup option when switching away from single line text

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2609,19 +2609,23 @@ function frmAdminBuildJS() {
 		var link, lookupBlock,
 			fieldID = this.name.replace( 'field_options[data_type_', '' ).replace( ']', '' );
 
+		link = document.getElementById( 'frm_add_watch_lookup_link_' + fieldID ).parentNode;
+
 		if ( this.value === 'text' ) {
 			lookupBlock = document.getElementById( 'frm_watch_lookup_block_' + fieldID );
 			if ( lookupBlock !== null ) {
-				// Clear the Watch Fields option
+				// Clear and hide the Watch Fields option
 				lookupBlock.innerHTML = '';
+				link.classList.add( 'frm_hidden' );
 
 				// Hide the Watch Fields row
-				link = document.getElementById( 'frm_add_watch_lookup_link_' + fieldID ).parentNode;
-				link.style.display = 'none';
 				link.previousElementSibling.style.display = 'none';
 				link.previousElementSibling.previousElementSibling.style.display = 'none';
 				link.previousElementSibling.previousElementSibling.previousElementSibling.style.display = 'none';
 			}
+		} else {
+			// Show the Watch Fields option
+			link.classList.remove( 'frm_hidden' );
 		}
 
 		toggleMultiSelect( fieldID, this.value );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2214

Pretty simple one. There was logic to hide it, and no logic to put it back again.