### PR TITLE
Add data-requires to actions with Business/Elite in the category list

### DIFF
--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -252,7 +252,7 @@ class FrmFormActionsController {
 		if ( ! isset( $upgrading['categories'] ) || ! is_array( $upgrading['categories'] ) ) {
 			return false;
 		}
-		$plans = array( 'Business', 'Elite', 'Personal' );
+		$plans = array( 'Business', 'Elite', 'Personal', 'Plus' );
 		foreach ( $upgrading['categories'] as $category ) {
 			if ( in_array( $category, $plans, true ) ) {
 				return $category;

--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -252,10 +252,13 @@ class FrmFormActionsController {
 		if ( ! isset( $upgrading['categories'] ) || ! is_array( $upgrading['categories'] ) ) {
 			return false;
 		}
-		$plans = array( 'Business', 'Elite' );
+		$plans = array( 'Business', 'Elite', 'Personal' );
 		foreach ( $upgrading['categories'] as $category ) {
 			if ( in_array( $category, $plans, true ) ) {
 				return $category;
+			}
+			if ( 'Creator' === $category ) {
+				return 'Personal';
 			}
 		}
 		return false;

--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -252,13 +252,14 @@ class FrmFormActionsController {
 		if ( ! isset( $upgrading['categories'] ) || ! is_array( $upgrading['categories'] ) ) {
 			return false;
 		}
-		$plans = array( 'Business', 'Elite', 'Personal', 'Plus' );
+		$plans      = array( 'Business', 'Elite', 'Basic' );
+		$plus_plans = array( 'Creator', 'Personal', 'Plus' );
 		foreach ( $upgrading['categories'] as $category ) {
 			if ( in_array( $category, $plans, true ) ) {
 				return $category;
 			}
-			if ( 'Creator' === $category ) {
-				return 'Personal';
+			if ( in_array( $category, $plus_plans, true ) ) {
+				return 'Plus';
 			}
 		}
 		return false;

--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -243,6 +243,8 @@ class FrmFormActionsController {
 	}
 
 	/**
+	 * @since 5.0.06
+	 *
 	 * @param array $upgrading
 	 * @return string|false
 	 */

--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -224,6 +224,11 @@ class FrmFormActionsController {
 			if ( isset( $upgrading['url'] ) ) {
 				$data['data-oneclick'] = json_encode( $upgrading );
 			}
+
+			$requires = self::action_requires( $upgrading );
+			if ( $requires ) {
+				$data['data-requires'] = $requires;
+			}
 		}
 
 		// HTML to include on the icon.
@@ -234,7 +239,24 @@ class FrmFormActionsController {
 			);
 		}
 
-		include( FrmAppHelper::plugin_path() . '/classes/views/frm-form-actions/_action_icon.php' );
+		include FrmAppHelper::plugin_path() . '/classes/views/frm-form-actions/_action_icon.php';
+	}
+
+	/**
+	 * @param array $upgrading
+	 * @return string|false
+	 */
+	private static function action_requires( $upgrading ) {
+		if ( ! isset( $upgrading['categories'] ) || ! is_array( $upgrading['categories'] ) ) {
+			return false;
+		}
+		$plans = array( 'Business', 'Elite' );
+		foreach ( $upgrading['categories'] as $category ) {
+			if ( in_array( $category, $plans, true ) ) {
+				return $category;
+			}
+		}
+		return false;
 	}
 
 	public static function get_form_actions( $action = 'all' ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3228

Super easy, the api data already includes a categories array that includes "Business" and "Elite" so the package can be really easily determined already 🚀.

<img width="497" alt="Screen Shot 2021-09-23 at 1 04 40 PM" src="https://user-images.githubusercontent.com/9134515/134543967-c13900f0-952b-4c8c-9e88-eba4bfdd966f.png">
<img width="497" alt="Screen Shot 2021-09-23 at 1 04 54 PM" src="https://user-images.githubusercontent.com/9134515/134543987-b2b0fd62-0ee0-419a-9112-b6c32d3dcc57.png">
<img width="498" alt="Screen Shot 2021-09-23 at 1 04 58 PM" src="https://user-images.githubusercontent.com/9134515/134543999-4aaad9ad-0cbe-4590-a1f8-ad5b21b65b2b.png">

![Screen Shot 2021-09-23 at 7 01 06 PM](https://user-images.githubusercontent.com/9134515/134590271-36bd871a-04a5-4561-97e9-5eba2ca0b518.png)

![Screen Shot 2021-09-23 at 7 00 47 PM](https://user-images.githubusercontent.com/9134515/134590295-75d5306f-52ab-49ce-b7d0-8f4948d6aef7.png)

![Screen Shot 2021-09-23 at 7 00 54 PM](https://user-images.githubusercontent.com/9134515/134590286-9c22db3e-e54c-435d-a2b6-f6b96500d300.png)