### PR TITLE
Use tiny mce for html field descriptions

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -651,9 +651,11 @@ class FrmFormsController {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function insert_form_popup() {
-		$page = basename( FrmAppHelper::get_server_value( 'PHP_SELF' ) );
-		if ( ! in_array( $page, array( 'post.php', 'page.php', 'page-new.php', 'post-new.php' ) ) ) {
+		if ( ! self::should_insert_form_popup() ) {
 			return;
 		}
 
@@ -665,10 +667,20 @@ class FrmFormsController {
 				'label' => __( 'Insert a Form', 'formidable' ),
 			),
 		);
-
 		$shortcodes = apply_filters( 'frm_popup_shortcodes', $shortcodes );
 
-		include( FrmAppHelper::plugin_path() . '/classes/views/frm-forms/insert_form_popup.php' );
+		include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/insert_form_popup.php';
+	}
+
+	/**
+	 * @return bool
+	 */
+	private static function should_insert_form_popup() {
+		$page = basename( FrmAppHelper::get_server_value( 'PHP_SELF' ) );
+		if ( 'admin.php' === $page && FrmAppHelper::is_formidable_admin( 'edit' ) ) {
+			return true;
+		}
+		return in_array( $page, array( 'post.php', 'page.php', 'page-new.php', 'post-new.php' ), true );
 	}
 
 	public static function get_shortcode_opts() {

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -673,6 +673,10 @@ class FrmFormsController {
 	}
 
 	/**
+	 * Check the page being loaded, determine if this is a page that should include the form popup.
+	 *
+	 * @since x.x
+	 *
 	 * @return bool
 	 */
 	private static function should_insert_form_popup() {

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -670,6 +670,16 @@ class FrmFormsController {
 		$shortcodes = apply_filters( 'frm_popup_shortcodes', $shortcodes );
 
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/insert_form_popup.php';
+
+		if ( FrmAppHelper::is_form_builder_page() && ! class_exists( '_WP_Editors', false ) ) {
+			// initialize a wysiwyg so we have usable settings defined in tinyMCEPreInit.mceInit
+			require ABSPATH . WPINC . '/class-wp-editor.php';
+			?>
+			<div class="frm_hidden">
+				<?php wp_editor( '', 'frm_description_placeholder', array() ); ?>
+			</div>
+			<?php
+		}
 	}
 
 	/**
@@ -680,10 +690,10 @@ class FrmFormsController {
 	 * @return bool
 	 */
 	private static function should_insert_form_popup() {
-		$page = basename( FrmAppHelper::get_server_value( 'PHP_SELF' ) );
-		if ( 'admin.php' === $page && FrmAppHelper::is_formidable_admin( 'edit' ) ) {
+		if ( FrmAppHelper::is_form_builder_page() ) {
 			return true;
 		}
+		$page = basename( FrmAppHelper::get_server_value( 'PHP_SELF' ) );
 		return in_array( $page, array( 'post.php', 'page.php', 'page-new.php', 'post-new.php' ), true );
 	}
 

--- a/classes/views/frm-fields/back-end/html-content.php
+++ b/classes/views/frm-fields/back-end/html-content.php
@@ -16,9 +16,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 				'title'     => esc_attr__( 'Toggle Options', 'formidable' ),
 			)
 		);
+		$e_args  = array(
+			'textarea_name' => 'field_options[description_' . absint( $field['id'] ) . ']',
+			'textarea_rows' => 8,
+		);
+		$html_id = 'frm_description_' . absint( $field['id'] );
+		wp_editor( $field['description'], $html_id, $e_args );
 		?>
-		<textarea name="field_options[description_<?php echo absint( $field['id'] ); ?>]" id="frm_description_<?php echo esc_attr( $field['id'] ); ?>" rows="8"><?php
-		echo FrmAppHelper::esc_textarea( $field['description'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		?></textarea>
 	</span>
 </p>

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6015,6 +6015,10 @@ function frmAdminBuildJS() {
 			newSettings = Object.assign(
 				{}, orgSettings, newValues
 			);
+		if ( 'undefined' !== typeof newSettings.toolbar1 ) {
+			// the link option does not work in the modal, so exclude it.
+			newSettings.toolbar1 = newSettings.toolbar1.replace( ',wp_more', '' );
+		}
 		tinymce.init( newSettings );
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6018,12 +6018,14 @@ function frmAdminBuildJS() {
 			.on(
 				'click',
 				function() {
+					var wrap;
+
 					if ( ! hasResetTinyMce ) {
 						resetTinyMce();
 						hasResetTinyMce = true;
 					}
 
-					var wrap = document.getElementById( 'wp-' + editor.id + '-wrap' );
+					wrap = document.getElementById( 'wp-' + editor.id + '-wrap' );
 					wrap.classList.add( 'tmce-active' );
 					wrap.classList.remove( 'html-active' );
 				}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5986,6 +5986,61 @@ function frmAdminBuildJS() {
 
 		singleField.classList.remove( 'frm_hidden' );
 		document.getElementById( 'frm-options-panel-tab' ).click();
+
+		resetTinyMce();
+	}
+
+	function resetTinyMce() {
+		jQuery( '.frm-single-settings .wp-editor-area' ).each( function() {
+			var isVisible = 'undefined' !== typeof tinyMCE.editors[ this.id ] && ! tinyMCE.editors[ this.id ].isHidden();
+			if ( isVisible ) {
+				removeRichText( this.id );
+				initRichText( this.id );
+			}
+		});
+	}
+
+	function removeRichText( id ) {
+		tinymce.EditorManager.execCommand( 'mceRemoveEditor', true, id );
+	}
+
+	function initRichText( id ) {
+		var key = Object.keys( tinyMCEPreInit.mceInit )[0],
+			orgSettings = tinyMCEPreInit.mceInit[ key ],
+			newValues = {
+				selector: '#' + id,
+				body_class: orgSettings.body_class.replace( key, id ),
+				setup: setupTinyMceEventHandlers
+			},
+			newSettings = Object.assign(
+				{}, orgSettings, newValues
+			);
+		tinymce.init( newSettings );
+	}
+
+	function setupTinyMceEventHandlers( editor ) {
+		editor.on( 'Change', function() {
+			handleTinyMceChange( editor );
+		});
+	}
+
+	function handleTinyMceChange( editor ) {
+		if ( isTinyMceActive() && ! tinyMCE.activeEditor.isHidden() ) {
+			editor.targetElm.value = editor.getContent();
+			jQuery( editor.targetElm ).trigger( 'change' );
+		}
+	}
+
+	function isTinyMceActive() {
+		var activeSettings, wrapper;
+
+		activeSettings = document.querySelector( '.frm-single-settings:not(.frm_hidden)' );
+		if ( ! activeSettings ) {
+			return false;
+		}
+
+		wrapper = activeSettings.querySelector( '.wp-editor-wrap' );
+		return null !== wrapper && wrapper.classList.contains( 'tmce-active' );
 	}
 
 	/**


### PR DESCRIPTION
Figured I'd give a go at this Sprint item https://app.asana.com/0/1201149924118706/1201160282718496

HTML fields are a free plugin thing and nothing here requires the paid plugin so I put everything here. If we want to move it and call it a more premium feature of HTML fields, let me know!

I also needed to update `should_insert_form_popup` a bit to include the formidable builder page now.

Most of this is JavaScript copied from pro and views code. All of the weird tiny mce issues I had I've had before so things weren't too hard to figure out.

I'm also not sure if we want to address the styling at all? There isn't a lot of space here for a wysiwyg so it gets kind of squished and take up more vertical space than it really needs.
![Screen Shot 2021-11-30 at 3 19 20 PM](https://user-images.githubusercontent.com/9134515/144113871-75459f35-0024-4fdf-b3d5-36d54fe010df.png)

Or if we want to remove any of the buttons? It might be that we want to keep this a bit more simple.