### PR TITLE
Exclude temp.xml when making zip

### DIFF
--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -58,6 +58,7 @@ zip -r $zipname $destination \
 	-x "*/README.md" \
 	-x "*/tests/*" \
 	-x "*/vendor/*" \
+	-x "*/temp.xml" \
 	-x "formidable-pro/views/*" \
 	-x "formidable-views/js/dom.js" \
 	-x "formidable-views/js/editor.js" \


### PR DESCRIPTION
I had packaged this in the pro release by accident initially, and ended up rebuilding to take it back out.

Adding an exception so it never gets added in.