### PR TITLE
Highlight the upgrade menu

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -11,16 +11,15 @@ class FrmAddonsController {
 		}
 
 		$label = __( 'Add-Ons', 'formidable' );
-		if ( FrmAppHelper::pro_is_installed() ) {
-			$label = '<span style="color:#fe5a1d">' . $label . '</span>';
-		}
+		$label = '<span style="color:#fe5a1d">' . $label . '</span>';
+
 		add_submenu_page( 'formidable', 'Formidable | ' . __( 'Add-Ons', 'formidable' ), $label, 'frm_view_forms', 'formidable-addons', 'FrmAddonsController::list_addons' );
 
 		if ( ! FrmAppHelper::pro_is_installed() ) {
 			add_submenu_page(
 				'formidable',
 				'Formidable | ' . __( 'Upgrade', 'formidable' ),
-				'<span style="color:#fe5a1d">' . __( 'Upgrade', 'formidable' ) . '</span>',
+				'<span class="frm-upgrade-submenu">' . __( 'Upgrade', 'formidable' ) . '</span>',
 				'frm_view_forms',
 				'formidable-pro-upgrade',
 				'FrmAddonsController::upgrade_to_pro'

--- a/css/font_icons.css
+++ b/css/font_icons.css
@@ -7,6 +7,16 @@
 	font-style: normal;
 }
 
+.frm-submenu-highlight {
+	background: #F15A24;
+}
+
+.frm-submenu-highlight a span {
+	color: #fff;
+	font-weight: 600;
+}
+
+
 .frmfont,
 .frm_icon_font,
 .frm_dashicon_font{

--- a/js/formidable_admin_global.js
+++ b/js/formidable_admin_global.js
@@ -5,7 +5,7 @@
 var frmWidgets, frmAdminPopup;
 
 jQuery( document ).ready( function() {
-    var deauthLink,
+    var deauthLink, submenuItem, li,
 		installLink = document.getElementById( 'frm_install_link' );
     if ( installLink !== null ) {
         jQuery( installLink ).on( 'click', frmInstallPro );
@@ -20,9 +20,9 @@ jQuery( document ).ready( function() {
         frmAdminPopup.init();
     }
 
-	var submenu_item = document.querySelector( '.frm-upgrade-submenu' );
-	if ( null !== submenu_item ) {
-		var li = submenu_item.parentNode.parentNode;
+	submenuItem = document.querySelector( '.frm-upgrade-submenu' );
+	if ( null !== submenuItem ) {
+		li = submenuItem.parentNode.parentNode;
 		if ( li ) {
 			li.classList.add( 'frm-submenu-highlight' );
 		}

--- a/js/formidable_admin_global.js
+++ b/js/formidable_admin_global.js
@@ -19,6 +19,14 @@ jQuery( document ).ready( function() {
     if ( typeof tb_remove === 'function' ) { // eslint-disable-line camelcase
         frmAdminPopup.init();
     }
+
+	var submenu_item = document.querySelector( '.frm-upgrade-submenu' );
+	if ( null !== submenu_item ) {
+		var li = submenu_item.parentNode.parentNode;
+		if ( li ) {
+			li.classList.add( 'frm-submenu-highlight' );
+		}
+	}
 });
 
 function frm_install_now() { // eslint-disable-line camelcase


### PR DESCRIPTION
This adds a background color on the upgrade menu in lite:
<img width="161" alt="Screen Shot 2021-07-29 at 1 19 39 PM" src="https://user-images.githubusercontent.com/1116876/127552960-fc6a1e0e-1dc3-4363-b658-73e9acb5e974.png">
