### PR TITLE
Clean up paradoxical psalm errors

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1530,7 +1530,7 @@ class FrmAppHelper {
 	}
 
 	public static function get_user_id_param( $user_id ) {
-		if ( ! $user_id || empty( $user_id ) || is_numeric( $user_id ) ) {
+		if ( ! $user_id || is_numeric( $user_id ) ) {
 			return $user_id;
 		}
 

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -385,7 +385,7 @@ class FrmEntriesHelper {
 	 */
 	public static function maybe_set_other_validation( $field, &$value, &$args ) {
 		$args['other'] = false;
-		if ( ! $value || empty( $value ) || ! FrmAppHelper::pro_is_installed() ) {
+		if ( ! $value || ! FrmAppHelper::pro_is_installed() ) {
 			return;
 		}
 

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -75,7 +75,7 @@ class FrmFormsHelper {
 	}
 
 	/**
-	 * @param string|object $selected - The label for the placeholder, or the form object.
+	 * @param string|object|false $selected - The label for the placeholder, or the form object.
 	 */
 	public static function form_switcher( $selected = false ) {
 		$where = apply_filters( 'frm_forms_dropdown', array(), '' );
@@ -751,7 +751,7 @@ BEFORE_HTML;
 	}
 
 	public static function submit_button_label( $submit ) {
-		if ( ! $submit || empty( $submit ) ) {
+		if ( ! $submit ) {
 			$frm_settings = FrmAppHelper::get_settings();
 			$submit       = $frm_settings->submit_value;
 		}

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -65,7 +65,7 @@ class FrmEntry {
 		global $wpdb;
 		$entry_exists = FrmDb::get_col( $wpdb->prefix . 'frm_items', $check_val, 'id', array( 'order_by' => 'created_at DESC' ) );
 
-		if ( ! $entry_exists || empty( $entry_exists ) || ! isset( $values['item_meta'] ) ) {
+		if ( ! $entry_exists || ! isset( $values['item_meta'] ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
I want to get psalm running as a workflow soon, but there are some errors still to fix before that.

This fixes 5/7 of the errors I'm seeing under my current configuration, mostly paradoxical code.

There's really no reason why you would ever check `if ( ! $var || empty( $var ) )` since the the second condition would never be true if the first is not.

```
ERROR: ParadoxicalCondition - classes/helpers/FrmFormsHelper.php:754:21 - Found a paradox when evaluating $submit of type non-empty-mixed and trying to reconcile it with a empty assertion (see https://psalm.dev/089)
		if ( ! $submit || empty( $submit ) ) {

ERROR: InvalidParamDefault - classes/helpers/FrmFormsHelper.php:78:12 - Default value type false for argument 1 of method FrmFormsHelper::form_switcher does not match the given type object|string (see https://psalm.dev/062)
	 * @param string|object $selected - The label for the placeholder, or the form object.

ERROR: ParadoxicalCondition - classes/helpers/FrmEntriesHelper.php:388:8 - Found a redundant condition when evaluating assertion (((!$value) || (!$value)) || (!<expr>)) (see https://psalm.dev/089)
		if ( ! $value || empty( $value ) || ! FrmAppHelper::pro_is_installed() ) {

ERROR: ParadoxicalCondition - classes/helpers/FrmAppHelper.php:1533:22 - Found a paradox when evaluating $user_id of type non-empty-mixed and trying to reconcile it with a empty assertion (see https://psalm.dev/089)
		if ( ! $user_id || empty( $user_id ) || is_numeric( $user_id ) ) {

ERROR: ParadoxicalCondition - classes/models/FrmEntry.php:68:27 - Found a paradox when evaluating $entry_exists of type non-empty-mixed and trying to reconcile it with a empty assertion (see https://psalm.dev/089)
```