### PR TITLE
Automatically focus on the first error input

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1007,7 +1007,7 @@ function frmFrontFormJS() {
 	}
 
 	function checkForErrorsAndMaybeSetFocus() {
-		var errors, element;
+		var errors, element, timeoutCallback;
 
 		errors = document.querySelectorAll( '.frm_form_field .frm_error' );
 		if ( ! errors.length ) {
@@ -1021,17 +1021,25 @@ function frmFrontFormJS() {
 				element.focus();
 				break;
 			}
-			if ( 'undefined' !== typeof element.classList && element.classList.contains( 'html-active' ) ) {
-				setTimeout(
-					function() {
+
+			if ( 'undefined' !== typeof element.classList ) {
+				if ( element.classList.contains( 'html-active' ) ) {
+					timeoutCallback = function() {
 						var textarea = element.querySelector( 'textarea' );
 						if ( null !== textarea ) {
 							textarea.focus();
 						}
-					},
-					0
-				);
-				break;
+					};
+				} else if ( element.classList.contains( 'tmce-active' ) ) {
+					timeoutCallback = function() {
+						tinyMCE.activeEditor.focus();
+					};
+				}
+
+				if ( 'function' === typeof timeoutCallback ) {
+					setTimeout( timeoutCallback, 0 );
+					break;
+				}
 			}
 		} while ( element.previousSibling );
 	}

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1017,7 +1017,7 @@ function frmFrontFormJS() {
 		element = errors[0];
 		do {
 			element = element.previousSibling;
-			if ( 'input' === element.nodeName.toLowerCase() ) {
+			if ( -1 !== [ 'input', 'select', 'textarea' ].indexOf( element.nodeName.toLowerCase() ) ) {
 				element.focus();
 				break;
 			}

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -608,6 +608,7 @@ function frmFrontFormJS() {
 						object.submit();
 					} else {
 						jQuery( object ).prepend( response.error_message );
+						checkForErrorsAndMaybeSetFocus();
 					}
 				} else {
 					// there may have been a plugin conflict, or the form is not set to submit with ajax
@@ -1005,6 +1006,24 @@ function frmFrontFormJS() {
 		});
 	}
 
+	function checkForErrorsAndMaybeSetFocus() {
+		var errors, element;
+
+		errors = document.querySelectorAll( '.frm_form_field .frm_error' );
+		if ( ! errors.length ) {
+			return;
+		}
+
+		element = errors[0];
+		do {
+			element = element.previousSibling;
+			if ( 'input' === element.nodeName.toLowerCase() ) {
+				element.focus();
+				break;
+			}
+		} while ( element.previousSibling );
+	}
+
 	return {
 		init: function() {
 			jQuery( document ).off( 'submit.formidable', '.frm-show-form' );
@@ -1029,6 +1048,8 @@ function frmFrontFormJS() {
 
 			jQuery( document ).on( 'click', 'a[data-frmconfirm]', confirmClick );
 			jQuery( 'a[data-frmtoggle]' ).on( 'click', toggleDiv );
+
+			checkForErrorsAndMaybeSetFocus();
 
 			// Focus on the first sub field when clicking to the primary label of combo field.
 			changeFocusWhenClickComboFieldLabel();
@@ -1203,6 +1224,7 @@ function frmFrontFormJS() {
 			}
 
 			scrollToFirstField( object );
+			checkForErrorsAndMaybeSetFocus();
 		},
 
 		checkFormErrors: function( object, action ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1021,6 +1021,18 @@ function frmFrontFormJS() {
 				element.focus();
 				break;
 			}
+			if ( 'undefined' !== typeof element.classList && element.classList.contains( 'html-active' ) ) {
+				setTimeout(
+					function() {
+						var textarea = element.querySelector( 'textarea' );
+						if ( null !== textarea ) {
+							textarea.focus();
+						}
+					},
+					0
+				);
+				break;
+			}
 		} while ( element.previousSibling );
 	}
 


### PR DESCRIPTION
I did some research on this topic. There's more we could probably do to make this even more accessible but I think this is a good start.

Fixes https://github.com/Strategy11/formidable-pro/issues/2897

I found some information on the issue at https://www.w3schools.com/accessibility/accessibility_errors.php

There's a section that reads:
> Move focus
> This is more important for server-side validations, compared to client-side validation. When the user submits a form, the focus moves to the first invalid field.
> In this example, all three fields have been invalid. The focus was moved to the first field.

So this checks out as a good best practice and it does make a form field easier to use when you mess it up, even if you're not blind 🥳.

I checked all of the many ways that errors are added that I can think of.

- A default form submission.
- With AJAX submit turned on.
- With JavaScript validation turned on.
- With multiple pages.
- A required name field (it autofocused the missing last name as expected)

Everything uses the same basic function that doesn't have terribly complicated logic so it should be good at catching every type of error.

@garretlaxton with this one, have fun really trying to trigger errors in as many ways as you can for whatever form configurations you can, see if I'm missing anything here.