### PR TITLE
Make name fields more accessible

### DIFF
--- a/classes/models/fields/FrmFieldCombo.php
+++ b/classes/models/fields/FrmFieldCombo.php
@@ -357,10 +357,10 @@ class FrmFieldCombo extends FrmFieldType {
 
 		if ( ! empty( $sub_field['optional'] ) ) {
 			$classes .= ' frm_optional';
-		} else {
-			$field['default_value'] = ''; // fake it to avoid printing frm-val attribute.
-			do_action( 'frm_field_input_html', $field );
 		}
+
+		$field['default_value'] = ''; // fake it to avoid printing frm-val attribute.
+		do_action( 'frm_field_input_html', $field );
 
 		if ( $classes ) {
 			$atts[] = 'class="' . esc_attr( $classes ) . '"';

--- a/classes/models/fields/FrmFieldCombo.php
+++ b/classes/models/fields/FrmFieldCombo.php
@@ -357,15 +357,13 @@ class FrmFieldCombo extends FrmFieldType {
 
 		if ( ! empty( $sub_field['optional'] ) ) {
 			$classes .= ' frm_optional';
+		} else {
+			$field['default_value'] = ''; // fake it to avoid printing frm-val attribute.
+			do_action( 'frm_field_input_html', $field );
 		}
 
 		if ( $classes ) {
 			$atts[] = 'class="' . esc_attr( $classes ) . '"';
-		}
-
-		// Required.
-		if ( FrmField::get_option( $field, 'required' ) ) {
-			$atts[] = 'aria-required="true"';
 		}
 
 		// Print custom attributes.

--- a/classes/models/fields/FrmFieldCombo.php
+++ b/classes/models/fields/FrmFieldCombo.php
@@ -363,6 +363,11 @@ class FrmFieldCombo extends FrmFieldType {
 			$atts[] = 'class="' . esc_attr( $classes ) . '"';
 		}
 
+		// Required.
+		if ( FrmField::get_option( $field, 'required' ) ) {
+			$atts[] = 'aria-required="true"';
+		}
+
 		// Print custom attributes.
 		if ( ! empty( $sub_field['atts'] ) && is_array( $sub_field['atts'] ) ) {
 			foreach ( $sub_field['atts'] as $att_name => $att_value ) {

--- a/classes/models/fields/FrmFieldCombo.php
+++ b/classes/models/fields/FrmFieldCombo.php
@@ -359,12 +359,13 @@ class FrmFieldCombo extends FrmFieldType {
 			$classes .= ' frm_optional';
 		}
 
-		$field['default_value'] = ''; // fake it to avoid printing frm-val attribute.
-		do_action( 'frm_field_input_html', $field );
-
 		if ( $classes ) {
-			$atts[] = 'class="' . esc_attr( $classes ) . '"';
+			$field['input_class'] = esc_attr( $classes );
 		}
+
+		$field['default_value'] = ''; // fake it to avoid printing frm-val attribute.
+
+		do_action( 'frm_field_input_html', $field );
 
 		// Print custom attributes.
 		if ( ! empty( $sub_field['atts'] ) && is_array( $sub_field['atts'] ) ) {


### PR DESCRIPTION
After updating the `aria-required` attributes for radios/checkboxes (https://github.com/Strategy11/formidable-forms/pull/531) I thought I'd check our other fields.

Some of the new fields have missing attributes. It looks like they're missing this call to the `frm_field_input_html` action which is pretty important.

It makes it more extendable, adds support for the `frm_field_classes` filter, adds `aria-invalid` when JavaScript validation is turned on, adds the missing `aria-required` attribute, adds the JavaScript validation messages that are missing.

@truongwp do you see any issues with this update? Do you think anything could go wrong here?

**Before**
![frm_blank_field data-sub-field-name=first event](https://user-images.githubusercontent.com/9134515/134515493-2d7ecc59-fd1b-4be8-a878-3125adb86b5b.png)

**After**
![data-sub-field-name=first](https://user-images.githubusercontent.com/9134515/134515511-d1f7005b-593f-48b4-91a5-d80ffb27effc.png)

**Before (JavaScript validation on in error state)**
![Required Name](https://user-images.githubusercontent.com/9134515/134515543-711b2031-dea5-4e1c-a4a3-24909aa2c141.png)

**After (JavaScript validation on in error state)**
![Required Name](https://user-images.githubusercontent.com/9134515/134515651-466a4ceb-30c6-4e3a-8ffc-5f2bf20aff6f.png)
