### PR TITLE
bump frm publishing max width a little more

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -431,7 +431,7 @@ ul.frm_form_nav > li {
 	float: right;
 	margin-top: 15px;
 	min-width: 225px;
-	max-width: 300px;
+	max-width: 325px;
 	min-height: 10px;
 }
 


### PR DESCRIPTION
Continuing from https://github.com/Strategy11/formidable-forms/pull/469

I neglected how much additional space the button takes up once you click it in Dutch and the text changes to "Opties bijwerken" after it is clicked.


Just giving it a bit more max-width. 300 wasn't enough.