### PR TITLE
Update section ids when moving a field group

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -829,6 +829,13 @@ function frmAdminBuildJS() {
 						// A new field was dragged into the form
 						insertNewFieldByDragging( this, ui.item, opts );
 					}
+				} else if ( ui.item.hasClass( 'frm_field_box' ) ) {
+					// dragging a group.
+					getFieldsInRow( ui.item.children( 'ul' ) ).each(
+						function() {
+							updateFieldAfterMovingBetweenSections( jQuery( this ) );
+						}
+					);
 				}
 			},
 			change: function( event, ui ) {


### PR DESCRIPTION
Working toward a solution for https://github.com/Strategy11/formidable-pro/issues/3154

For now I'm not calling this a fix. It looks like there are other issues with the repeater form caching the fields so they appear in two places.

But I think this is important to include in this release, just so section ids don't get messed up anymore than they need to.

This currently calls the action once per field in the group that is being moved and would benefit to get optimized in the future.