### PR TITLE
Always return a number when calling scheduled delete

### DIFF
--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -518,7 +518,7 @@ class FrmForm {
 		$trash_forms = FrmDb::get_results( $wpdb->prefix . 'frm_forms', array( 'status' => 'trash' ), 'id, options' );
 
 		if ( ! $trash_forms ) {
-			return;
+			return 0;
 		}
 
 		if ( empty( $delete_timestamp ) ) {


### PR DESCRIPTION
I was looking at `FrmForm::scheduled_delete` and noticed an invalid return.

Fixes part of https://github.com/Strategy11/formidable-pro/issues/3184

Now it actually shows the 0 instead of a blank deleted value.
<img width="744" alt="Screen Shot 2021-10-08 at 10 15 59 AM" src="https://user-images.githubusercontent.com/9134515/136564514-3f639322-df5a-431e-8d03-e91bcc3e1d3f.png">