### PR TITLE
Support rgba in adjust brightness function

### DIFF
--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -273,6 +273,15 @@ class FrmStylesHelper {
 	public static function adjust_brightness( $hex, $steps ) {
 		$steps = max( - 255, min( 255, $steps ) );
 
+		if ( 0 === strpos( $hex, 'rgba(' ) ) {
+			$rgba                   = str_replace( ')', '', str_replace( 'rgba(', '', $hex ) );
+			list ( $r, $g, $b, $a ) = array_map( 'trim', explode( ',', $rgba ) );
+			$r                      = max( 0, min( 255, $r + $steps ) );
+			$g                      = max( 0, min( 255, $g + $steps ) );
+			$b                      = max( 0, min( 255, $b + $steps ) );
+			return 'rgba(' . $r . ',' . $g . ',' . $b . ',' . $a . ')';
+		}
+
 		// Normalize into a six character long hex string
 		$hex = str_replace( '#', '', $hex );
 		if ( strlen( $hex ) == 3 ) {

--- a/tests/styles/test_FrmStylesHelper.php
+++ b/tests/styles/test_FrmStylesHelper.php
@@ -86,6 +86,11 @@ class test_FrmStylesHelper extends FrmUnitTest {
 				'steps' => -20,
 				'end'   => '#858585',
 			),
+			array(
+				'start' => 'rgba(32,14,237,1)',
+				'steps' => 45,
+				'end'   => 'rgba(77,59,255,1)',
+			),
 		);
 
 		foreach ( $colors as $color ) {


### PR DESCRIPTION
https://secure.helpscout.net/conversation/1704392934/86079?folderId=2445391

It looks like border colors are the only setting that calls this function. It's used to calculate the color of an alt table row (zebra striped).

I missed this when I added rgba support to styles. Now I'm checking for rgba, and adjusting it if I find it.