### PR TITLE
Add insert form popup on elementor admin

### DIFF
--- a/classes/controllers/FrmElementorController.php
+++ b/classes/controllers/FrmElementorController.php
@@ -1,0 +1,29 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'You are not allowed to call this page directly.' );
+}
+
+/**
+ * @since 5.0.06
+ */
+class FrmElementorController {
+
+	public static function register_elementor_hooks() {
+		require_once FrmAppHelper::plugin_path() . '/classes/widgets/FrmElementorWidget.php';
+		\Elementor\Plugin::instance()->widgets_manager->register_widget_type( new \FrmElementorWidget() );
+
+		if ( is_admin() ) {
+			add_action(
+				'elementor/editor/after_enqueue_styles',
+				function() {
+					wp_enqueue_style( 'font_icons', FrmAppHelper::plugin_url() . '/css/font_icons.css', array(), FrmAppHelper::plugin_version() );
+				}
+			);
+		}
+	}
+
+	public static function admin_init() {
+		FrmAppController::load_wp_admin_style();
+		FrmFormsController::insert_form_popup();
+	}
+}

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -93,7 +93,8 @@ class FrmHooksController {
 		 */
 		add_filter( 'frm_keep_name_value_array', '__return_true' );
 
-		add_action( 'elementor/widgets/widgets_registered', 'FrmHooksController::register_elementor_hooks' );
+		// Elementor.
+		add_action( 'elementor/widgets/widgets_registered', 'FrmElementorController::register_elementor_hooks' );
 	}
 
 	public static function load_admin_hooks() {
@@ -131,6 +132,10 @@ class FrmHooksController {
 
 		add_filter( 'set-screen-option', 'FrmFormsController::save_per_page', 10, 3 );
 		add_action( 'admin_footer', 'FrmFormsController::insert_form_popup' );
+
+		// Elementor.
+		add_action( 'elementor/editor/footer', 'FrmElementorController::admin_init' );
+
 		add_action( 'media_buttons', 'FrmFormsController::insert_form_button' );
 		add_action( 'et_pb_admin_excluded_shortcodes', 'FrmFormsController::prevent_divi_conflict' );
 
@@ -248,17 +253,11 @@ class FrmHooksController {
 		add_filter( 'wpmu_drop_tables', 'FrmAppController::drop_tables' );
 	}
 
+	/**
+	 * @deprecated 5.0.06 use FrmElementorController::register_elementor_hooks directly.
+	 */
 	public static function register_elementor_hooks() {
-		require_once FrmAppHelper::plugin_path() . '/classes/widgets/FrmElementorWidget.php';
-		\Elementor\Plugin::instance()->widgets_manager->register_widget_type( new \FrmElementorWidget() );
-
-		if ( is_admin() ) {
-			add_action(
-				'elementor/editor/after_enqueue_styles',
-				function() {
-					wp_enqueue_style( 'font_icons', FrmAppHelper::plugin_url() . '/css/font_icons.css', array(), FrmAppHelper::plugin_version() );
-				}
-			);
-		}
+		_deprecated_function( __FUNCTION__, '5.0.06', 'FrmElementorController::register_elementor_hooks' );
+		FrmElementorController::register_elementor_hooks();
 	}
 }


### PR DESCRIPTION
https://secure.helpscout.net/conversation/1637476380/81364/

Fixes https://github.com/Strategy11/formidable-pro/issues/3223

Moving the logic now into a new Elementor controller since this is the second time I've wanted to put hooks for Elementor somewhere and didn't have a great place for it. I didn't want to add another function to the Hooks controller. I've deprecated the other one I had added.

The pop up would just appear blank before because the required JavaScript and HTML were not being added to the page.

https://recordit.co/O9GK1pNHvz

@garretlaxton to test this, I'd like to see if this pop up has any other issues on this Elementor page that I didn't catch.