### PR TITLE
Fixes for white styles on dark bg

### DIFF
--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -425,11 +425,16 @@ class FrmStylesHelper {
 			'fieldset_color',
 			'fieldset_bg_color',
 			'bg_color',
+			'bg_color_active',
+			'bg_color_disabled',
 			'section_bg_color',
 			'error_bg',
 			'success_bg_color',
 			'progress_bg_color',
 			'progress_active_bg_color',
+			'submit_hover_bg_color',
+			'submit_active_bg_color',
+			'success_bg_color',
 		);
 
 		return array(

--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -222,6 +222,7 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 .<?php echo esc_html( $style_class ); ?> .chosen-container-active .chosen-choices{
 	background-color:<?php echo esc_html( $bg_color_active . $important ); ?>;
 	border-color:<?php echo esc_html( $border_color_active . $important ); ?>;
+	color: var(--text-color);
 	<?php if ( isset( $remove_box_shadow_active ) && $remove_box_shadow_active ) { ?>
 	box-shadow:none;
 	<?php } else { ?>


### PR DESCRIPTION
- allow for more transparent bg colors
- On focus, use the color set for input fields

These came up while working on this style template:
https://sandbox.formidableforms.com/demos/wp-admin/admin-ajax.php?action=frm_forms_preview&form=contact-us

Before:
Read only fields and fields with focus had a white background and black text

After:
Transparent bg is allowed for read only and fields with focus.
The active input color now overrides the theme.

This is all tested and pretty minor changes.