### PR TITLE
Fix issue with duplicating long form keys

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1585,8 +1585,8 @@ class FrmAppHelper {
 	 * @param string $name
 	 * @param string $table_name
 	 * @param string $column
-	 * @param int $id
-	 * @param int $num_chars
+	 * @param int    $id
+	 * @param int    $num_chars
 	 */
 	public static function get_unique_key( $name, $table_name, $column, $id = 0, $num_chars = 5 ) {
 		$key = '';
@@ -1611,10 +1611,29 @@ class FrmAppHelper {
 		);
 
 		if ( $key_check || is_numeric( $key_check ) ) {
+			$key = self::maybe_truncate_key_before_appending( $column, $key );
 			// Create a unique field id if it has already been used.
 			$key = $key . substr( md5( microtime() . rand() ), 0, 10 );
 		}
 
+		return $key;
+	}
+
+	/**
+	 * Avoid trying to append to a really long key,
+	 * The database limit is 100 for form and field keys so we want to avoid getting too close.
+	 *
+	 * @param string $column
+	 * @param string $key
+	 * @return string
+	 */
+	private static function maybe_truncate_key_before_appending( $column, $key ) {
+		if ( in_array( $column, array( 'form_key', 'field_key' ), true ) ) {
+			$max_key_length_before_truncating = 60;
+			if ( strlen( $key ) > $max_key_length_before_truncating ) {
+				$key = substr( $key, 0, $max_key_length_before_truncating );
+			}
+		}
 		return $key;
 	}
 

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -455,5 +455,15 @@ class test_FrmAppHelper extends FrmUnitTest {
 		$name = 123;
 		$key  = FrmAppHelper::get_unique_key( $name, $table_name, $column );
 		$this->assertFalse( is_numeric( $key ), 'key should never be numeric.' );
+
+		$super_long_form_key = 'formkeywithlikeseventycharacterscanyouevenimaginehavingthismanyletters';
+		// reserve the form key so one has to be generated with this as the base.
+		$this->factory->form->create(
+			array( 'form_key' => $super_long_form_key )
+		);
+
+		$unique_key = FrmAppHelper::get_unique_key( $super_long_form_key, 'frm_forms', 'form_key' );
+		$this->assertTrue( strlen( $unique_key ) <= 70 );
+		$this->assertNotEquals( $super_long_form_key, $unique_key );
 	}
 }


### PR DESCRIPTION
I'm not totally sure what willed me to test this but duplicating long form keys totally breaks, similar to the long field key duplicating issue I fixed a while ago.

![Screen Shot 2021-08-12 at 10 54 26 AM](https://user-images.githubusercontent.com/9134515/129209296-17d70382-d734-4327-bfb4-4f759ff6c971.png)

This double checks that a key is long before making it longer, if we're extending a key that was reserved in the database.