### PR TITLE
Bump up ubuntu, target WP 5.8 for now.

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ on:
 name: PHPUnit
 jobs:
   build-test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         include:
@@ -19,9 +19,6 @@ jobs:
             wordpress: master
             phpunit: 6.5.14
           - php: 7.3
-            wordpress: master
-            phpunit: 6.5.14
-          - php: 7.1
             wordpress: master
             phpunit: 6.5.14
           - php: 7.0.33
@@ -39,7 +36,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: phpunit:${{ matrix.phpunit }}
+          tools: phpunit:${{ matrix.phpunit }}, composer:2.0.10
 
       - name: Installing WordPress
         run: |

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: phpunit:${{ matrix.phpunit }}, composer:2.0.10
+          tools: phpunit:${{ matrix.phpunit }}
 
       - name: Installing WordPress
         run: |

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -16,10 +16,10 @@ jobs:
       matrix:
         include:
           - php: 7.4
-            wordpress: master
+            wordpress: 5.8
             phpunit: 6.5.14
           - php: 7.3
-            wordpress: master
+            wordpress: 5.8
             phpunit: 6.5.14
           - php: 7.0.33
             wordpress: 4.9


### PR DESCRIPTION
I think this is a fix for what I'm experiencing, from 8 hours ago https://core.trac.wordpress.org/changeset/51598

An update in WP master appears to have broken our workflow, assuming that composer is running update.

For now I'm just targeting WP 5.8. Should be fine changing back to master shortly.