### PR TITLE
Allow for larger save/preview form button labels before wrapping

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -430,7 +430,8 @@ ul.frm_form_nav > li {
 #frm-publishing {
 	float: right;
 	margin-top: 15px;
-	width: 225px;
+	min-width: 225px;
+    max-width: 300px;
 	min-height: 10px;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -431,7 +431,7 @@ ul.frm_form_nav > li {
 	float: right;
 	margin-top: 15px;
 	min-width: 225px;
-    max-width: 300px;
+	max-width: 300px;
 	min-height: 10px;
 }
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2276

I tested using "Nieuwe toevoegen" for the "Add New" button (Dutch), it looks like this was improved earlier and doesn't look so bad.
![Screen Shot 2021-07-26 at 10 54 17 AM](https://user-images.githubusercontent.com/9134515/127000575-1adc8956-6c6f-4fa5-a3b3-dbf0b89f9d7d.png)

But the Aktualisieren (Update) and Vorschau (Preview) example (German) was still an issue. Now it looks like:
![Screen Shot 2021-07-26 at 10 32 49 AM](https://user-images.githubusercontent.com/9134515/126999453-b175bd65-b09c-41c7-afe1-e8c8e6ecd9cd.png)

And I tested it in Dutch as well
![Screen Shot 2021-07-26 at 10 55 12 AM](https://user-images.githubusercontent.com/9134515/127000765-72094b19-21d2-4765-a580-bc7761a794c6.png)

I tried using the rest of the site in plugin in Dutch for a moment and nothing else really seemed off 🕺.