### PR TITLE
Rename variable when sanitizing post content on preview

### DIFF
--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -336,21 +336,21 @@ class FrmStylesHelper {
 		if ( self::previewing_style() ) {
 
 			if ( isset( $_POST['frm_style_setting'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-				$style = new FrmStyle();
+				$frm_style = new FrmStyle();
 
 				// Sanitizing is done later.
 				$posted = wp_unslash( $_POST['frm_style_setting'] ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing
 				if ( ! is_array( $posted ) ) {
 					$posted = json_decode( $posted, true );
 					FrmAppHelper::format_form_data( $posted );
-					$settings   = $style->sanitize_post_content( $posted['frm_style_setting']['post_content'] );
+					$settings   = $frm_style->sanitize_post_content( $posted['frm_style_setting']['post_content'] );
 					$style_name = sanitize_title( $posted['style_name'] );
 				} else {
-					$settings   = $style->sanitize_post_content( $posted['post_content'] );
+					$settings   = $frm_style->sanitize_post_content( $posted['post_content'] );
 					$style_name = FrmAppHelper::get_post_param( 'style_name', '', 'sanitize_title' );
 				}
 			} else {
-				$settings   = $style->sanitize_post_content( wp_unslash( $_GET ) );
+				$settings   = $frm_style->sanitize_post_content( wp_unslash( $_GET ) );
 				$style_name = FrmAppHelper::get_param( 'style_name', '', 'get', 'sanitize_title' );
 			}
 

--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -335,8 +335,8 @@ class FrmStylesHelper {
 	public static function get_settings_for_output( $style ) {
 		if ( self::previewing_style() ) {
 
+			$frm_style = new FrmStyle();
 			if ( isset( $_POST['frm_style_setting'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-				$frm_style = new FrmStyle();
 
 				// Sanitizing is done later.
 				$posted = wp_unslash( $_POST['frm_style_setting'] ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing


### PR DESCRIPTION
I don't think this was causing issues because the variable was never accessed in this condition but it looks like `$style` was already taken as a variable name.

And it looks like I didn't declare it early enough if the get condition was being used, which is actually a bug.

Noticed this running phpstan
```
 ------ ---------------------------------------------------------------
  Line   classes/helpers/FrmStylesHelper.php
 ------ ---------------------------------------------------------------
  353    Call to an undefined method WP_Post::sanitize_post_content().
 ------ ---------------------------------------------------------------
```