### PR TITLE
Deprecate backend dropdown view

### DIFF
--- a/classes/views/frm-fields/back-end/dropdown-field.php
+++ b/classes/views/frm-fields/back-end/dropdown-field.php
@@ -3,36 +3,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
 
-if ( isset( $field['post_field'] ) && 'post_category' === $field['post_field'] && FrmAppHelper::pro_is_installed() ) {
-	echo FrmProPost::get_category_dropdown( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		$field,
-		array(
-			'name'     => $field_name,
-			'id'       => 'placeholder_id',
-			'location' => 'form_builder',
-		)
-	);
-} else {
-	?>
-	<select id="frm_dropdown_<?php echo esc_attr( $field['id'] ); ?>"
-		name="<?php echo esc_attr( $field_name ) . ( FrmField::is_option_true( $field, 'multiple' ) ? '[]' : '' ); ?>" <?php echo FrmField::is_option_true( $field, 'size' ) ? 'class="auto_width"' : ''; ?> <?php echo FrmField::is_option_true( $field, 'multiple' ) ? 'multiple="multiple"' : ''; ?>>
-		<?php
-		foreach ( $field['options'] as $opt_key => $opt ) {
-			$field_val = apply_filters( 'frm_field_value_saved', $opt, $opt_key, $field );
-			$opt = FrmFieldsHelper::get_label_from_array( $opt, $opt_key, $field );
-			$selected = ( $field['default_value'] === $field_val || FrmFieldsHelper::get_other_val( array( 'opt_key', 'field' ) ) ) ? ' selected="selected"' : '';
-			?>
-			<option value="<?php echo esc_attr( $field_val ); ?>"<?php echo $selected; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>><?php echo esc_html( $opt ); ?> </option>
-		<?php } ?>
-	</select>
-<?php } ?>
+$replacement = FrmAppHelper::plugin_path() . '/classes/views/frm-fields/front-end/dropdown-field.php';
+_deprecated_file( esc_html( basename( __FILE__ ) ), '5.0.13', esc_html( $replacement ) );
 
-<div class="clear"></div>
-<div class="frm-show-click frm_small_top_margin">
-	<?php if ( ! isset( $field['post_field'] ) || 'post_category' !== $field['post_field'] ) { ?>
-		<?php do_action( 'frm_add_multiple_opts_labels', $field ); ?>
-		<ul id="frm_field_<?php echo esc_attr( $field['id'] ); ?>_opts" class="frm_sortable_field_opts<?php echo ( count( $field['options'] ) > 10 ) ? ' frm_field_opts_list' : ''; ?>">
-			<?php FrmFieldsHelper::show_single_option( $field ); ?>
-		</ul>
-	<?php } ?>
-</div>
+if ( ! isset( $read_only ) ) {
+	$read_only = FrmField::get_option( $field, 'read_only' );
+}
+
+if ( ! isset( $html_id ) ) {
+	$html_id = isset( $field['html_id'] ) ? $field['html_id'] : FrmFieldsHelper::get_html_id( $field );
+}
+
+require $replacement;

--- a/classes/views/frm-fields/front-end/dropdown-field.php
+++ b/classes/views/frm-fields/front-end/dropdown-field.php
@@ -2,7 +2,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
-
 if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' && FrmAppHelper::pro_is_installed() ) {
 	echo FrmProPost::get_category_dropdown( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		$field,

--- a/classes/views/frm-fields/front-end/dropdown-field.php
+++ b/classes/views/frm-fields/front-end/dropdown-field.php
@@ -2,6 +2,7 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
+
 if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' && FrmAppHelper::pro_is_installed() ) {
 	echo FrmProPost::get_category_dropdown( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		$field,


### PR DESCRIPTION
Removes two phpcs:ignore comments by removing the code entirely since it isn't used anymore.

Tested with a snippet:

```
add_action(
	'plugins_loaded',
	function() {
		$field_object = FrmField::getOne( 326 );
		$field        = FrmFieldsHelper::setup_edit_vars( $field_object );
		$field_name   = 'item_meta[326]';
		$view = FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/dropdown-field.php';
		require $view;
		die();
	}
);
```

It renders fine by the back end view file, after I made sure that `$read_only` and `$html_id` are actually set. Otherwise, the require was throwing errors since the two views are fairly different.