### PR TITLE
Set update plugins transient to object instead of null

### DIFF
--- a/classes/models/FrmAddon.php
+++ b/classes/models/FrmAddon.php
@@ -697,6 +697,12 @@ class FrmAddon {
 	}
 
 	public function manually_queue_update() {
-		set_site_transient( 'update_plugins', null );
+		$updates               = new stdClass();
+		$updates->last_checked = 0;
+		$updates->response     = array();
+		$updates->translations = array();
+		$updates->no_update    = array();
+		$updates->checked      = array();
+		set_site_transient( 'update_plugins', $updates );
 	}
 }


### PR DESCRIPTION
_I don't really know how to run this directly, this is pretty deep in EDD code, but I believe this shouldn't have any issues._

Related to https://secure.helpscout.net/conversation/1694625984/85305?folderId=4324209

If I have woocommerce installed and I run the following snippet:

```
set_site_transient( 'update_plugins', null );
```

> PHP Fatal error:  Uncaught Error: Attempt to assign property "translations" on null in /var/www/src/wp-content/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php:81
> Stack trace:
> #0 /var/www/src/wp-includes/class-wp-hook.php(305): WC_Helper_Updater::transient_update_plugins(NULL)
> #1 /var/www/src/wp-includes/plugin.php(189): WP_Hook->apply_filters(NULL, Array)
> #2 /var/www/src/wp-includes/option.php(1977): apply_filters('pre_set_site_tr...', NULL, 'update_plugins')
> #3 /var/www/src/wp-content/plugins/code-snippets/php/snippet-ops.php(446) : eval()'d code(12): set_site_transient('update_plugins', NULL)
> #4 /var/www/src/wp-content/plugins/code-snippets/php/snippet-ops.php(446): eval()
> #5 /var/www/src/wp-content/plugins/code-snippets/php/snippet-ops.php(534): execute_snippet('/*\r\n$updates   ...', 185)
> #6 /var/www/src/wp-includes/class-wp-hook.php(03): execute_active_snippets('')
> #7 /var/www/src/wp-includes/class-wp-hook.php(327): WP_Hook->apply_filters(NULL, Array)
> #8 /var/www/src/wp-includes/plugin.php(470): WP_Hook->do_action(Array)
> #9 /var/www/src/wp-settings.php(441): do_action('plugins_loaded')
> #10 /var/www/wp-config.php(73): require_once('/var/www/src/wp...')
> #11 /var/www/src/wp-load.php(55): require_once('/var/www/wp-con...')
> #12 /var/www/src/wp-admin/admin.php(34): require_once('/var/www/src/wp...')
> #13 {main}
>   thrown in /var/www/src/wp-content/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php on line 81
> [12-Nov-2021 14:28:03 UTC] PHP Notice:  is_embed was called <strong>incorrectly</strong>. Conditional query tags do not work before the query is run. Before then, they always return false. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 3.1.0.) in /var/www/src/wp-includes/functions.php on line 5663
> [12-Nov-2021 14:28:03 UTC] PHP Notice:  is_search was called <strong>incorrectly</strong>. Conditional query tags do not work before the query is run. Before then, they always return false. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 3.1.0.) in /var/www/src/wp-includes/functions.php on line 5663

However this snippet:

```
$updates               = new stdClass();
$updates->last_checked = 0;
$updates->response     = array();
$updates->translations = array();
$updates->no_update    = array();
$updates->checked      = array();
set_site_transient( 'update_plugins', $updates );
```

Runs just fine.

In woocommerce, in WC_Helper_Updater::transient_update_plugins it has this line:

```
$transient->translations = array_merge( isset( $transient->translations ) ? $transient->translations : array(), $translations );
```

There are also a few lines above that could be problematic as well:
```
if ( version_compare( $plugin['Version'], $data['version'], '<' ) ) {
	$transient->response[ $filename ] = (object) $item;
	unset( $transient->no_update[ $filename ] );
} else {
	$transient->no_update[ $filename ] = (object) $item;
	unset( $transient->response[ $filename ] );
}
```

It really expects that the transient is an object. This is really more of a bug with woocommerce expecting data that could definitely be something else, but it's something we can fix on our end.

I borrowed most of this code from WordPress, see https://developer.wordpress.org/reference/functions/wp_update_plugins/