### PR TITLE
JS validation error messages do not appear for required radios with an empty other field

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -318,11 +318,6 @@ function frmFrontFormJS() {
 		return errors;
 	}
 
-	function fieldHasClass( field, targetClass ) {
-		var className = ' ' + field.className + ' ';
-		return -1 !== className.indexOf( targetClass );
-	}
-
 	function getFileVals( fileID ) {
 		var val = '',
 			fileFields = jQuery( 'input[name="file' + fileID + '"], input[name="file' + fileID + '[]"], input[name^="item_meta[' + fileID + ']"]' );

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -289,6 +289,10 @@ function frmFrontFormJS() {
 				fieldID = getFieldId( field, true );
 			} else {
 				fieldID = getFieldId( field, false );
+
+				if ( val === '' ) {
+					field = document.getElementById( field.id.replace( '-otext', '' ) );
+				}
 			}
 
 			if ( fieldClasses.indexOf( 'frm_time_select' ) !== -1 ) {
@@ -312,6 +316,11 @@ function frmFrontFormJS() {
 		}
 
 		return errors;
+	}
+
+	function fieldHasClass( field, targetClass ) {
+		var className = ' ' + field.className + ' ';
+		return -1 !== className.indexOf( targetClass );
 	}
 
 	function getFileVals( fileID ) {


### PR DESCRIPTION
Found another case of an error not always appearing with JavaScript validation on. In this case if you submit a required radio button with other selected and empty Other text the error never appears.

**Before**
https://recordit.co/CsD88j5JgU

**After**
https://recordit.co/EYJdbUPjyq

There's already a check here for `frm_other_input` so I'm just hooking into that.