### PR TITLE
Set antispam token on new form creation

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -570,6 +570,9 @@ class FrmFormsController {
 
 		$new_values             = self::get_modal_values();
 		$new_values['form_key'] = $new_values['name'];
+		$new_values['options']  = array(
+			'antispam' => 1,
+		);
 
 		$form_id = FrmForm::create( $new_values );
 

--- a/classes/controllers/FrmXMLController.php
+++ b/classes/controllers/FrmXMLController.php
@@ -59,8 +59,8 @@ class FrmXMLController {
 
 		self::set_new_form_name( $xml );
 
-		$imported = FrmXMLHelper::import_xml_now( $xml );
-		if ( isset( $imported['form_status'] ) && ! empty( $imported['form_status'] ) ) {
+		$imported = FrmXMLHelper::import_xml_now( $xml, true );
+		if ( ! empty( $imported['form_status'] ) ) {
 			// Get the last form id in case there are child forms.
 			end( $imported['form_status'] );
 			$form_id  = key( $imported['form_status'] );

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -5,6 +5,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class FrmXMLHelper {
 
+	/**
+	 * @var bool $installing_template true if importing an XML from API, false if importing an XML file manually.
+	 */
+	private static $installing_template = false;
+
 	public static function get_xml_values( $opt, $padding ) {
 		if ( is_array( $opt ) ) {
 			foreach ( $opt as $ok => $ov ) {
@@ -56,14 +61,18 @@ class FrmXMLHelper {
 	 * Add terms, forms (form and field ids), posts (post ids), and entries to db, in that order
 	 *
 	 * @since 3.06
+	 *
+	 * @param object $xml
+	 * @param bool   $installing_template
 	 * @return array The number of items imported
 	 */
-	public static function import_xml_now( $xml ) {
+	public static function import_xml_now( $xml, $installing_template = false ) {
 		if ( ! defined( 'WP_IMPORTING' ) ) {
 			define( 'WP_IMPORTING', true );
 		}
 
-		$imported = self::pre_import_data();
+		self::$installing_template = $installing_template;
+		$imported                  = self::pre_import_data();
 
 		foreach ( array( 'term', 'form', 'view' ) as $item_type ) {
 			// Grab cats, tags, and terms, or forms or posts.
@@ -235,6 +244,11 @@ class FrmXMLHelper {
 		}
 
 		$form['options'] = FrmAppHelper::maybe_json_decode( $form['options'] );
+
+		if ( self::$installing_template ) {
+			// Templates don't necessarily have antispam on, but we want our templates to all have antispam on by default.
+			$form['options']['antispam'] = 1;
+		}
 
 		return $form;
 	}


### PR DESCRIPTION
Part of https://github.com/Strategy11/formidable-pro/issues/3260

Because of caching-related issues I can never just turn this on and change the actual default with likely breaking a ton of forms. I have a few other items in my list to help promote this feature for those old forms.

But this part is easy and makes a big difference to change the default on new forms.