### PR TITLE
Allow custom columns in CSV export

### DIFF
--- a/classes/controllers/FrmXMLController.php
+++ b/classes/controllers/FrmXMLController.php
@@ -570,9 +570,7 @@ class FrmXMLController {
 		$form_id = $form->id;
 
 		$form_cols = self::get_fields_for_csv_export( $form_id, $form );
-
-		// TODO reduce form cols if a subset of field ids is provided.
-		$form_cols = self::reduce_fields_for_csv_export( $form_cols );
+		$form_cols = self::maybe_reduce_fields_for_csv_export( $form_cols );
 
 		$item_id = FrmAppHelper::get_param( 'item_id', 0, 'get', 'sanitize_text_field' );
 		if ( ! empty( $item_id ) ) {
@@ -607,7 +605,10 @@ class FrmXMLController {
 		wp_die();
 	}
 
-	private static function reduce_fields_for_csv_export( $form_cols ) {
+	/**
+	 * if $_REQUEST['columns'] is passed, limit the export to only specific fields.
+	 */
+	private static function maybe_reduce_fields_for_csv_export( $form_cols ) {
 		if ( ! FrmCSVExportHelper::exporting_specific_columns_only() ) {
 			return $form_cols;
 		}

--- a/classes/controllers/FrmXMLController.php
+++ b/classes/controllers/FrmXMLController.php
@@ -571,6 +571,9 @@ class FrmXMLController {
 
 		$form_cols = self::get_fields_for_csv_export( $form_id, $form );
 
+		// TODO reduce form cols if a subset of field ids is provided.
+		$form_cols = self::reduce_fields_for_csv_export( $form_cols );
+
 		$item_id = FrmAppHelper::get_param( 'item_id', 0, 'get', 'sanitize_text_field' );
 		if ( ! empty( $item_id ) ) {
 			$item_id = explode( ',', $item_id );
@@ -602,6 +605,34 @@ class FrmXMLController {
 		}
 
 		wp_die();
+	}
+
+	private static function reduce_fields_for_csv_export( $form_cols ) {
+		if ( ! FrmCSVExportHelper::exporting_specific_columns_only() ) {
+			return $form_cols;
+		}
+
+		$ids = array_reduce(
+			FrmCSVExportHelper::get_custom_columns(),
+			function( $total, $id ) {
+				$id = absint( $id );
+				if ( $id ) {
+					$total[] = $id;
+				}
+				return $total;
+			},
+			array()
+		);
+		return array_reduce(
+			$form_cols,
+			function( $total, $form_col ) use ( $ids ) {
+				if ( in_array( (int) $form_col->id, $ids, true ) ) {
+					$total[] = $form_col;
+				}
+				return $total;
+			},
+			array()
+		);
 	}
 
 	/**

--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -243,7 +243,7 @@ class FrmCSVExportHelper {
 	}
 
 	public static function get_custom_columns() {
-		$ids_csv = FrmAppHelper::simple_get( 'columns', 'sanitize_text_field' );
+		$ids_csv = FrmAppHelper::get_param( 'columns', '', 'get', 'sanitize_text_field' );
 		return explode( ',', $ids_csv );
 	}
 

--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -220,17 +220,70 @@ class FrmCSVExportHelper {
 			unset( $i );
 		}
 
-		$headings['created_at'] = __( 'Timestamp', 'formidable' );
-		$headings['updated_at'] = __( 'Last Updated', 'formidable' );
-		$headings['user_id']    = __( 'Created By', 'formidable' );
-		$headings['updated_by'] = __( 'Updated By', 'formidable' );
-		$headings['is_draft']   = __( 'Draft', 'formidable' );
-		$headings['ip']         = __( 'IP', 'formidable' );
-		$headings['id']         = __( 'ID', 'formidable' );
-		$headings['item_key']   = __( 'Key', 'formidable' );
-		if ( self::has_parent_id() ) {
-			$headings['parent_id'] = __( 'Parent ID', 'formidable' );
+		if ( self::exporting_specific_columns_only() ) {
+			$keys = array_reduce(
+				self::get_custom_columns(),
+				function( $total, $id ) {
+					if ( ! is_numeric( $id ) ) {
+						$total[] = $id;
+					}
+					return $total;
+				},
+				array()
+			);
+		} else {
+			$keys = false;
 		}
+
+		$headings += self::get_headings( $keys );
+	}
+
+	public static function exporting_specific_columns_only() {
+		return isset( $_GET['columns'] );
+	}
+
+	public static function get_custom_columns() {
+		$ids_csv = FrmAppHelper::simple_get( 'columns', 'sanitize_text_field' );
+		return explode( ',', $ids_csv );
+	}
+
+	private static function get_headings( $keys = false ) {
+		$all_headings = array( 'created_at', 'updated_at', 'user_id', 'updated_by', 'is_draft', 'ip', 'id', 'item_key' );
+		if ( self::has_parent_id() ) {
+			$all_headings[] = 'parent_id';
+		}
+
+		$filtered_headings = array();
+		foreach ( $all_headings as $heading ) {
+			if ( false !== $keys && ! in_array( $heading, $keys, true ) ) {
+				continue;
+			}
+			$filtered_headings[ $heading ] = self::get_heading_label( $heading );
+		}
+
+		return $filtered_headings;
+	}
+
+	private static function get_heading_label( $heading ) {
+		switch ( $heading ) {
+			case 'created_at':
+				return __( 'Timestamp', 'formidable' );
+			case 'updated_at':
+				return __( 'Last Updated', 'formidable' );
+			case 'user_id':
+				return __( 'Created By', 'formidable' );
+			case 'updated_by':
+				return __( 'Updated By', 'formidable' );
+			case 'ip':
+				return __( 'IP', 'formidable' );
+			case 'id':
+				return __( 'ID', 'formidable' );
+			case 'item_key':
+				return __( 'Key', 'formidable' );
+			case 'parent_id':
+				return __( 'Parent ID', 'formidable' );
+		}
+		return '';
 	}
 
 	/**


### PR DESCRIPTION
This update adds basic support for downloading a custom subset of the CSV data.

So far there is no UI for this but it already works really well and could probably be useful enough for many purposes as is.

@stephywells would it make sense to put a popup in the free plugin, or to make that a pro enhancement?

An example url
`http://localhost:8889/wp-admin/admin-ajax.php?frm_action=0&action=frm_entries_csv&form=111&columns=992,994,created_at,updated_at`