### PR TITLE
Do not return section for section field

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1293,10 +1293,9 @@ function frmAdminBuildJS() {
 	// Get the section where a field is dropped
 	function getSectionForFieldPlacement( currentItem ) {
 		var section = '';
-		if ( typeof currentItem !== 'undefined' ) {
+		if ( typeof currentItem !== 'undefined' && ! currentItem.hasClass( 'edit_field_type_divider' ) ) {
 			section = currentItem.closest( '.edit_field_type_divider' );
 		}
-
 		return section;
 	}
 


### PR DESCRIPTION
Think this fixes the issue behind https://github.com/Strategy11/formidable-pro/issues/3157

It seems moving a repeater can cause it to assign itself as a section. This update just makes sure that a section never returns itself when trying to determine what section a field is in.

Leaving that issue open for now as this doesn't really fix the issues automatically. I think we could use some extra checks to make sure nothing ever tries to embed into itself.