### PR TITLE
Add padding to calculations before sanitizing happens

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: phpunit:${{ matrix.phpunit }}
+          tools: composer:v2.1.4, phpunit:${{ matrix.phpunit }}
 
       - name: Installing WordPress
         run: |

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: composer:v2.1.4, phpunit:${{ matrix.phpunit }}
+          tools: composer:v2.1.3, phpunit:${{ matrix.phpunit }}
 
       - name: Installing WordPress
         run: |

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ on:
 name: PHPUnit
 jobs:
   build-test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
     strategy:
       matrix:
         include:
@@ -19,6 +19,9 @@ jobs:
             wordpress: master
             phpunit: 6.5.14
           - php: 7.3
+            wordpress: master
+            phpunit: 6.5.14
+          - php: 7.1
             wordpress: master
             phpunit: 6.5.14
           - php: 7.0.33
@@ -36,7 +39,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: composer:v2.1.3, phpunit:${{ matrix.phpunit }}
+          tools: phpunit:${{ matrix.phpunit }}
 
       - name: Installing WordPress
         run: |

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ on:
 name: PHPUnit
 jobs:
   build-test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         include:
@@ -19,9 +19,6 @@ jobs:
             wordpress: master
             phpunit: 6.5.14
           - php: 7.3
-            wordpress: master
-            phpunit: 6.5.14
-          - php: 7.1
             wordpress: master
             phpunit: 6.5.14
           - php: 7.0.33

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -267,16 +267,30 @@ class FrmForm {
 	private static function sanitize_field_opt( $opt, &$value ) {
 		if ( is_string( $value ) ) {
 			if ( $opt === 'calc' ) {
-				$allow = array( '<= ', ' >=' ); // Allow <= and >=
-				$temp  = array( '< = ', ' > =' );
-				$value = str_replace( $allow, $temp, $value );
-				$value = strip_tags( $value );
-				$value = str_replace( $temp, $allow, $value );
+				$value = self::sanitize_calc( $value );
 			} else {
 				$value = FrmAppHelper::kses( $value, 'all' );
 			}
 			$value = trim( $value );
 		}
+	}
+
+	/**
+	 * @param string $value
+	 * @return string
+	 */
+	private static function sanitize_calc( $value ) {
+		$allow = array( '<= ', ' >=' ); // Allow <= and >=
+		$temp  = array( '< = ', ' > =' );
+		$value = str_replace( $allow, $temp, $value );
+
+		if ( false !== strpos( $value, '<' ) ) {
+			$value = preg_replace( '/(\d)<(\d)/', '$1 < $2', $value );
+		}
+
+		$value = strip_tags( $value );
+		$value = str_replace( $temp, $allow, $value );
+		return $value;
 	}
 
 	/**

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -280,14 +280,12 @@ class FrmForm {
 	 * @return string
 	 */
 	private static function sanitize_calc( $value ) {
+		if ( false !== strpos( $value, '<' ) ) {
+			$value = preg_replace( '/(\d)( ){0,1}<(=){0,1}( ){0,1}(\d)/', '$1 <$3 $5', $value );
+		}
 		$allow = array( '<= ', ' >=' ); // Allow <= and >=
 		$temp  = array( '< = ', ' > =' );
 		$value = str_replace( $allow, $temp, $value );
-
-		if ( false !== strpos( $value, '<' ) ) {
-			$value = preg_replace( '/(\d)( ){0,1}<( ){0,1}(\d)/', '$1 < $4', $value );
-		}
-
 		$value = strip_tags( $value );
 		$value = str_replace( $temp, $allow, $value );
 		return $value;

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -292,7 +292,8 @@ class FrmForm {
 	}
 
 	/**
-	 * Format a comparison like 5<10 to 5 < 10. Also works on 5< 10, 5 <10 variations.
+	 * Format a comparison like 5<10 to 5 < 10. Also works on 5< 10, 5 <10, 5<=10 variations.
+	 * This is to avoid an issue with unspaced calculations being recognized as HTML that gets removed when strip_tags is called.
 	 *
 	 * @param string $calc
 	 * @return string

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -281,7 +281,7 @@ class FrmForm {
 	 */
 	private static function sanitize_calc( $value ) {
 		if ( false !== strpos( $value, '<' ) ) {
-			$value = preg_replace( '/(\d)( ){0,1}<(=){0,1}( ){0,1}(\d)/', '$1 <$3 $5', $value );
+			$value = self::normalize_calc_spaces( $value );
 		}
 		$allow = array( '<= ', ' >=' ); // Allow <= and >=
 		$temp  = array( '< = ', ' > =' );
@@ -289,6 +289,22 @@ class FrmForm {
 		$value = strip_tags( $value );
 		$value = str_replace( $temp, $allow, $value );
 		return $value;
+	}
+
+	/**
+	 * Format a comparison like 5<10 to 5 < 10. Also works on 5< 10, 5 <10 variations.
+	 *
+	 * @param string $calc
+	 * @return string
+	 */
+	private static function normalize_calc_spaces( $calc ) {
+		// Check for a pattern with 5 parts
+		// $1 \d the first comparison digit.
+		// $2 a space (optional).
+		// $3 an equals sign (optional) that follows the < operator for <= comparisons.
+		// $4 another space (optional).
+		// $5 \d the second comparison digit.
+		return preg_replace( '/(\d)( ){0,1}<(=){0,1}( ){0,1}(\d)/', '$1 <$3 $5', $calc );
 	}
 
 	/**

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -285,7 +285,7 @@ class FrmForm {
 		$value = str_replace( $allow, $temp, $value );
 
 		if ( false !== strpos( $value, '<' ) ) {
-			$value = preg_replace( '/(\d)<(\d)/', '$1 < $2', $value );
+			$value = preg_replace( '/(\d)( ){0,1}<( ){0,1}(\d)/', '$1 < $4', $value );
 		}
 
 		$value = strip_tags( $value );

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -129,6 +129,7 @@ class test_FrmForm extends FrmUnitTest {
 
 	/**
 	 * @covers FrmForm::sanitize_field_opt
+	 * @group mike
 	 */
 	public function test_sanitize_field_opt() {
 		$this->assert_sanitize_field_opt_calc( '', '<div></div>', 'HTML should be stripped from calculations' );
@@ -173,5 +174,24 @@ class test_FrmForm extends FrmUnitTest {
 			array( 'FrmForm', 'sanitize_field_opt' ),
 			array( $opt, &$value )
 		);
+	}
+
+	/**
+	 * @covers FrmForm::normalize_calc_spaces
+	 * @group mike
+	 */
+	public function test_normalize_calc_spaces() {
+		$this->assertEquals( '5 < 10', $this->normalize_calc_spaces( '5<10' ) );
+		$this->assertEquals( '5 < 10', $this->normalize_calc_spaces( '5 <10' ) );
+		$this->assertEquals( '5 < 10', $this->normalize_calc_spaces( '5< 10' ) );
+		$this->assertEquals( '1 < 2 && 3 < 4 && 5 < 6', $this->normalize_calc_spaces( '1<2 && 3<4 && 5<6' ) );
+		$this->assertEquals( '5 <= 10', $this->normalize_calc_spaces( '5<=10' ) );
+		$this->assertEquals( '5 <= 10', $this->normalize_calc_spaces( '5 <=10' ) );
+		$this->assertEquals( '5 <= 10', $this->normalize_calc_spaces( '5<= 10' ) );
+		$this->assertEquals( '1 <= 2 && 3 <= 4 && 5 <= 6', $this->normalize_calc_spaces( '1<=2 && 3<=4 && 5<=6' ) );
+	}
+
+	private function normalize_calc_spaces( $calc ) {
+		return $this->run_private_method( array( 'FrmForm', 'normalize_calc_spaces' ), array( $calc ) );
 	}
 }

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -134,16 +134,17 @@ class test_FrmForm extends FrmUnitTest {
 		$original_value = '[189] > 1 && [189] < 5 ? 20 : [189] > 5 && [189] < 8 ? 21 : 0';
 		$this->assert_sanitize_field_opt_calc( $original_value, $original_value, 'comparisons should not be detected as unsafe html tags' );
 
-		$this->assert_sanitize_field_opt_calc( '50 < 100 ? 1 : 0', '50<100 ? 1 : 0', 'unspaced comparisons will be padded by a space to avoid strip_tags issues.' );
-		$this->assert_sanitize_field_opt_calc( '50 < 100 ? 1 : 0', '50 <100 ? 1 : 0' );
-		$this->assert_sanitize_field_opt_calc( '50 < 100 ? 1 : 0', '50< 100 ? 1 : 0' );
+		$safe_less_than_comparison = '50 < 100 ? 1 : 0';
+		$this->assert_sanitize_field_opt_calc( $safe_less_than_comparison, $safe_less_than_comparison );
+		$this->assert_sanitize_field_opt_calc( $safe_less_than_comparison, '50<100 ? 1 : 0', 'unspaced comparisons will be padded by a space to avoid strip_tags issues.' );
+		$this->assert_sanitize_field_opt_calc( $safe_less_than_comparison, '50 <100 ? 1 : 0' );
+		$this->assert_sanitize_field_opt_calc( $safe_less_than_comparison, '50< 100 ? 1 : 0' );
 
 		$original_value = '50>100 ? 1 : 0';
 		$this->assert_sanitize_field_opt_calc( $original_value, $original_value, 'greater than comparisons do not get stripped, so they do not get any additional string padding.' );
 
 		$original_value = '50 >100 ? 1 : 0';
 		$this->assert_sanitize_field_opt_calc( $original_value, $original_value );
-
 	}
 
 	private function assert_sanitize_field_opt_calc( $expected, $original_value, $message = '' ) {

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -129,7 +129,6 @@ class test_FrmForm extends FrmUnitTest {
 
 	/**
 	 * @covers FrmForm::sanitize_field_opt
-	 * @group mike
 	 */
 	public function test_sanitize_field_opt() {
 		$this->assert_sanitize_field_opt_calc( '', '<div></div>', 'HTML should be stripped from calculations' );
@@ -178,7 +177,6 @@ class test_FrmForm extends FrmUnitTest {
 
 	/**
 	 * @covers FrmForm::normalize_calc_spaces
-	 * @group mike
 	 */
 	public function test_normalize_calc_spaces() {
 		$this->assertEquals( '5 < 10', $this->normalize_calc_spaces( '5<10' ) );

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -145,6 +145,10 @@ class test_FrmForm extends FrmUnitTest {
 
 		$original_value = '50 >100 ? 1 : 0';
 		$this->assert_sanitize_field_opt_calc( $original_value, $original_value );
+
+		$safe_less_than_equals_comparison = '50 <= 100 ? 1 : 0';
+		$this->assert_sanitize_field_opt_calc( $safe_less_than_equals_comparison, $safe_less_than_equals_comparison );
+		$this->assert_sanitize_field_opt_calc( '50 <= 100 ? 1 : 0', '50<=100 ? 1 : 0' );
 	}
 
 	private function assert_sanitize_field_opt_calc( $expected, $original_value, $message = '' ) {

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -149,6 +149,15 @@ class test_FrmForm extends FrmUnitTest {
 		$safe_less_than_equals_comparison = '50 <= 100 ? 1 : 0';
 		$this->assert_sanitize_field_opt_calc( $safe_less_than_equals_comparison, $safe_less_than_equals_comparison );
 		$this->assert_sanitize_field_opt_calc( '50 <= 100 ? 1 : 0', '50<=100 ? 1 : 0' );
+
+		$original_value = '50 >=100 ? 1 : 0';
+		$this->assert_sanitize_field_opt_calc( $original_value, $original_value );
+
+		$original_value = '50>= 100 ? 1 : 0';
+		$this->assert_sanitize_field_opt_calc( $original_value, $original_value );
+
+		$original_value = '50>=100 ? 1 : 0';
+		$this->assert_sanitize_field_opt_calc( $original_value, $original_value );
 	}
 
 	private function assert_sanitize_field_opt_calc( $expected, $original_value, $message = '' ) {

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -136,6 +136,11 @@ class test_FrmForm extends FrmUnitTest {
 		$value          = $original_value;
 		$this->sanitize_field_opt( $opt, $value );
 		$this->assertEquals( $original_value, $value, 'comparisons should not be detected as unsafe html tags' );
+
+		$original_value = '50<100 ? 1 : 0';
+		$value          = $original_value;
+		$this->sanitize_field_opt( $opt, $value );
+		$this->assertEquals( '50 < 100 ? 1 : 0', $value, 'unspaced comparisons will be padded by a space to avoid strip_tags issues.' );
 	}
 
 	private function sanitize_field_opt( $opt, &$value ) {

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -131,6 +131,8 @@ class test_FrmForm extends FrmUnitTest {
 	 * @covers FrmForm::sanitize_field_opt
 	 */
 	public function test_sanitize_field_opt() {
+		$this->assert_sanitize_field_opt_calc( '', '<div></div>', 'HTML should be stripped from calculations' );
+
 		$original_value = '[189] > 1 && [189] < 5 ? 20 : [189] > 5 && [189] < 8 ? 21 : 0';
 		$this->assert_sanitize_field_opt_calc( $original_value, $original_value, 'comparisons should not be detected as unsafe html tags' );
 

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -131,16 +131,25 @@ class test_FrmForm extends FrmUnitTest {
 	 * @covers FrmForm::sanitize_field_opt
 	 */
 	public function test_sanitize_field_opt() {
-		$opt            = 'calc';
 		$original_value = '[189] > 1 && [189] < 5 ? 20 : [189] > 5 && [189] < 8 ? 21 : 0';
-		$value          = $original_value;
-		$this->sanitize_field_opt( $opt, $value );
-		$this->assertEquals( $original_value, $value, 'comparisons should not be detected as unsafe html tags' );
+		$this->assert_sanitize_field_opt_calc( $original_value, $original_value, 'comparisons should not be detected as unsafe html tags' );
 
-		$original_value = '50<100 ? 1 : 0';
-		$value          = $original_value;
-		$this->sanitize_field_opt( $opt, $value );
-		$this->assertEquals( '50 < 100 ? 1 : 0', $value, 'unspaced comparisons will be padded by a space to avoid strip_tags issues.' );
+		$this->assert_sanitize_field_opt_calc( '50 < 100 ? 1 : 0', '50<100 ? 1 : 0', 'unspaced comparisons will be padded by a space to avoid strip_tags issues.' );
+		$this->assert_sanitize_field_opt_calc( '50 < 100 ? 1 : 0', '50 <100 ? 1 : 0' );
+		$this->assert_sanitize_field_opt_calc( '50 < 100 ? 1 : 0', '50< 100 ? 1 : 0' );
+
+		$original_value = '50>100 ? 1 : 0';
+		$this->assert_sanitize_field_opt_calc( $original_value, $original_value, 'greater than comparisons do not get stripped, so they do not get any additional string padding.' );
+
+		$original_value = '50 >100 ? 1 : 0';
+		$this->assert_sanitize_field_opt_calc( $original_value, $original_value );
+
+	}
+
+	private function assert_sanitize_field_opt_calc( $expected, $original_value, $message = '' ) {
+		$value = $original_value;
+		$this->sanitize_field_opt( 'calc', $value );
+		$this->assertEquals( $expected, $value, $message );
 	}
 
 	private function sanitize_field_opt( $opt, &$value ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2977

I'm just normalizing the expression a bit before it goes through the other sanitizing that was already there.

`5<10`, `5<=10`, get stripped. `5 < 10`, `5 <= 10` don't. Making sure that the spaces are always there before the sanitizing happens prevents the final value getting saved as just a `5`.

To avoid the preg_replace when it would have no effect, I've also added a small strpos check first so it only processes if it sees any `<` characters.

I also moved the calc sanitizing to its own function, and added unit tests to cover a lot similar patterns.

It looks like workflows are also breaking because of the ubuntu version. I tried playing with that briefly but it looks like there are other issues too. I think a new version of composer might be causing issues.