### PR TITLE
Add backslashed if conditional to switch_field_ids function

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1304,16 +1304,18 @@ class FrmFieldsHelper {
 			$replace_with[] = '[if ' . $new . ' ';
 			$replace[]      = '[/if ' . $old . ']';
 			$replace_with[] = '[/if ' . $new . ']';
+			$replace[]      = '[\/if ' . $old . ']';
+			$replace_with[] = '[\/if ' . $new . ']';
 			$replace[]      = '[foreach ' . $old . ']';
 			$replace_with[] = '[foreach ' . $new . ']';
 			$replace[]      = '[/foreach ' . $old . ']';
 			$replace_with[] = '[/foreach ' . $new . ']';
+			$replace[]      = '[\/foreach ' . $old . ']';
+			$replace_with[] = '[\/foreach ' . $new . ']';
 			$replace[]      = '[' . $old . ']';
 			$replace_with[] = '[' . $new . ']';
 			$replace[]      = '[' . $old . ' ';
 			$replace_with[] = '[' . $new . ' ';
-			$replace[]      = '[\/if ' . $old . ']';
-			$replace_with[] = '[\/if ' . $new . ']';
 			unset( $old, $new );
 		}
 		if ( is_array( $val ) ) {

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -840,9 +840,9 @@ class FrmFieldsHelper {
 			return null;
 		}
 
-		if ( isset( $atts['show'] ) && $atts['show'] == 'field_label' ) {
+		if ( isset( $atts['show'] ) && $atts['show'] === 'field_label' ) {
 			$replace_with = $field->name;
-		} elseif ( isset( $atts['show'] ) && $atts['show'] == 'description' ) {
+		} elseif ( isset( $atts['show'] ) && $atts['show'] === 'description' ) {
 			$replace_with = $field->description;
 		} else {
 			$replace_with = FrmEntryMeta::get_meta_value( $atts['entry'], $field->id );
@@ -1312,6 +1312,8 @@ class FrmFieldsHelper {
 			$replace_with[] = '[' . $new . ']';
 			$replace[]      = '[' . $old . ' ';
 			$replace_with[] = '[' . $new . ' ';
+			$replace[]      = '[\/if ' . $old . ']';
+			$replace_with[] = '[\/if ' . $new . ']';
 			unset( $old, $new );
 		}
 		if ( is_array( $val ) ) {

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -840,9 +840,9 @@ class FrmFieldsHelper {
 			return null;
 		}
 
-		if ( isset( $atts['show'] ) && $atts['show'] === 'field_label' ) {
+		if ( isset( $atts['show'] ) && $atts['show'] == 'field_label' ) {
 			$replace_with = $field->name;
-		} elseif ( isset( $atts['show'] ) && $atts['show'] === 'description' ) {
+		} elseif ( isset( $atts['show'] ) && $atts['show'] == 'description' ) {
 			$replace_with = $field->description;
 		} else {
 			$replace_with = FrmEntryMeta::get_meta_value( $atts['entry'], $field->id );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3303

The issue isn't too crazy. It just has to replace `[\/if 4938]`. Since the post content can be in JSON objects now it can be backslashed.