### PR TITLE
Reduce server calls for license checks

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -44,7 +44,7 @@ class FrmAddonsController {
 		$errors = array();
 
 		if ( isset( $addons['error'] ) ) {
-			$api    = new FrmFormApi();
+			$api    = FrmFormApi::get_instance();
 			$errors = $api->get_error_from_response( $addons );
 			$license_type = isset( $addons['error']['type'] ) ? $addons['error']['type'] : '';
 			unset( $addons['error'] );
@@ -81,7 +81,7 @@ class FrmAddonsController {
 	}
 
 	protected static function get_api_addons() {
-		$api    = new FrmFormApi();
+		$api    = FrmFormApi::get_instance();
 		$addons = $api->get_api_info();
 
 		if ( empty( $addons ) ) {
@@ -198,7 +198,7 @@ class FrmAddonsController {
 	 */
 	public static function get_pro_download_url() {
 		$license   = self::get_pro_license();
-		$api       = new FrmFormApi( $license );
+		$api       = FrmFormApi::get_instance( $license );
 		$downloads = $api->get_api_info();
 		$pro       = self::get_pro_from_addons( $downloads );
 
@@ -394,7 +394,7 @@ class FrmAddonsController {
 
 			$checked_licenses[] = $new_license;
 
-			$api = new FrmFormApi( $new_license );
+			$api = FrmFormApi::get_instance( $new_license );
 			if ( empty( $version_info ) ) {
 				$version_info = $api->get_api_info();
 				continue;

--- a/classes/controllers/FrmInboxController.php
+++ b/classes/controllers/FrmInboxController.php
@@ -22,7 +22,7 @@ class FrmInboxController {
 	private static function get_notice_count() {
 		FrmFormMigratorsHelper::maybe_add_to_inbox();
 
-		$inbox = new FrmInbox();
+		$inbox = FrmInbox::get_instance();
 		return $inbox->unread_html();
 	}
 
@@ -47,7 +47,7 @@ class FrmInboxController {
 		self::add_tracking_request();
 		self::add_free_template_message();
 
-		$inbox    = new FrmInbox();
+		$inbox    = FrmInbox::get_instance();
 		$messages = $inbox->get_messages( 'filter' );
 		$messages = array_reverse( $messages );
 		$user     = wp_get_current_user();
@@ -66,7 +66,7 @@ class FrmInboxController {
 
 		$key = FrmAppHelper::get_param( 'key', '', 'post', 'sanitize_text_field' );
 		if ( ! empty( $key ) ) {
-			$message = new FrmInbox();
+			$message = FrmInbox::get_instance();
 			$message->dismiss( $key );
 			if ( $key === 'review' ) {
 				$reviews = new FrmReviews();
@@ -88,7 +88,7 @@ class FrmInboxController {
 
 		$link = admin_url( 'admin.php?page=formidable-settings&t=misc_settings' );
 
-		$message = new FrmInbox();
+		$message = FrmInbox::get_instance();
 		$message->add_message(
 			array(
 				'key'     => 'usage',
@@ -117,7 +117,7 @@ class FrmInboxController {
 
 		$link = admin_url( 'admin.php?page=formidable&triggerNewFormModal=1&free-templates=1' );
 
-		$message = new FrmInbox();
+		$message = FrmInbox::get_instance();
 		$message->add_message(
 			array(
 				'key'     => 'free_templates',

--- a/classes/helpers/FrmFormMigratorsHelper.php
+++ b/classes/helpers/FrmFormMigratorsHelper.php
@@ -34,7 +34,7 @@ class FrmFormMigratorsHelper {
 	 * @since 4.05
 	 */
 	public static function maybe_add_to_inbox() {
-		$inbox = new FrmInbox();
+		$inbox = FrmInbox::get_instance();
 		$forms = self::import_links();
 
 		foreach ( $forms as $form ) {

--- a/classes/models/FrmAddon.php
+++ b/classes/models/FrmAddon.php
@@ -107,7 +107,7 @@ class FrmAddon {
 				),
 			);
 		} else {
-			$api     = new FrmFormApi( $this->license );
+			$api     = FrmFormApi::get_instance( $this->license );
 			$plugins = $api->get_api_info();
 			$_data   = $plugins[ $item_id ];
 		}
@@ -147,7 +147,7 @@ class FrmAddon {
 			return false;
 		}
 
-		$api = new FrmFormApi();
+		$api = FrmFormApi::get_instance();
 		$api->get_pro_updater();
 		$license = $api->get_license();
 		if ( empty( $license ) ) {
@@ -276,7 +276,7 @@ class FrmAddon {
 	protected function delete_cache() {
 		delete_transient( 'frm_api_licence' );
 
-		$api = new FrmFormApi( $this->license );
+		$api = FrmFormApi::get_instance( $this->license );
 		$api->reset_cached();
 
 		$api = new FrmFormTemplateApi( $this->license );
@@ -304,7 +304,7 @@ class FrmAddon {
 			/* translators: %1$s: Plugin name, %2$s: Start link HTML, %3$s: end link HTML */
 			$message = sprintf( esc_html__( 'Your %1$s license key is missing. Please add it on the %2$slicenses page%3$s.', 'formidable' ), esc_html( $this->plugin_name ), '<a href="' . esc_url( admin_url( 'admin.php?page=formidable-settings' ) ) . '">', '</a>' );
 		} else {
-			$api    = new FrmFormApi( $this->license );
+			$api    = FrmFormApi::get_instance( $this->license );
 			$errors = $api->error_for_license();
 			if ( ! empty( $errors ) ) {
 				$message = reset( $errors );
@@ -384,7 +384,7 @@ class FrmAddon {
 	 * @since 3.04.03
 	 */
 	protected function get_api_info( $license ) {
-		$api   = new FrmFormApi( $license );
+		$api   = FrmFormApi::get_instance( $license );
 		$addon = $api->get_addon_for_license( $this );
 
 		// if there is no download url, this license does not apply to the addon
@@ -409,7 +409,7 @@ class FrmAddon {
 		$timeout = ( isset( $version_info->timeout ) && ! empty( $version_info->timeout ) ) ? $version_info->timeout : 0;
 		if ( ! empty( $timeout ) && time() > $timeout ) {
 			$version_info = false; // Cache is expired
-			$api          = new FrmFormApi( $this->license );
+			$api          = FrmFormApi::get_instance( $this->license );
 			$api->reset_cached();
 		}
 	}

--- a/classes/models/FrmFormApi.php
+++ b/classes/models/FrmFormApi.php
@@ -81,6 +81,7 @@ class FrmFormApi {
 				'user-agent' => $agent . '; ' . get_bloginfo( 'url' ),
 			)
 		);
+
 		if ( is_array( $response ) && ! is_wp_error( $response ) ) {
 			$addons = $response['body'] ? json_decode( $response['body'], true ) : array();
 
@@ -97,13 +98,13 @@ class FrmFormApi {
 					unset( $addons[ $k ] );
 				}
 			}
-
-			$this->set_cached( $addons );
 		}
 
 		if ( empty( $addons ) ) {
-			return array();
+			$addons = array();
 		}
+
+		$this->set_cached( $addons );
 
 		return $addons;
 	}

--- a/classes/models/FrmFormTemplateApi.php
+++ b/classes/models/FrmFormTemplateApi.php
@@ -127,7 +127,7 @@ class FrmFormTemplateApi extends FrmFormApi {
 		$key  = FrmAppHelper::get_param( 'key', '', 'post', 'sanitize_key' );
 
 		// Remove message from Inbox page.
-		$message = new FrmInbox();
+		$message = FrmInbox::get_instance();
 		$message->remove( 'free_templates' );
 
 		if ( $key ) {

--- a/classes/models/FrmPluginSearch.php
+++ b/classes/models/FrmPluginSearch.php
@@ -136,7 +136,7 @@ class FrmPluginSearch {
 	 * @return array
 	 */
 	private function get_addons() {
-		$api    = new FrmFormApi();
+		$api    = FrmFormApi::get_instance();
 		return $api->get_api_info();
 	}
 

--- a/classes/models/FrmReviews.php
+++ b/classes/models/FrmReviews.php
@@ -117,7 +117,7 @@ class FrmReviews {
 	}
 
 	private function add_to_inbox( $title, $name, $asked ) {
-		$message = new FrmInbox();
+		$message = FrmInbox::get_instance();
 		$requests = $message->get_messages();
 		$key      = $this->inbox_key . ( $asked ? $asked : '' );
 
@@ -176,7 +176,7 @@ class FrmReviews {
 	 * @since 4.05.01
 	 */
 	private function set_inbox_dismissed() {
-		$message = new FrmInbox();
+		$message = FrmInbox::get_instance();
 		foreach ( $this->inbox_keys() as $key ) {
 			$message->dismiss( $key );
 		}
@@ -186,7 +186,7 @@ class FrmReviews {
 	 * @since 4.05.01
 	 */
 	private function set_inbox_read() {
-		$message = new FrmInbox();
+		$message = FrmInbox::get_instance();
 		foreach ( $this->inbox_keys() as $key ) {
 			$message->mark_read( $key );
 		}

--- a/classes/models/FrmSolution.php
+++ b/classes/models/FrmSolution.php
@@ -464,7 +464,7 @@ class FrmSolution {
 
 		$this->step_top( $step );
 
-		$api    = new FrmFormApi();
+		$api    = FrmFormApi::get_instance();
 		$addons = $api->get_api_info();
 
 		$id = $this->download_id();

--- a/deprecated/FrmDeprecated.php
+++ b/deprecated/FrmDeprecated.php
@@ -162,7 +162,7 @@ class FrmDeprecated {
 	 */
 	public static function get_pro_updater() {
 		_deprecated_function( __FUNCTION__, '3.06', 'FrmFormApi::get_pro_updater' );
-		$api = new FrmFormApi();
+		$api = FrmFormApi::get_instance();
 		return $api->get_pro_updater();
 	}
 
@@ -185,7 +185,7 @@ class FrmDeprecated {
 	 */
 	public static function error_for_license( $license ) {
 		_deprecated_function( __FUNCTION__, '3.06', 'FrmFormApi::error_for_license' );
-		$api = new FrmFormApi( $license );
+		$api = FrmFormApi::get_instance( $license );
 		return $api->error_for_license();
 	}
 
@@ -195,7 +195,7 @@ class FrmDeprecated {
 	 */
 	public static function reset_cached_addons( $license = '' ) {
 		_deprecated_function( __FUNCTION__, '3.06', 'FrmFormApi::reset_cached' );
-		$api = new FrmFormApi( $license );
+		$api = FrmFormApi::get_instance( $license );
 		$api->reset_cached();
 	}
 
@@ -206,7 +206,7 @@ class FrmDeprecated {
 	 */
 	public static function get_cache_key( $license ) {
 		_deprecated_function( __FUNCTION__, '3.06', 'FrmFormApi::get_cache_key' );
-		$api = new FrmFormApi( $license );
+		$api = FrmFormApi::get_instance( $license );
 		return $api->get_cache_key();
 	}
 
@@ -218,7 +218,7 @@ class FrmDeprecated {
 	 */
 	public static function get_addon_info( $license = '' ) {
 		_deprecated_function( __FUNCTION__, '3.06', 'FrmFormApi::get_api_info' );
-		$api = new FrmFormApi( $license );
+		$api = FrmFormApi::get_instance( $license );
 		return $api->get_api_info();
 	}
 


### PR DESCRIPTION
Any ideas on a better way of doing this?

If server response isn't array, don't keep checking. We're getting a lot of repeat pings from the same sites. The inbox fixes were part of it, but I think it's a problem with version checks too.

This can be replicated by commenting out "return addons" on line 92 in FrmFormApi to skip the cache:
```
		$addons = $this->get_cached();
		if ( is_array( $addons ) ) {
			return $addons;
		}
```

This change uses thee same instance, so we know if the url has already been pinged on that page load. If the url has been called, we know the cache isn't working. This saves about 8 pings per page load in this scenario. 

The incoming pro version PR saves 7 more.

This log is edited a bit since this is public:

```
User-Agents grouped with IP: non-HIT's, sorted by most up top:
awk: warning: regexp escape sequence `\"' is not a known regexp operator
  16590 35.20.1.23 "form_action_automation/2.04; https://samesite.com"
  16583 35.20.1.23 "authorizenet_aim/2.01; https://samesite.com"
```
Many of these requests have been rate limited but it might be worth blocking the IP or making the rate limiting much stricter.

These are the types of requests we're seeing:

```
35.20.1.23 - - [28/Oct/2021:17:04:51 +0000] formidableforms.com "GET /wp-json/s11edd/v1/updates/?l=ZDdlOTU3ZTI0MTExNmNjNmFhMzFmMmE%3D HTTP/1.1" 200 31308 "formidable-pro/5.0.09; https://samesite.com" EXPIRED 1.756
35.20.1.23 - - [28/Oct/2021:17:04:51 +0000] formidableforms.com "GET /wp-json/s11edd/v1/updates/?l=ZDdlOTU3ZTI0MTExNmNjNmFhMzFmMmE%3D HTTP/1.1" 200 31308 "formidable-pro/5.0.09; https://samesite.com" EXPIRED 1.933
35.20.1.23 - - [28/Oct/2021:17:04:52 +0000] formidableforms.com "GET /wp-json/s11edd/v1/updates/?l=ZDdlOTU3ZTI0MTExNmNjNmFhMzFmMmE%3D HTTP/1.1" 200 31321 "formidable-pro/5.0.09; https://samesite.com" EXPIRED 2.101
35.20.1.23 - - [28/Oct/2021:17:04:52 +0000] formidableforms.com "GET /wp-json/s11edd/v1/updates/?l=ZDdlOTU3ZTI0MTExNmNjNmFhMzFmMmE%3D HTTP/1.1" 200 31321 "formidable-pro/5.0.09; https://samesite.com" EXPIRED 2.321
35.20.1.23 - - [28/Oct/2021:17:04:53 +0000] formidableforms.com "GET /wp-json/s11edd/v1/updates/?l=ZDdlOTU3ZTI0MTExNmNjNmFhMzFmMmE%3D HTTP/1.1" 200 31321 "formidable-pro/5.0.09; https://samesite.com" EXPIRED 2.875
35.20.1.23 - - [28/Oct/2021:17:04:53 +0000] formidableforms.com "GET /wp-json/s11edd/v1/updates/?l=ZDdlOTU3ZTI0MTExNmNjNmFhMzFmMmE%3D HTTP/1.1" 200 31308 "formidable-pro/5.0.09; https://samesite.com" EXPIRED 3.176
35.20.1.23 - - [28/Oct/2021:17:04:53 +0000] formidableforms.com "GET /wp-json/s11edd/v1/updates/?l=ZDdlOTU3ZTI0MTExNmNjNmFhMzFmMmE%3D HTTP/1.1" 200 31309 "formidable-pro/5.0.09; https://samesite.com" EXPIRED 3.321
```
