### PR TITLE
Allow custom HTML for error messages when validate with JavaScript is on

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -721,16 +721,17 @@ class FrmFieldsController {
 
 	/**
 	 * @param stdClass $form
-	 * @param array $field
+	 * @param array    $field
+	 * @param array    $errors
 	 * @return string|false
 	 */
-	public static function pull_custom_error_body_from_custom_html( $form, $field ) {
+	public static function pull_custom_error_body_from_custom_html( $form, $field, $errors = array() ) {
 		if ( empty( $field['custom_html'] ) ) {
 			return false;
 		}
 
 		$custom_html = $field['custom_html'];
-		$custom_html = apply_filters( 'frm_before_replace_shortcodes', $custom_html, $field, array(), $form );
+		$custom_html = apply_filters( 'frm_before_replace_shortcodes', $custom_html, $field, $errors, $form );
 
 		$start = strpos( $custom_html, '[if error]' );
 		if ( false === $start ) {

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -706,11 +706,12 @@ class FrmFieldsController {
 	 * @param array $add_html
 	 */
 	private static function maybe_add_error_html_for_js_validation( $field, array &$add_html ) {
-		$form = FrmForm::getOne( $field['form_id'] );
-		if ( empty( $form->options['js_validate'] ) ) {
+		global $frm_vars;
+		if ( empty( $frm_vars['js_validate_forms'] ) || ! isset( $frm_vars['js_validate_forms'][ $field['form_id'] ] ) ) {
 			return;
 		}
 
+		$form       = $frm_vars['js_validate_forms'][ $field['form_id'] ];
 		$error_body = self::pull_custom_error_body_from_custom_html( $form, $field );
 		if ( false !== $error_body ) {
 			$error_body                  = urlencode( $error_body );

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -702,21 +702,41 @@ class FrmFieldsController {
 	}
 
 	/**
+	 * @since 5.0.03
+	 *
 	 * @param array $field
 	 * @param array $add_html
 	 */
 	private static function maybe_add_error_html_for_js_validation( $field, array &$add_html ) {
-		global $frm_vars;
-		if ( empty( $frm_vars['js_validate_forms'] ) || ! isset( $frm_vars['js_validate_forms'][ $field['form_id'] ] ) ) {
+		$form = self::get_form_for_js_validation( $field );
+		if ( false === $form ) {
 			return;
 		}
 
-		$form       = $frm_vars['js_validate_forms'][ $field['form_id'] ];
 		$error_body = self::pull_custom_error_body_from_custom_html( $form, $field );
 		if ( false !== $error_body ) {
 			$error_body                  = urlencode( $error_body );
 			$add_html['data-error-html'] = 'data-error-html="' . esc_attr( $error_body ) . '"';
 		}
+	}
+
+	/**
+	 * @since 5.0.03
+	 *
+	 * @param array $field
+	 * @return stdClass|false false if there is no form object found with JS validation active.
+	 */
+	private static function get_form_for_js_validation( $field ) {
+		global $frm_vars;
+		if ( ! empty( $frm_vars['js_validate_forms'] ) ) {
+			if ( isset( $frm_vars['js_validate_forms'][ $field['form_id'] ] ) ) {
+				return $frm_vars['js_validate_forms'][ $field['form_id'] ];
+			}
+			if ( ! empty( $field['parent_form_id'] ) && isset( $frm_vars['js_validate_forms'][ $field['parent_form_id'] ] ) ) {
+				return $frm_vars['js_validate_forms'][ $field['parent_form_id'] ];
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1327,13 +1327,21 @@ class FrmFormsController {
 
 		if ( ! empty( $form->options['js_validate'] ) ) {
 			echo ' frm_js_validate ';
-
-			global $frm_vars;
-			if ( ! isset( $frm_vars['js_validate_forms'] ) ) {
-				$frm_vars['js_validate_forms'] = array();
-			}
-			$frm_vars['js_validate_forms'][ $form->id ] = $form;
+			self::add_js_validate_form_to_global_vars( $form );
 		}
+	}
+
+	/**
+	 * @since 5.0.03
+	 *
+	 * @param stdClass $form
+	 */
+	public static function add_js_validate_form_to_global_vars( $form ) {
+		global $frm_vars;
+		if ( ! isset( $frm_vars['js_validate_forms'] ) ) {
+			$frm_vars['js_validate_forms'] = array();
+		}
+		$frm_vars['js_validate_forms'][ $form->id ] = $form;
 	}
 
 	public static function get_email_html() {

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1325,8 +1325,14 @@ class FrmFormsController {
 			echo esc_attr( sanitize_text_field( $form->options['form_class'] ) );
 		}
 
-		if ( isset( $form->options['js_validate'] ) && $form->options['js_validate'] ) {
+		if ( ! empty( $form->options['js_validate'] ) ) {
 			echo ' frm_js_validate ';
+
+			global $frm_vars;
+			if ( ! isset( $frm_vars['js_validate_forms'] ) ) {
+				$frm_vars['js_validate_forms'] = array();
+			}
+			$frm_vars['js_validate_forms'][ $form->id ] = $form;
 		}
 	}
 

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -463,10 +463,20 @@ function frmFrontFormJS() {
 	}
 
 	function getFieldValidationMessage( field, messageType ) {
-		var msg = field.getAttribute( messageType );
-		if ( msg === null ) {
+		var msg, errorHtml;
+
+		msg = field.getAttribute( messageType );
+		if ( null === msg ) {
 			msg = '';
 		}
+
+		errorHtml = field.getAttribute( 'data-error-html' );
+		if ( null !== errorHtml ) {
+			errorHtml = errorHtml.replace( /\+/g, '%20' );
+			msg = decodeURIComponent( errorHtml ).replace( '[error]', msg );
+			msg = msg.replace( '[key]', getFieldId( field, false ) );
+		}
+
 		return msg;
 	}
 
@@ -702,7 +712,13 @@ function frmFrontFormJS() {
 			if ( typeof frmThemeOverride_frmPlaceError === 'function' ) { // eslint-disable-line camelcase
 				frmThemeOverride_frmPlaceError( key, jsErrors );
 			} else {
-				$fieldCont.append( '<div class="frm_error" id="' + id + '">' + jsErrors[key] + '</div>' );
+				if ( -1 !== jsErrors[key].indexOf( '<div' ) ) {
+					$fieldCont.append(
+						jsErrors[key]
+					);
+				} else {
+					$fieldCont.append( '<div class="frm_error" id="' + id + '">' + jsErrors[key] + '</div>' );
+				}
 
 				if ( typeof describedBy === 'undefined' ) {
 					describedBy = id;

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -470,11 +470,13 @@ function frmFrontFormJS() {
 			msg = '';
 		}
 
-		errorHtml = field.getAttribute( 'data-error-html' );
-		if ( null !== errorHtml ) {
-			errorHtml = errorHtml.replace( /\+/g, '%20' );
-			msg = decodeURIComponent( errorHtml ).replace( '[error]', msg );
-			msg = msg.replace( '[key]', getFieldId( field, false ) );
+		if ( '' !== msg ) {
+			errorHtml = field.getAttribute( 'data-error-html' );
+			if ( null !== errorHtml ) {
+				errorHtml = errorHtml.replace( /\+/g, '%20' );
+				msg = decodeURIComponent( errorHtml ).replace( '[error]', msg );
+				msg = msg.replace( '[key]', getFieldId( field, false ) );
+			}
 		}
 
 		return msg;

--- a/tests/fields/test_FrmFieldsController.php
+++ b/tests/fields/test_FrmFieldsController.php
@@ -33,4 +33,36 @@ class test_FrmFieldsController extends FrmUnitTest {
 	private function prepare_placeholder( $field ) {
 		return $this->run_private_method( array( 'FrmFieldsController', 'prepare_placeholder' ), array( $field ) );
 	}
+
+	/**
+	 * @covers FrmFieldsController::pull_custom_error_body_from_custom_html
+	 */
+	public function test_pull_custom_error_body_from_custom_html() {
+		$form       = $this->factory->form->create_and_get();
+		$field      = $this->factory->field->create_and_get(
+			array(
+				'form_id' => $form->id,
+				'type'    => 'text',
+				'field_options' => array(
+					'custom_html' => '
+						<div id="frm_field_[id]_container" class="frm_form_field form-field [required_class][error_class]">
+						<label for="field_[key]" id="field_[key]_label" class="frm_primary_label">[field_name]
+							<span class="frm_required" aria-hidden="true">[required_label]</span>
+						</label>
+						[input]
+						[if description]<div class="frm_description" id="frm_desc_field_[key]">[description]</div>[/if description]
+						[if error]<div class="frm_error my_custom_error_class" id="frm_error_field_[key]">My custom error label: [error]</div>[/if error]
+					</div>
+					',
+				),
+			)
+		);
+		$field      = FrmFieldsHelper::setup_edit_vars( $field );
+		$error_body = FrmFieldsController::pull_custom_error_body_from_custom_html( $form, $field );
+
+		$this->assertEquals(
+			'<div class="frm_error my_custom_error_class" id="frm_error_field_[key]">My custom error label: [error]</div>',
+			$error_body
+		);
+	}
 }


### PR DESCRIPTION
Related to https://github.com/Strategy11/formidable-pro/issues/2360 and includes part of a fix for that as well.

Also see https://github.com/Strategy11/formidable-pro/pull/3177 for a related fix (submit with AJAX).

I noticed while working on that issue that we have all of these gaps as well with our JavaScript validation, which I got confused with this at first since it's the same set of issues.

I tried to make it as performant as possible by storing the form object as a variable when we initially check for the js validation in the global var, by only checking if there are required/invalid errors embedded in the HTML, and by ignoring the default HTML so only custom HTML is added to the form.

This update adds support for custom HTML from the "Customize HTML" part of settings but also via the frm_before_replace_shortcodes filter.

_With the JavaScript validation, the frm_before_replace_shortcodes filter will always pass an empty array for $errors, which isn't something we can workaround. If you notice this during testing, nothing can really be done about it. It might make sense to mention this limitation in our documentation though._