### PR TITLE
Replace field ids on unserialized grid view content

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -11,7 +11,7 @@ class FrmAppHelper {
 	/**
 	 * @since 2.0
 	 */
-	public static $plug_version = '4.11.03';
+	public static $plug_version = '4.11.04';
 
 	/**
 	 * @since 1.07.02

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -733,18 +733,25 @@ class FrmXMLHelper {
 		);
 
 		foreach ( $views as $item ) {
-			$unserialized_content = maybe_unserialize( (string) $item->content );
+			$post_content         = (string) $item->content;
+			$unserialized_content = maybe_unserialize( $post_content );
 			if ( is_array( $unserialized_content ) && isset( $unserialized_content[0] ) && isset( $unserialized_content[0]['box'] ) ) {
+				$updated_box_content = false;
 				// grid views and the new table views use this format.
 				foreach ( $unserialized_content as $box_index => $box ) {
 					if ( ! empty( $box['content'] ) ) {
 						$unserialized_content[ $box_index ]['content'] = FrmFieldsHelper::switch_field_ids( $box['content'] );
+						if ( $unserialized_content[ $box_index ]['content'] !== $box['content'] ) {
+							$updated_box_content = true;
+						}
 					}
 				}
-				unset( $box_index, $box );
-				$post_content = serialize( $unserialized_content );
+				if ( $updated_box_content ) {
+					$post_content = maybe_serialize( $unserialized_content );
+				}
+				unset( $updated_box_content );
 			} else {
-				$post_content = FrmFieldsHelper::switch_field_ids( (string) $item->content );
+				$post_content = FrmFieldsHelper::switch_field_ids( $post_content );
 			}
 			unset( $unserialized_content );
 			$post = array(

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -733,6 +733,20 @@ class FrmXMLHelper {
 		);
 
 		foreach ( $views as $item ) {
+			$unserialized_content = maybe_unserialize( $item->content );
+			if ( is_array( $unserialized_content ) && isset( $unserialized_content[0] ) && isset( $unserialized_content[0]['box'] ) ) {
+				// grid views and the new table views use this format.
+				foreach ( $unserialized_content as $box_index => $box ) {
+					if ( ! empty( $box['content'] ) ) {
+						$unserialized_content[ $box_index ]['content'] = FrmFieldsHelper::switch_field_ids( $box['content'] );
+					}
+				}
+				unset( $box_index, $box );
+				$post_content = serialize( $unserialized_content );
+			} else {
+				$post_content = FrmFieldsHelper::switch_field_ids( (string) $item->content );
+			}
+			unset( $unserialized_content );
 			$post = array(
 				'post_title'     => (string) $item->title,
 				'post_name'      => (string) $item->post_name,
@@ -744,7 +758,7 @@ class FrmXMLHelper {
 				'post_id'        => (int) $item->post_id,
 				'post_parent'    => (int) $item->post_parent,
 				'menu_order'     => (int) $item->menu_order,
-				'post_content'   => FrmFieldsHelper::switch_field_ids( (string) $item->content ),
+				'post_content'   => $post_content,
 				'post_excerpt'   => FrmFieldsHelper::switch_field_ids( (string) $item->excerpt ),
 				'is_sticky'      => (string) $item->is_sticky,
 				'comment_status' => (string) $item->comment_status,
@@ -755,6 +769,8 @@ class FrmXMLHelper {
 				'layout'         => array(),
 				'tax_input'      => array(),
 			);
+
+			unset( $post_content );
 
 			$old_id = $post['post_id'];
 			self::populate_post( $post, $item, $imported );

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -733,7 +733,7 @@ class FrmXMLHelper {
 		);
 
 		foreach ( $views as $item ) {
-			$unserialized_content = maybe_unserialize( $item->content );
+			$unserialized_content = maybe_unserialize( (string) $item->content );
 			if ( is_array( $unserialized_content ) && isset( $unserialized_content[0] ) && isset( $unserialized_content[0]['box'] ) ) {
 				// grid views and the new table views use this format.
 				foreach ( $unserialized_content as $box_index => $box ) {

--- a/formidable.php
+++ b/formidable.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Formidable Forms
 Description: Quickly and easily create drag-and-drop forms
-Version: 4.11.03
+Version: 4.11.04
 Plugin URI: https://formidableforms.com/
 Author URI: https://formidableforms.com/
 Author: Strategy11


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-views/issues/191

I figure we can squeeze this into the 4.11.04 release since it's important 🚢.

Looks like I also added some commits for 4.11.04 in here by accident but I don't see any reason to bother taking them out at this point.