### PR TITLE
Adjust addon status to account for views vs visual views

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -533,8 +533,11 @@ class FrmAddonsController {
 			}
 
 			$addon['installed'] = self::is_installed( $file_name );
-			if ( 'formidable-views/formidable-views.php' === $file_name && 'views' === $slug && self::is_plugin_active( $file_name, 'visual-views' ) ) {
-				$addon['installed'] = false;
+			if ( $addon['installed'] && 'formidable-views/formidable-views.php' === $file_name ) {
+				$active_views_version = self::get_active_views_version();
+				if ( false !== $active_views_version && $slug !== $active_views_version ) {
+					$addon['installed'] = false;
+				}
 			}
 
 			$addon['activate_url'] = '';


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3146 by checking for the differences between the two plugins in the installed/active logic. They're a little more complex since they both use the same plugin path, but I tried to make this as simple as possible.

**With visual views active:**
![Screen Shot 2021-08-26 at 11 14 41 AM](https://user-images.githubusercontent.com/9134515/130978844-f2873525-cb06-4ba0-9706-1e81951e8895.png)

**With views active**
![Screen Shot 2021-08-26 at 11 14 55 AM](https://user-images.githubusercontent.com/9134515/130978877-a0cfe331-ee23-4285-9bc2-6aef0b31d52a.png)

**With visual views uninstalled / views installed:**
![Screen Shot 2021-08-26 at 11 13 26 AM](https://user-images.githubusercontent.com/9134515/130978796-16be3ccc-d111-4ce6-96ce-02ccc5fb312f.png)