### PR TITLE
Add sanitize_url=1 to redirect url shortcodes on save

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -746,6 +746,7 @@ class FrmFieldsHelper {
 			$replace_with  = self::get_value_for_shortcode( $atts );
 
 			if ( $replace_with !== null ) {
+				$replace_with = self::trigger_shortcode_atts( $replace_with, $atts );
 				self::sanitize_embedded_shortcodes( compact( 'entry' ), $replace_with );
 				$content = str_replace( $shortcodes[0][ $short_key ], $replace_with, $content );
 			}
@@ -754,6 +755,36 @@ class FrmFieldsHelper {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * @param string $replace_with
+	 * @param array  $atts
+	 */
+	private static function trigger_shortcode_atts( $replace_with, $atts ) {
+		$supported_atts = array( 'sanitize', 'sanitize_url' );
+		$included_atts  = array_intersect( $supported_atts, array_keys( $atts ) );
+		foreach ( $included_atts as $included_att ) {
+			$function     = 'atts_' . $included_att;
+			$replace_with = self::$function( $replace_with, $atts );
+		}
+		return $replace_with;
+	}
+
+	/**
+	 * @param string $replace_with
+	 * @return string
+	 */
+	private static function atts_sanitize( $replace_with ) {
+		return sanitize_title_with_dashes( $replace_with );
+	}
+
+	/**
+	 * @param string $replace_with
+	 * @return string
+	 */
+	private static function atts_sanitize_url( $replace_with ) {
+		return urlencode( $replace_with );
 	}
 
 	/**

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -1654,7 +1654,7 @@ BEFORE_HTML;
 				continue;
 			}
 
-			if ( false !== strpos( $options, 'sanitize_url=' ) ) {
+			if ( false !== strpos( $options, 'sanitize_url=' ) || false !== strpos( $options, 'sanitize=' ) ) {
 				// A sanitize option is already set so leave it alone.
 				continue;
 			}

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -1627,8 +1627,18 @@ BEFORE_HTML;
 			return $url;
 		}
 
-		$shortcodes = FrmFieldsHelper::get_shortcodes( $url, $form_id );
+		$parsed = wp_parse_url( $url );
+		if ( empty( $parsed['query'] ) ) {
+			// Do nothing if no query can be detected in the url string.
+			return $url;
+		}
+
+		$original_query = $parsed['query'];
+		$query          = $parsed['query'];
+
+		$shortcodes = FrmFieldsHelper::get_shortcodes( $query, $form_id );
 		if ( empty( $shortcodes[0] ) ) {
+			// No shortcodes found, do nothing.
 			return $url;
 		}
 
@@ -1651,9 +1661,13 @@ BEFORE_HTML;
 			}
 			$new_shortcode .= ' sanitize_url=1]';
 
-			$url = str_replace( $shortcode, $new_shortcode, $url );
+			$query = str_replace( $shortcode, $new_shortcode, $query );
 		}
 
-		return $url;
+		if ( $query === $original_query ) {
+			return $url;
+		}
+
+		return str_replace( $original_query, $query, $url );
 	}
 }

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -1610,4 +1610,45 @@ BEFORE_HTML;
 			0
 		);
 	}
+
+	/**
+	 * Make sure the field shortcodes in a url always add the sanitize_url=1 option if nothing is defined.
+	 * This is to prevent some field characters like ', @, and | from being stripped from the redirect URL.
+	 *
+	 * @since 5.0.16
+	 *
+	 * @param string $url
+	 * @param int    $form_id
+	 * @return string
+	 */
+	public static function maybe_add_sanitize_url_attr( $url, $form_id ) {
+		if ( false === strpos( $url, '[' ) ) {
+			// Do nothing if no shortcodes are detected.
+			return $url;
+		}
+
+		$shortcodes = FrmFieldsHelper::get_shortcodes( $url, $form_id );
+		if ( empty( $shortcodes[0] ) ) {
+			return $url;
+		}
+
+		foreach ( $shortcodes[0] as $key => $shortcode ) {
+			$options = trim( $shortcodes[3][ $key ] );
+
+			if ( false !== strpos( $options, 'sanitize_url=' ) ) {
+				// A sanitize option is already set so leave it alone.
+				continue;
+			}
+
+			$new_shortcode = '[' . $shortcodes[2][ $key ];
+			if ( $options ) {
+				$new_shortcode .= ' ' . $options;
+			}
+			$new_shortcode .= ' sanitize_url=1]';
+
+			$url = str_replace( $shortcode, $new_shortcode, $url );
+		}
+
+		return $url;
+	}
 }

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -561,6 +561,10 @@ BEFORE_HTML;
 		if ( $possible_email_field ) {
 			$class .= ' show_frm_not_email_to';
 		}
+
+		if ( 'url' === $args['type'] ) {
+			$class .= ' frm_insert_url';
+		}
 		?>
 		<li class="<?php echo esc_attr( $class ); ?>">
 			<a href="javascript:void(0)" class="frmids frm_insert_code"

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -1635,6 +1635,11 @@ BEFORE_HTML;
 		foreach ( $shortcodes[0] as $key => $shortcode ) {
 			$options = trim( $shortcodes[3][ $key ] );
 
+			if ( in_array( $shortcodes[1][ $key ], array( 'if ' ), true ) ) {
+				// Skip if shortcodes.
+				continue;
+			}
+
 			if ( false !== strpos( $options, 'sanitize_url=' ) ) {
 				// A sanitize option is already set so leave it alone.
 				continue;

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -152,7 +152,7 @@ class FrmForm {
 
 		$form_fields = array( 'form_key', 'name', 'description', 'status', 'parent_form_id' );
 
-		$new_values = self::set_update_options( array(), $values );
+		$new_values = self::set_update_options( array(), $values, array( 'form_id' => $id ) );
 
 		foreach ( $values as $value_key => $value ) {
 			if ( $value_key && in_array( $value_key, $form_fields ) ) {
@@ -183,9 +183,12 @@ class FrmForm {
 	}
 
 	/**
+	 * @param array $new_values
+	 * @param array $values
+	 * @param array $args
 	 * @return array
 	 */
-	public static function set_update_options( $new_values, $values ) {
+	public static function set_update_options( $new_values, $values, $args = array() ) {
 		if ( ! isset( $values['options'] ) ) {
 			return $new_values;
 		}
@@ -197,6 +200,11 @@ class FrmForm {
 		$options['before_html']  = isset( $values['options']['before_html'] ) ? $values['options']['before_html'] : FrmFormsHelper::get_default_html( 'before' );
 		$options['after_html']   = isset( $values['options']['after_html'] ) ? $values['options']['after_html'] : FrmFormsHelper::get_default_html( 'after' );
 		$options['submit_html']  = ( isset( $values['options']['submit_html'] ) && '' !== $values['options']['submit_html'] ) ? $values['options']['submit_html'] : FrmFormsHelper::get_default_html( 'submit' );
+
+		if ( ! empty( $options['success_url'] ) && ! empty( $args['form_id'] ) ) {
+			$options['success_url']           = FrmFormsHelper::maybe_add_sanitize_url_attr( $options['success_url'], (int) $args['form_id'] );
+			$values['options']['success_url'] = $options['success_url'];
+		}
 
 		$options               = apply_filters( 'frm_form_options_before_update', $options, $values );
 		$options               = self::maybe_filter_form_options( $options );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6887,6 +6887,11 @@ function frmAdminBuildJS() {
 		}
 
 		element = element[0];
+		if ( ! element.closest( '#frm-insert-fields-box' ) ) {
+			// Only add sanitize_url=1 to field shortcodes.
+			return variable;
+		}
+
 		if ( ! element.parentNode.classList.contains( 'frm_insert_url' ) ) {
 			variable = variable.replace( ']', ' sanitize_url=1]' );
 		}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6875,9 +6875,23 @@ function frmAdminBuildJS() {
 				}
 			});
 		} else {
+			variable = maybeAddSanitizeUrlToShortcodeVariable( variable, element, contentBox );
 			insertContent( contentBox, variable );
 		}
 		return false;
+	}
+
+	function maybeAddSanitizeUrlToShortcodeVariable( variable, element, contentBox ) {
+		if ( 'object' !== typeof element || ! ( element instanceof jQuery ) || 'success_url' !== contentBox[0].id ) {
+			return variable;
+		}
+
+		element = element[0];
+		if ( ! element.parentNode.classList.contains( 'frm_insert_url' ) ) {
+			variable = variable.replace( ']', ' sanitize_url=1]' );
+		}
+
+		return variable;
 	}
 
 	function insertContent( contentBox, variable ) {

--- a/tests/forms/test_FrmFormsHelper.php
+++ b/tests/forms/test_FrmFormsHelper.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @group forms
+ */
+class test_FrmFormsHelper extends FrmUnitTest {
+
+	/**
+	 * @covers FrmFormsHelper::maybe_add_sanitize_url_attr
+	 */
+	public function test_maybe_add_sanitize_url_attr() {
+		$form  = $this->factory->form->create_and_get();
+		$field = $this->factory->field->create_and_get(
+			array(
+				'form_id' => $form->id,
+				'type'    => 'text',
+			)
+		);
+
+		// Test that the sanitize_url option gets added.
+		$url           = 'https://example.org/?param=[' . $field->id . ']';
+		$sanitized_url = FrmFormsHelper::maybe_add_sanitize_url_attr( $url, (int) $form->id );
+		$this->assertNotEquals( $url, $sanitized_url );
+		$this->assertEquals( 'https://example.org/?param=[' . $field->id . ' sanitize_url=1]', $sanitized_url );
+
+		// Test that a setting does not get overwritten.
+		$url           = 'https://example.org/?param=[' . $field->id . ' sanitize_url=0]';
+		$sanitized_url = FrmFormsHelper::maybe_add_sanitize_url_attr( $url, (int) $form->id );
+		$this->assertEquals( $url, $sanitized_url );
+
+		// Test that other options are preserved.
+		$url           = 'https://example.org/?param=[' . $field->id . ' show="field_label"]';
+		$sanitized_url = FrmFormsHelper::maybe_add_sanitize_url_attr( $url, (int) $form->id );
+		$this->assertNotEquals( $url, $sanitized_url );
+		$this->assertEquals( 'https://example.org/?param=[' . $field->id . ' show="field_label" sanitize_url=1]', $sanitized_url );
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/830

This update does a few things:

1. When you click to insert a field shortcode, if the field is not a URL type, the sanitize_url=1 option is injected automatically.
2. On save, if there are shortcodes detected in the success_url URL params, I add in the `sanitize_url=1` option. This way they get caught even if you didn't use the pop up.
3. Added support for sanitize_url and sanitize shortcode options when replacing shortcodes in the free plugin.

**Before saving**
![Screen Shot 2021-12-17 at 1 18 27 PM](https://user-images.githubusercontent.com/9134515/146584313-1ac5f8aa-1aa2-422e-9896-9f307a6f91f5.png)

**After saving**
![Screen Shot 2021-12-17 at 1 18 31 PM](https://user-images.githubusercontent.com/9134515/146584352-45665716-dcb3-4f5a-b603-ffd715d6a5b8.png)