### PR TITLE
Remove phpcs exceptions from textarea show_on_form_builder function

### DIFF
--- a/classes/models/fields/FrmFieldTextarea.php
+++ b/classes/models/fields/FrmFieldTextarea.php
@@ -31,18 +31,23 @@ class FrmFieldTextarea extends FrmFieldType {
 	 * @param string $name
 	 */
 	public function show_on_form_builder( $name = '' ) {
-		$size      = FrmField::get_option( $this->field, 'size' );
-		$size_html = $size ? ' style="width:' . esc_attr( $size . ( is_numeric( $size ) ? 'px' : '' ) ) . '";' : '';
+		$size = FrmField::get_option( $this->field, 'size' );
+		$max  = FrmField::get_option( $this->field, 'max' );
 
-		$max           = FrmField::get_option( $this->field, 'max' );
-		$default_value = FrmAppHelper::esc_textarea( force_balance_tags( $this->get_field_column( 'default_value' ) ) );
+		if ( is_numeric( $size ) ) {
+			$size .= 'px';
+		}
 
-		echo '<textarea name="' . esc_attr( $this->html_name( $name ) ) . '" ' . // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			$size_html // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			. ' rows="' . esc_attr( $max ) . '" ' .
-			'id="' . esc_attr( $this->html_id() ) . '" class="dyn_default_value">' .
-			$default_value // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			. '</textarea>';
+		$style = $size ? 'width:' . $size . ';' : false;
+
+		echo '<textarea name="' . esc_attr( $this->html_name( $name ) ) . '" rows="' . esc_attr( $max ) . '" id="' . esc_attr( $this->html_id() ) . '" class="dyn_default_value"';
+		if ( false !== $style ) {
+			echo ' style="' . esc_attr( $style ) . '"';
+		}
+
+		echo '>';
+		echo FrmAppHelper::esc_textarea( force_balance_tags( $this->get_field_column( 'default_value' ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '</textarea>';
 	}
 
 	protected function prepare_display_value( $value, $atts ) {

--- a/classes/models/fields/FrmFieldTextarea.php
+++ b/classes/models/fields/FrmFieldTextarea.php
@@ -34,14 +34,13 @@ class FrmFieldTextarea extends FrmFieldType {
 		$size = FrmField::get_option( $this->field, 'size' );
 		$max  = FrmField::get_option( $this->field, 'max' );
 
-		if ( is_numeric( $size ) ) {
-			$size .= 'px';
-		}
-
-		$style = $size ? 'width:' . $size . ';' : false;
-
 		echo '<textarea name="' . esc_attr( $this->html_name( $name ) ) . '" rows="' . esc_attr( $max ) . '" id="' . esc_attr( $this->html_id() ) . '" class="dyn_default_value"';
-		if ( false !== $style ) {
+
+		if ( $size ) {
+			if ( is_numeric( $size ) ) {
+				$size .= 'px';
+			}
+			$style = 'width:' . $size . ';';
 			echo ' style="' . esc_attr( $style ) . '"';
 		}
 


### PR DESCRIPTION
Looking for more opportunities to improve on https://github.com/Strategy11/formidable-pro/issues/3253

This update removes two `phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped` comments. It turns out the first one was there for no reason and was passing without the comment.

I broke it out into multiple echo statements. The big echo was making it difficult to output the style without the need for an exception, and it wasn't really escaping in the right place as it was happening after `width:`, and the semi colon is after it closes the style attribute, which looks like a bug.

Instead of setting `$default_value`, I echo at the same time that we call `FrmAppHelper::esc_textarea` so it's more clear that escaping is happening here. That's the only exception that can't be removed.