### PR TITLE
Use wordpress trunk branch in phpunit workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -18,10 +18,10 @@ jobs:
       matrix:
         include:
           - php: 7.3
-            wordpress: master
+            wordpress: trunk
             multisite: 0
           - php: 7.2
-            wordpress: master
+            wordpress: trunk
             multisite: 1
 
     name: PHP ${{ matrix.php }} tests in WP ${{ matrix.wordpress }}


### PR DESCRIPTION
Seems this has one breaking test at the moment.

```
There was 1 error:

1) test_FrmStylesController::test_front_head
file_get_contents(/tmp/wordpress/src/wp-includes/js/wp-emoji-loader.min.js): failed to open stream: No such file or directory
```

I'm not totally sure when that file is ever generated but it isn't in the source code.