### PR TITLE
Add echo params to array_to_html_params and js_redirect functions

### DIFF
--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -406,7 +406,7 @@ class FrmEntriesController {
 		if ( $pagenum > $total_pages && $total_pages > 0 ) {
 			$url = add_query_arg( 'paged', $total_pages );
 			if ( headers_sent() ) {
-				echo FrmAppHelper::js_redirect( $url ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				FrmAppHelper::js_redirect( $url );
 			} else {
 				wp_redirect( esc_url_raw( $url ) );
 			}
@@ -417,7 +417,7 @@ class FrmEntriesController {
 			$message = __( 'Your import is complete', 'formidable' );
 		}
 
-		require( FrmAppHelper::plugin_path() . '/classes/views/frm-entries/list.php' );
+		require FrmAppHelper::plugin_path() . '/classes/views/frm-entries/list.php';
 	}
 
 	private static function get_delete_form_time( $form, &$errors ) {

--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -406,7 +406,7 @@ class FrmEntriesController {
 		if ( $pagenum > $total_pages && $total_pages > 0 ) {
 			$url = add_query_arg( 'paged', $total_pages );
 			if ( headers_sent() ) {
-				FrmAppHelper::js_redirect( $url );
+				FrmAppHelper::js_redirect( $url, true );
 			} else {
 				wp_redirect( esc_url_raw( $url ) );
 			}

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1022,23 +1022,36 @@ class FrmAppHelper {
 	 * @return string|void
 	 */
 	public static function array_to_html_params( $atts, $echo = false ) {
-		if ( ! $atts ) {
-			if ( ! $echo ) {
-				return '';
+		$callback = function() use ( $atts ) {
+			if ( $atts ) {
+				foreach ( $atts as $key => $value ) {
+					echo ' ' . esc_attr( $key ) . '="' . esc_attr( $value ) . '"';
+				}
 			}
-			return;
+		};
+		return self::clip( $callback, $echo );
+	}
+
+	/**
+	 * Call an echo function and either echo it or return the result as a string.
+	 *
+	 * @since 5.0.13
+	 *
+	 * @param Closure $echo_function
+	 * @param bool    $echo
+	 * @return string|void
+	 */
+	public static function clip( $echo_function, $echo = false ) {
+		if ( ! $echo ) {
+			ob_start();
 		}
+
+		$echo_function();
 
 		if ( ! $echo ) {
-			$html = '';
-			foreach ( $atts as $key => $value ) {
-				$html .= ' ' . esc_attr( $key ) . '="' . esc_attr( $value ) . '"';
-			}
-			return $html;
-		}
-
-		foreach ( $atts as $key => $value ) {
-			echo ' ' . esc_attr( $key ) . '="' . esc_attr( $value ) . '"';
+			$return = ob_get_contents();
+			ob_end_clean();
+			return $return;
 		}
 	}
 
@@ -1714,12 +1727,10 @@ class FrmAppHelper {
 	 * @return string|void
 	 */
 	public static function js_redirect( $url, $echo = false ) {
-		if ( ! $echo ) {
-			return '<script type="text/javascript">window.location="' . esc_url_raw( $url ) . '"</script>';
-		}
-		?>
-		<script type="text/javascript">window.location="<?php echo esc_url_raw( $url ); ?>"</script>
-		<?php
+		$callback = function() use ( $url ) {
+			echo '<script type="text/javascript">window.location="' . esc_url_raw( $url ) . '"</script>';
+		};
+		return FrmAppHelper::clip( $callback, $echo );
 	}
 
 	public static function get_user_id_param( $user_id ) {

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1730,7 +1730,7 @@ class FrmAppHelper {
 		$callback = function() use ( $url ) {
 			echo '<script type="text/javascript">window.location="' . esc_url_raw( $url ) . '"</script>';
 		};
-		return FrmAppHelper::clip( $callback, $echo );
+		return self::clip( $callback, $echo );
 	}
 
 	public static function get_user_id_param( $user_id ) {

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1015,17 +1015,31 @@ class FrmAppHelper {
 	 * Convert an associative array to HTML values.
 	 *
 	 * @since 4.0.02
+	 * @since 5.0.13 added $echo parameter.
+	 *
 	 * @param array $atts
-	 * @return string
+	 * @param bool  $echo
+	 * @return string|void
 	 */
-	public static function array_to_html_params( $atts ) {
-		$html = '';
-		if ( ! empty( $atts ) ) {
+	public static function array_to_html_params( $atts, $echo = false ) {
+		if ( ! $atts ) {
+			if ( ! $echo ) {
+				return '';
+			}
+			return;
+		}
+
+		if ( ! $echo ) {
+			$html = '';
 			foreach ( $atts as $key => $value ) {
 				$html .= ' ' . esc_attr( $key ) . '="' . esc_attr( $value ) . '"';
 			}
+			return $html;
 		}
-		return $html;
+
+		foreach ( $atts as $key => $value ) {
+			echo ' ' . esc_attr( $key ) . '="' . esc_attr( $value ) . '"';
+		}
 	}
 
 	/**
@@ -1692,8 +1706,20 @@ class FrmAppHelper {
 		return $ver;
 	}
 
-	public static function js_redirect( $url ) {
-		return '<script type="text/javascript">window.location="' . esc_url_raw( $url ) . '"</script>';
+	/**
+	 * @since 5.0.13 added $echo param.
+	 *
+	 * @param string $url
+	 * @param bool   $echo
+	 * @return string|void
+	 */
+	public static function js_redirect( $url, $echo = false ) {
+		if ( ! $echo ) {
+			return '<script type="text/javascript">window.location="' . esc_url_raw( $url ) . '"</script>';
+		}
+		?>
+		<script type="text/javascript">window.location="<?php echo esc_url_raw( $url ); ?>"</script>
+		<?php
 	}
 
 	public static function get_user_id_param( $user_id ) {

--- a/classes/views/frm-fields/front-end/combo-field/combo-field.php
+++ b/classes/views/frm-fields/front-end/combo-field/combo-field.php
@@ -19,27 +19,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
 
-$field       = $args['field'];
-$field_id    = $field['id'];
-$field_label = $field['name'];
-$field_value = $field['value'];
-$sub_fields  = $args['sub_fields'];
-$html_id     = $args['html_id'];
-$field_name  = $args['field_name'];
-$errors      = $args['errors'];
-
-$inputs_attrs     = $this->get_inputs_container_attrs();
-$inputs_attrs_str = '';
-foreach ( $inputs_attrs as $key => $inputs_attr ) {
-	$inputs_attrs_str .= sprintf( ' %s="%s"', esc_attr( $key ), esc_attr( $inputs_attr ) );
-}
+$field        = $args['field'];
+$field_id     = $field['id'];
+$field_label  = $field['name'];
+$field_value  = $field['value'];
+$sub_fields   = $args['sub_fields'];
+$html_id      = $args['html_id'];
+$field_name   = $args['field_name'];
+$errors       = $args['errors'];
+$inputs_attrs = $this->get_inputs_container_attrs();
 ?>
 <fieldset aria-labelledby="<?php echo esc_attr( $html_id ); ?>_label">
 	<legend class="frm_screen_reader frm_hidden">
 		<?php echo esc_html( $field_label ); ?>
 	</legend>
 
-	<div<?php echo $inputs_attrs_str; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+	<div <?php FrmAppHelper::array_to_html_params( $inputs_attrs, true ); ?>>
 		<?php
 		foreach ( $sub_fields as $name => $sub_field ) {
 			$sub_field['name'] = $name;

--- a/classes/views/frm-form-actions/_action_icon.php
+++ b/classes/views/frm-form-actions/_action_icon.php
@@ -7,13 +7,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<a href="javascript:void(0)" class="<?php echo esc_attr( $classes ); ?>"
 		data-limit="<?php echo esc_attr( $action_control->action_options['limit'] ); ?>"
 		data-actiontype="<?php echo esc_attr( $action_control->id_base ); ?>"
-		<?php
-		echo FrmAppHelper::array_to_html_params( $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		?>
+		<?php FrmAppHelper::array_to_html_params( $data, true ); ?>
 		>
 		<span class="frm-outer-circle">
 			<span class="frm-inner-circle<?php echo esc_attr( strpos( $action_control->action_options['classes'], 'frm-inverse' ) === false ? '' : ' frm-inverse' ); ?>" <?php
-				echo FrmAppHelper::array_to_html_params( $icon_atts ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				FrmAppHelper::array_to_html_params( $icon_atts, true );
 			?>>
 				<?php FrmAppHelper::icon_by_class( $action_control->action_options['classes'], $icon_atts ); ?>
 			</span>

--- a/classes/views/frm-form-actions/settings.php
+++ b/classes/views/frm-form-actions/settings.php
@@ -56,9 +56,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<li class="frm-action frm-not-installed">
 						<a href="javascript:void(0)" class="frm-single-action frm_show_upgrade">
 							<span class="frm-outer-circle">
-								<span class="frm-inner-circle" <?php
-									echo FrmAppHelper::array_to_html_params( $icon_atts ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-								?>>
+								<span class="frm-inner-circle" <?php FrmAppHelper::array_to_html_params( $icon_atts, true ); ?>>
 								<?php
 								$icon_atts = array();
 								if ( isset( $group['color'] ) ) {

--- a/classes/views/shared/form-nav.php
+++ b/classes/views/shared/form-nav.php
@@ -17,7 +17,7 @@ foreach ( $nav_items as $nav_item ) {
 				<?php FrmAppHelper::select_current_page( $nav_item['page'], $current_page, $nav_item['current'] ); ?>
 				<?php
 				if ( isset( $nav_item['atts'] ) ) {
-					echo FrmAppHelper::array_to_html_params( $nav_item['atts'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					FrmAppHelper::array_to_html_params( $nav_item['atts'], true );
 				}
 				?>>
 				<?php echo esc_html( $nav_item['label'] ); ?>


### PR DESCRIPTION
Related to https://github.com/Strategy11/formidable-pro/issues/3253

I'm trying to remove phpcs:ignore lines wherever possible. In both of these cases (array_to_html_params and js_redirect), if the function handles the echo there is no need for any phpcs:ignore line, as long as the logic is duplicated in a way that doesn't involve echoing an unescaped variable.

So with both of these I've added a new `$echo` param. I also found a line in a combo field view where this function was able to replace some logic.

This update removes 6 phpcs:ignore comments.