### PR TITLE
Make the style more specific to avoid other repeated field icons

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -1432,7 +1432,7 @@ select.frm_loading_lookup{
 	display:block;
 }
 
-.with_frm_style .frm_repeat_sec .frm_form_field .frm_icon_font::before {
+.with_frm_style .frm_repeat_sec .frm_form_field.frm_repeat_buttons .frm_icon_font::before {
 	color:<?php echo esc_html( $defaults['repeat_icon_color'] . $important ); ?>;
 	color:var(--repeat-icon-color)<?php echo esc_html( $important ); ?>;
 }


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3116

Issue with the update to set custom repeater icon colors. It was applying to all of the repeated fields, not just the add/remove buttons.

I'm making this more specific. But for the style editor preview to work, I also need to add this target class to the sample form with https://github.com/Strategy11/formidable-pro/pull/3117