### PR TITLE
Add aria required to required radio and checkbox fields

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -764,7 +764,7 @@ class FrmFieldsController {
 	}
 
 	/**
-	 * If 'required' is added to a conditionall hidden field, the form won't
+	 * If 'required' is added to a conditionally hidden field, the form won't
 	 * submit in many browsers. Check to make sure the javascript to conditionally
 	 * remove it is present if needed.
 	 *
@@ -773,7 +773,7 @@ class FrmFieldsController {
 	 * @param array $add_html
 	 */
 	private static function maybe_add_html_required( $field, array &$add_html ) {
-		if ( in_array( $field['type'], array( 'radio', 'checkbox', 'file', 'data', 'lookup' ) ) ) {
+		if ( in_array( $field['type'], array( 'file', 'data', 'lookup' ), true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3207, at least how it should. We use `aria-required`, not `required` but this covers the issue.

@stephywells any idea why radio and checkbox were ever excluded here? Was it just an oversight or something?

It removed them from this exception and they work well with the `aria-required` attributes added.