### PR TITLE
Fix unit tests for combo fields after removing phpcs exception

### DIFF
--- a/classes/models/fields/FrmFieldCombo.php
+++ b/classes/models/fields/FrmFieldCombo.php
@@ -369,7 +369,7 @@ class FrmFieldCombo extends FrmFieldType {
 		// Print custom attributes.
 		if ( ! empty( $sub_field['atts'] ) && is_array( $sub_field['atts'] ) ) {
 			foreach ( $sub_field['atts'] as $att_name => $att_value ) {
-				echo esc_attr( trim( $att_name ) ) . '="' . esc_attr( trim( $att_value ) ) . '"';
+				echo esc_attr( trim( $att_name ) ) . '="' . esc_attr( trim( $att_value ) ) . '" ';
 			}
 		}
 	}

--- a/tests/fields/test_FrmFieldCombo.php
+++ b/tests/fields/test_FrmFieldCombo.php
@@ -220,6 +220,9 @@ class test_FrmFieldCombo extends FrmUnitTest {
 		);
 	}
 
+	/**
+	 * @covers FrmFieldCombo::print_input_atts
+	 */
 	public function test_print_input_atts() {
 		$combo_field = new FrmFieldCombo();
 
@@ -259,7 +262,7 @@ class test_FrmFieldCombo extends FrmUnitTest {
 		);
 		$atts = ob_get_clean();
 
-		$this->assertEquals( $atts, ' class="frm-custom-class"  placeholder="First placeholder" maxlength="10" data-attr="custom-attr"' );
+		$this->assertEquals( $atts, ' placeholder="First placeholder" class="frm-custom-class"  maxlength="10" data-attr="custom-attr" ' );
 
 		$sub_field = array(
 			'name'     => 'second',


### PR DESCRIPTION
Didn't notice I broke the unit tests with https://github.com/Strategy11/formidable-forms/pull/618

The string looks slightly different (order of attributes has changed, spacing has slightly changed). Nothing big.