### PR TITLE
Fix search filter is cut if half in Entries page when no results #3169

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5344,7 +5344,7 @@ span.howto {
 	line-height: 200%;
 }
 
-.formidable_page_formidable-entries .no-items {
+#form_entries_page #the-list .no-items {
 	height: 240px; /* Equals to the max height of search dropdown */
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5344,6 +5344,10 @@ span.howto {
 	line-height: 200%;
 }
 
+.formidable_page_formidable-entries .no-items {
+	height: 240px; /* Equals to the max height of search dropdown */
+}
+
 /* Reports Page */
 #form_reports_page img.frm_no_reports {
 	max-width: 100%;


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3169