### PR TITLE
Change $_POST plugin check for get current plugin

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -1040,7 +1040,7 @@ class FrmAddonsController {
 	protected static function install_addon_permissions() {
 		check_ajax_referer( 'frm_ajax', 'nonce' );
 
-		if ( ! current_user_can( 'activate_plugins' ) || ! isset( $_POST['plugin'] ) ) {
+		if ( ! current_user_can( 'activate_plugins' ) || ! self::get_current_plugin() ) {
 			echo json_encode( true );
 			wp_die();
 		}


### PR DESCRIPTION
Related to https://github.com/Strategy11/formidable-forms/pull/587

This check is safer.