### PR TITLE
Confirm field name is a string before calling substr

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -313,7 +313,7 @@ function frmFrontFormJS() {
 			if ( hasClass( field, 'frm_time_select' ) ) {
 				// set id for time field
 				fieldID = fieldID.replace( '-H', '' ).replace( '-m', '' );
-			} else if ( '[typed]' === field.getAttribute( 'name' ).substr( -7 ) ) {
+			} else if ( isSignatureField( field ) ) {
 				if ( val === '' ) {
 					val = jQuery( field ).closest( '.frm_form_field' ).find( '[name="' + field.getAttribute( 'name' ).replace( '[typed]', '[output]' ) + '"]' ).val();
 				}
@@ -336,6 +336,11 @@ function frmFrontFormJS() {
 		}
 
 		return errors;
+	}
+
+	function isSignatureField( field ) {
+		var name = field.getAttribute( 'name' );
+		return 'string' === typeof name && '[typed]' === name.substr( -7 );
 	}
 
 	function getFileVals( fileID ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3281

Didn't account for the possibility that an input might have no `name`.