### PR TITLE
Check unfiltered html permission before allowing unfiltered form/field data

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -782,18 +782,18 @@ class FrmAppHelper {
 				'xlink:href' => true,
 			),
 			'ul'         => $allow_class,
-			'label' => array(
-				'for'   => true,
+			'label'      => array(
+				'for'    => true,
 				'class' => true,
 				'id'    => true,
 			),
-			'button' => array(
+			'button'     => array(
 				'class' => true,
 				'type'  => true,
 			),
-			'legend' => array(
+			'legend'     => array(
 				'class' => true,
-			)
+			),
 		);
 	}
 

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2943,6 +2943,8 @@ class FrmAppHelper {
 	}
 
 	/**
+	 * @since 5.0.07
+	 *
 	 * @return bool true if the current user is allowed to save unfiltered HTML.
 	 */
 	public static function allow_unfiltered_html() {
@@ -2953,6 +2955,8 @@ class FrmAppHelper {
 	}
 
 	/**
+	 * @since 5.0.07
+	 *
 	 * @param array $values
 	 * @param array $keys
 	 * @return array

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2958,7 +2958,7 @@ class FrmAppHelper {
 	 * @return array
 	 */
 	public static function maybe_filter_array( $values, $keys ) {
-		$allow_unfiltered_html = FrmAppHelper::allow_unfiltered_html();
+		$allow_unfiltered_html = self::allow_unfiltered_html();
 
 		if ( $allow_unfiltered_html ) {
 			return $values;

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2953,6 +2953,27 @@ class FrmAppHelper {
 	}
 
 	/**
+	 * @param array $values
+	 * @param array $keys
+	 * @return array
+	 */
+	public static function maybe_filter_array( $values, $keys ) {
+		$allow_unfiltered_html = FrmAppHelper::allow_unfiltered_html();
+
+		if ( $allow_unfiltered_html ) {
+			return $values;
+		}
+
+		foreach ( $keys as $key ) {
+			if ( isset( $values[ $key ] ) ) {
+				$values[ $key ] = self::kses( $values[ $key ], 'all' );
+			}
+		}
+
+		return $values;
+	}
+
+	/**
 	 * @since 4.07
 	 * @deprecated 4.09.01
 	 */

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2975,7 +2975,7 @@ class FrmAppHelper {
 	 * @return array
 	 */
 	public static function maybe_filter_array( $values, $keys ) {
-		$allow_unfiltered_html = false;//self::allow_unfiltered_html();
+		$allow_unfiltered_html = self::allow_unfiltered_html();
 
 		if ( $allow_unfiltered_html ) {
 			return $values;

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -651,7 +651,7 @@ class FrmAppHelper {
 	private static function allowed_html( $allowed ) {
 		$html         = self::safe_html();
 		$allowed_html = array();
-		if ( $allowed == 'all' ) {
+		if ( $allowed === 'all' ) {
 			$allowed_html = $html;
 		} elseif ( ! empty( $allowed ) ) {
 			foreach ( (array) $allowed as $a ) {
@@ -754,10 +754,11 @@ class FrmAppHelper {
 			),
 			'section'    => $allow_class,
 			'span'       => array(
-				'class' => true,
-				'id'    => true,
-				'title' => true,
-				'style' => true,
+				'class'       => true,
+				'id'          => true,
+				'title'       => true,
+				'style'       => true,
+				'aria-hidden' => true,
 			),
 			'strike'     => array(),
 			'strong'     => array(),
@@ -781,6 +782,18 @@ class FrmAppHelper {
 				'xlink:href' => true,
 			),
 			'ul'         => $allow_class,
+			'label' => array(
+				'for'   => true,
+				'class' => true,
+				'id'    => true,
+			),
+			'button' => array(
+				'class' => true,
+				'type'  => true,
+			),
+			'legend' => array(
+				'class' => true,
+			)
 		);
 	}
 
@@ -2962,7 +2975,7 @@ class FrmAppHelper {
 	 * @return array
 	 */
 	public static function maybe_filter_array( $values, $keys ) {
-		$allow_unfiltered_html = self::allow_unfiltered_html();
+		$allow_unfiltered_html = false;//self::allow_unfiltered_html();
 
 		if ( $allow_unfiltered_html ) {
 			return $values;

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2943,6 +2943,16 @@ class FrmAppHelper {
 	}
 
 	/**
+	 * @return bool true if the current user is allowed to save unfiltered HTML.
+	 */
+	public static function allow_unfiltered_html() {
+		if ( defined( 'DISALLOW_UNFILTERED_HTML' ) && DISALLOW_UNFILTERED_HTML ) {
+			return false;
+		}
+		return current_user_can( 'unfiltered_html' );
+	}
+
+	/**
 	 * @since 4.07
 	 * @deprecated 4.09.01
 	 */

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -386,6 +386,19 @@ class FrmField {
 
 		$id = absint( $id );
 
+		$allow_unfiltered_html = FrmAppHelper::allow_unfiltered_html();
+		$filter_all_html       = ! $allow_unfiltered_html;
+
+		$filter_keys = array();
+		if ( $filter_all_html ) {
+			$filter_keys = array( 'name', 'description' );
+		}
+		foreach ( $filter_keys as $key ) {
+			if ( isset( $values[ $key ] ) ) {
+				$values[ $key ] = FrmAppHelper::kses( $values[ $key ], 'all' );
+			}
+		}
+
 		if ( isset( $values['field_key'] ) ) {
 			$values['field_key'] = FrmAppHelper::get_unique_key( $values['field_key'], $wpdb->prefix . 'frm_fields', 'field_key', $id );
 		}
@@ -399,7 +412,7 @@ class FrmField {
 		if ( isset( $values['type'] ) ) {
 			$values = apply_filters( 'frm_clean_' . $values['type'] . '_field_options_before_update', $values );
 
-			if ( $values['type'] == 'hidden' && isset( $values['field_options'] ) && isset( $values['field_options']['clear_on_focus'] ) ) {
+			if ( $values['type'] === 'hidden' && isset( $values['field_options'] ) && isset( $values['field_options']['clear_on_focus'] ) ) {
 				// don't keep the old placeholder setting for hidden fields
 				$values['field_options']['clear_on_focus'] = 0;
 			}

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -409,7 +409,7 @@ class FrmField {
 		// serialize array values
 		foreach ( array( 'field_options', 'options' ) as $opt ) {
 			if ( isset( $values[ $opt ] ) && is_array( $values[ $opt ] ) ) {
-				$values[ $opt ] = FrmAppHelper::maybe_filter_array( $values, array( 'custom_html' ) );
+				$values[ $opt ] = FrmAppHelper::maybe_filter_array( $values[ $opt ], array( 'custom_html' ) );
 				$values[ $opt ] = serialize( $values[ $opt ] );
 			}
 		}

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -384,20 +384,8 @@ class FrmField {
 	public static function update( $id, $values ) {
 		global $wpdb;
 
-		$id = absint( $id );
-
-		$allow_unfiltered_html = FrmAppHelper::allow_unfiltered_html();
-		$filter_all_html       = ! $allow_unfiltered_html;
-
-		$filter_keys = array();
-		if ( $filter_all_html ) {
-			$filter_keys = array( 'name', 'description' );
-		}
-		foreach ( $filter_keys as $key ) {
-			if ( isset( $values[ $key ] ) ) {
-				$values[ $key ] = FrmAppHelper::kses( $values[ $key ], 'all' );
-			}
-		}
+		$id     = absint( $id );
+		$values = FrmAppHelper::maybe_filter_array( $values, array( 'name', 'description' ) );
 
 		if ( isset( $values['field_key'] ) ) {
 			$values['field_key'] = FrmAppHelper::get_unique_key( $values['field_key'], $wpdb->prefix . 'frm_fields', 'field_key', $id );
@@ -421,6 +409,7 @@ class FrmField {
 		// serialize array values
 		foreach ( array( 'field_options', 'options' ) as $opt ) {
 			if ( isset( $values[ $opt ] ) && is_array( $values[ $opt ] ) ) {
+				$values[ $opt ] = FrmAppHelper::maybe_filter_array( $values, array( 'custom_html' ) );
 				$values[ $opt ] = serialize( $values[ $opt ] );
 			}
 		}

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -126,6 +126,8 @@ class FrmForm {
 	public static function update( $id, $values, $create_link = false ) {
 		global $wpdb;
 
+		$values = FrmAppHelper::maybe_filter_array( $values, array( 'name', 'description' ) );
+
 		if ( ! isset( $values['status'] ) && ( $create_link || isset( $values['options'] ) || isset( $values['item_meta'] ) || isset( $values['field_options'] ) ) ) {
 			$values['status'] = 'published';
 		}
@@ -183,6 +185,7 @@ class FrmForm {
 		$options['submit_html']  = ( isset( $values['options']['submit_html'] ) && '' !== $values['options']['submit_html'] ) ? $values['options']['submit_html'] : FrmFormsHelper::get_default_html( 'submit' );
 
 		$options               = apply_filters( 'frm_form_options_before_update', $options, $values );
+		$options               = FrmAppHelper::maybe_filter_array( $options, array( 'submit_value', 'success_msg', 'before_html', 'after_html', 'submit_html' ) );
 		$new_values['options'] = serialize( $options );
 
 		return $new_values;


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3250 though there maybe other places to filter as well that I missed.

For now I'm filtering field label, description, and custom_html.
As well as form name, description, submit text, success message, before html, after html, and submit html.

This is only if:
- The DISALLOW_UNFILTERED_HTML constant is on
or 
- The user logged in does not have the unfiltered_html permission

A super admin shouldn't notice a difference unless the constant was on.