### PR TITLE
Remove jquery placeholder from combined js code

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1012,7 +1012,6 @@ class FrmAppHelper {
 		$new_file  = new FrmCreateFile( $file_atts );
 
 		$files = array(
-			self::plugin_path() . '/js/jquery/jquery.placeholder.min.js',
 			self::plugin_path() . '/js/formidable.min.js',
 		);
 		$files = apply_filters( 'frm_combined_js_files', $files );


### PR DESCRIPTION
This line confuses me a bit but I noticed a warning in a log and looked wanted to fix this.

![Level All](https://user-images.githubusercontent.com/9134515/136388939-e2fa9534-d4e3-453b-82ff-707fba1582e5.png)

It doesn't look like this file exists anywhere, and I really couldn't even find a tag when it ever did.