### PR TITLE
Explode sep value labels for repeated fields

### DIFF
--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -391,16 +391,16 @@ class FrmCSVExportHelper {
 			);
 
 			if ( ! empty( $col->field_options['separate_value'] ) ) {
+				$label_key = $col->id . '_label';
 				if ( self::is_the_child_of_a_repeater( $col ) ) {
-					$label_key         = $col->id . '_label';
 					$row[ $label_key ] = array();
 					foreach ( $field_value as $value ) {
 						$row[ $label_key ][] = self::get_separate_value_label( $value, $col );
 					}
-					unset( $label_key );
 				} else {
-					$row[ $col->id . '_label' ] = self::get_separate_value_label( $field_value, $col );
+					$row[ $label_key ] = self::get_separate_value_label( $field_value, $col );
 				}
+				unset( $label_key );
 			}
 
 			$row[ $col->id ] = $field_value;

--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -391,32 +391,44 @@ class FrmCSVExportHelper {
 			);
 
 			if ( ! empty( $col->field_options['separate_value'] ) ) {
-				$sep_value = FrmEntriesHelper::display_value(
-					$field_value,
-					$col,
-					array(
-						'type'              => $col->type,
-						'post_id'           => self::$entry->post_id,
-						'show_icon'         => false,
-						'entry_id'          => self::$entry->id,
-						'sep'               => self::$separator,
-						'embedded_field_id' => ( isset( self::$entry->embedded_fields ) && isset( self::$entry->embedded_fields[ self::$entry->id ] ) ) ? 'form' . self::$entry->embedded_fields[ self::$entry->id ] : 0,
-					)
-				);
-
 				if ( self::is_the_child_of_a_repeater( $col ) ) {
-					$row[ $col->id . '_label' ] = explode( self::$separator, $sep_value );
+					$label_key         = $col->id . '_label';
+					$row[ $label_key ] = array();
+					foreach ( $field_value as $value ) {
+						$row[ $label_key ][] = self::get_separate_value_label( $value, $col );
+					}
+					unset( $label_key );
 				} else {
-					$row[ $col->id . '_label' ] = $sep_value;
+					$row[ $col->id . '_label' ] = self::get_separate_value_label( $field_value, $col );
 				}
-
-				unset( $sep_value );
 			}
 
 			$row[ $col->id ] = $field_value;
 
 			unset( $col, $field_value );
 		}
+	}
+
+	/**
+	 * @since 5.0.06
+	 *
+	 * @param mixed    $field_value
+	 * @param stdClass $field
+	 * @return string
+	 */
+	private static function get_separate_value_label( $field_value, $field ) {
+		return FrmEntriesHelper::display_value(
+			$field_value,
+			$field,
+			array(
+				'type'              => $field->type,
+				'post_id'           => self::$entry->post_id,
+				'show_icon'         => false,
+				'entry_id'          => self::$entry->id,
+				'sep'               => self::$separator,
+				'embedded_field_id' => ( isset( self::$entry->embedded_fields ) && isset( self::$entry->embedded_fields[ self::$entry->id ] ) ) ? 'form' . self::$entry->embedded_fields[ self::$entry->id ] : 0,
+			)
+		);
 	}
 
 	/**

--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -128,7 +128,7 @@ class FrmCSVExportHelper {
 
 		$field_headings  = array();
 		$separate_values = array( 'user_id', 'file', 'data', 'date' );
-		if ( isset( $col->field_options['separate_value'] ) && $col->field_options['separate_value'] && ! in_array( $col->type, $separate_values, true ) ) {
+		if ( ! empty( $col->field_options['separate_value'] ) && ! in_array( $col->type, $separate_values, true ) ) {
 			$field_headings[ $col->id . '_label' ] = strip_tags( $col->name . ' ' . __( '(label)', 'formidable' ) );
 		}
 
@@ -404,7 +404,12 @@ class FrmCSVExportHelper {
 					)
 				);
 
-				$row[ $col->id . '_label' ] = $sep_value;
+				if ( self::is_the_child_of_a_repeater( $col ) ) {
+					$row[ $col->id . '_label' ] = explode( self::$separator, $sep_value );
+				} else {
+					$row[ $col->id . '_label' ] = $sep_value;
+				}
+
 				unset( $sep_value );
 			}
 


### PR DESCRIPTION
https://secure.helpscout.net/conversation/1633894310/81145?folderId=4324209

**Separate values _label columns were not exporting properly when inside of a repeater.**

It looks like this was missed when I did the repeater csv export.

Pretty simple fix. The labels are all together as a CSV, just have to be exploded.

**Before**
![Screen Shot 2021-09-21 at 3 46 03 PM](https://user-images.githubusercontent.com/9134515/134229396-24651678-b6f3-4402-afa6-e37ebe85eaf7.png)

**After**
![Screen Shot 2021-09-21 at 3 46 17 PM](https://user-images.githubusercontent.com/9134515/134229435-5b1bca2f-71ac-4ef1-8b9a-d41ce38687a9.png)