### PR TITLE
Fix issue with some add-ons not showing the plugin info

### DIFF
--- a/classes/models/FrmAddon.php
+++ b/classes/models/FrmAddon.php
@@ -90,8 +90,9 @@ class FrmAddon {
 			return $_data;
 		}
 
-		$slug = basename( $this->plugin_file, '.php' );
-		if ( ! isset( $_args->slug ) || $_args->slug != $slug ) {
+		$slug  = basename( $this->plugin_file, '.php' );
+		$slug2 = str_replace( '/' . $slug . '.php', '', $this->plugin_folder );
+		if ( empty( $_args->slug ) || ( $_args->slug != $slug && $_args->slug !== $slug2 ) ) {
 			return $_data;
 		}
 


### PR DESCRIPTION
This should fix the issue with any add-ons with a different name for the main file as the plugin folder. This was written assuming the plugin folder name would always have a file with the same name to go with it.

There is a separate issue in the signature plugin too. PR incoming for that in the add-on.