### PR TITLE
Add save and reload to settings page after plugin activation

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -964,9 +964,30 @@ class FrmAddonsController {
 		$plugin = FrmAppHelper::get_param( 'plugin', '', 'post', 'sanitize_text_field' );
 		self::maybe_activate_addon( $plugin );
 
-		// Send back a response.
-		echo json_encode( __( 'Your plugin has been activated. Please reload the page to see more options.', 'formidable' ) );
+		echo json_encode( self::get_addon_activation_response() );
 		wp_die();
+	}
+
+	/**
+	 * @return array|string
+	 */
+	private static function get_addon_activation_response() {
+		if ( self::activating_from_settings_page() ) {
+			$response = array(
+				'message'       => __( 'Your plugin has been activated. Would you like to save and reload the page now?', 'formidable' ),
+				'saveAndReload' => 'settings',
+			);
+		} else {
+			$response = __( 'Your plugin has been activated. Please reload the page to see more options.', 'formidable' );
+		}
+		return $response;
+	}
+
+	/**
+	 * @return bool
+	 */
+	private static function activating_from_settings_page() {
+		return false !== strpos( FrmAppHelper::get_server_value( 'HTTP_REFERER' ), 'frm_action=settings' );
 	}
 
 	/**
@@ -1163,8 +1184,7 @@ class FrmAddonsController {
 
 		self::download_and_activate();
 
-		// Send back a response.
-		echo json_encode( __( 'Your plugin has been installed. Please reload the page to see more options.', 'formidable' ) );
+		echo json_encode( self::get_addon_activation_response() );
 		wp_die();
 	}
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1802,7 +1802,7 @@ h2.frm-h2 + .howto {
 	font-size: 13px;
 }
 
-#frm_save_and_reloading_settings, #frm_save_and_reloading_settings + .frm-button-secondary {
+#frm_save_and_reload_settings, #frm_save_and_reload_settings + .frm-button-secondary {
 	visibility: visible;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1797,6 +1797,15 @@ h2.frm-h2 + .howto {
 	visibility: hidden;
 }
 
+#frm_save_and_reload_options {
+	margin-top: 10px;
+	font-size: 13px;
+}
+
+#frm_save_and_reloading_settings, #frm_save_and_reloading_settings + .frm-button-secondary {
+	visibility: visible;
+}
+
 .addon-status-label {
 	opacity: .7;
 }

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7486,7 +7486,7 @@ function frmAdminBuildJS() {
 
 	function saveAndReloadSettingsButton() {
 		var button = document.createElement( 'button' );
-		button.id = 'frm_save_and_reloading_settings';
+		button.id = 'frm_save_and_reload_settings';
 		button.classList.add( 'button', 'button-primary', 'frm-button-primary' );
 		button.textContent = __( 'Save and Reload', 'formidable' );
 		return button;
@@ -8977,7 +8977,7 @@ function frmAdminBuildJS() {
 
 			jQuery( document ).on( 'submit', '.frm_form_settings', settingsSubmitted );
 			jQuery( document ).on( 'change', '#form_settings_page input:not(.frm-search-input), #form_settings_page select, #form_settings_page textarea', fieldUpdated );
-			jQuery( document ).on( 'click', '#frm_save_and_reloading_settings', saveAndReloadSettings );
+			jQuery( document ).on( 'click', '#frm_save_and_reload_settings', saveAndReloadSettings );
 
             // Page Selection Autocomplete
 			initSelectionAutocomplete();


### PR DESCRIPTION
https://recordit.co/5zjic0q2aC

Setting up the landing page plugin, I find the flow really jarring that I have to activate it and then close the pop up and save myself.

I've added a check, if we're activating a plugin from the settings page, I've added an option to trigger the save button from the pop up.

This update also removed some duplicate strings and moves some var declarations to the top of the function.

We should probably do this on other pages too but settings seems to cover most of these.