### PR TITLE
Change box shadow style on draggable options

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3707,7 +3707,7 @@ li.sortable-placeholder {
 }
 
 .frm_single_option.ui-sortable-placeholder {
-	box-shadow: 20px -3px 0 1px var(--primary-color);
+	box-shadow: 0 0 1px 1px var(--primary-color);
 }
 
 .frm-is-collapsed + .sortable-placeholder {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3227

It looks like it's just a big box shadow making it look so off.

I made the box shadow tiny now and I don't offset it at all so it takes up the proper space.

I think it looks a lot better, https://recordit.co/wGws2tTqY1