### PR TITLE
More accessible field dropdowns

### DIFF
--- a/classes/views/frm-forms/add_field.php
+++ b/classes/views/frm-forms/add_field.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</a>
 
 		<div class="dropdown">
-			<a href="#" class="frm_bstooltip frm-hover-icon frm-dropdown-toggle dropdown-toggle" title="<?php esc_attr_e( 'More Options', 'formidable' ); ?>" data-toggle="dropdown" data-container="body">
+			<a href="#" class="frm_bstooltip frm-hover-icon frm-dropdown-toggle dropdown-toggle" title="<?php esc_attr_e( 'More Options', 'formidable' ); ?>" data-toggle="dropdown" data-container="body" aria-expanded="false">
 				<?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_thick_more_vert_icon' ); ?>
 			</a>
 			<ul class="frm-dropdown-menu" role="menu"></ul>

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6765,10 +6765,10 @@ ul .frm_col_two {
 #frm_field_group_controls .frm-dropdown-menu .frm_dropdown_li,
 .frm-field-action-icons .frm-dropdown-menu .frm_dropdown_li {
 	padding: 5px 10px;
+	color: rgba(40, 47, 54, 0.85);
 	cursor: pointer;
 }
 
-.frm-field-action-icons .frm-dropdown-menu .frm_dropdown_li,
 .frm-field-action-icons .frm-dropdown-menu .frm_dropdown_li .frmsvg {
 	color: rgba(40, 47, 54, 0.85) !important;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6765,8 +6765,16 @@ ul .frm_col_two {
 #frm_field_group_controls .frm-dropdown-menu .frm_dropdown_li,
 .frm-field-action-icons .frm-dropdown-menu .frm_dropdown_li {
 	padding: 5px 10px;
-	color: rgba(40, 47, 54, 0.85);
 	cursor: pointer;
+}
+
+.frm-field-action-icons .frm-dropdown-menu .frm_dropdown_li,
+.frm-field-action-icons .frm-dropdown-menu .frm_dropdown_li .frmsvg {
+	color: rgba(40, 47, 54, 0.85) !important;
+}
+
+.frm-field-action-icons .frm-dropdown-menu .frm_dropdown_li a {
+	padding: 3px 0;
 }
 
 #frm_field_group_controls .frm-dropdown-menu .frm_dropdown_li:hover,

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1954,6 +1954,9 @@ function frmAdminBuildJS() {
 				if ( null === ul ) {
 					return;
 				}
+				if ( null === ul.getAttribute( 'aria-label' ) ) {
+					ul.setAttribute( 'aria-label', __( 'More Options', 'formidable' ) );
+				}
 				if ( 0 === ul.children.length ) {
 					fillFieldActionDropdown( ul, true === isFieldGroup );
 				}
@@ -1981,18 +1984,21 @@ function frmAdminBuildJS() {
 		}
 		options.forEach(
 			function( option ) {
-				var li, span;
+				var li, anchor, span;
 				li = document.createElement( 'li' );
-				li.classList.add( 'frm_dropdown_li', option.class + classSuffix );
-				if ( 'frm_delete' === option.class ) {
-					// delete using a confirmation that will cause a redirect if href isn't set to #.
-					li.setAttribute( 'href', '#' );
-				}
+				li.classList.add( 'frm_dropdown_li' );
+
+				anchor = document.createElement( 'a' );
+				anchor.classList.add( option.class + classSuffix );
+				anchor.setAttribute( 'href', '#' );
+
 				span = document.createElement( 'span' );
 				span.textContent = option.label;
-				li.innerHTML = '<svg class="frmsvg"><use xlink:href="#' + option.icon + '"></use></svg>';
-				li.appendChild( document.createTextNode( ' ' ) );
-				li.appendChild( span );
+				anchor.innerHTML = '<svg class="frmsvg"><use xlink:href="#' + option.icon + '"></use></svg>';
+				anchor.appendChild( document.createTextNode( ' ' ) );
+				anchor.appendChild( span );
+
+				li.appendChild( anchor );
 				ul.appendChild( li );
 			}
 		);


### PR DESCRIPTION
Trying to make field dropdowns more accessible

**Related to** 
https://github.com/Strategy11/formidable-pro/issues/3172
https://github.com/Strategy11/formidable-pro/issues/3207

I can use the keyboard to delete and duplicate fields now when following VoiceOver instructions.

Tried a few things to make this nicer (giving the list an aria-label, setting a default aria-expanded=false, changing the li elements to use anchor which focus better).