### PR TITLE
Remove jquery_ui_base_url from free plugin

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2552,6 +2552,7 @@ class FrmAppHelper {
 				'updating'          => __( 'Please wait while your site updates.', 'formidable' ),
 				'no_save_warning'   => __( 'Warning: There is no way to retrieve unsaved entries.', 'formidable' ),
 				'private_label'     => __( 'Private', 'formidable' ),
+				'jquery_ui_url'     => '',
 				'pro_url'           => is_callable( 'FrmProAppHelper::plugin_url' ) ? FrmProAppHelper::plugin_url() : '',
 				'no_licenses'       => __( 'No new licenses were found', 'formidable' ),
 				'unmatched_parens'  => __( 'This calculation has at least one unmatched ( ) { } [ ].', 'formidable' ),

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1541,17 +1541,6 @@ class FrmAppHelper {
 	}
 
 	/**
-	 * @since 2.0
-	 * @return string The base Google APIS url for the current version of jQuery UI
-	 */
-	public static function jquery_ui_base_url() {
-		$url = 'http' . ( is_ssl() ? 's' : '' ) . '://ajax.googleapis.com/ajax/libs/jqueryui/' . self::script_version( 'jquery-ui-core', '1.11.4' );
-		$url = apply_filters( 'frm_jquery_ui_base_url', $url );
-
-		return $url;
-	}
-
-	/**
 	 * @param string $handle
 	 */
 	public static function script_version( $handle, $default = 0 ) {
@@ -2563,7 +2552,6 @@ class FrmAppHelper {
 				'updating'          => __( 'Please wait while your site updates.', 'formidable' ),
 				'no_save_warning'   => __( 'Warning: There is no way to retrieve unsaved entries.', 'formidable' ),
 				'private_label'     => __( 'Private', 'formidable' ),
-				'jquery_ui_url'     => self::jquery_ui_base_url(),
 				'pro_url'           => is_callable( 'FrmProAppHelper::plugin_url' ) ? FrmProAppHelper::plugin_url() : '',
 				'no_licenses'       => __( 'No new licenses were found', 'formidable' ),
 				'unmatched_parens'  => __( 'This calculation has at least one unmatched ( ) { } [ ].', 'formidable' ),
@@ -3236,5 +3224,16 @@ class FrmAppHelper {
 	 */
 	public static function prepend_and_or_where( $starts_with = ' WHERE ', $where = '' ) {
 		return FrmDeprecated::prepend_and_or_where( $starts_with, $where );
+	}
+
+	/**
+	 * @since 2.0
+	 * @deprecated 5.0.13
+	 *
+	 * @return string The base Google APIS url for the current version of jQuery UI
+	 */
+	public static function jquery_ui_base_url() {
+		_deprecated_function( __FUNCTION__, '5.0.13', 'FrmProAppHelper::jquery_ui_base_url' );
+		return is_callable( 'FrmProAppHelper::jquery_ui_base_url' ) ? FrmProAppHelper::jquery_ui_base_url() : '';
 	}
 }

--- a/deprecated/FrmDeprecated.php
+++ b/deprecated/FrmDeprecated.php
@@ -816,25 +816,11 @@ class FrmDeprecated {
 	public static function jquery_css_url( $theme_css ) {
 		_deprecated_function( __FUNCTION__, '3.02.03', 'FrmProStylesController::jquery_css_url' );
 
-        if ( $theme_css == -1 ) {
-            return;
-        }
+		if ( ! is_callable( 'FrmProStylesController::jquery_css_url' ) ) {
+			return;
+		}
 
-        if ( ! $theme_css || $theme_css == '' || $theme_css == 'ui-lightness' ) {
-            $css_file = FrmAppHelper::plugin_url() . '/css/ui-lightness/jquery-ui.css';
-		} elseif ( preg_match( '/^http.?:\/\/.*\..*$/', $theme_css ) ) {
-            $css_file = $theme_css;
-        } else {
-            $uploads = FrmStylesHelper::get_upload_base();
-			$file_path = '/formidable/css/' . $theme_css . '/jquery-ui.css';
-			if ( file_exists( $uploads['basedir'] . $file_path ) ) {
-                $css_file = $uploads['baseurl'] . $file_path;
-            } else {
-				$css_file = FrmAppHelper::jquery_ui_base_url() . '/themes/' . $theme_css . '/jquery-ui.min.css';
-            }
-        }
-
-        return $css_file;
+		return FrmProStylesController::jquery_css_url( $theme_css );
     }
 
 	/**

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7113,25 +7113,6 @@ function frmAdminBuildJS() {
 	}
 
 	/* Styling */
-
-	//function to append a new theme stylesheet with the new style changes
-	function updateUICSS( locStr ) {
-		var $cssLink, $link;
-
-		if ( locStr == -1 ) {
-			jQuery( 'link.ui-theme' ).remove();
-			return false;
-		}
-
-		$cssLink = jQuery( '<link href="' + locStr + '" type="text/css" rel="Stylesheet" class="ui-theme" />' );
-		jQuery( 'head' ).append( $cssLink );
-
-		$link = jQuery( 'link.ui-theme' );
-		if ( $link.length > 1 ) {
-			$link.first().remove();
-		}
-	}
-
 	function setPosClass() {
 		/*jshint validthis:true */
 		var value = this.value;
@@ -9397,24 +9378,6 @@ function frmAdminBuildJS() {
 			jQuery( '.frm_pro_form #datepicker_sample' ).datepicker({ changeMonth: true, changeYear: true });
 
 			jQuery( document.getElementById( 'frm_position' ) ).on( 'change', setPosClass );
-
-			jQuery( 'select[name$="[theme_selector]"]' ).on( 'change', function() {
-				var themeVal = jQuery( this ).val();
-				var css = themeVal;
-				if ( themeVal !== -1 ) {
-					if ( themeVal === 'ui-lightness' && frm_admin_js.pro_url !== '' ) {
-						css = frm_admin_js.pro_url + '/css/ui-lightness/jquery-ui.css';
-						jQuery( '.frm_date_color' ).show();
-					} else {
-						css = frm_admin_js.jquery_ui_url + '/themes/' + themeVal + '/jquery-ui.css';
-						jQuery( '.frm_date_color' ).hide();
-					}
-				}
-
-				updateUICSS( css );
-				document.getElementById( 'frm_theme_css' ).value = themeVal;
-				return false;
-			}).trigger( 'change' );
 
 			jQuery( '.frm_image_preview_wrapper' ).on( 'click', '.frm_choose_image_box', addImageToOption );
 			jQuery( '.frm_image_preview_wrapper' ).on( 'click', '.frm_remove_image_option', removeImageFromOption );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3254
Also requires https://github.com/Strategy11/formidable-pro/pull/3305

Since the theme selector is a pro-only feature I've also moved all of the JavaScript events out and put them into the newer pro style-settings.js file.