### PR TITLE
Use css grid for spam settings and add tooltips

### DIFF
--- a/classes/views/frm-forms/settings-advanced.php
+++ b/classes/views/frm-forms/settings-advanced.php
@@ -109,19 +109,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</label>
 </p>
 
-<table class="form-table">
-	<tr>
-		<td colspan="2">
-			<label for="no_save" class="frm_inline_block">
-				<input type="checkbox" name="options[no_save]" id="no_save" value="1" <?php checked( $values['no_save'], 1 ); ?> />
-				<?php esc_html_e( 'Do not store entries submitted from this form', 'formidable' ); ?>
-			</label>
-		</td>
-	</tr>
-	<?php is_callable( 'self::render_spam_settings' ) && self::render_spam_settings( $values ); ?>
-</table>
+<p class="frm8 frm_form_field">
+	<label for="no_save" class="frm_inline_block">
+		<input type="checkbox" name="options[no_save]" id="no_save" value="1" <?php checked( $values['no_save'], 1 ); ?> />
+		<?php esc_html_e( 'Do not store entries submitted from this form', 'formidable' ); ?>
+	</label>
+</p>
 
-<?php FrmTipsHelper::pro_tip( 'get_form_settings_tip', 'p' ); ?>
+<?php
+is_callable( 'self::render_spam_settings' ) && self::render_spam_settings( $values );
+FrmTipsHelper::pro_tip( 'get_form_settings_tip', 'p' );
+?>
 
 <!--AJAX Section-->
 <h3><?php esc_html_e( 'AJAX', 'formidable' ); ?>
@@ -154,7 +152,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<label for="js_validate" class="frm_inline_block">
 				<input type="checkbox" name="options[js_validate]" id="js_validate" value="1" <?php checked( $values['js_validate'], 1 ); ?> />
 				<?php esc_html_e( 'Validate this form with javascript', 'formidable' ); ?>
-				<span class="frm_help frm_icon_font frm_tooltip_icon" title="<?php esc_attr_e( 'Required fields, email format, and number format can be checked instantly in your browser. You may want to turn this option off if you have any customizations to remove validation messages on certain fields.', 'formidable' ); ?>"></span>
+				<span class="frm_help frm_icon_font frm_tooltip_icon" title="<?php esc_attr_e( 'Required fields, email format, and number format can be checked instantly in your browser. You may want to turn this option off if you have any customizations to remove validation messages on certain fields.', 'formidable' ); ?>" data-container="body"></span>
 			</label>
 		</td>
 	</tr>

--- a/classes/views/frm-forms/spam-settings/akismet.php
+++ b/classes/views/frm-forms/spam-settings/akismet.php
@@ -3,18 +3,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
 ?>
-<tr>
-	<td colspan="2"><?php esc_html_e( 'Use Akismet to check entries for spam for', 'formidable' ); ?>
-		<select name="options[akismet]">
-			<option value="">
-				<?php esc_html_e( 'no one', 'formidable' ); ?>
-			</option>
-			<option value="1" <?php selected( $values['akismet'], 1 ); ?>>
-				<?php esc_html_e( 'everyone', 'formidable' ); ?>
-			</option>
-			<option value="logged" <?php selected( $values['akismet'], 'logged' ); ?>>
-				<?php esc_html_e( 'visitors who are not logged in', 'formidable' ); ?>
-			</option>
-		</select>
-	</td>
-</tr>
+<p class="frm6 frm_form_field frm_first">
+	<label for="frm_akismet"><?php esc_html_e( 'Use Akismet to check entries for spam for', 'formidable' ); ?></label>
+	<select id="frm_akismet" name="options[akismet]">
+		<option value="">
+			<?php esc_html_e( 'no one', 'formidable' ); ?>
+		</option>
+		<option value="1" <?php selected( $values['akismet'], 1 ); ?>>
+			<?php esc_html_e( 'everyone', 'formidable' ); ?>
+		</option>
+		<option value="logged" <?php selected( $values['akismet'], 'logged' ); ?>>
+			<?php esc_html_e( 'visitors who are not logged in', 'formidable' ); ?>
+		</option>
+	</select>
+</p>

--- a/classes/views/frm-forms/spam-settings/antispam.php
+++ b/classes/views/frm-forms/spam-settings/antispam.php
@@ -2,10 +2,15 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
+$tooltip = __( 'Generate unique tokens for validating form submissions.', 'formidable' );
+if ( FrmAppHelper::pro_is_installed() ) {
+	$tooltip .= ' ' . __( 'Uploaded files will also be validated for spam.', 'formidable' );
+}
 ?>
-<tr>
-	<td colspan="2">
+<p class="frm6 frm_form_field frm_first">
+	<label for="antispam">
 		<input id="antispam" type="checkbox" name="options[antispam]" <?php checked( $values['antispam'], 1 ); ?> value="1" />
-		<label for="antispam"><?php esc_html_e( 'Check entries for spam using JavaScript', 'formidable' ); ?></label>
-	</td>
-</tr>
+		<?php esc_html_e( 'Check entries for spam using JavaScript', 'formidable' ); ?>
+		<span class="frm_help frm_icon_font frm_tooltip_icon" title="<?php echo esc_attr( $tooltip ); ?>" data-container="body"></span>
+	</label>
+</p>

--- a/classes/views/frm-forms/spam-settings/honeypot.php
+++ b/classes/views/frm-forms/spam-settings/honeypot.php
@@ -3,13 +3,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
 ?>
-<tr>
-	<td colspan="2">
-		<label for="honeypot"><?php esc_html_e( 'Use Honeypot to check entries for spam', 'formidable' ); ?></label>
-		<select id="honeypot" name="options[honeypot]">
-			<option value="off" <?php selected( $values['honeypot'], 'off' ); ?>><?php esc_html_e( 'Off', 'formidable' ); ?></option>
-			<option value="basic" <?php selected( $values['honeypot'], 'basic' ); ?>><?php esc_html_e( 'Basic', 'formidable' ); ?></option>
-			<option value="strict" <?php selected( $values['honeypot'], 'strict' ); ?>><?php esc_html_e( 'Strict', 'formidable' ); ?></option>
-		</select>
-	</td>
-</tr>
+<p class="frm6 frm_form_field frm_first">
+	<label for="honeypot"><?php esc_html_e( 'Use Honeypot to check entries for spam', 'formidable' ); ?>
+		<span class="frm_help frm_icon_font frm_tooltip_icon" title="<?php esc_attr_e( 'Include an invisible field in your form to trick bots. Setting to strict will catch more spam but issues with autocomplete may prevent real people from submitting on some browsers.', 'formidable' ); ?>" data-container="body"></span>
+	</label>
+	<select id="honeypot" name="options[honeypot]">
+		<option value="off" <?php selected( $values['honeypot'], 'off' ); ?>><?php esc_html_e( 'Off', 'formidable' ); ?></option>
+		<option value="basic" <?php selected( $values['honeypot'], 'basic' ); ?>><?php esc_html_e( 'Basic', 'formidable' ); ?></option>
+		<option value="strict" <?php selected( $values['honeypot'], 'strict' ); ?>><?php esc_html_e( 'Strict', 'formidable' ); ?></option>
+	</select>
+</p>


### PR DESCRIPTION
The other day a ticket came up asking about the difference between honeypot and the antispam token (https://secure.helpscout.net/conversation/1709526153/86563).

We have enough information on this in our documentation at https://formidableforms.com/knowledgebase/add-spam-protection/. But if people don't check the documentation, this can be confusing. It isn't very clear what the new JavaScript token option actually is from a glance, or that it's even a token at all.

I've just added tooltips to make the plugin more educational on the topic as it isn't very straight forward. Hoping this can help avoid future tickets like that one. I also mention that file uploads can be protected with the antispam token if pro is installed only as it isn't applicable for free use, which is somewhat related to https://github.com/Strategy11/formidable-pro/issues/3260

And while I was at it, these spam settings were all in a table, which was complicating things. I never liked how the dropdowns were 100%, they need much less space. The easiest way to enforce this is using the grid classes like some of the other settings on this page are.

I ended up moving around the markup quite a bit in this process. The Akismet label wasn't in a label tag before, so now it's more accessible as well 🥳. I also added a `data-container="body"` to the JavaScript validation to avoid an issue with the tooltip losing opacity when I disable the JavaScript validation option when chat forms are active.

**Before**
<img width="932" alt="Screen Shot 2021-11-29 at 10 34 01 AM" src="https://user-images.githubusercontent.com/9134515/143886591-cd1056d7-487b-4edd-845b-eb77d0db64fd.png">

**After**
<img width="650" alt="Screen Shot 2021-11-29 at 10 31 35 AM" src="https://user-images.githubusercontent.com/9134515/143886509-515c873c-da21-4f46-9dc4-b6f9c42bcaf5.png">
<img width="497" alt="Screen Shot 2021-11-29 at 10 31 43 AM" src="https://user-images.githubusercontent.com/9134515/143886525-0a5109e1-6709-4f08-910d-409d5a45ca99.png">
<img width="518" alt="Screen Shot 2021-11-29 at 10 31 47 AM" src="https://user-images.githubusercontent.com/9134515/143886529-9cc82493-b738-443c-9052-cdebc24aa807.png">