### PR TITLE
Fix issues with failing unit tests

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -22,7 +22,7 @@ jobs:
             wordpress: master
             phpunit: 6.5.14
           - php: 7.0.33
-            wordpress: 4.9
+            wordpress: 5.8
             phpunit: 6.5.14
 
     name: PHP ${{ matrix.php }} tests in WP ${{ matrix.wordpress }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -24,9 +24,6 @@ jobs:
           - php: 7.0.33
             wordpress: 4.9
             phpunit: 6.5.14
-          - php: 5.6.20
-            wordpress: 4.7
-            phpunit: 5.7.27
 
     name: PHP ${{ matrix.php }} tests in WP ${{ matrix.wordpress }}
     steps:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -16,10 +16,10 @@ jobs:
       matrix:
         include:
           - php: 7.4
-            wordpress: 5.8
+            wordpress: master
             phpunit: 6.5.14
           - php: 7.3
-            wordpress: 5.8
+            wordpress: master
             phpunit: 6.5.14
           - php: 7.0.33
             wordpress: 4.9
@@ -36,7 +36,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: phpunit:${{ matrix.phpunit }}
+          tools: phpunit:${{ matrix.phpunit }}, yoast/phpunit-polyfills
 
       - name: Installing WordPress
         run: |

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,6 @@
 		]
 	},
     "require-dev": {
-        "phpunit/phpunit": "6.*"
+		"yoast/phpunit-polyfills": "^1.0"
     }
 }

--- a/tests/base/FrmAjaxUnitTest.php
+++ b/tests/base/FrmAjaxUnitTest.php
@@ -21,7 +21,7 @@ class FrmAjaxUnitTest extends WP_Ajax_UnitTestCase {
 		FrmUnitTest::wpTearDownAfterClass();
 	}
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		FrmHooksController::trigger_load_hook( 'load_ajax_hooks' );

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -198,7 +198,6 @@ class FrmUnitTest extends WP_UnitTestCase {
 				$filename = basename( $val );
 				$path     = $uploads_dir . $filename;
 				if ( file_exists( $path ) ) {
-					error_log( '-- found a repeat file, saved a call to CDN. --' );
 					if ( ! is_array( $media_ids ) ) {
 						$media_ids = array();
 					}

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -16,6 +16,11 @@ class FrmUnitTest extends WP_UnitTestCase {
 	protected $is_pro_active = false;
 
 	/**
+	 * @var FrmUnitTest $instance
+	 */
+	protected static $instance;
+
+	/**
 	 * Ensure that the plugin has been installed and activated.
 	 */
 	public static function wpSetUpBeforeClass() {
@@ -35,6 +40,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 	}
 
 	public function setUp() {
+		self::$instance = $this;
 		parent::setUp();
 
 		// The JavaScript antispam check doesn't work with unit tests so turn it off.
@@ -183,8 +189,30 @@ class FrmUnitTest extends WP_UnitTestCase {
 		);
 
 		$_REQUEST['csv_files'] = 1;
+		$uploads_dir           = wp_upload_dir()['basedir'] . '/formidable/';
+		$test                  = new FrmUnitTest();
 		foreach ( $file_urls as $values ) {
-			$media_ids = FrmProFileImport::import_attachment( $values['val'], $values['field'] );
+			$vals      = (array) $values['val'];
+			$media_ids = false;
+			foreach ( $vals as $val ) {
+				$filename = basename( $val );
+				$path     = $uploads_dir . $filename;
+				if ( file_exists( $path ) ) {
+					error_log( '-- found a repeat file, saved a call to CDN. --' );
+					if ( ! is_array( $media_ids ) ) {
+						$media_ids = array();
+					}
+					$id          = $test->run_private_method( array( 'FrmProFileImport', 'attach_existing_image' ), array( $filename ) );
+					$media_ids[] = $id;
+				}
+			}
+			if ( is_array( $media_ids ) ) {
+				$media_ids = implode( ',', $media_ids );
+			}
+
+			if ( false === $media_ids ) {
+				$media_ids = FrmProFileImport::import_attachment( $values['val'], $values['field'] );
+			}
 
 			if ( is_array( $values['val'] ) ) {
 				$media_ids = explode( ',', $media_ids );

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -39,7 +39,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 		self::empty_tables();
 	}
 
-	public function setUp() {
+	public function setUp(): void {
 		self::$instance = $this;
 		parent::setUp();
 

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -36,7 +36,7 @@ class test_FrmEmail extends FrmUnitTest {
 	 */
 	protected $entry = null;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->contact_form = $this->factory->form->get_object_by_id( $this->email_form_key );

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -467,8 +467,8 @@ class test_FrmEmail extends FrmUnitTest {
 	}
 
 	protected function check_senders( $expected, $mock_email ) {
-		$this->assertContains( 'From: ' . $expected['from'], $mock_email['header'], 'From does not match expected.' );
-		$this->assertContains( 'Reply-To: ' . $expected['reply_to'], $mock_email['header'], 'Reply-to does not match expected.' );
+		$this->assertNotFalse( strpos( $mock_email['header'], 'From: ' . $expected['from'] ), 'From does not match expected.' );
+		$this->assertNotFalse( strpos( $mock_email['header'], 'Reply-To: ' . $expected['reply_to'] ), 'Reply-to does not match expected.' );
 	}
 
 	protected function check_subject( $expected, $mock_email ) {
@@ -486,15 +486,15 @@ class test_FrmEmail extends FrmUnitTest {
 	}
 
 	protected function check_content_type( $expected, $mock_email ) {
-		$this->assertContains( $expected['content_type'], $mock_email['header'], 'Content type does not match expected.' );
+		$this->assertFalse( strpos( $mock_email['header'], $expected['content_type'] ), 'Content type does not match expected.' );
 	}
 
 	protected function check_no_cc_included( $mock_email ) {
-		$this->assertNotContains( 'Cc:', $mock_email['header'], 'CC is included when it should not be.' );
+		$this->assertFalse( strpos( $mock_email['header'], 'Cc:' ), 'CC is included when it should not be.' );
 	}
 
 	protected function check_no_bcc_included( $mock_email ) {
-		$this->assertNotContains( 'Bcc:', $mock_email['header'], 'BCC is included when it should not be.' );
+		$this->assertFalse( strpos( $mock_email['header'] ,'Bcc:' ), 'BCC is included when it should not be.' );
 	}
 
 	public function add_to_emails( $to_emails, $values, $form_id, $args ) {
@@ -656,10 +656,10 @@ class test_FrmEmail extends FrmUnitTest {
 			$email = new FrmEmail( $action, $this->entry, $this->contact_form );
 			$actual = $this->get_private_property( $email, 'message' );
 
-			if ( $setting['compare'] == 'Contains' ) {
-				$this->assertContains( 'Referrer:', $actual );
+			if ( $setting['compare'] === 'Contains' ) {
+				$this->assertNotFalse( strpos( $actual, 'Referrer:' ) );
 			} else {
-				$this->assertNotContains( 'Referrer:', $actual );
+				$this->assertFalse( strpos( $actual, 'Referrer:' ) );
 			}
 		}
 	}
@@ -668,7 +668,7 @@ class test_FrmEmail extends FrmUnitTest {
 	 * @covers FrmEmail::set_message
 	 */
 	public function test_plain_text_message() {
-		$action = $this->email_action;
+		$action                                = $this->email_action;
 		$action->post_content['email_message'] = 'Value <br/>with HTML';
 
 		$settings = array(
@@ -678,9 +678,9 @@ class test_FrmEmail extends FrmUnitTest {
 
 		foreach ( $settings as $setting => $expected ) {
 			$action->post_content['plain_text'] = $setting;
-			$email = new FrmEmail( $action, $this->entry, $this->contact_form );
-			$actual = $this->get_private_property( $email, 'message' );
-			$this->assertContains( $expected, $actual );
+			$email                              = new FrmEmail( $action, $this->entry, $this->contact_form );
+			$actual                             = $this->get_private_property( $email, 'message' );
+			$this->assertNotFalse( strpos( $actual, $expected ) );
 		}
 	}
 
@@ -693,8 +693,8 @@ class test_FrmEmail extends FrmUnitTest {
 
 		foreach ( $settings as $setting => $expected ) {
 			$action->post_content[ $setting_name ] = $setting;
-			$email = new FrmEmail( $action, $this->entry, $this->contact_form );
-			$actual = $this->get_private_property( $email, $property );
+			$email                                 = new FrmEmail( $action, $this->entry, $this->contact_form );
+			$actual                                = $this->get_private_property( $email, $property );
 			$this->assertEquals( $expected, $actual );
 		}
 	}

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -486,7 +486,7 @@ class test_FrmEmail extends FrmUnitTest {
 	}
 
 	protected function check_content_type( $expected, $mock_email ) {
-		$this->assertFalse( strpos( $mock_email['header'], $expected['content_type'] ), 'Content type does not match expected.' );
+		$this->assertNotFalse( strpos( $mock_email['header'], $expected['content_type'] ), 'Content type does not match expected.' );
 	}
 
 	protected function check_no_cc_included( $mock_email ) {
@@ -494,7 +494,7 @@ class test_FrmEmail extends FrmUnitTest {
 	}
 
 	protected function check_no_bcc_included( $mock_email ) {
-		$this->assertFalse( strpos( $mock_email['header'] ,'Bcc:' ), 'BCC is included when it should not be.' );
+		$this->assertFalse( strpos( $mock_email['header'], 'Bcc:' ), 'BCC is included when it should not be.' );
 	}
 
 	public function add_to_emails( $to_emails, $values, $form_id, $args ) {

--- a/tests/fields/test_FrmFieldCombo.php
+++ b/tests/fields/test_FrmFieldCombo.php
@@ -280,7 +280,7 @@ class test_FrmFieldCombo extends FrmUnitTest {
 		);
 		$atts = ob_get_clean();
 
-		$this->assertEquals( $atts, 'class="frm-class1 frm-class2 frm_optional"' );
+		$this->assertEquals( $atts, ' class="frm-class1 frm-class2 frm_optional"  ' );
 
 		$sub_field = array(
 			'name'    => 'forth',

--- a/tests/fields/test_FrmFieldCombo.php
+++ b/tests/fields/test_FrmFieldCombo.php
@@ -259,7 +259,7 @@ class test_FrmFieldCombo extends FrmUnitTest {
 		);
 		$atts = ob_get_clean();
 
-		$this->assertEquals( $atts, 'placeholder="First placeholder" class="frm-custom-class" maxlength="10" data-attr="custom-attr"' );
+		$this->assertEquals( $atts, ' class="frm-custom-class"  placeholder="First placeholder" maxlength="10" data-attr="custom-attr"' );
 
 		$sub_field = array(
 			'name'     => 'second',

--- a/tests/fields/test_FrmFieldCombo.php
+++ b/tests/fields/test_FrmFieldCombo.php
@@ -296,7 +296,7 @@ class test_FrmFieldCombo extends FrmUnitTest {
 		);
 		$atts = ob_get_clean();
 
-		$this->assertEquals( $atts, '' );
+		$this->assertEquals( $atts, '   ' );
 	}
 
 	public function test_get_export_headings() {

--- a/tests/fields/test_FrmFieldCombo.php
+++ b/tests/fields/test_FrmFieldCombo.php
@@ -250,6 +250,8 @@ class test_FrmFieldCombo extends FrmUnitTest {
 			),
 		);
 
+		add_action( 'frm_load_form_hooks', 'FrmHooksController::trigger_load_form_hooks' );
+
 		ob_start();
 		$this->run_private_method(
 			array( $combo_field, 'print_input_atts' ),

--- a/tests/fields/test_FrmFieldCombo.php
+++ b/tests/fields/test_FrmFieldCombo.php
@@ -250,7 +250,7 @@ class test_FrmFieldCombo extends FrmUnitTest {
 			),
 		);
 
-		add_action( 'frm_load_form_hooks', 'FrmHooksController::trigger_load_form_hooks' );
+		FrmHooksController::load_form_hooks();
 
 		ob_start();
 		$this->run_private_method(

--- a/tests/fields/test_FrmFieldType.php
+++ b/tests/fields/test_FrmFieldType.php
@@ -10,7 +10,7 @@ class test_FrmFieldType extends FrmUnitTest {
 	 */
 	public function test_html_min_number() {
 		$form_id = $this->factory->form->create();
-		$field = $this->factory->field->create_and_get(
+		$field   = $this->factory->field->create_and_get(
 			array(
 				'type'    => 'number',
 				'form_id' => $form_id,
@@ -28,9 +28,9 @@ class test_FrmFieldType extends FrmUnitTest {
 				'id' => $form_id,
 			)
 		);
-		$this->assertContains( ' min="10"', $form );
-		$this->assertContains( ' max="999"', $form );
-		$this->assertContains( ' step="any"', $form );
+		$this->assertNotFalse( strpos( $form, ' min="10"' ) );
+		$this->assertNotFalse( strpos( $form, ' max="999"' ) );
+		$this->assertNotFalse( strpos( $form, ' step="any"' ) );
 	}
 
 	/**

--- a/tests/fields/test_FrmFieldValidate.php
+++ b/tests/fields/test_FrmFieldValidate.php
@@ -7,7 +7,7 @@ class test_FrmFieldValidate extends FrmUnitTest {
 
 	protected $form;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->create_validation_form();

--- a/tests/fields/test_FrmFieldsAjax.php
+++ b/tests/fields/test_FrmFieldsAjax.php
@@ -83,7 +83,7 @@ class test_FrmFieldsAjax extends FrmAjaxUnitTest {
 		);
 
 		$response = $this->trigger_action( 'frm_duplicate_field' );
-		$this->assertContains( '<input type="hidden" name="frm_fields_submitted[]" ', $response, 'Field was not created in form ' . $original_field->form_id . ' duplicated from field ' . $original_field->id );
+		$this->assertNotFalse( strpos( $response, '<input type="hidden" name="frm_fields_submitted[]" ' ), 'Field was not created in form ' . $original_field->form_id . ' duplicated from field ' . $original_field->id );
 
 		global $frm_duplicate_ids;
 		$this->assertNotEmpty( $frm_duplicate_ids );

--- a/tests/fields/test_FrmFieldsAjax.php
+++ b/tests/fields/test_FrmFieldsAjax.php
@@ -10,7 +10,7 @@ class test_FrmFieldsAjax extends FrmAjaxUnitTest {
 
 	protected $user_id = 0;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		// Set a user so the $post has 'post_author'

--- a/tests/forms/test_FrmFormsController.php
+++ b/tests/forms/test_FrmFormsController.php
@@ -178,7 +178,7 @@ class test_FrmFormsController extends FrmUnitTest {
 		$this->assertNotEmpty( $created_entry, 'No entry found with key ' . $entry_key );
 
 		$response = FrmFormsController::show_form( $form->id ); // this is where the redirect happens
-		$this->assertContains( "window.location='http://example.com'", $response );
+		$this->assertNotFalse( strpos( $response, "window.location='http://example.com'" ) );
 	}
 
 	/**
@@ -220,9 +220,9 @@ class test_FrmFormsController extends FrmUnitTest {
 		$this->assertNotFalse( strpos( $response, 'frmFrontForm.scrollMsg(' . $form->id . ')' ) );
 
 		if ( $show_form ) {
-			$this->assertContains( '<input type="hidden" name="form_id" value="' . $form->id . '" />', $response );
+			$this->assertNotFalse( strpos( $response, '<input type="hidden" name="form_id" value="' . $form->id . '" />' ) );
 		} else {
-			$this->assertNotContains( '<input type="hidden" name="form_id" value="' . $form->id . '" />', $response );
+			$this->assertFalse( strpos( $response, '<input type="hidden" name="form_id" value="' . $form->id . '" />' ) );
 		}
 	}
 

--- a/tests/forms/test_FrmFormsController.php
+++ b/tests/forms/test_FrmFormsController.php
@@ -171,7 +171,7 @@ class test_FrmFormsController extends FrmUnitTest {
 
 		if ( headers_sent() ) {
 			// since headers are sent by phpunit, we will get the js redirect
-			$this->assertContains( "window.location='http://example.com'", $response );
+			$this->assertNotFalse( strpos( $response, "window.location='http://example.com'" ) );
 		}
 
 		$created_entry = FrmEntry::get_id_by_key( $entry_key );
@@ -216,8 +216,8 @@ class test_FrmFormsController extends FrmUnitTest {
 		$this->assertNotEmpty( $created_entry, 'No entry found with key ' . $entry_key );
 
 		$response = FrmFormsController::show_form( $form->id ); // this is where the message is returned
-		$this->assertContains( '<div class="frm_message" role="status"><p>Done!</p>', $response );
-		$this->assertContains( 'frmFrontForm.scrollMsg(' . $form->id . ')', $response );
+		$this->assertNotFalse( strpos( $response, '<div class="frm_message" role="status"><p>Done!</p>' ) );
+		$this->assertNotFalse( strpos( $response, 'frmFrontForm.scrollMsg(' . $form->id . ')' ) );
 
 		if ( $show_form ) {
 			$this->assertContains( '<input type="hidden" name="form_id" value="' . $form->id . '" />', $response );

--- a/tests/forms/test_FrmFormsControllerAjax.php
+++ b/tests/forms/test_FrmFormsControllerAjax.php
@@ -5,7 +5,7 @@
  */
 class test_FrmFormsControllerAjax extends FrmAjaxUnitTest {
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );

--- a/tests/misc/test_FrmAddon.php
+++ b/tests/misc/test_FrmAddon.php
@@ -7,7 +7,7 @@ class test_FrmAddon extends FrmUnitTest {
 
 	private $addon;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->check_php_version( '5.4' );

--- a/tests/misc/test_FrmAntiSpam.php
+++ b/tests/misc/test_FrmAntiSpam.php
@@ -7,7 +7,7 @@ class test_FrmAntiSpam extends FrmUnitTest {
 
 	private $antispam;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$form_id        = $this->factory->form->create();
 		$this->antispam = new FrmAntiSpam( $form_id );

--- a/tests/misc/test_FrmHoneypot.php
+++ b/tests/misc/test_FrmHoneypot.php
@@ -9,7 +9,7 @@ class test_FrmHoneypot extends FrmUnitTest {
 
 	private $honeypot;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->form_id  = $this->factory->form->create();
 		$this->honeypot = new FrmHoneypot( $this->form_id );

--- a/tests/styles/test_FrmStylesController.php
+++ b/tests/styles/test_FrmStylesController.php
@@ -23,16 +23,16 @@ class test_FrmStylesController extends FrmUnitTest {
 		ob_end_clean();
 		$this->assertNotEmpty( $styles );
 
-		$frm_settings = FrmAppHelper::get_settings();
+		$frm_settings    = FrmAppHelper::get_settings();
 		$stylesheet_urls = $this->get_custom_stylesheet();
-		$css_html = "<link rel='stylesheet' id='formidable-css'";
+		$css_html        = "<link rel='stylesheet' id='formidable-css'";
 
-		if ( $frm_settings->load_style == 'all' ) {
-			$this->assertContains( $css_html, $styles, 'The formidablepro stylesheet is missing' );
+		if ( $frm_settings->load_style === 'all' ) {
+			$this->assertNotFalse( strpos( $styles, $css_html ), 'The formidablepro stylesheet is missing' );
 			//$this->assertContains( $stylesheet_urls['formidable'], $styles, 'The formidablepro stylesheet is missing' );
 		} else {
-			$this->assertNotContains( $css_html, $styles, 'The formidablepro stylesheet is missing' );
-			$this->assertNotContains( $stylesheet_urls['formidable'], $styles, 'The formidablepro stylesheet is included when it should not be' );
+			$this->assertFalse( strpos( $styles, $css_html ), 'The formidablepro stylesheet is missing' );
+			$this->assertFalse( strpos( $styles, $stylesheet_urls['formidable'] ), 'The formidablepro stylesheet is included when it should not be' );
 		}
 	}
 

--- a/tests/styles/test_FrmStylesController.php
+++ b/tests/styles/test_FrmStylesController.php
@@ -73,7 +73,7 @@ class test_FrmStylesController extends FrmUnitTest {
 		$returned = ob_get_contents();
 		ob_end_clean();
 
-		$this->assertContains( 'Your styling settings have been saved.', $returned );
+		$this->assertNotFalse( strpos( $returned, 'Your styling settings have been saved.' ) );
 		$frm_style = new FrmStyle( $style->ID );
 		$updated_style = $frm_style->get_one();
 		$this->assertEquals( $style->post_title . ' Updated', $updated_style->post_title );

--- a/tests/views/shortcodes/test_FrmFieldShortcodes.php
+++ b/tests/views/shortcodes/test_FrmFieldShortcodes.php
@@ -10,7 +10,7 @@ class test_FrmFieldShortcodes extends FrmUnitTest {
 	protected $test_form;
 	protected $test_entry;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->test_form = $this->get_form_for_test();


### PR DESCRIPTION
Trying to capture 2 pretty big issues with our unit tests here.

A lot of tests fail with this `The following file is not importing correctly: https://s3.amazonaws.com/fp.strategy11.com/images/knowledgebase/global-settings_enter-license1.png` message lately. I think, because we have more tests than before, that we're hitting rate limits trying to get files from our CDN.

These are grabbed every time setUp is called which can be quite often. I tested running the pro unit tests locally and logging how many times this avoided a download and I got _186 hits_. That should hopefully help speed up unit tests too if we don't have to download files from an external server as often.

```
1) test_FrmProFieldRange
The following file is not importing correctly: https://s3.amazonaws.com/fp.strategy11.com/images/knowledgebase/global-settings_enter-license1.png
Failed asserting that false is true.

/tmp/wordpress/src/wp-content/plugins/formidable/tests/base/FrmUnitTest.php:193
/tmp/wordpress/src/wp-content/plugins/formidable/tests/base/FrmUnitTest.php:87
/tmp/wordpress/src/wp-content/plugins/formidable/tests/base/FrmUnitTest.php:23
/tmp/wordpress/tests/phpunit/includes/abstract-testcase.php:76
```

And the other big issue:

```
Error: The PHPUnit Polyfills library is a requirement for running the WP test suite. 
```

Which introduced new issues:

```
PHP Fatal error:  Declaration of FrmUnitTest::setUp() must be compatible with Yoast\PHPUnitPolyfills\TestCases\TestCase::setUp(): void
```

The addition of the `: void` piece is sort of annoying. It means that we need to drop tests in PHP 5.6 because 5.6 doesn't support that feature. I also think we'll likely have to stop running PHPUnit against any free branches but master for a while because of these breaking changes with WordPress/PHPUnit requirements.

And because WordPress < 5.8 doesn't support any of this either, I had to drop our WordPress 4.9 compatibility tests too.

Unfortunately this means there's less coverage for a lot of backwards compatibility stuff but I don't think there's any way around this.

```
Parse error: syntax error, unexpected ':', expecting ';' or '{' in /tmp/wordpress/src/wp-content/plugins/formidable/tests/base/FrmUnitTest.php on line 42
```

And then after all of that, a lot of `assertContains`/`assertNotContains` checks broke because they're only supposed to get called on arrays but they're being used on strings in a few places.
```
14) test_FrmStylesController::test_front_head
TypeError: Argument 2 passed to PHPUnit\Framework\Assert::assertContains() must be iterable, string given, called in /tmp/wordpress/src/wp-content/plugins/formidable/tests/styles/test_FrmStylesController.php on line 31
```

And it looks like I did break a unit test with name fields when I moved the class. I've updated the test so the action gets called, and I moved the class in the check because it happens earlier in the string now and there are extra spaces added to the HTML than there were before.