### PR TITLE
Add a grayed out submit with AJAX option with tooltip

### DIFF
--- a/classes/helpers/FrmTipsHelper.php
+++ b/classes/helpers/FrmTipsHelper.php
@@ -124,13 +124,6 @@ class FrmTipsHelper {
 			),
 			array(
 				'link' => array(
-					'content' => 'ajax',
-				),
-				'tip'  => __( 'Want to submit forms without reloading the page?', 'formidable' ),
-				'call' => __( 'Get ajax form submit.', 'formidable' ),
-			),
-			array(
-				'link' => array(
 					'content' => 'form-scheduling',
 					'param'   => 'schedule-forms-wordpress',
 				),
@@ -139,6 +132,19 @@ class FrmTipsHelper {
 			),
 		);
 
+		return $tips;
+	}
+
+	public static function get_ajax_submit_tip() {
+		$tips = array(
+			array(
+				'link' => array(
+					'content' => 'ajax',
+				),
+				'tip'  => __( 'Want to submit forms without reloading the page?', 'formidable' ),
+				'call' => __( 'Get ajax form submit.', 'formidable' ),
+			),
+		);
 		return $tips;
 	}
 

--- a/classes/helpers/FrmTipsHelper.php
+++ b/classes/helpers/FrmTipsHelper.php
@@ -135,19 +135,6 @@ class FrmTipsHelper {
 		return $tips;
 	}
 
-	public static function get_ajax_submit_tip() {
-		$tips = array(
-			array(
-				'link' => array(
-					'content' => 'ajax',
-				),
-				'tip'  => __( 'Want to submit forms without reloading the page?', 'formidable' ),
-				'call' => __( 'Get ajax form submit.', 'formidable' ),
-			),
-		);
-		return $tips;
-	}
-
 	public static function get_form_action_tip() {
 		$tips = array(
 			array(

--- a/classes/views/frm-forms/settings-advanced.php
+++ b/classes/views/frm-forms/settings-advanced.php
@@ -141,11 +141,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php if ( ! FrmAppHelper::pro_is_installed() ) { ?>
 		<tr>
 			<td>
-				<label>
+				<label data-upgrade="<?php esc_attr_e( 'AJAX Form Submissions', 'formidable' ); ?>" data-medium="ajax" data-message="<?php esc_attr_e( 'Want to submit forms without reloading the page?', 'formidable' ); ?>">
 					<input type="checkbox" disabled="disabled" />
 					<span class="frm_noallow"><?php esc_html_e( 'Submit this form with AJAX', 'formidable' ); ?></span>
 					<span class="frm_help frm_icon_font frm_tooltip_icon" title="<?php esc_attr_e( 'Submit the form without refreshing the page.', 'formidable' ); ?>"></span>
-					<div class="frm-ib frm-ml10"><?php FrmTipsHelper::pro_tip( 'get_ajax_submit_tip', 'p' ); ?></div>
 				</label>
 			</td>
 		</tr>

--- a/classes/views/frm-forms/settings-advanced.php
+++ b/classes/views/frm-forms/settings-advanced.php
@@ -141,9 +141,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php if ( ! FrmAppHelper::pro_is_installed() ) { ?>
 		<tr>
 			<td>
-				<label class="frm-grey-color">
+				<label>
 					<input type="checkbox" disabled="disabled" />
-					<?php esc_html_e( 'Submit this form with AJAX', 'formidable' ); ?>
+					<span class="frm_noallow"><?php esc_html_e( 'Submit this form with AJAX', 'formidable' ); ?></span>
 					<span class="frm_help frm_icon_font frm_tooltip_icon" title="<?php esc_attr_e( 'Submit the form without refreshing the page.', 'formidable' ); ?>"></span>
 					<div class="frm-ib frm-ml10"><?php FrmTipsHelper::pro_tip( 'get_ajax_submit_tip', 'p' ); ?></div>
 				</label>

--- a/classes/views/frm-forms/settings-advanced.php
+++ b/classes/views/frm-forms/settings-advanced.php
@@ -121,11 +121,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php is_callable( 'self::render_spam_settings' ) && self::render_spam_settings( $values ); ?>
 </table>
 
+<?php FrmTipsHelper::pro_tip( 'get_form_settings_tip', 'p' ); ?>
+
 <!--AJAX Section-->
 <h3><?php esc_html_e( 'AJAX', 'formidable' ); ?>
 	<span class="frm_help frm_icon_font frm_tooltip_icon" data-placement="right" title="<?php esc_attr_e( 'Make stuff happen in the background without a page refresh', 'formidable' ); ?>" ></span>
 </h3>
-<?php FrmTipsHelper::pro_tip( 'get_form_settings_tip', 'p' ); ?>
+
 <table class="form-table">
 	<tr>
 		<td>
@@ -136,6 +138,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</td>
 	</tr>
 	<?php do_action( 'frm_add_form_ajax_options', $values ); ?>
+	<?php if ( ! FrmAppHelper::pro_is_installed() ) { ?>
+		<tr>
+			<td>
+				<label class="frm-grey-color">
+					<input type="checkbox" disabled="disabled" />
+					<?php esc_html_e( 'Submit this form with AJAX', 'formidable' ); ?>
+					<span class="frm_help frm_icon_font frm_tooltip_icon" title="<?php esc_attr_e( 'Submit the form without refreshing the page.', 'formidable' ); ?>"></span>
+					<div class="frm-ib frm-ml10"><?php FrmTipsHelper::pro_tip( 'get_ajax_submit_tip', 'p' ); ?></div>
+				</label>
+			</td>
+		</tr>
+	<?php } ?>
 	<tr>
 		<td>
 			<label for="js_validate" class="frm_inline_block">

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -108,10 +108,6 @@ a, .widget .widget-top, .stuffbox h3, .frm-collapsed {
 	color: var(--grey);
 }
 
-.frm-grey-color {
-	color: var(--grey) !important;
-}
-
 .frm-ib {
 	display: inline-block;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -108,6 +108,18 @@ a, .widget .widget-top, .stuffbox h3, .frm-collapsed {
 	color: var(--grey);
 }
 
+.frm-grey-color {
+	color: var(--grey) !important;
+}
+
+.frm-ib {
+	display: inline-block;
+}
+
+.frm-ml10 {
+	margin-left: 10px;
+}
+
 .frm-white-body .columns-2 {
 	border-bottom: 1px solid var(--grey-border);
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -108,14 +108,6 @@ a, .widget .widget-top, .stuffbox h3, .frm-collapsed {
 	color: var(--grey);
 }
 
-.frm-ib {
-	display: inline-block;
-}
-
-.frm-ml10 {
-	margin-left: 10px;
-}
-
 .frm-white-body .columns-2 {
 	border-bottom: 1px solid var(--grey-border);
 }


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3150

I bumped the old tooltip up into the other section, at the bottom, then added a new one that is more in-position and targeted with a placeholder checkbox.

**Before**
<img width="954" alt="Screen Shot 2021-09-09 at 4 38 40 PM" src="https://user-images.githubusercontent.com/9134515/132751691-42e50db7-a2bd-4e23-b59a-c3bb7ca6639f.png">

**After**
<img width="548" alt="Screen Shot 2021-09-13 at 12 06 32 PM" src="https://user-images.githubusercontent.com/9134515/133108839-4bf9700c-55ce-47a4-bf42-a10642a72dc0.png">
<img width="596" alt="Screen Shot 2021-09-13 at 12 06 35 PM" src="https://user-images.githubusercontent.com/9134515/133108854-06d803df-f755-46fe-9063-33e726104c9c.png">

Adding a couple generic classes because I keep wanting an easier way to set some basic styles like tachyons/tailwind. Adding just a few, that I've wanted pretty often.