### PR TITLE
Add more kses icon unit tests and an exception for svg title

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -962,13 +962,14 @@ class FrmAppHelper {
 	}
 
 	/**
-	 * @since 5.0.14
+	 * @since 5.0.13.1
 	 *
 	 * @param array $allowed_html
 	 * @return array
 	 */
 	public static function add_allowed_icon_tags( $allowed_html ) {
 		$allowed_html['svg']['data-open'] = true;
+		$allowed_html['svg']['title']     = true;
 		return $allowed_html;
 	}
 

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -355,6 +355,12 @@ class test_FrmAppHelper extends FrmUnitTest {
 
 		$icon = '<svg class="frmsvg frm_zapier_icon frm_show_upgrade" style="--primary-hover:#efefef"><use xlink:href="#frm_zapier_icon" /></svg>';
 		$this->assertEquals( $icon, FrmAppHelper::kses_icon( $icon ) );
+
+		$icon = '<svg class="frmsvg frm_more_horiz_solid_icon frm-show-inline-modal" data-open="frm-layout-classes-box" title="Toggle Options"><use xlink:href="#frm_more_horiz_solid_icon" /></svg>';
+		$this->assertEquals( $icon, FrmAppHelper::kses_icon( $icon ) );
+
+		$icon = '<svg class="frmsvg" aria-label="WordPress" style="width:90px;height:90px"><use xlink:href="#frm_wordpress_icon" /></svg>';
+		$this->assertEquals( $icon, FrmAppHelper::kses_icon( $icon ) );
 	}
 
 	/**


### PR DESCRIPTION
I looked at every call to `FrmAppHelper::icon_by_class` to make sure I wasn't missing anything this time.

Found one more missing attribute (title) getting removed.

Added a few extra unit tests as well to cover this.