### PR TITLE
More psalm cleanup

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -95,7 +95,7 @@ class FrmFormsController {
 	 *
 	 * @since 2.02.11
 	 *
-	 * @param object $form
+	 * @param object|int $form
 	 */
 	private static function create_default_email_action( $form ) {
 		FrmForm::maybe_get_form( $form );
@@ -429,7 +429,7 @@ class FrmFormsController {
 	/**
 	 * @param string $status
 	 *
-	 * @return int The number of forms changed
+	 * @return void
 	 */
 	public static function change_form_status( $status ) {
 		$available_status = array(

--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -185,10 +185,10 @@ class FrmStylesHelper {
 
 	/**
 	 * @since 2.0
-	 * @return The class for this icon
+	 * @return string The class for this icon.
 	 */
 	public static function icon_key_to_class( $key, $icon = '+', $type = 'arrow' ) {
-		if ( 'arrow' == $type && is_numeric( $key ) ) {
+		if ( 'arrow' === $type && is_numeric( $key ) ) {
 			//frm_arrowup6_icon
 			$arrow = array(
 				'-' => 'down',

--- a/classes/models/FrmEntryMeta.php
+++ b/classes/models/FrmEntryMeta.php
@@ -6,7 +6,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmEntryMeta {
 
 	/**
-	 * @param string $meta_key
+	 * @param int    $entry_id
+	 * @param int    $field_id
+	 * @param string $meta_key usually set to '' as this parameter is no longer used.
+	 * @param mixed  $meta_value
 	 */
 	public static function add_entry_meta( $entry_id, $field_id, $meta_key, $meta_value ) {
 		global $wpdb;
@@ -164,7 +167,7 @@ class FrmEntryMeta {
 	public static function duplicate_entry_metas( $old_id, $new_id ) {
 		$metas = self::get_entry_meta_info( $old_id );
 		foreach ( $metas as $meta ) {
-			self::add_entry_meta( $new_id, $meta->field_id, null, $meta->meta_value );
+			self::add_entry_meta( $new_id, $meta->field_id, '', $meta->meta_value );
 			unset( $meta );
 		}
 		self::clear_cache();

--- a/classes/models/FrmFieldValue.php
+++ b/classes/models/FrmFieldValue.php
@@ -182,7 +182,7 @@ class FrmFieldValue {
 	 *
 	 * @param array $atts
 	 *
-	 * @return mixed
+	 * @return void
 	 */
 	protected function generate_displayed_value_for_field_type( $atts ) {
 		if ( ! FrmAppHelper::is_empty_value( $this->displayed_value, '' ) ) {


### PR DESCRIPTION
I wanted to know how close we were to passing level psalm level 6. I saw 52 errors.

So far I'm improving the code around 5 pretty clear ones. Really helps to clean up the comments that are lying to us 😂.

> ERROR: InvalidReturnType - classes/controllers/FrmFormsController.php:432:13 - The declared return type 'int' for FrmFormsController::change_form_status is incorrect, got 'void' (see https://psalm.dev/011)
>          * @return int The number of forms changed
> 
> ERROR: InvalidArgument - classes/controllers/FrmFormsController.php:576:38 - Argument 1 of FrmFormsController::create_default_email_action expects object, bool|int provided (see https://psalm.dev/004)
>                 self::create_default_email_action( $form_id );
> 
> ERROR: InvalidReturnType - classes/helpers/FrmStylesHelper.php:188:13 - The declared return type 'The' for FrmStylesHelper::icon_key_to_class is incorrect, got 'non-empty-string' (see https://psalm.dev/011)
>          * @return The class for this icon
> 
> ERROR: NullArgument - classes/models/FrmEntryMeta.php:167:52 - Argument 3 of FrmEntryMeta::add_entry_meta cannot be null, null value provided to parameter with type string (see https://psalm.dev/057)
>                         self::add_entry_meta( $new_id, $meta->field_id, null, $meta->meta_value );
> 
> ERROR: InvalidReturnType - classes/models/FrmFieldValue.php:185:13 - No return statements were found for method FrmFieldValue::generate_displayed_value_for_field_type but return type 'mixed' was expected (see https://psalm.dev/011)