### PR TITLE
Tweak field dropdowns

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -21,7 +21,7 @@ jobs:
           - php: 7.3
             wordpress: master
             phpunit: 6.5.14
-          - php: 7.0.33
+          - php: 7.1
             wordpress: 5.8
             phpunit: 6.5.14
 

--- a/classes/views/frm-forms/add_field.php
+++ b/classes/views/frm-forms/add_field.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<a href="#" class="frm-collapse-section frm-hover-icon frm_icon_font frm_arrowdown6_icon" title="<?php esc_attr_e( 'Expand/Collapse Section', 'formidable' ); ?>"></a>
 		<?php } ?>
 
-		<a href="#" class="frm_bstooltip frm-move frm-hover-icon" title="<?php esc_attr_e( 'Move Field', 'formidable' ); ?>" data-container="body">
+		<a href="#" class="frm_bstooltip frm-move frm-hover-icon" title="<?php esc_attr_e( 'Move Field', 'formidable' ); ?>" data-container="body" aria-label="<?php esc_attr_e( 'Move Field', 'formidable' ); ?>">
 			<?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_thick_move_icon' ); ?>
 		</a>
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6762,23 +6762,35 @@ ul .frm_col_two {
 	font-size: 15px;
 }
 
-#frm_field_group_controls .frm-dropdown-menu .frm_dropdown_li,
-.frm-field-action-icons .frm-dropdown-menu .frm_dropdown_li {
-	padding: 5px 10px;
-	color: rgba(40, 47, 54, 0.85);
-	cursor: pointer;
+#frm_field_group_controls .frm-dropdown-menu,
+.frm-field-action-icons .frm-dropdown-menu {
+	padding: 0;
+	margin: 0;
 }
 
-.frm-field-action-icons .frm-dropdown-menu .frm_dropdown_li .frmsvg {
+#frm_builder_page .frm-dropdown-menu .frm_dropdown_li.frm_more_options_li  {
+	padding: 0;
+	color: rgba(40, 47, 54, 0.85);
+	cursor: pointer;
+	position: relative;
+	height: 32px;
+}
+
+#frm_builder_page  .frm-dropdown-menu .frm_dropdown_li.frm_more_options_li .frmsvg {
 	color: rgba(40, 47, 54, 0.85) !important;
 }
 
-.frm-field-action-icons .frm-dropdown-menu .frm_dropdown_li a {
-	padding: 3px 0;
+#frm_builder_page .frm-dropdown-menu .frm_dropdown_li.frm_more_options_li  a {
+	padding: 6px 10px;
+	position: absolute;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	width: 100%;
+	box-sizing: border-box;
 }
 
-#frm_field_group_controls .frm-dropdown-menu .frm_dropdown_li:hover,
-.frm-field-action-icons .frm-dropdown-menu .frm_dropdown_li:hover {
+#frm_builder_page .frm-dropdown-menu .frm_dropdown_li.frm_more_options_li:hover {
 	background: #F6F7FB;
 }
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -588,6 +588,14 @@ function frmAdminBuildJS() {
 		});
 	}
 
+	function deleteTooltips() {
+		document.querySelectorAll( '.tooltip' ).forEach(
+			function( tooltip ) {
+				tooltip.remove();
+			}
+		);
+	}
+
 	function removeThisTag() {
 		/*jshint validthis:true */
 		var show, hide, removeMore,
@@ -1964,6 +1972,10 @@ function frmAdminBuildJS() {
 				if ( $ul.offset().left > jQuery( window ).width() - $ul.outerWidth() ) {
 					ul.style.left = ( -$ul.outerWidth() ) + 'px';
 				}
+				const firstAnchor = ul.firstElementChild.querySelector( 'a' );
+				if ( firstAnchor ) {
+					firstAnchor.focus();
+				}
 			},
 			0
 		);
@@ -1986,11 +1998,12 @@ function frmAdminBuildJS() {
 			function( option ) {
 				var li, anchor, span;
 				li = document.createElement( 'li' );
-				li.classList.add( 'frm_dropdown_li' );
+				li.classList.add( 'frm_dropdown_li', 'frm_more_options_li' );
 
 				anchor = document.createElement( 'a' );
 				anchor.classList.add( option.class + classSuffix );
 				anchor.setAttribute( 'href', '#' );
+				anchor.setAttribute( 'tabindex', 1 );
 
 				span = document.createElement( 'span' );
 				span.textContent = option.label;
@@ -4112,6 +4125,9 @@ function frmAdminBuildJS() {
 					} else {
 						$liWrapper.remove();
 					}
+
+					// prevent "More Options" tooltips from staying around after their target field is deleted.
+					deleteTooltips();
 				});
 			}
 		});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1191,8 +1191,19 @@ function frmAdminBuildJS() {
 	}
 
 	function setFieldControlsHtml( controls ) {
-		controls.innerHTML = '<span><svg class="frmsvg"><use xlink:href="#frm_field_group_layout_icon"></use></svg></span>';
-		controls.innerHTML += '<span class="frm-move"><svg class="frmsvg"><use xlink:href="#frm_thick_move_icon"></use></svg></span>';
+		var layoutOption, moveOption;
+
+		layoutOption = document.createElement( 'span' );
+		layoutOption.innerHTML = '<svg class="frmsvg"><use xlink:href="#frm_field_group_layout_icon"></use></svg>';
+		makeTabbable( layoutOption, __( 'Set Row Layout', 'formidable' ) );
+
+		moveOption = document.createElement( 'span' );
+		moveOption.innerHTML = '<svg class="frmsvg"><use xlink:href="#frm_thick_move_icon"></use></svg>';
+		makeTabbable( moveOption, __( 'Move Field Group', 'formidable' ) );
+
+		controls.innerHTML = '';
+		controls.appendChild( layoutOption );
+		controls.appendChild( moveOption );
 		controls.appendChild( getFieldControlsDropdown() );
 	}
 
@@ -1207,6 +1218,7 @@ function frmAdminBuildJS() {
 		trigger.setAttribute( 'title', __( 'More Options', 'formidable' ) );
 		trigger.setAttribute( 'data-toggle', 'dropdown' );
 		trigger.setAttribute( 'data-container', 'body' );
+		makeTabbable( trigger, __( 'More Options', 'formidable' ) );
 		trigger.innerHTML = '<span><svg class="frmsvg"><use xlink:href="#frm_thick_more_vert_icon"></use></svg></span>';
 		dropdown.appendChild( trigger );
 
@@ -2003,7 +2015,7 @@ function frmAdminBuildJS() {
 				anchor = document.createElement( 'a' );
 				anchor.classList.add( option.class + classSuffix );
 				anchor.setAttribute( 'href', '#' );
-				anchor.setAttribute( 'tabindex', 1 );
+				makeTabbable( anchor );
 
 				span = document.createElement( 'span' );
 				span.textContent = option.label;
@@ -3264,6 +3276,11 @@ function frmAdminBuildJS() {
 		popupWrapper.style.position = 'relative';
 		popupWrapper.appendChild( getFieldGroupPopup( sizeOfFieldGroup, this ) );
 		this.parentNode.appendChild( popupWrapper );
+
+		const firstLayoutOption = popupWrapper.querySelector( '.frm-row-layout-option' );
+		if ( firstLayoutOption ) {
+			firstLayoutOption.focus();
+		}
 	}
 
 	function destroyFieldGroupPopupOnOutsideClick( event ) {
@@ -3340,7 +3357,16 @@ function frmAdminBuildJS() {
 		option.textContent = __( 'Custom layout', 'formidable' );
 		jQuery( option ).prepend( getIconClone( 'frm_gear_svg' ) );
 		option.classList.add( 'frm-custom-field-group-layout' );
+		makeTabbable( option );
 		return option;
+	}
+
+	function makeTabbable( element, ariaLabel ) {
+		element.setAttribute( 'tabindex', 1 );
+		element.setAttribute( 'role', 'button' );
+		if ( 'undefined' !== typeof ariaLabel ) {
+			element.setAttribute( 'aria-label', ariaLabel );
+		}
 	}
 
 	function getIconClone( iconId ) {
@@ -3354,6 +3380,7 @@ function frmAdminBuildJS() {
 		option.textContent = __( 'Break into rows', 'formidable' );
 		jQuery( option ).prepend( getIconClone( 'frm_break_field_group_svg' ) );
 		option.classList.add( 'frm-break-field-group' );
+		makeTabbable( option );
 		return option;
 	}
 
@@ -3392,6 +3419,7 @@ function frmAdminBuildJS() {
 
 		option = div();
 		option.classList.add( 'frm-row-layout-option' );
+		makeTabbable( option, type );
 
 		switch ( size ) {
 			case 6:
@@ -3643,6 +3671,16 @@ function frmAdminBuildJS() {
 		wrapper.appendChild( buttonsWrapper );
 
 		popup.appendChild( wrapper );
+
+		setTimeout(
+			function() {
+				const firstInput = popup.querySelector( 'input.frm-custom-grid-size-input' ).focus();
+				if ( firstInput ) {
+					firstInput.focus();
+				}
+			},
+			0
+		);
 	}
 
 	function customFieldGroupLayoutInsideMergeClick() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1182,6 +1182,8 @@ function frmAdminBuildJS() {
 
 			controls = div();
 			controls.id = 'frm_field_group_controls';
+			controls.setAttribute( 'role', 'group' );
+			controls.setAttribute( 'tabindex', 0 );
 			setFieldControlsHtml( controls );
 			document.getElementById( 'frm_builder_page' ).appendChild( controls );
 		}
@@ -1195,16 +1197,34 @@ function frmAdminBuildJS() {
 
 		layoutOption = document.createElement( 'span' );
 		layoutOption.innerHTML = '<svg class="frmsvg"><use xlink:href="#frm_field_group_layout_icon"></use></svg>';
-		makeTabbable( layoutOption, __( 'Set Row Layout', 'formidable' ) );
+		const layoutOptionLabel = __( 'Set Row Layout', 'formidable' );
+		addTooltip( layoutOption, layoutOptionLabel );
+		makeTabbable( layoutOption, layoutOptionLabel );
 
 		moveOption = document.createElement( 'span' );
 		moveOption.innerHTML = '<svg class="frmsvg"><use xlink:href="#frm_thick_move_icon"></use></svg>';
-		makeTabbable( moveOption, __( 'Move Field Group', 'formidable' ) );
+		const moveOptionLabel = __( 'Move Field Group', 'formidable' );
+		addTooltip( moveOption, moveOptionLabel );
+		makeTabbable( moveOption, moveOptionLabel );
 
 		controls.innerHTML = '';
 		controls.appendChild( layoutOption );
 		controls.appendChild( moveOption );
 		controls.appendChild( getFieldControlsDropdown() );
+	}
+
+	function addTooltip( element, title ) {
+		element.setAttribute( 'data-toggle', 'tooltip' );
+		element.setAttribute( 'data-container', 'body' );
+		element.setAttribute( 'title', title );
+		element.addEventListener(
+			'mouseover',
+			function() {
+				if ( null === element.getAttribute( 'data-original-title' ) ) {
+					jQuery( element ).tooltip();
+				}
+			}
+		);
 	}
 
 	function getFieldControlsDropdown() {
@@ -3362,7 +3382,7 @@ function frmAdminBuildJS() {
 	}
 
 	function makeTabbable( element, ariaLabel ) {
-		element.setAttribute( 'tabindex', 1 );
+		element.setAttribute( 'tabindex', 0 );
 		element.setAttribute( 'role', 'button' );
 		if ( 'undefined' !== typeof ariaLabel ) {
 			element.setAttribute( 'aria-label', ariaLabel );


### PR DESCRIPTION
Following up on the other field dropdown accessibility update, I missed a couple details.

- It looks like I had messed up the styling on the Delete Group/Duplicate Group options because it uses a different style definition.
- It also looks like clicking just the edge of a Delete Field/Duplicate Field/Field Settings option wasn't triggering it, only if you clicked the text.
- It looks like it was still difficult to Delete/Duplicate a Field Group using a screenreader.

So I've made them use the same style class now with a new `frm_more_options_li` class, added a tabindex and focus() when the dropdown opens to help imrprove accessibility.

I also added in a fix that was on my todo list for side-by-side field enhancements, to delete tooltips when a field is deleted. I don't think there's a very effective way to target a specific tooltip, but deleting all of them doesn't seem to have a very negative effect in my experience since they will just get generated again by bootstrap.

I feel way better about them now. Hopefully eliminating most of the weird Delete/Duplicate related issues.