### PR TITLE
Fix inbox visibility assignment issue

### DIFF
--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -160,13 +160,19 @@ class FrmInbox extends FrmFormApi {
 
 	/**
 	 * Show different messages for different accounts.
+	 *
+	 * @param array $message
+	 * @return bool
 	 */
 	private function is_for_user( $message ) {
 		if ( ! isset( $message['who'] ) || $message['who'] === 'all' ) {
 			return true;
 		}
-
-		return in_array( $this->get_user_type(), (array) $message['who'] );
+		$who = (array) $message['who'];
+		if ( in_array( 'everyone', $who, true ) ) {
+			return true;
+		}
+		return in_array( $this->get_user_type(), $who, true );
 	}
 
 	private function get_user_type() {

--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -169,7 +169,7 @@ class FrmInbox extends FrmFormApi {
 			return true;
 		}
 		$who = (array) $message['who'];
-		if ( in_array( 'everyone', $who, true ) ) {
+		if ( in_array( 'all', $who, true ) ) {
 			return true;
 		}
 		return in_array( $this->get_user_type(), $who, true );

--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -169,7 +169,7 @@ class FrmInbox extends FrmFormApi {
 			return true;
 		}
 		$who = (array) $message['who'];
-		if ( in_array( 'all', $who, true ) ) {
+		if ( in_array( 'all', $who, true ) || in_array( 'everyone', $who, true ) ) {
 			return true;
 		}
 		return in_array( $this->get_user_type(), $who, true );


### PR DESCRIPTION
I was testing messages and noticed that there's data coming from the API but I never see the message.

It looks like the who value I'm seeing is an array with an everyone option:

```
[who] => Array
        (
            [0] => everyone
        )
```

I'm adding to the check so that passes. It seems to expect an 'all' message instead, but this must have changed at some point.

With this update I actually see the new message.
<img width="998" alt="Screen Shot 2021-09-13 at 2 47 29 PM" src="https://user-images.githubusercontent.com/9134515/133131902-3b7fd4c7-6fe1-4215-ae48-7753c882817d.png">