### PR TITLE
Add duplicate/delete options to field groups

### DIFF
--- a/classes/views/frm-forms/add_field.php
+++ b/classes/views/frm-forms/add_field.php
@@ -3,8 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
 ?>
-<li id="frm_field_id_<?php echo esc_attr( $field['id'] ); ?>" class="<?php echo esc_attr( $li_classes ); ?>" data-fid="<?php echo esc_attr( $field['id'] ); ?>" data-formid="<?php echo esc_attr( 'divider' == $field['type'] ? $field['form_select'] : $field['form_id'] ); ?>" data-ftype="<?php echo esc_attr( $display['type'] ); ?>" data-type="<?php echo esc_attr( $field['type'] ); ?>">
-<?php if ( $field['type'] == 'divider' ) { ?>
+<li id="frm_field_id_<?php echo esc_attr( $field['id'] ); ?>" class="<?php echo esc_attr( $li_classes ); ?>" data-fid="<?php echo esc_attr( $field['id'] ); ?>" data-formid="<?php echo esc_attr( 'divider' === $field['type'] ? $field['form_select'] : $field['form_id'] ); ?>" data-ftype="<?php echo esc_attr( $display['type'] ); ?>" data-type="<?php echo esc_attr( $field['type'] ); ?>">
+<?php if ( $field['type'] === 'divider' ) { ?>
 <div class="divider_section_only">
 <?php } ?>
 
@@ -29,18 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<a href="#" class="frm_bstooltip frm-hover-icon frm-dropdown-toggle dropdown-toggle" title="<?php esc_attr_e( 'More Options', 'formidable' ); ?>" data-toggle="dropdown" data-container="body">
 				<?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_thick_more_vert_icon' ); ?>
 			</a>
-			<ul class="frm-dropdown-menu" role="menu">
-				<li class="frm_dropdown_li frm_delete_field" href="#">
-					<?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_delete_icon' ); ?> <?php esc_html_e( 'Delete', 'formidable' ); ?>
-				</li>
-				<li class="frm_dropdown_li frm_clone_field" href="#">
-					<?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_clone_icon' ); ?> <?php esc_html_e( 'Duplicate', 'formidable' ); ?>
-				</li>
-				<hr>
-				<li class="frm_dropdown_li frm_select_field">
-					<?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_settings_icon' ); ?> <?php esc_html_e( 'Field settings', 'formidable' ); ?>
-				</li>
-			</ul>
+			<ul class="frm-dropdown-menu" role="menu"></ul>
 		</div>
 
 	</div>
@@ -59,7 +48,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php $field_obj->show_on_form_builder(); ?>
 		<div class="clear"></div>
 	</div>
-	<?php if ( $display['description'] || in_array( $field['type'], array( 'address', 'credit_card' ) ) ) { ?>
+	<?php if ( $display['description'] || in_array( $field['type'], array( 'address', 'credit_card' ), true ) ) { ?>
 		<div class="frm_description" id="field_description_<?php echo esc_attr( $field['id'] ); ?>">
 			<?php echo FrmAppHelper::kses( force_balance_tags( $field['description'] ), 'all' ); // WPCS: XSS ok. ?>
 		</div>

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6745,12 +6745,14 @@ ul .frm_col_two {
 	font-size: 15px;
 }
 
+#frm_field_group_controls .frm-dropdown-menu .frm_dropdown_li,
 .frm-field-action-icons .frm-dropdown-menu .frm_dropdown_li {
 	padding: 5px 10px;
 	color: rgba(40, 47, 54, 0.85);
 	cursor: pointer;
 }
 
+#frm_field_group_controls .frm-dropdown-menu .frm_dropdown_li:hover,
 .frm-field-action-icons .frm-dropdown-menu .frm_dropdown_li:hover {
 	background: #F6F7FB;
 }

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8565,7 +8565,6 @@ function frmAdminBuildJS() {
 			jQuery( document ).on( 'click', '.frm-merge-fields-into-row', mergeFieldsIntoRowClick );
 			jQuery( document ).on( 'click', '.frm-delete-field-groups', deleteFieldGroupsClick );
 			$newFields.on( 'click', '.frm-field-action-icons [data-toggle="dropdown"]', function() {
-				// TODO can I move this into the show listener?
 				this.closest( 'li.form-field' ).classList.add( 'frm-field-settings-open' );
 				jQuery( document ).on( 'click', '#frm_builder_page', handleClickOutsideOfFieldSettings );
 			});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3652,6 +3652,7 @@ function frmAdminBuildJS() {
 		} else {
 			// not multi-selecting
 			unselectFieldGroups();
+			numberOfSelectedGroups = 1;
 		}
 
 		hoverTarget.classList.add( 'frm-selected-field-group' );
@@ -3663,12 +3664,16 @@ function frmAdminBuildJS() {
 
 	function syncAfterMultiSelect( numberOfSelectedGroups ) {
 		clearSettingsBox( true ); // unselect any fields if one is selected.
-		if ( numberOfSelectedGroups >= 2 ) {
+		if ( numberOfSelectedGroups >= 2 || ( 1 === numberOfSelectedGroups && selectedGroupHasMultipleFields() ) ) {
 			addFieldMultiselectPopup();
 		} else {
 			maybeRemoveMultiselectPopup();
 		}
 		maybeRemoveGroupHoverTarget();
+	}
+
+	function selectedGroupHasMultipleFields() {
+		return getFieldsInRow( jQuery( document.querySelector( '.frm-selected-field-group' ) ) ).length > 1;
 	}
 
 	function unselectFieldGroups( event ) {
@@ -3753,6 +3758,9 @@ function frmAdminBuildJS() {
 		var selectedFieldGroups, totalFieldCount, length, index, fieldGroup;
 		selectedFieldGroups = document.querySelectorAll( '.frm-selected-field-group' );
 		length = selectedFieldGroups.length;
+		if ( 1 === length ) {
+			return false;
+		}
 		totalFieldCount = 0;
 		for ( index = 0; index < length; ++index ) {
 			fieldGroup = selectedFieldGroups[ index ];

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1861,36 +1861,36 @@ function frmAdminBuildJS() {
 	}
 
 	function onFieldGroupActionDropdownShow() {
-        onFieldActionDropdownShow( true );
-    }
+		onFieldActionDropdownShow( true );
+	}
 
-    function fillFieldActionDropdown( ul, isFieldGroup ) {
-        var classSuffix, options;
-        classSuffix = isFieldGroup ? '_field_group' : '_field';
-        options = [ getDeleteActionOption( isFieldGroup ), getDuplicateActionOption( isFieldGroup ) ];
-        if ( ! isFieldGroup ) {
-            options.push(
-                { class: 'frm_select', icon: 'frm_settings_icon', label: __( 'Field settings', 'formidable' ) }
-            );
-        }
-        options.forEach(
-            function( option ) {
-                var li, span;
-                li = document.createElement( 'li' );
-                li.classList.add( 'frm_dropdown_li', option.class + classSuffix );
+	function fillFieldActionDropdown( ul, isFieldGroup ) {
+		var classSuffix, options;
+		classSuffix = isFieldGroup ? '_field_group' : '_field';
+		options = [ getDeleteActionOption( isFieldGroup ), getDuplicateActionOption( isFieldGroup ) ];
+		if ( ! isFieldGroup ) {
+			options.push(
+				{ class: 'frm_select', icon: 'frm_settings_icon', label: __( 'Field settings', 'formidable' ) }
+			);
+		}
+		options.forEach(
+			function( option ) {
+				var li, span;
+				li = document.createElement( 'li' );
+				li.classList.add( 'frm_dropdown_li', option.class + classSuffix );
 				if ( 'frm_delete' === option.class ) {
 					// delete using a confirmation that will cause a redirect if href isn't set to #.
 					li.setAttribute( 'href', '#' );
 				}
-                span = document.createElement( 'span' );
-                span.textContent = option.label;
-                li.innerHTML = '<svg class="frmsvg"><use xlink:href="#' + option.icon + '"></use></svg>';
-                li.appendChild( document.createTextNode( ' ' ) );
-                li.appendChild( span );
-                ul.appendChild( li );
-            }
-        );
-    }
+				span = document.createElement( 'span' );
+				span.textContent = option.label;
+				li.innerHTML = '<svg class="frmsvg"><use xlink:href="#' + option.icon + '"></use></svg>';
+				li.appendChild( document.createTextNode( ' ' ) );
+				li.appendChild( span );
+				ul.appendChild( li );
+			}
+		);
+	}
 
 	function getDeleteActionOption( isFieldGroup ) {
 		var option = { class: 'frm_delete', icon: 'frm_delete_icon' };

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3031,7 +3031,7 @@ function frmAdminBuildJS() {
 					);
 				}
 
-				syncLayoutClasses( getFieldsInRow( $newRowUl ).first(), syncDetails );
+				syncLayoutClasses( $duplicatedFields.first(), syncDetails );
 				$newRow.removeClass( 'frm_hidden' );
 				updateFieldOrder();
 			}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1849,8 +1849,8 @@ function frmAdminBuildJS() {
 					return;
 				}
 				if ( 0 === ul.children.length ) {
-                    fillFieldActionDropdown( ul, true === isFieldGroup );
-                }
+					fillFieldActionDropdown( ul, true === isFieldGroup );
+				}
 				$ul = jQuery( ul );
 				if ( $ul.offset().left > jQuery( window ).width() - $ul.outerWidth() ) {
 					ul.style.left = ( -$ul.outerWidth() ) + 'px';
@@ -2968,8 +2968,8 @@ function frmAdminBuildJS() {
 		this.closest( 'li.form-field' ).click();
 	}
 
-    function clickDeleteFieldGroup() {
-        var hoverTarget, decoy;
+	function clickDeleteFieldGroup() {
+		var hoverTarget, decoy;
 
 		hoverTarget = document.querySelector( '.frm-field-group-hover-target' );
 		if ( null === hoverTarget ) {
@@ -2982,9 +2982,9 @@ function frmAdminBuildJS() {
 		decoy.classList.add( 'frm-delete-field-groups', 'frm_hidden' );
 		document.body.appendChild( decoy );
 		decoy.click();
-    }
+	}
 
-    function duplicateFieldGroup() {
+	function duplicateFieldGroup() {
 		var hoverTarget, newRowId, $newRow, $fields, syncDetails, expectedLength, interval, injectedCloneOptions;
 
 		hoverTarget = document.querySelector( '.frm-field-group-hover-target' );
@@ -3044,7 +3044,7 @@ function frmAdminBuildJS() {
 			},
 			50
 		);
-    }
+	}
 
 	function clickFieldGroupLayout() {
 		var hoverTarget, sizeOfFieldGroup, popupWrapper;
@@ -8551,7 +8551,7 @@ function frmAdminBuildJS() {
 			$newFields.on( 'click', '.frm_delete_field', clickDeleteField );
 			$newFields.on( 'click', '.frm_select_field', clickSelectField );
 			jQuery( document ).on( 'click', '.frm_delete_field_group', clickDeleteFieldGroup );
-            jQuery( document ).on( 'click', '.frm_clone_field_group', duplicateFieldGroup );
+			jQuery( document ).on( 'click', '.frm_clone_field_group', duplicateFieldGroup );
 			jQuery( document ).on( 'click', '#frm_field_group_controls > span:first-child', clickFieldGroupLayout );
 			jQuery( document ).on( 'click', '.frm-row-layout-option', handleFieldGroupLayoutOptionClick );
 			jQuery( document ).on( 'click', '.frm-merge-fields-into-row .frm-row-layout-option', handleFieldGroupLayoutOptionInsideMergeClick );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1161,9 +1161,16 @@ function frmAdminBuildJS() {
 			controls = div();
 			controls.id = 'frm_field_group_controls';
 			controls.innerHTML = ''.concat(
-				'<span><svg class="frmsvg"><use xlink:href="#frm_field_group_layout_icon"></use></svg></span>',
-				'<span class="frm-move"><svg class="frmsvg"><use xlink:href="#frm_thick_move_icon"></use></svg></span>'
-			);
+                '<span><svg class="frmsvg"><use xlink:href="#frm_field_group_layout_icon"></use></svg></span>',
+                '<span class="frm-move"><svg class="frmsvg"><use xlink:href="#frm_thick_move_icon"></use></svg></span>',
+                // TODO escape this. it shouldn't be a one liner thing.
+                '<span class="dropdown">',
+                    '<a href="#" class="frm_bstooltip frm-hover-icon frm-dropdown-toggle dropdown-toggle" title="', __( 'More Options', 'formidable' ), '" data-toggle="dropdown" data-container="body">',
+                        '<span><svg class="frmsvg"><use xlink:href="#frm_thick_more_vert_icon"></use></svg></span>',
+                    '</a>',
+                    '<ul class="frm-dropdown-menu" role="menu"></ul>',
+                '</span>'
+            );
 			document.getElementById( 'frm_builder_page' ).appendChild( controls );
 		}
 
@@ -1793,7 +1800,7 @@ function frmAdminBuildJS() {
 		maybeRemoveGroupHoverTarget();
 	}
 
-	function onFieldActionDropdownShow() {
+	function onFieldActionDropdownShow( isFieldGroup ) {
 		unselectFieldGroups();
 		// maybe offset the dropdown if it goes off of the right of the screen.
 		setTimeout(
@@ -1803,6 +1810,9 @@ function frmAdminBuildJS() {
 				if ( null === ul ) {
 					return;
 				}
+				if ( 0 === ul.children.length ) {
+                    fillFieldActionDropdown( ul, true === isFieldGroup );
+                }
 				$ul = jQuery( ul );
 				if ( $ul.offset().left > jQuery( window ).width() - $ul.outerWidth() ) {
 					ul.style.left = ( -$ul.outerWidth() ) + 'px';
@@ -1811,6 +1821,38 @@ function frmAdminBuildJS() {
 			0
 		);
 	}
+
+	function onFieldGroupActionDropdownShow() {
+        onFieldActionDropdownShow( true );
+    }
+
+    function fillFieldActionDropdown( ul, isFieldGroup ) {
+        var classSuffix, options;
+        classSuffix = isFieldGroup ? '_field_group' : '_field';
+        options = [
+            { class: 'frm_delete', icon: 'frm_delete_icon', label: __( 'Delete', 'formidable' ) },
+            { class: 'frm_clone', icon: 'frm_clone_icon', label: __( 'Duplicate', 'formidable' ) }
+        ];
+        if ( ! isFieldGroup ) {
+            options.push(
+                { class: 'frm_select', icon: 'frm_settings_icon', label: __( 'Field settings', 'formidable' ) }
+            );
+        }
+        options.forEach(
+            function( option ) {
+                var li, span;
+                li = document.createElement( 'li' );
+                li.classList.add( 'frm_dropdown_li', option.class + classSuffix );
+                li.setAttribute( 'href', '#' );
+                span = document.createElement( 'span' );
+                span.textContent = option.label;
+                li.innerHTML = '<svg class="frmsvg"><use xlink:href="#' + option.icon + '"></use></svg>';
+                li.appendChild( document.createTextNode( ' ' ) );
+                li.appendChild( span );
+                ul.appendChild( li );
+            }
+        );
+    }
 
 	function wrapFieldLi( li ) {
 		return jQuery( '<li>' )
@@ -2875,6 +2917,16 @@ function frmAdminBuildJS() {
 	function clickSelectField() {
 		this.closest( 'li.form-field' ).click();
 	}
+
+    function clickDeleteFieldGroup() {
+        // TODO
+        alert( 'delete' );
+    }
+
+    function duplicateFieldGroup() {
+        // TODO
+        alert( 'duplicate' );
+    }
 
 	function clickFieldGroupLayout() {
 		var hoverTarget, sizeOfFieldGroup, popupWrapper;
@@ -8376,6 +8428,8 @@ function frmAdminBuildJS() {
 			$newFields.on( 'click', 'input[type=radio], input[type=checkbox]', stopFieldFocus );
 			$newFields.on( 'click', '.frm_delete_field', clickDeleteField );
 			$newFields.on( 'click', '.frm_select_field', clickSelectField );
+			jQuery( document ).on( 'click', '.frm_delete_field_group', clickDeleteFieldGroup );
+            jQuery( document ).on( 'click', '.frm_clone_field_group', duplicateFieldGroup );
 			jQuery( document ).on( 'click', '#frm_field_group_controls > span:first-child', clickFieldGroupLayout );
 			jQuery( document ).on( 'click', '.frm-row-layout-option', handleFieldGroupLayoutOptionClick );
 			jQuery( document ).on( 'click', '.frm-merge-fields-into-row .frm-row-layout-option', handleFieldGroupLayoutOptionInsideMergeClick );
@@ -8389,11 +8443,13 @@ function frmAdminBuildJS() {
 			jQuery( document ).on( 'click', '.frm-merge-fields-into-row', mergeFieldsIntoRowClick );
 			jQuery( document ).on( 'click', '.frm-delete-field-groups', deleteFieldGroupsClick );
 			$newFields.on( 'click', '.frm-field-action-icons [data-toggle="dropdown"]', function() {
+				// TODO can I move this into the show listener?
 				this.closest( 'li.form-field' ).classList.add( 'frm-field-settings-open' );
 				jQuery( document ).on( 'click', '#frm_builder_page', handleClickOutsideOfFieldSettings );
 			});
 			$newFields.on( 'mousemove', 'ul.frm_sorting', checkForMultiselectKeysOnMouseMove );
 			$newFields.on( 'show.bs.dropdown', '.frm-field-action-icons', onFieldActionDropdownShow );
+			jQuery( document ).on( 'show.bs.dropdown', '#frm_field_group_controls', onFieldGroupActionDropdownShow );
 			$builderForm.on( 'click', '.frm_single_option a[data-removeid]', deleteFieldOption );
 			$builderForm.on( 'mousedown', '.frm_single_option input[type=radio]', maybeUncheckRadio );
 			$builderForm.on( 'focusin', '.frm_single_option input[type=text]', maybeClearOptText );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2997,6 +2997,7 @@ function frmAdminBuildJS() {
 		$newRow = wrapFieldLi( '' );
 		$newRowUl = $newRow.find( 'ul' );
 		$newRowUl.attr( 'id', newRowId );
+		$newRow.addClass( 'frm_hidden' );
 		jQuery( hoverTarget ).closest( 'li.frm_field_box' ).after( $newRow );
 
 		$fields = getFieldsInRow( jQuery( hoverTarget ) );
@@ -3039,6 +3040,7 @@ function frmAdminBuildJS() {
 					}
 
 					syncLayoutClasses( getFieldsInRow( $newRowUl ).first(), syncDetails );
+					$newRow.removeClass( 'frm_hidden' );
 					updateFieldOrder();
 				}
 			},


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3132

I moved the dropdown options for fields out of the HTML/PHP for each field, which should help to optimize long forms by removing tons of HTML on load 🥳.

For now these just use the individual field hooks. In the future I'd love to make this a little optimized but this is much less error prone as it is.