### PR TITLE
Remove captcha settings placeholders

### DIFF
--- a/classes/views/frm-settings/recaptcha.php
+++ b/classes/views/frm-settings/recaptcha.php
@@ -19,18 +19,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<label class="frm_help" for="frm_pubkey" title="<?php esc_attr_e( 'reCAPTCHA is a free, accessible CAPTCHA service that helps to digitize books while blocking spam on your blog. reCAPTCHA asks commenters to retype two words scanned from a book to prove that they are a human. This verifies that they are not a spambot.', 'formidable' ); ?>">
 		<?php esc_html_e( 'Site Key', 'formidable' ); ?>
 	</label>
-	<input type="text" name="frm_pubkey" id="frm_pubkey" size="42"
-		value="<?php echo esc_attr( $frm_settings->pubkey ); ?>"
-		placeholder="<?php esc_attr_e( 'Optional', 'formidable' ); ?>"/>
+	<input type="text" name="frm_pubkey" id="frm_pubkey" size="42" value="<?php echo esc_attr( $frm_settings->pubkey ); ?>" />
 </p>
 
 <p class="frm6 frm_form_field">
 	<label for="frm_privkey">
 		<?php esc_html_e( 'Secret Key', 'formidable' ); ?>
 	</label>
-	<input type="text" name="frm_privkey" id="frm_privkey" size="42"
-		value="<?php echo esc_attr( $frm_settings->privkey ); ?>"
-		placeholder="<?php esc_attr_e( 'Optional', 'formidable' ); ?>"/>
+	<input type="text" name="frm_privkey" id="frm_privkey" size="42" value="<?php echo esc_attr( $frm_settings->privkey ); ?>" />
 </p>
 
 <p class="frm6 frm_form_field">


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3162

I feel like there isn't a lot of reason to have a placeholder on these at all so I'm just removing them. I agree the placeholder we have is just doing more harm than good.

Easy peasy

**Before**
![Screen Shot 2021-09-02 at 11 15 34 AM](https://user-images.githubusercontent.com/9134515/131860041-b48a1f37-9811-4810-ae08-4a5cb6c50bc1.png)

**After**
![Screen Shot 2021-09-02 at 11 15 26 AM](https://user-images.githubusercontent.com/9134515/131860083-2ed96d9d-af6e-4c99-b60e-ad542b0e197f.png)