### PR TITLE
Include HubSpot signup

### DIFF
--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -204,7 +204,7 @@ class FrmFormActionsController {
 		/* translators: %s: Name of form action */
 		$upgrade_label = sprintf( esc_html__( '%s form actions', 'formidable' ), $action_control->action_options['tooltip'] );
 
-		$default_shown    = array( 'wppost', 'register', 'paypal', 'payment', 'mailchimp' );
+		$default_shown    = array( 'wppost', 'register', 'paypal', 'payment', 'hubspot' );
 		$default_shown    = array_values( array_diff( $default_shown, $allowed ) );
 		$default_position = array_search( $action_control->id_base, $default_shown );
 		$allowed_count    = count( $allowed );
@@ -223,6 +223,10 @@ class FrmFormActionsController {
 			$upgrading = FrmAddonsController::install_link( $action_control->action_options['plugin'] );
 			if ( isset( $upgrading['url'] ) ) {
 				$data['data-oneclick'] = json_encode( $upgrading );
+			}
+
+			if ( isset( $action_control->action_options['message'] ) ) {
+				$data['data-message'] = $action_control->action_options['message'];
 			}
 
 			$requires = self::action_requires( $upgrading );

--- a/classes/views/addons/list.php
+++ b/classes/views/addons/list.php
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<?php echo esc_html( $addon['title'] ); ?>
 					</h2>
 					<p>
-						<?php echo esc_html( $addon['excerpt'] ); ?>
+						<?php echo FrmAppHelper::kses( $addon['excerpt'], array( 'a' ) ); ?>
 						<?php $show_docs = isset( $addon['docs'] ) && ! empty( $addon['docs'] ) && $addon['installed']; ?>
 						<?php if ( $show_docs ) { ?>
 							<br/><a href="<?php echo esc_url( $addon['docs'] ); ?>" target="_blank" aria-label="<?php esc_attr_e( 'View Docs', 'formidable' ); ?>">

--- a/classes/views/addons/list.php
+++ b/classes/views/addons/list.php
@@ -52,8 +52,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<?php echo esc_html( $addon['title'] ); ?>
 					</h2>
 					<p>
-						<?php echo FrmAppHelper::kses( $addon['excerpt'], array( 'a' ) ); ?>
-						<?php $show_docs = isset( $addon['docs'] ) && ! empty( $addon['docs'] ) && $addon['installed']; ?>
+						<?php
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo FrmAppHelper::kses( $addon['excerpt'], array( 'a' ) );
+
+						$show_docs = isset( $addon['docs'] ) && ! empty( $addon['docs'] ) && $addon['installed'];
+						?>
 						<?php if ( $show_docs ) { ?>
 							<br/><a href="<?php echo esc_url( $addon['docs'] ); ?>" target="_blank" aria-label="<?php esc_attr_e( 'View Docs', 'formidable' ); ?>">
 								<?php esc_html_e( 'View Docs', 'formidable' ); ?>

--- a/classes/views/frm-form-actions/default_actions.php
+++ b/classes/views/frm-form-actions/default_actions.php
@@ -120,7 +120,7 @@ class FrmDefHubspotAction extends FrmFormAction {
 			$action_ops['message'] .= __( 'The HubSpot integration is not available on your plan. Did you know you can upgrade to unlock more awesome features?', 'formidable' ) . '<br/><br/>';
 		}
 		$link                   = FrmAppHelper::admin_upgrade_link( 'add-action', 'knowledgebase/hubspot-forms/' );
-		$action_ops['message'] .= '<a href="' . esc_url( $link ) .'" target="_blank" rel="noopener" class="button button-secondary frm-button-secondary">Get Free HubSpot Account</a>';
+		$action_ops['message'] .= '<a href="' . esc_url( $link ) . '" target="_blank" rel="noopener" class="button button-secondary frm-button-secondary">Get Free HubSpot Account</a>';
 		parent::__construct( 'hubspot', 'Hubspot', $action_ops );
 	}
 }

--- a/classes/views/frm-form-actions/default_actions.php
+++ b/classes/views/frm-form-actions/default_actions.php
@@ -117,10 +117,10 @@ class FrmDefHubspotAction extends FrmFormAction {
 
 		$action_ops['message'] = '';
 		if ( ! FrmAppHelper::pro_is_installed() ) {
-			$action_ops['message'] .= __( 'The HubSpot integration is not available on your plan. Did you know you can upgrade to unlock more awesome features?', 'formidable' );
+			$action_ops['message'] .= __( 'The HubSpot integration is not available on your plan. Did you know you can upgrade to unlock more awesome features?', 'formidable' ) . '<br/><br/>';
 		}
 		$link                   = FrmAppHelper::admin_upgrade_link( 'add-action', 'go/hubspot-signup/' );
-		$action_ops['message'] .= '<br/><br/><a href="' . esc_url( $link ) .'" target="_blank" rel="noopener" class="button button-secondary frm-button-secondary">Get Free HubSpot Account</a>';
+		$action_ops['message'] .= '<a href="' . esc_url( $link ) .'" target="_blank" rel="noopener" class="button button-secondary frm-button-secondary">Get Free HubSpot Account</a>';
 		parent::__construct( 'hubspot', 'Hubspot', $action_ops );
 	}
 }

--- a/classes/views/frm-form-actions/default_actions.php
+++ b/classes/views/frm-form-actions/default_actions.php
@@ -119,7 +119,7 @@ class FrmDefHubspotAction extends FrmFormAction {
 		if ( ! FrmAppHelper::pro_is_installed() ) {
 			$action_ops['message'] .= __( 'The HubSpot integration is not available on your plan. Did you know you can upgrade to unlock more awesome features?', 'formidable' ) . '<br/><br/>';
 		}
-		$link                   = FrmAppHelper::admin_upgrade_link( 'add-action', 'go/hubspot-signup/' );
+		$link                   = FrmAppHelper::admin_upgrade_link( 'add-action', 'knowledgebase/hubspot-forms/' );
 		$action_ops['message'] .= '<a href="' . esc_url( $link ) .'" target="_blank" rel="noopener" class="button button-secondary frm-button-secondary">Get Free HubSpot Account</a>';
 		parent::__construct( 'hubspot', 'Hubspot', $action_ops );
 	}

--- a/classes/views/frm-form-actions/default_actions.php
+++ b/classes/views/frm-form-actions/default_actions.php
@@ -114,6 +114,13 @@ class FrmDefHubspotAction extends FrmFormAction {
 	public function __construct() {
 		$action_ops = FrmFormAction::default_action_opts( 'frm_hubspot_icon frm_show_upgrade' );
 		$action_ops['color'] = 'var(--orange)';
+
+		$action_ops['message'] = '';
+		if ( ! FrmAppHelper::pro_is_installed() ) {
+			$action_ops['message'] .= __( 'The HubSpot integration is not available on your plan. Did you know you can upgrade to unlock more awesome features?', 'formidable' );
+		}
+		$link                   = FrmAppHelper::admin_upgrade_link( 'add-action', 'go/hubspot-signup/' );
+		$action_ops['message'] .= '<br/><br/><a href="' . esc_url( $link ) .'" target="_blank" rel="noopener" class="button button-secondary frm-button-secondary">Get Free HubSpot Account</a>';
 		parent::__construct( 'hubspot', 'Hubspot', $action_ops );
 	}
 }

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5725,10 +5725,14 @@ function frmAdminBuildJS() {
 			newMessage = link.getAttribute( 'data-message' ),
 			button = document.getElementById( 'frm-oneclick-button' ),
 			showIt = 'block',
+			showMsg = 'block',
 			hideIt = 'none';
 
 		// If one click upgrade, hide other content.
 		if ( oneclickMessage !== null && typeof oneclick !== 'undefined' && oneclick ) {
+			if ( newMessage === null ) {
+				showMsg = 'none';
+			}
 			showIt = 'none';
 			hideIt = 'block';
 			oneclick = JSON.parse( oneclick );
@@ -5753,7 +5757,7 @@ function frmAdminBuildJS() {
 		document.getElementById( 'frm-addon-status' ).style.display = 'none';
 		oneclickMessage.style.display = hideIt;
 		button.style.display = hideIt === 'block' ? 'inline-block' : hideIt;
-		upgradeMessage.style.display = showIt;
+		upgradeMessage.style.display = showMsg;
 		showLink.style.display = showIt === 'block' ? 'inline-block' : showIt;
 	}
 


### PR DESCRIPTION
This PR does a few things:
- Before, MailChimp shows in the top row of the form actions. This replaces MailChimp with HubSpot.
- The message shown for add-ons in the upgrade modal can be customized with data-message (the same as fields)
- Allow links in the download excerpt on the add-ons list page
- If the message is customized, show it separately from the upgrade button
- Add a custom message in the HubSpot class

There are three different scenarios for this modal:
1. Only Lite installed
2. Pro installed without access to HubSpot
3. Pro installed with access to HubSpot

(When the HubSpot add-on is installed, nothing should be different since the modal doesn't show.)