### PR TITLE
Update previews for next button and slider labels

### DIFF
--- a/classes/views/frm-fields/back-end/number-range.php
+++ b/classes/views/frm-fields/back-end/number-range.php
@@ -9,10 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</label>
 	<span class="frm_grid_container">
 		<span class="frm5 frm_form_field frm-range-min">
-			<input type="text" name="field_options[minnum_<?php echo absint( $field['id'] ); ?>]" value="<?php echo esc_attr( $field['minnum'] ); ?>" />
+			<input type="text" name="field_options[minnum_<?php echo absint( $field['id'] ); ?>]" value="<?php echo esc_attr( $field['minnum'] ); ?>" data-changeme="field_<?php echo esc_attr( $field['field_key'] ); ?>" data-changeatt="min" />
 		</span>
 		<span class="frm5 frm_last frm_form_field">
-			<input type="text" name="field_options[maxnum_<?php echo absint( $field['id'] ); ?>]" value="<?php echo esc_attr( $field['maxnum'] ); ?>" />
+			<input type="text" name="field_options[maxnum_<?php echo absint( $field['id'] ); ?>]" value="<?php echo esc_attr( $field['maxnum'] ); ?>" data-changeme="field_<?php echo esc_attr( $field['field_key'] ); ?>" data-changeatt="max" />
 		</span>
 	</span>
 </p>

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2542,11 +2542,25 @@ function frmAdminBuildJS() {
 				}
 			} else if ( att === 'class' ) {
 				changeFieldClass( changes, this );
-			} else {
-				changes.setAttribute( att, newValue );
-				if ( 'value' === att && 'range' === changes.type && changes.parentNode.classList.contains( 'frm_range_container' ) ) {
+			} else if ( isSliderField( changes ) ) {
+				if ( 'value' === att ) {
+					if ( '' === newValue ) {
+						newValue = getSliderMidpoint( changes );
+					}
+					changes.value = newValue;
+				} else {
+					changes.setAttribute( att, newValue );
+				}
+
+				if ( -1 !== [ 'value', 'min', 'max' ].indexOf( att ) ) {
+					if ( ( 'max' === att || 'min' === att ) && '' === getSliderDefaultValueInput( changes.id ) ) {
+						changes.value = getSliderMidpoint( changes );
+					}
+
 					changes.parentNode.querySelector( '.frm_range_value' ).textContent = changes.value;
 				}
+			} else {
+				changes.setAttribute( att, newValue );
 			}
 		} else if ( changes.id.indexOf( 'setup-message' ) === 0 ) {
 			if ( newValue !== '' ) {
@@ -2558,6 +2572,18 @@ function frmAdminBuildJS() {
 				changes.nextElementSibling.querySelector( '.frm_button_submit' ).textContent = newValue;
 			}
 		}
+	}
+
+	function getSliderDefaultValueInput( previewInputId ) {
+		return document.querySelector( 'input[data-changeme="' + previewInputId + '"][data-changeatt="value"]' ).value;
+	}
+
+	function getSliderMidpoint( sliderInput ) {
+		return ( parseFloat( sliderInput.getAttribute( 'max' ) ) - parseFloat( sliderInput.getAttribute( 'min' ) ) ) / 2;
+	}
+
+	function isSliderField( previewInput ) {
+		return 'range' === previewInput.type && previewInput.parentNode.classList.contains( 'frm_range_container' );
 	}
 
 	function toggleInvalidMsg() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2544,6 +2544,9 @@ function frmAdminBuildJS() {
 				changeFieldClass( changes, this );
 			} else {
 				changes.setAttribute( att, newValue );
+				if ( 'value' === att && 'range' === changes.type && changes.parentNode.classList.contains( 'frm_range_container' ) ) {
+					changes.parentNode.querySelector( '.frm_range_value' ).textContent = newValue;
+				}
 			}
 		} else if ( changes.id.indexOf( 'setup-message' ) === 0 ) {
 			if ( newValue !== '' ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2543,22 +2543,7 @@ function frmAdminBuildJS() {
 			} else if ( att === 'class' ) {
 				changeFieldClass( changes, this );
 			} else if ( isSliderField( changes ) ) {
-				if ( 'value' === att ) {
-					if ( '' === newValue ) {
-						newValue = getSliderMidpoint( changes );
-					}
-					changes.value = newValue;
-				} else {
-					changes.setAttribute( att, newValue );
-				}
-
-				if ( -1 !== [ 'value', 'min', 'max' ].indexOf( att ) ) {
-					if ( ( 'max' === att || 'min' === att ) && '' === getSliderDefaultValueInput( changes.id ) ) {
-						changes.value = getSliderMidpoint( changes );
-					}
-
-					changes.parentNode.querySelector( '.frm_range_value' ).textContent = changes.value;
-				}
+				updateSliderFieldPreview( changes, att, newValue );
 			} else {
 				changes.setAttribute( att, newValue );
 			}
@@ -2571,6 +2556,25 @@ function frmAdminBuildJS() {
 			if ( changes.classList.contains( 'frm_primary_label' ) && 'break' === changes.nextElementSibling.getAttribute( 'data-ftype' ) ) {
 				changes.nextElementSibling.querySelector( '.frm_button_submit' ).textContent = newValue;
 			}
+		}
+	}
+
+	function updateSliderFieldPreview( field, att, newValue ) {
+		if ( 'value' === att ) {
+			if ( '' === newValue ) {
+				newValue = getSliderMidpoint( field );
+			}
+			field.value = newValue;
+		} else {
+			field.setAttribute( att, newValue );
+		}
+
+		if ( -1 !== [ 'value', 'min', 'max' ].indexOf( att ) ) {
+			if ( ( 'max' === att || 'min' === att ) && '' === getSliderDefaultValueInput( field.id ) ) {
+				field.value = getSliderMidpoint( field );
+			}
+
+			field.parentNode.querySelector( '.frm_range_value' ).textContent = field.value;
 		}
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5050,14 +5050,6 @@ function frmAdminBuildJS() {
 		container.append( '<div class="clear"></div>' );
 	}
 
-	function updateAddRemoveLabelInPreview() {
-		const type = -1 === this.name.indexOf( 'remove' ) ? 'add' : 'remove';
-		const button = getElementFromFieldInPreview( getFieldIdFromSettingsField( this ), '.frm_' + type + '_form_row' );
-		if ( null !== button ) {
-			button.querySelector( '.frm_repeat_label' ).textContent = this.value;
-		}
-	}
-
 	function updateNextButtonInPreview() {
 		const button = getElementFromFieldInPreview( getFieldIdFromSettingsField( this ), '.frm_button_submit' );
 		if ( null !== button ) {
@@ -8651,7 +8643,6 @@ function frmAdminBuildJS() {
 			$builderForm.on( 'change', '.frm_logic_field_opts', getFieldValues );
 			$builderForm.on( 'change', '.scale_maxnum, .scale_minnum', setScaleValues );
 			$builderForm.on( 'change', '.radio_maxnum', setStarValues );
-			$builderForm.on( 'change', 'input[name^="field_options[add_label_"],input[name^="field_options[remove_label_"]', updateAddRemoveLabelInPreview );
 			$builderForm.on( 'change', '.frm-single-settings.frm-type-break input[name^="field_options[name_"]', updateNextButtonInPreview );
 			$builderForm.on( 'frm-multiselect-changed', 'select[name^="field_options[admin_only_"]', adjustVisibilityValuesForEveryoneValues );
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2554,6 +2554,9 @@ function frmAdminBuildJS() {
 			}
 		} else {
 			changes.innerHTML = newValue;
+			if ( changes.classList.contains( 'frm_primary_label' ) && 'break' === changes.nextElementSibling.getAttribute( 'data-ftype' ) ) {
+				changes.nextElementSibling.querySelector( '.frm_button_submit' ).textContent = newValue;
+			}
 		}
 	}
 
@@ -5051,21 +5054,6 @@ function frmAdminBuildJS() {
 			container.append( '<div class="frm_scale"><label><input type="hidden" name="field_options[options_' + fieldID + '][' + i + ']" value="' + i + '"> <input type="radio" name="item_meta[' + fieldID + ']" value="' + i + '"> ' + i + ' </label></div>' );
 		}
 		container.append( '<div class="clear"></div>' );
-	}
-
-	function updateNextButtonInPreview() {
-		const button = getElementFromFieldInPreview( getFieldIdFromSettingsField( this ), '.frm_button_submit' );
-		if ( null !== button ) {
-			button.textContent = this.value;
-		}
-	}
-
-	function getFieldIdFromSettingsField( field ) {
-		return parseInt( field.closest( '.frm-single-settings' ).getAttribute( 'data-fid' ) );
-	}
-
-	function getElementFromFieldInPreview( fieldId, selector ) {
-		return document.getElementById( 'frm_field_id_' + fieldId ).querySelector( selector );
 	}
 
 	function getFieldValues() {
@@ -8646,7 +8634,6 @@ function frmAdminBuildJS() {
 			$builderForm.on( 'change', '.frm_logic_field_opts', getFieldValues );
 			$builderForm.on( 'change', '.scale_maxnum, .scale_minnum', setScaleValues );
 			$builderForm.on( 'change', '.radio_maxnum', setStarValues );
-			$builderForm.on( 'change', '.frm-single-settings.frm-type-break input[name^="field_options[name_"]', updateNextButtonInPreview );
 			$builderForm.on( 'frm-multiselect-changed', 'select[name^="field_options[admin_only_"]', adjustVisibilityValuesForEveryoneValues );
 
 			jQuery( document.getElementById( 'frm-insert-fields' ) ).on( 'click', '.frm_add_field', addFieldClick );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2585,7 +2585,9 @@ function frmAdminBuildJS() {
 	}
 
 	function getSliderMidpoint( sliderInput ) {
-		return ( parseFloat( sliderInput.getAttribute( 'max' ) ) - parseFloat( sliderInput.getAttribute( 'min' ) ) ) / 2;
+		const max = parseFloat( sliderInput.getAttribute( 'max' ) );
+		const min = parseFloat( sliderInput.getAttribute( 'min' ) );
+		return ( max - min ) / 2 + min;
 	}
 
 	function isSliderField( previewInput ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2545,7 +2545,7 @@ function frmAdminBuildJS() {
 			} else {
 				changes.setAttribute( att, newValue );
 				if ( 'value' === att && 'range' === changes.type && changes.parentNode.classList.contains( 'frm_range_container' ) ) {
-					changes.parentNode.querySelector( '.frm_range_value' ).textContent = newValue;
+					changes.parentNode.querySelector( '.frm_range_value' ).textContent = changes.value;
 				}
 			}
 		} else if ( changes.id.indexOf( 'setup-message' ) === 0 ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2569,13 +2569,15 @@ function frmAdminBuildJS() {
 			field.setAttribute( att, newValue );
 		}
 
-		if ( -1 !== [ 'value', 'min', 'max' ].indexOf( att ) ) {
-			if ( ( 'max' === att || 'min' === att ) && '' === getSliderDefaultValueInput( field.id ) ) {
-				field.value = getSliderMidpoint( field );
-			}
-
-			field.parentNode.querySelector( '.frm_range_value' ).textContent = field.value;
+		if ( -1 === [ 'value', 'min', 'max' ].indexOf( att ) ) {
+			return;
 		}
+
+		if ( ( 'max' === att || 'min' === att ) && '' === getSliderDefaultValueInput( field.id ) ) {
+			field.value = getSliderMidpoint( field );
+		}
+
+		field.parentNode.querySelector( '.frm_range_value' ).textContent = field.value;
 	}
 
 	function getSliderDefaultValueInput( previewInputId ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5050,6 +5050,29 @@ function frmAdminBuildJS() {
 		container.append( '<div class="clear"></div>' );
 	}
 
+	function updateAddRemoveLabelInPreview() {
+		const type = -1 === this.name.indexOf( 'remove' ) ? 'add' : 'remove';
+		const button = getElementFromFieldInPreview( getFieldIdFromSettingsFile( this ), '.frm_' + type + '_form_row' );
+		if ( null !== button ) {
+			button.querySelector( '.frm_repeat_label' ).textContent = this.value;
+		}
+	}
+
+	function updateNextButtonInPreview() {
+		const button = getElementFromFieldInPreview( getFieldIdFromSettingsFile( this ), '.frm_button_submit' );
+		if ( null !== button ) {
+			button.textContent = this.value;
+		}
+	}
+
+	function getFieldIdFromSettingsFile( field ) {
+		return parseInt( field.closest( '.frm-single-settings' ).getAttribute( 'data-fid' ) );
+	}
+
+	function getElementFromFieldInPreview( fieldId, selector ) {
+		return document.getElementById( 'frm_field_id_' + fieldId ).querySelector( selector );
+	}
+
 	function getFieldValues() {
 		/*jshint validthis:true */
 		var isTaxonomy,
@@ -8628,6 +8651,8 @@ function frmAdminBuildJS() {
 			$builderForm.on( 'change', '.frm_logic_field_opts', getFieldValues );
 			$builderForm.on( 'change', '.scale_maxnum, .scale_minnum', setScaleValues );
 			$builderForm.on( 'change', '.radio_maxnum', setStarValues );
+			$builderForm.on( 'change', 'input[name^="field_options[add_label_"],input[name^="field_options[remove_label_"]', updateAddRemoveLabelInPreview );
+			$builderForm.on( 'change', '.frm-single-settings.frm-type-break input[name^="field_options[name_"]', updateNextButtonInPreview );
 			$builderForm.on( 'frm-multiselect-changed', 'select[name^="field_options[admin_only_"]', adjustVisibilityValuesForEveryoneValues );
 
 			jQuery( document.getElementById( 'frm-insert-fields' ) ).on( 'click', '.frm_add_field', addFieldClick );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5052,20 +5052,20 @@ function frmAdminBuildJS() {
 
 	function updateAddRemoveLabelInPreview() {
 		const type = -1 === this.name.indexOf( 'remove' ) ? 'add' : 'remove';
-		const button = getElementFromFieldInPreview( getFieldIdFromSettingsFile( this ), '.frm_' + type + '_form_row' );
+		const button = getElementFromFieldInPreview( getFieldIdFromSettingsField( this ), '.frm_' + type + '_form_row' );
 		if ( null !== button ) {
 			button.querySelector( '.frm_repeat_label' ).textContent = this.value;
 		}
 	}
 
 	function updateNextButtonInPreview() {
-		const button = getElementFromFieldInPreview( getFieldIdFromSettingsFile( this ), '.frm_button_submit' );
+		const button = getElementFromFieldInPreview( getFieldIdFromSettingsField( this ), '.frm_button_submit' );
 		if ( null !== button ) {
 			button.textContent = this.value;
 		}
 	}
 
-	function getFieldIdFromSettingsFile( field ) {
+	function getFieldIdFromSettingsField( field ) {
 		return parseInt( field.closest( '.frm-single-settings' ).getAttribute( 'data-fid' ) );
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3153

Also requires https://github.com/Strategy11/formidable-pro/pull/3160 for some of the fix.

Applies to the next button for page break fields and slider labels, and the add/remove labels for repeater fields in the other pull request.