### PR TITLE
Fix issues with frm_alignright class

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -179,21 +179,11 @@ class FrmFieldsController {
 	 * @since 3.0
 	 */
 	private static function get_classes_for_builder_field( $field, $display, $field_info ) {
-		$li_classes = $field_info->form_builder_classes( $display['type'] );
-		$classes    = isset( $field['classes'] ) ? $field['classes'] : '';
-
-		// Exclude alignright for now since we aren't using widths.
-		$classes = str_replace( ' frm_alignright ', ' ', $classes );
-		$classes = trim( $classes );
-
-		if ( 'frm_alignright' === $classes ) {
-			$classes = '';
-		}
-
+		$li_classes  = $field_info->form_builder_classes( $display['type'] );
 		$li_classes .= ' frm_form_field frmstart ';
 
-		if ( $classes ) {
-			$li_classes .= $classes . ' ';
+		if ( isset( $field['classes'] ) ) {
+			$li_classes .= trim( $field['classes'] ) . ' ';
 		}
 
 		$li_classes .= 'frmend';

--- a/css/frm_grids.css
+++ b/css/frm_grids.css
@@ -226,7 +226,6 @@
 .frm_form_field.frm_last,
 .frm_form_field.frm_alignright{
 	grid-column-end:-1;
-	grid-row-start: span 100;
 	justify-content: end;
 }
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5453,7 +5453,7 @@ function frmAdminBuildJS() {
 		replaceWith += ' ';
 
 		// Allow for the column number dropdown.
-		replaceWith = replaceWith.replace( ' block ', ' ' ).replace( ' inline ', ' horizontal_radio ' ).replace( ' frm_alignright ', ' ' );
+		replaceWith = replaceWith.replace( ' block ', ' ' ).replace( ' inline ', ' horizontal_radio ' );
 
 		classes = field.className.split( ' frmstart ' )[1];
 		classes = 0 === classes.indexOf( 'frmend ' ) ? '' : classes.split( ' frmend ' )[0];


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3246

So it looks like `frm_alignright` is never shown in the back end as it was messing up layouts. This causes a lot of confusion now with the front end results because people expect everything to match now with the side-by-side fields.

The big issue here is this `grid-row-start: span 100;` line which seems totally wrong. Taking it out seems to fix all of the weird `frm_alignright` issues on the front end.

And now when you try to edit the classes on an `frm_alignright` field it doesn't suddenly lose its class.

An example similar to the last one with a gap so I can actually see it working (otherwise there's really no reason for this class at all. Every use case I've seen still seems like misuse to me since it's only really important if there's a gap).
![Screen Shot 2021-10-21 at 9 34 16 AM](https://user-images.githubusercontent.com/9134515/138278198-033a599c-19f8-4d40-8ed7-9a3a88b8ca8c.png)

And on the front end
![Screen Shot 2021-10-21 at 9 36 09 AM](https://user-images.githubusercontent.com/9134515/138278364-eedba914-c6c9-409c-8edd-2d2d3c84528f.png)