### PR TITLE
fix autocomplete styling

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -4517,9 +4517,20 @@ h2.frm-h2,
 	font-weight: normal;
 }
 
+.frm_wrap .ui-autocomplete li div.ui-state-active,
 .frm_wrap .ui-autocomplete li.ui-state-focus {
 	background: rgb(65, 153, 253);
 	color: #fff;
+}
+
+.frm_wrap .ui-autocomplete .ui-menu-item-wrapper {
+	padding: 2px 10px;
+	border-radius: var(--small-radius);
+}
+
+.frm_wrap .ui-autocomplete .ui-menu-item-wrapper.ui-state-active {
+	border: none;
+	font-weight: inherit;
 }
 
 .frm_select_with_label {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2959

Here's what it looks like now:
<img width="739" alt="Screen Shot 2021-07-09 at 2 27 57 PM" src="https://user-images.githubusercontent.com/1116876/125132679-e62dc000-e0c1-11eb-9ab1-4e6f82d1560b.png">
