### PR TITLE
Unset margin on block select caret svg

### DIFF
--- a/css/frm_blocks.css
+++ b/css/frm_blocks.css
@@ -28,6 +28,10 @@
 	color: #4d4d4d;
 }
 
+.frm-block-intro-content select + span svg {
+    margin: unset;
+}
+
 .editor-styles-wrapper h2.frm-block-title {
 	color: #4d4d4d;
 	font-weight: 500;


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3190

The rule above this new rule:
```
.frm-block-intro-content svg {
	margin-top: 32px;
	margin-bottom: 12px;
}
```

Is causing issues. I'm undoing that and it seems to do the trick.

<img width="528" alt="Screen Shot 2021-09-24 at 11 00 48 AM" src="https://user-images.githubusercontent.com/9134515/134687123-2afcdc8e-ad2b-4553-9d1b-7509009811c9.png">

<img width="295" alt="Screen Shot 2021-09-24 at 10 59 09 AM" src="https://user-images.githubusercontent.com/9134515/134687154-6b16d40e-67bc-46d6-93d8-f4018aaf9dc1.png">