### PR TITLE
Set fields updated to 0 on save and reload

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6760,6 +6760,7 @@ function frmAdminBuildJS() {
 		if ( null !== page ) {
 			form = page.querySelector( 'form.frm_form_settings' );
 			if ( null !== form ) {
+				fieldsUpdated = 0;
 				form.submit();
 			}
 		}


### PR DESCRIPTION
Caught a small issue with my new update. If there were changes it was actually showing the warning still. Looks like the fieldsUpdated value doesn't get flagged here automatically.