### PR TITLE
Stop trying to validate rich text buttons

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -201,7 +201,7 @@ function frmFrontFormJS() {
 	 *
 	 * @param {object} element
 	 * @param {string} targetClass
-	 * @returns bool
+	 * @returns {boolean}
 	 */
 	function hasClass( element, targetClass ) {
 		var className = ' ' + element.className + ' ';

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -208,7 +208,7 @@ function frmFrontFormJS() {
 		return -1 !== className.indexOf( ' ' + targetClass + ' ' );
 	}
 
-	function maybeValidateChange( fieldId, field ) {
+	function maybeValidateChange( field ) {
 		if ( field.type === 'url' ) {
 			maybeAddHttpToUrl( field );
 		}
@@ -1367,7 +1367,7 @@ function frmFrontFormJS() {
 			jQuery( document ).trigger( 'frmFieldChanged', [ this, fieldId, e ]);
 
 			if ( e.selfTriggered !== true ) {
-				maybeValidateChange( fieldId, this );
+				maybeValidateChange( this );
 			}
 		},
 

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -196,6 +196,13 @@ function frmFrontFormJS() {
 		return errors;
 	}
 
+	/**
+	 * @since 5.0.10
+	 *
+	 * @param {object} field
+	 * @param {string} targetClass
+	 * @returns bool
+	 */
 	function fieldHasClass( field, targetClass ) {
 		var className = ' ' + field.className + ' ';
 		return -1 !== className.indexOf( ' ' + targetClass + ' ' );

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -160,7 +160,7 @@ function frmFrontFormJS() {
 		).filter( ':not(.frm_optional)' );
 		if ( requiredFields.length ) {
 			for ( r = 0, rl = requiredFields.length; r < rl; r++ ) {
-				if ( fieldHasClass( requiredFields[r], 'ed_button' ) ) {
+				if ( hasClass( requiredFields[r], 'ed_button' ) ) {
 					// skip rich text field buttons.
 					continue;
 				}
@@ -199,12 +199,12 @@ function frmFrontFormJS() {
 	/**
 	 * @since 5.0.10
 	 *
-	 * @param {object} field
+	 * @param {object} element
 	 * @param {string} targetClass
 	 * @returns bool
 	 */
-	function fieldHasClass( field, targetClass ) {
-		var className = ' ' + field.className + ' ';
+	function hasClass( element, targetClass ) {
+		var className = ' ' + element.className + ' ';
 		return -1 !== className.indexOf( ' ' + targetClass + ' ' );
 	}
 
@@ -282,7 +282,7 @@ function frmFrontFormJS() {
 			}
 			fieldID = fileID;
 		} else {
-			if ( fieldHasClass( field, 'frm_pos_none' ) ) {
+			if ( hasClass( field, 'frm_pos_none' ) ) {
 				// skip hidden other fields
 				return errors;
 			}
@@ -300,7 +300,7 @@ function frmFrontFormJS() {
 				}
 			}
 
-			if ( fieldHasClass( field, 'frm_other_input' ) ) {
+			if ( hasClass( field, 'frm_other_input' ) ) {
 				fieldID = getFieldId( field, false );
 
 				if ( val === '' ) {
@@ -310,7 +310,7 @@ function frmFrontFormJS() {
 				fieldID = getFieldId( field, true );
 			}
 
-			if ( fieldHasClass( field, 'frm_time_select' ) ) {
+			if ( hasClass( field, 'frm_time_select' ) ) {
 				// set id for time field
 				fieldID = fieldID.replace( '-H', '' ).replace( '-m', '' );
 			}

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -160,7 +160,7 @@ function frmFrontFormJS() {
 		).filter( ':not(.frm_optional)' );
 		if ( requiredFields.length ) {
 			for ( r = 0, rl = requiredFields.length; r < rl; r++ ) {
-				if ( requiredFields[r].classList.contains( 'ed_button' ) ) {
+				if ( fieldHasClass( requiredFields[r], 'ed_button' ) ) {
 					// skip rich text field buttons.
 					continue;
 				}
@@ -194,6 +194,11 @@ function frmFrontFormJS() {
 		errors = validateRecaptcha( object, errors );
 
 		return errors;
+	}
+
+	function fieldHasClass( field, targetClass ) {
+		var className = ' ' + field.className + ' ';
+		return -1 !== className.indexOf( ' ' + targetClass + ' ' );
 	}
 
 	function maybeValidateChange( fieldId, field ) {
@@ -245,7 +250,7 @@ function frmFrontFormJS() {
 	}
 
 	function checkRequiredField( field, errors ) {
-		var checkGroup, fieldClasses, tempVal, i, placeholder,
+		var checkGroup, tempVal, i, placeholder,
 			val = '',
 			fieldID = '',
 			fileID = field.getAttribute( 'data-frmfile' );
@@ -270,8 +275,7 @@ function frmFrontFormJS() {
 			}
 			fieldID = fileID;
 		} else {
-			fieldClasses = field.className;
-			if ( fieldClasses.indexOf( 'frm_pos_none' ) !== -1 ) {
+			if ( fieldHasClass( field, 'frm_pos_none' ) ) {
 				// skip hidden other fields
 				return errors;
 			}
@@ -289,13 +293,13 @@ function frmFrontFormJS() {
 				}
 			}
 
-			if ( fieldClasses.indexOf( 'frm_other_input' ) === -1 ) {
+			if ( fieldHasClass( field, 'frm_other_input' ) ) {
 				fieldID = getFieldId( field, true );
 			} else {
 				fieldID = getFieldId( field, false );
 			}
 
-			if ( fieldClasses.indexOf( 'frm_time_select' ) !== -1 ) {
+			if ( fieldHasClass( field, 'frm_time_select' ) ) {
 				// set id for time field
 				fieldID = fieldID.replace( '-H', '' ).replace( '-m', '' );
 			}

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -160,6 +160,10 @@ function frmFrontFormJS() {
 		).filter( ':not(.frm_optional)' );
 		if ( requiredFields.length ) {
 			for ( r = 0, rl = requiredFields.length; r < rl; r++ ) {
+				if ( requiredFields[r].classList.contains( 'ed_button' ) ) {
+					// skip rich text field buttons.
+					continue;
+				}
 				errors = checkRequiredField( requiredFields[r], errors );
 			}
 		}
@@ -197,7 +201,7 @@ function frmFrontFormJS() {
 			maybeAddHttpToUrl( field );
 		}
 		if ( jQuery( field ).closest( 'form' ).hasClass( 'frm_js_validate' ) ) {
-			validateField( fieldId, field );
+			validateField( field );
 		}
 	}
 
@@ -209,11 +213,11 @@ function frmFrontFormJS() {
 		}
 	}
 
-	function validateField( fieldId, field ) {
+	function validateField( field ) {
 		var key,
-			errors = [];
+			errors = [],
+			$fieldCont = jQuery( field ).closest( '.frm_form_field' );
 
-		var $fieldCont = jQuery( field ).closest( '.frm_form_field' );
 		if ( $fieldCont.hasClass( 'frm_required_field' ) && ! jQuery( field ).hasClass( 'frm_optional' ) ) {
 			errors = checkRequiredField( field, errors );
 		}
@@ -376,7 +380,7 @@ function frmFrontFormJS() {
 				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( confirmField, 'data-confmsg' );
 			}
 		} else {
-			validateField( 'conf_' + strippedFieldID, confirmField );
+			validateField( confirmField );
 		}
 	}
 

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -301,13 +301,13 @@ function frmFrontFormJS() {
 			}
 
 			if ( fieldHasClass( field, 'frm_other_input' ) ) {
-				fieldID = getFieldId( field, true );
-			} else {
 				fieldID = getFieldId( field, false );
 
 				if ( val === '' ) {
 					field = document.getElementById( field.id.replace( '-otext', '' ) );
 				}
+			} else {
+				fieldID = getFieldId( field, true );
 			}
 
 			if ( fieldHasClass( field, 'frm_time_select' ) ) {


### PR DESCRIPTION
I noticed that because of this `.frm_required_field:visible input` selector every single rich text button (bold, italic, etc) is checked.

<img width="697" alt="Screen Shot 2021-10-20 at 11 39 16 AM" src="https://user-images.githubusercontent.com/9134515/138114842-6f7a4ad3-db49-4a9c-b9b8-ed6364b96338.png">

I'm just skipping these earlier rather than calling checkRequiredField on something that is not a field.

Also cleaning up the validate function. It takes fieldId as the first parameter but never uses it. It looks like it's inaccessible outside of this file so removing it should be safe.