### PR TITLE
New inbox banners

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -422,9 +422,15 @@ class FrmAppController {
 			self::admin_js();
 		}
 
-		if ( FrmAppHelper::is_admin_page( 'formidable' ) && in_array( FrmAppHelper::get_param( 'frm_action' ), array( 'add_new', 'list_templates' ), true ) ) {
-			wp_safe_redirect( admin_url( 'admin.php?page=formidable&triggerNewFormModal=1' ) );
-			exit;
+		if ( FrmAppHelper::is_admin_page( 'formidable' ) ) {
+			$action = FrmAppHelper::get_param( 'frm_action' );
+
+			if ( in_array( $action, array( 'add_new', 'list_templates' ), true ) ) {
+				wp_safe_redirect( admin_url( 'admin.php?page=formidable&triggerNewFormModal=1' ) );
+				exit;
+			}
+
+			FrmInbox::maybe_disable_screen_options();
 		}
 	}
 

--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -76,7 +76,6 @@ class FrmInbox extends FrmFormApi {
 		}
 
 		foreach ( $api as $message ) {
-			$message['banner'] = 'here';
 			$this->add_message( $message );
 		}
 	}

--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -76,8 +76,6 @@ class FrmInbox extends FrmFormApi {
 		}
 
 		foreach ( $api as $message ) {
-			$message['emoji']  = '🥳';
-			$message['banner'] = 'Fake message'; // TODO remove this.
 			$this->add_message( $message );
 		}
 	}

--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -76,6 +76,7 @@ class FrmInbox extends FrmFormApi {
 		}
 
 		foreach ( $api as $message ) {
+			$message['banner'] = 'here';
 			$this->add_message( $message );
 		}
 	}
@@ -298,7 +299,7 @@ class FrmInbox extends FrmFormApi {
 		if ( empty( self::$banner_messages ) ) {
 			return;
 		}
-		$message = reset( self::$banner_messages );
+		$message = end( self::$banner_messages );
 		require FrmAppHelper::plugin_path() . '/classes/views/inbox/banner.php';
 	}
 

--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -14,6 +14,11 @@ class FrmInbox extends FrmFormApi {
 
 	private $messages = false;
 
+	/**
+	 * @param array
+	 */
+	private static $banner_messages;
+
 	public function __construct( $for_parent = null ) {
 		$this->set_cache_key();
 		$this->set_messages();
@@ -292,12 +297,19 @@ class FrmInbox extends FrmFormApi {
 	}
 
 	public static function maybe_show_banner() {
-		$banner_messages = self::get_banner_messages();
-		if ( ! $banner_messages ) {
+		if ( empty( self::$banner_messages ) ) {
 			return;
 		}
-		$message = reset( $banner_messages );
+		$message = reset( self::$banner_messages );
 		require FrmAppHelper::plugin_path() . '/classes/views/inbox/banner.php';
+	}
+
+	public static function maybe_disable_screen_options() {
+		self::$banner_messages = self::get_banner_messages();
+		if ( self::$banner_messages ) {
+			// disable screen options tab when displaying banner messages because it gets in the way of the banner.
+			add_filter( 'screen_options_show_screen', '__return_false' );
+		}
 	}
 
 	/**

--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -160,13 +160,19 @@ class FrmInbox extends FrmFormApi {
 
 	/**
 	 * Show different messages for different accounts.
+	 *
+	 * @param array $message
+	 * @return bool
 	 */
 	private function is_for_user( $message ) {
 		if ( ! isset( $message['who'] ) || $message['who'] === 'all' ) {
 			return true;
 		}
-
-		return in_array( $this->get_user_type(), (array) $message['who'] );
+		$who = (array) $message['who'];
+		if ( in_array( 'everyone', $who, true ) ) {
+			return true;
+		}
+		return in_array( $this->get_user_type(), $who, true );
 	}
 
 	private function get_user_type() {

--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -318,7 +318,7 @@ class FrmInbox extends FrmFormApi {
 	private static function get_banner_messages() {
 		$inbox = new self();
 		return array_filter(
-			$inbox->get_messages(),
+			$inbox->get_messages( 'filter' ),
 			function( $message ) {
 				return ! empty( $message['banner'] );
 			}

--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -71,6 +71,8 @@ class FrmInbox extends FrmFormApi {
 		}
 
 		foreach ( $api as $message ) {
+			$message['emoji']  = '🥳';
+			$message['banner'] = 'Fake message'; // TODO remove this.
 			$this->add_message( $message );
 		}
 	}
@@ -287,5 +289,27 @@ class FrmInbox extends FrmFormApi {
 
 	private function update_list() {
 		update_option( $this->option, $this->messages, 'no' );
+	}
+
+	public static function maybe_show_banner() {
+		$banner_messages = self::get_banner_messages();
+		if ( ! $banner_messages ) {
+			return;
+		}
+		$message = reset( $banner_messages );
+		require FrmAppHelper::plugin_path() . '/classes/views/inbox/banner.php';
+	}
+
+	/**
+	 * @return array
+	 */
+	private static function get_banner_messages() {
+		$inbox = new self();
+		return array_filter(
+			$inbox->get_messages(),
+			function( $message ) {
+				return ! empty( $message['banner'] );
+			}
+		);
 	}
 }

--- a/classes/views/frm-forms/list.php
+++ b/classes/views/frm-forms/list.php
@@ -2,7 +2,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
-FrmInbox::maybe_show_banner();
 ?>
 <div class="frm_wrap">
 	<?php

--- a/classes/views/frm-forms/list.php
+++ b/classes/views/frm-forms/list.php
@@ -2,6 +2,7 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
+FrmInbox::maybe_show_banner();
 ?>
 <div class="frm_wrap">
 	<?php

--- a/classes/views/inbox/banner.php
+++ b/classes/views/inbox/banner.php
@@ -1,0 +1,14 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'You are not allowed to call this page directly.' );
+}
+?>
+<div id="frm_banner">
+	<?php if ( ! empty( $message['emoji'] ) ) { ?>
+		<span class="frm-banner-emoji"><?php echo esc_html( $message['emoji'] ); ?></span>
+	<?php } ?>
+	<span class="frm-banner-title"><?php echo esc_html( $message['subject'] ); ?></span>
+	<span class="frm-banner-content"><?php echo esc_html( $message['banner'] ); ?></span>
+	<span class="frm-banner-cta"><?php echo FrmAppHelper::kses( $message['cta'], 'all' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+	<?php /* TODO: dismiss icon */ ?>
+</div>

--- a/classes/views/inbox/banner.php
+++ b/classes/views/inbox/banner.php
@@ -3,12 +3,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
 ?>
-<div id="frm_banner">
+<div id="frm_banner" data-key="<?php echo esc_attr( $message['key'] ); ?>">
 	<?php if ( ! empty( $message['emoji'] ) ) { ?>
 		<span class="frm-banner-emoji"><?php echo esc_html( $message['emoji'] ); ?></span>
 	<?php } ?>
 	<strong class="frm-banner-title"><?php echo esc_html( $message['subject'] ); ?></strong>
 	<span class="frm-banner-content"><?php echo esc_html( $message['banner'] ); ?></span>
 	<span class="frm-banner-cta"><?php echo FrmAppHelper::kses( $message['cta'], 'all' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
-	<?php /* TODO: dismiss icon */ ?>
+	<span class="frm-banner-dismiss frmsvg"><?php FrmAppHelper::icon_by_class( 'frmfont frm_close_icon', array( 'aria-label' => 'Dismiss' ) ); ?></span>
 </div>

--- a/classes/views/inbox/banner.php
+++ b/classes/views/inbox/banner.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php if ( ! empty( $message['emoji'] ) ) { ?>
 		<span class="frm-banner-emoji"><?php echo esc_html( $message['emoji'] ); ?></span>
 	<?php } ?>
-	<span class="frm-banner-title"><?php echo esc_html( $message['subject'] ); ?></span>
+	<strong class="frm-banner-title"><?php echo esc_html( $message['subject'] ); ?></strong>
 	<span class="frm-banner-content"><?php echo esc_html( $message['banner'] ); ?></span>
 	<span class="frm-banner-cta"><?php echo FrmAppHelper::kses( $message['cta'], 'all' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
 	<?php /* TODO: dismiss icon */ ?>

--- a/classes/views/inbox/banner.php
+++ b/classes/views/inbox/banner.php
@@ -2,6 +2,7 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
+$cta = str_replace( 'button-secondary', 'button-primary', $message['cta'] );
 ?>
 <div id="frm_banner" data-key="<?php echo esc_attr( $message['key'] ); ?>">
 	<?php if ( ! empty( $message['emoji'] ) ) { ?>
@@ -9,6 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php } ?>
 	<strong class="frm-banner-title"><?php echo esc_html( $message['subject'] ); ?></strong>
 	<span class="frm-banner-content"><?php echo esc_html( $message['banner'] ); ?></span>
-	<span class="frm-banner-cta"><?php echo FrmAppHelper::kses( $message['cta'], 'all' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+	<span class="frm-banner-cta"><?php echo FrmAppHelper::kses( $cta, 'all' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
 	<span class="frm-banner-dismiss frmsvg"><?php FrmAppHelper::icon_by_class( 'frmfont frm_close_icon', array( 'aria-label' => 'Dismiss' ) ); ?></span>
 </div>

--- a/classes/views/shared/admin-header.php
+++ b/classes/views/shared/admin-header.php
@@ -11,6 +11,7 @@ if ( current_user_can( 'administrator' ) && ! FrmAppHelper::pro_is_installed() &
 	</div>
 	<?php
 }
+FrmInbox::maybe_show_banner();
 ?>
 <div id="frm_top_bar">
 	<?php if ( FrmAppHelper::is_full_screen() ) { ?>

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8355,7 +8355,7 @@ Responsive Design
 }
 
 .frm-banner-emoji {
-	font-size: 15px;
+	font-size: 19px;
 }
 
 .frm-banner-emoji,

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8354,12 +8354,9 @@ Responsive Design
 	text-align: center;
 }
 
-.frm-banner-emoji {
-	margin-right: 5px;
-}
-
+.frm-banner-emoji,
 .frm-banner-title {
-	font-weight: bold;
+	margin-right: 5px;
 }
 
 .frm-banner-cta a {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8344,3 +8344,24 @@ Responsive Design
 .frm-multiselect-key-is-down li.form-field:not(.edit_field_type_divider) {
 	pointer-events: none;
 }
+
+#frm_banner {
+	width: 100%;
+	color: #fff;
+	background: #4199FD;
+	height: 40px;
+	line-height: 40px;
+	text-align: center;
+}
+
+.frm-banner-emoji {
+	margin-right: 5px;
+}
+
+.frm-banner-title {
+	font-weight: bold;
+}
+
+.frm-banner-cta a {
+	text-decoration: underline !important;
+}

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8272,7 +8272,7 @@ Responsive Design
 
 #frm_field_group_popup .frm-row-layout-option.frm-active-row-layout,
 #frm_field_group_popup .frm-row-layout-option:hover {
-	outline: 1px solid #4199FD;
+	outline: 1px solid var(--primary-color);
 }
 
 .frm-custom-field-group-layout,
@@ -8357,7 +8357,7 @@ Responsive Design
 #frm_banner {
 	width: 100%;
 	color: #fff;
-	background: #4199FD;
+	background: var(--primary-color);
 	height: 40px;
 	line-height: 40px;
 	text-align: center;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8354,9 +8354,14 @@ Responsive Design
 	text-align: center;
 }
 
+.frm-banner-emoji {
+	font-size: 15px;
+}
+
 .frm-banner-emoji,
 .frm-banner-title {
 	margin-right: 5px;
+	vertical-align: top;
 }
 
 .frm-banner-cta a {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8361,6 +8361,7 @@ Responsive Design
 	height: 40px;
 	line-height: 40px;
 	text-align: center;
+	position: relative;
 }
 
 .frm-banner-emoji {
@@ -8375,4 +8376,16 @@ Responsive Design
 
 .frm-banner-cta a {
 	text-decoration: underline !important;
+}
+
+.frm-banner-dismiss {
+	cursor: pointer;
+	position: absolute;
+	right: 10px;
+	top: 50%;
+	transform: translateY( -50% );
+}
+
+.frm-banner-dismiss .frmsvg {
+	vertical-align: top;
 }

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8609,6 +8609,7 @@ function frmAdminBuildJS() {
 				// New form selection page
 				initNewFormModal();
 				initSelectionAutocomplete();
+				frmAdminBuild.inboxBannerInit();
 
 				jQuery( '[data-frmprint]' ).on( 'click', function() {
 					window.print();
@@ -9312,6 +9313,40 @@ function frmAdminBuildJS() {
 				});
 				this.parentElement.remove();
 			});
+		},
+
+		inboxBannerInit: function() {
+			const banner = document.getElementById( 'frm_banner' );
+			if ( ! banner ) {
+				return;
+			}
+
+			const dismissButton = banner.querySelector( '.frm-banner-dismiss' );
+			document.addEventListener(
+				'click',
+				function( event ) {
+					if ( event.target !== dismissButton ) {
+						return;
+					}
+
+					const data = {
+						action: 'frm_inbox_dismiss',
+						key: banner.dataset.key,
+						nonce: frmGlobal.nonce
+					};
+					postAjax(
+						data,
+						function() {
+							jQuery( banner ).fadeOut(
+								400,
+								function() {
+									banner.remove();
+								}
+							);
+						}
+					);
+				}
+			);
 		},
 
 		updateOpts: function( fieldId, opts, modal ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8578,6 +8578,8 @@ function frmAdminBuildJS() {
 				thisFormId = jQuery( document.getElementById( 'form_id' ) ).val();
 			}
 
+			frmAdminBuild.inboxBannerInit();
+
 			if ( $newFields.length > 0 ) {
 				// only load this on the form builder page
 				frmAdminBuild.buildInit();
@@ -8609,7 +8611,6 @@ function frmAdminBuildJS() {
 				// New form selection page
 				initNewFormModal();
 				initSelectionAutocomplete();
-				frmAdminBuild.inboxBannerInit();
 
 				jQuery( '[data-frmprint]' ).on( 'click', function() {
 					window.print();


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3022

The Inbox API can now pass along two new keys, emoji and banner.

![Screen Shot 2021-09-15 at 12 27 11 PM](https://user-images.githubusercontent.com/9134515/133463600-67636841-5c6b-4d18-8f44-70b9d0426c01.png)

For now any testing has to be done with fake data.

I was injecting into the current active message with:

```
$message['emoji']  = '🕺';
$message['banner'] = 'Multi-column forms are easier to create with the all-new form layout tool';
```