### PR TITLE
Remove phpcs ignore from FrmFieldCombo

### DIFF
--- a/classes/models/fields/FrmFieldCombo.php
+++ b/classes/models/fields/FrmFieldCombo.php
@@ -339,13 +339,12 @@ class FrmFieldCombo extends FrmFieldType {
 	protected function print_input_atts( $args ) {
 		$field     = $args['field'];
 		$sub_field = $args['sub_field'];
-		$atts      = array();
 
 		// Placeholder.
 		if ( in_array( 'placeholder', $sub_field['options'], true ) ) {
 			$placeholders = FrmField::get_option( $field, 'placeholder' );
 			if ( ! empty( $placeholders[ $sub_field['name'] ] ) ) {
-				$atts[] = 'placeholder="' . esc_attr( $placeholders[ $sub_field['name'] ] ) . '"';
+				$field['placeholder'] = $placeholders[ $sub_field['name'] ];
 			}
 		}
 
@@ -370,11 +369,9 @@ class FrmFieldCombo extends FrmFieldType {
 		// Print custom attributes.
 		if ( ! empty( $sub_field['atts'] ) && is_array( $sub_field['atts'] ) ) {
 			foreach ( $sub_field['atts'] as $att_name => $att_value ) {
-				$atts[] = esc_attr( trim( $att_name ) ) . '="' . esc_attr( trim( $att_value ) ) . '"';
+				echo esc_attr( trim( $att_name ) ) . '="' . esc_attr( trim( $att_value ) ) . '"';
 			}
 		}
-
-		echo implode( ' ', $atts ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**


### PR DESCRIPTION
Part of https://github.com/Strategy11/formidable-pro/issues/3253

The line
```
formidable/classes/models/fields/FrmFieldCombo.php:377: echo implode( ' ', $atts ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
```

Was brought up. And I'm trying to use phpcs:ignore as little as possible now.

Getting around this is pretty easy by just doing the escaping in the loop instead. I also got rid of `$atts` as the only other use for it was for placeholder which appears to be safe just passing into `$field` and letting `do_action( 'frm_field_input_html', $field );` handle it.

Requesting your review on this @truongwp since you wrote it initially. See any issues with this update?