### PR TITLE
Use email from from value when reply to value is a shortcode that returns empty

### DIFF
--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -180,11 +180,14 @@ class FrmEmail {
 	private function set_reply_to( $user_id_args ) {
 		$this->reply_to = trim( $this->settings['reply_to'] );
 
-		if ( empty( $this->reply_to ) ) {
-			$this->reply_to = $this->get_email_from_name( $this->from );
-		} else {
+		if ( $this->reply_to ) {
 			$this->reply_to = $this->prepare_email_setting( $this->settings['reply_to'], $user_id_args );
 		}
+
+		if ( ! $this->reply_to ) {
+			$this->reply_to = $this->get_email_from_name( $this->from );
+		}
+
 		$this->reply_to = $this->format_reply_to( $this->reply_to );
 	}
 

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -550,8 +550,8 @@ class test_FrmEmail extends FrmUnitTest {
 		$entry_id                                    = $this->factory->entry->create( $entry_data );
 		$entry                                       = FrmEntry::getOne( $entry_id, true );
 		$action                                      = $this->email_action;
-		$action->post_content[ 'from' ]              = 'fromemail@example.com';
-		$action->post_content[ 'reply_to' ]          = '[free-email-field]';
+		$action->post_content['from']                = 'fromemail@example.com';
+		$action->post_content['reply_to']            = '[free-email-field]';
 		$email                                       = new FrmEmail( $action, $entry, $this->contact_form );
 		$actual                                      = $this->get_private_property( $email, 'reply_to' );
 		$this->assertEquals( 'fromemail@example.com', $actual );

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -534,15 +534,27 @@ class test_FrmEmail extends FrmUnitTest {
 	 */
 	public function test_set_reply_to() {
 		$default_email = get_option( 'admin_email' );
-
-		$reply_to = array(
-			'admin2.[admin_email]' => 'admin2.' . $default_email,
-			''                     => $default_email,
-			'Reply Name'           => 'Reply Name <' . $default_email . '>',
+		$reply_to      = array(
+			'admin2.[admin_email]'          => 'admin2.' . $default_email,
+			''                              => $default_email,
+			'Reply Name'                    => 'Reply Name <' . $default_email . '>',
 			'Reply To <tester@example.com>' => 'Reply To <tester@example.com>',
 		);
-
 		$this->check_private_properties( $reply_to, 'reply_to' );
+
+		// create an entry with no email and then try to use its shortcode to get a reply_to value.
+		// the default should use the from email, not the admin "default email".
+		$entry_data                                  = $this->factory->field->generate_entry_array( $this->contact_form );
+		$email_field                                 = FrmField::getOne( 'free-email-field' );
+		$entry_data['item_meta'][ $email_field->id ] = '';
+		$entry_id                                    = $this->factory->entry->create( $entry_data );
+		$entry                                       = FrmEntry::getOne( $entry_id, true );
+		$action                                      = $this->email_action;
+		$action->post_content[ 'from' ]              = 'fromemail@example.com';
+		$action->post_content[ 'reply_to' ]          = '[free-email-field]';
+		$email                                       = new FrmEmail( $action, $entry, $this->contact_form );
+		$actual                                      = $this->get_private_property( $email, 'reply_to' );
+		$this->assertEquals( 'fromemail@example.com', $actual );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2823

Quite simple. It was checking if the reply to was empty and then using the from name. But it wasn't check if the processed result was empty. So I flipped the logic a bit. First, we check if it's set, process it. Then if it's empty (which could have been true before, but it also matters if it is empty after), we use the from name.