### PR TITLE
Do not wrap html around validation pattern

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -750,9 +750,13 @@ class FrmFieldsController {
 			return false;
 		}
 
-		$error_body = substr( $custom_html, $start + 10, $end - $start - 10 );
-		if ( '<div class="frm_error" id="frm_error_field_[key]">[error]</div>' === $error_body ) {
-			// no custom HTML if the default is detected, so do nothing special.
+		$error_body   = substr( $custom_html, $start + 10, $end - $start - 10 );
+		$default_html = array(
+			'<div class="frm_error" id="frm_error_field_[key]">[error]</div>',
+			'<div class="frm_error">[error]</div>',
+		);
+
+		if ( in_array( $error_body, $default_html, true ) ) {
 			return false;
 		}
 

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -470,7 +470,7 @@ function frmFrontFormJS() {
 			msg = '';
 		}
 
-		if ( '' !== msg ) {
+		if ( '' !== msg && shouldWrapErrorHtmlAroundMessageType( messageType ) ) {
 			errorHtml = field.getAttribute( 'data-error-html' );
 			if ( null !== errorHtml ) {
 				errorHtml = errorHtml.replace( /\+/g, '%20' );
@@ -480,6 +480,10 @@ function frmFrontFormJS() {
 		}
 
 		return msg;
+	}
+
+	function shouldWrapErrorHtmlAroundMessageType( type ) {
+		return 'pattern' !== type;
 	}
 
 	function shouldJSValidate( object ) {


### PR DESCRIPTION
https://secure.helpscout.net/conversation/1634066257/81156/
And now also https://secure.helpscout.net/conversation/1636090425/81257?folderId=2445391
And looks like a third time now as well https://secure.helpscout.net/conversation/1636180030/81261?folderId=2445391

Looks like my custom error html update had a funny side effect I wasn't expecting.

`getFieldValidationMessage` is actually called in one place to get the pattern. It's not always a "validation message" as the function might lead you to think.

So the custom error html (which wasn't actually custom, it turns out that the error html sometimes doesn't include an id and I wasn't checking for that), was applying over the pattern so the pattern would break.

I also updated the default check so it would include these missing id cases better too. If that check was better, this customer wouldn't have been effected.

_This bug would effect any pattern checks with JavaScript validation on for a field that either had custom error HTML or is missing the id from the default. It's common enough that I think an early patch release might make some sense._