### PR TITLE
Add frm_inline_form to forms with inline submit class (if missing)

### DIFF
--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -824,7 +824,7 @@ BEFORE_HTML;
 	 * @return bool
 	 */
 	private static function form_should_be_inline_and_missing_class( $form ) {
-		if ( isset( $form['form_class'] ) && false !== strpos( ' ' . $form['form_class'] . ' ', 'frm_inline_form' ) ) {
+		if ( isset( $form['form_class'] ) && false !== strpos( ' ' . $form['form_class'] . ' ', ' frm_inline_form ' ) ) {
 			// not missing class, avoid adding it twice.
 			return false;
 		}

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -795,7 +795,11 @@ BEFORE_HTML;
 			$form = $form->options;
 		}
 
-		$submit_align = isset( $form['submit_align'] ) ? $form['submit_align'] : '';
+		if ( ! empty( $form['submit_align'] ) ) {
+			$submit_align = $form['submit_align'];
+		} else {
+			$submit_align = ! empty( $form['submit_html'] ) && false !== strpos( $form['submit_html'], 'frm_inline_submit' ) ? 'inline' : '';
+		}
 
 		if ( 'inline' === $submit_align ) {
 			$class .= ' frm_inline_form';

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -797,8 +797,10 @@ BEFORE_HTML;
 
 		if ( ! empty( $form['submit_align'] ) ) {
 			$submit_align = $form['submit_align'];
+		} elseif ( self::form_should_be_inline_and_missing_class( $form ) ) {
+			$submit_align = 'inline';
 		} else {
-			$submit_align = ! empty( $form['submit_html'] ) && false !== strpos( $form['submit_html'], 'frm_inline_submit' ) ? 'inline' : '';
+			$submit_align = '';
 		}
 
 		if ( 'inline' === $submit_align ) {
@@ -811,6 +813,22 @@ BEFORE_HTML;
 		$class = apply_filters( 'frm_add_form_style_class', $class, $style );
 
 		return $class;
+	}
+
+	/**
+	 * In order for frm_inline_submit to inline the submit button the form must also have the frm_inline_form that adds the grid-column style rules required for it to work.
+	 *
+	 * @since 5.0.12
+	 *
+	 * @param array $form
+	 * @return bool
+	 */
+	private static function form_should_be_inline_and_missing_class( $form ) {
+		if ( isset( $form['form_class'] ) && false !== strpos( ' ' . $form['form_class'] . ' ', 'frm_inline_form' ) ) {
+			// not missing class, avoid adding it twice.
+			return false;
+		}
+		return ! empty( $form['submit_html'] ) && false !== strpos( $form['submit_html'], 'frm_inline_submit' );
 	}
 
 	/**


### PR DESCRIPTION
Talked about this in slack the other day.  It came up in Helpscout the other week. As I went into this code, it becomes pretty clear what is missing (the frm_inline_form class). We could probably make this more clear just with documentation, but it's also something we can just check for and add automatically 🕺

When `frm_inline_submit` is added in custom HTML for a form, the frm_inline_form class will be added automatically (if it isn't already set), because without it it does nothing.

**Before**
![Screen Shot 2021-11-02 at 2 15 23 PM](https://user-images.githubusercontent.com/9134515/139913505-65d1a39d-50f7-4f0d-9f36-7573466408f7.png)

**After**
![Screen Shot 2021-11-02 at 2 15 00 PM](https://user-images.githubusercontent.com/9134515/139913450-2d42bca6-b7c2-45dc-97a3-c5ca41840e07.png)