### PR TITLE
Prevent dragging a summary field into a field group

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1484,8 +1484,8 @@ function frmAdminBuildJS() {
 				return false;
 			}
 
-			if ( ui.item.hasClass( 'frm_thidden' ) && insideFieldGroup ) {
-				// do not allow a hidden field in a field group.
+			if ( insideFieldGroup && ( ui.item.hasClass( 'frm_thidden' ) || ui.item.hasClass( 'frm_tsummary' ) ) ) {
+				// do not allow a hidden field or summary field in a field group.
 				return false;
 			}
 


### PR DESCRIPTION
Testing things, noticed a little side effect of the side-by-side fields update.

Preventing adding a summary field to a field group. Once it auto-inserts the page break and stuff it comes out pretty funny.