### PR TITLE
Add checks if editor actually exists in field setting

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5999,19 +5999,25 @@ function frmAdminBuildJS() {
 
 	function setUpTinyMceVisualButtonListener( fieldSettings ) {
 		var editor = fieldSettings.querySelector( '.wp-editor-area' );
-		jQuery( document ).on(
-			'click', '#' + editor.id + '-html',
-			function() {
-				editor.style.visibility = 'visible';
-				initQuickTagsButtons( fieldSettings );
-			}
-		);
+		if ( editor ) {
+			jQuery( document ).on(
+				'click', '#' + editor.id + '-html',
+				function() {
+					editor.style.visibility = 'visible';
+					initQuickTagsButtons( fieldSettings );
+				}
+			);
+		}
 	}
 
 	function setUpTinyMceHtmlButtonListener( fieldSettings ) {
 		var editor, hasResetTinyMce;
 
 		editor = fieldSettings.querySelector( '.wp-editor-area' );
+		if ( ! editor ) {
+			return;
+		}
+
 		hasResetTinyMce = false;
 
 		jQuery( '#' + editor.id + '-tmce' )
@@ -6037,7 +6043,7 @@ function frmAdminBuildJS() {
 
 		editor = fieldSettings.querySelector( '.wp-editor-area' );
 
-		if ( 'function' !== typeof window.quicktags || typeof window.QTags.instances[ editor.id ] !== 'undefined' ) {
+		if ( ! editor || 'function' !== typeof window.quicktags || typeof window.QTags.instances[ editor.id ] !== 'undefined' ) {
 			return;
 		}
 


### PR DESCRIPTION
I noticed the new rich text HTML editor logic is triggering JavaScript errors for fields that do not have a wysiwyg. Surprised this was missed to now. It doesn't seem to break anything though.

Just adding a few checks if editor is there before going further.

![Screen Shot 2021-12-09 at 11 55 39 AM](https://user-images.githubusercontent.com/9134515/145430271-a7cafd82-76a5-4b62-b570-8a648f9df027.png)