### PR TITLE
Fix compare for update unit test

### DIFF
--- a/tests/misc/test_FrmAppController.php
+++ b/tests/misc/test_FrmAppController.php
@@ -121,16 +121,16 @@ class test_FrmAppController extends FrmUnitTest {
 			),
 			array(
 				'version'  => '5.0',
-				'db'       => 50,
+				'db'       => 98,
 				'expected' => true,
 			),
 			array(
-				'version'  => '5.0',
+				'version'  => '6.0',
 				'db'       => FrmAppHelper::$db_version + 1,
 				'expected' => false,
 			),
 			array(
-				'version'  => '5.01.10',
+				'version'  => '6.01.10',
 				'db'       => 900,
 				'expected' => false,
 			),


### PR DESCRIPTION
I made a release and it didn't go live because of this failing unit test that seemed to happen when I bumped the version.

It looks like it has specific tests for going up to the next major version? It seems that it breaks now that we're at 5.0.

This update makes it pass. I'm targeting the 6.0 major version now instead, which I think is what needs to be done here? I set the 5.0 test to use the current db version. I think that's what that's intended for?