### PR TITLE
Validate form exists when trying to export csv

### DIFF
--- a/classes/controllers/FrmXMLController.php
+++ b/classes/controllers/FrmXMLController.php
@@ -566,9 +566,14 @@ class FrmXMLController {
 
 		global $wpdb;
 
-		$form    = FrmForm::getOne( $form_id );
-		$form_id = $form->id;
+		$form = FrmForm::getOne( $form_id );
 
+		if ( ! $form ) {
+			esc_html_e( 'Form not found.', 'formidable' );
+			wp_die();
+		}
+
+		$form_id   = $form->id;
 		$form_cols = self::get_fields_for_csv_export( $form_id, $form );
 
 		$item_id = FrmAppHelper::get_param( 'item_id', 0, 'get', 'sanitize_text_field' );


### PR DESCRIPTION
Tried exporting a CSV for a form that wasn't on my server and it results in two errors when there is no form found (since it's trying to find things with no id).

```
PHP Warning:  Attempt to read property "id" on null in /var/www/src/wp-content/plugins/formidable/classes/controllers/FrmXMLController.php on line 570
[04-Nov-2021 13:38:46 UTC] PHP Notice:  wpdb::prepare was called <strong>incorrectly</strong>. The query argument of wpdb::prepare() must have a placeholder. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 3.9.0.) in /var/www/src/wp-includes/functions.php on line 5663
```

Just making this safer by checking if no form is found and exiting early.