### PR TITLE
Cache empty inbox API responses

### DIFF
--- a/classes/models/FrmFormApi.php
+++ b/classes/models/FrmFormApi.php
@@ -64,7 +64,7 @@ class FrmFormApi {
 		}
 
 		$addons = $this->get_cached();
-		if ( ! empty( $addons ) ) {
+		if ( is_array( $addons ) ) {
 			return $addons;
 		}
 
@@ -82,22 +82,23 @@ class FrmFormApi {
 			)
 		);
 		if ( is_array( $response ) && ! is_wp_error( $response ) ) {
-			$addons = $response['body'];
-			if ( ! empty( $addons ) ) {
-				$addons = json_decode( $addons, true );
+			$addons = $response['body'] ? json_decode( $response['body'], true ) : array();
 
-				foreach ( $addons as $k => $addon ) {
-					if ( ! isset( $addon['categories'] ) ) {
-						continue;
-					}
-					$cats = array_intersect( $this->skip_categories(), $addon['categories'] );
-					if ( ! empty( $cats ) ) {
-						unset( $addons[ $k ] );
-					}
-				}
-
-				$this->set_cached( $addons );
+			if ( ! is_array( $addons ) ) {
+				$addons = array();
 			}
+
+			foreach ( $addons as $k => $addon ) {
+				if ( ! isset( $addon['categories'] ) ) {
+					continue;
+				}
+				$cats = array_intersect( $this->skip_categories(), $addon['categories'] );
+				if ( ! empty( $cats ) ) {
+					unset( $addons[ $k ] );
+				}
+			}
+
+			$this->set_cached( $addons );
 		}
 
 		if ( empty( $addons ) ) {


### PR DESCRIPTION
Now that the inbox API is returning nothing when there are no inbox notices it never gets cached 😱.

I'm changing some of these checks so they'll still cache/return an empty array instead of trying to call the inbox API five times in a single request (which is what was happening because the first would try, and find nothing, then try again).

I tested this with a fake API endpoint. I set up https://qa.formidableforms.com/mike2?return_nothing=1 to return nothing, like the inbox API was. For now, I've extended the surveys news another couple days so it isn't empty.