### PR TITLE
Add a filter to allow Akismet to modify the values that get sent to the Akismet API

### DIFF
--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -373,6 +373,15 @@ class FrmEntryValidate {
 		);
 		self::parse_akismet_array( $datas, $values );
 
+		/**
+		 * Allows modifying the values sent to Akismet.
+		 *
+		 * @since 5.0.07
+		 *
+		 * @param array $datas The array of values being sent to Akismet.
+		 */
+		$datas = apply_filters( 'frm_akismet_values', $datas );
+
 		$query_string = _http_build_query( $datas, '', '&' );
 		$response     = Akismet::http_post( $query_string, 'comment-check' );
 


### PR DESCRIPTION
This will allow the Akismet plugin to have better integration and supply more relevant data for spam checks.

We're working on improving Akismet's accuracy with contact forms, and this filter will allow us to have the same level of integration that we have with Jetpack, Gravity Forms, and Contact Form 7.

If there's an existing way for another plugin to add additional information to the `$datas` array that gets sent to Akismet, let me know.