### PR TITLE
Add Auto Height option for the text field

### DIFF
--- a/classes/models/fields/FrmFieldTextarea.php
+++ b/classes/models/fields/FrmFieldTextarea.php
@@ -65,9 +65,10 @@ class FrmFieldTextarea extends FrmFieldType {
 		$input_html = $this->get_field_input_html_hook( $this->field );
 		$this->add_aria_description( $args, $input_html );
 		$rows = ( $this->field['max'] ) ? 'rows="' . esc_attr( $this->field['max'] ) . '" ' : '';
+		$auto_height = ( $this->field['auto_height'] ) ? 'data-auto-height="' . esc_attr( $this->field['auto_height'] ) . '" ' : '';
 
 		return '<textarea name="' . esc_attr( $args['field_name'] ) . '" id="' . esc_attr( $args['html_id'] ) . '" ' .
-			$rows . $input_html . '>' .
+			$rows . $input_html . $auto_height . '>' .
 			FrmAppHelper::esc_textarea( $this->field['value'] ) .
 			'</textarea>';
 	}

--- a/classes/models/fields/FrmFieldTextarea.php
+++ b/classes/models/fields/FrmFieldTextarea.php
@@ -65,10 +65,9 @@ class FrmFieldTextarea extends FrmFieldType {
 		$input_html = $this->get_field_input_html_hook( $this->field );
 		$this->add_aria_description( $args, $input_html );
 		$rows = ( $this->field['max'] ) ? 'rows="' . esc_attr( $this->field['max'] ) . '" ' : '';
-		$auto_height = ( $this->field['auto_height'] ) ? 'data-auto-height="' . esc_attr( $this->field['auto_height'] ) . '" ' : '';
 
 		return '<textarea name="' . esc_attr( $args['field_name'] ) . '" id="' . esc_attr( $args['html_id'] ) . '" ' .
-			$rows . $input_html . $auto_height . '>' .
+			$rows . $input_html . '>' .
 			FrmAppHelper::esc_textarea( $this->field['value'] ) .
 			'</textarea>';
 	}

--- a/classes/views/frm-fields/back-end/settings.php
+++ b/classes/views/frm-fields/back-end/settings.php
@@ -58,6 +58,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php
 			}
 
+			if ( $display['auto_height'] ) {
+				?>
+				<label for="frm_auto_height_field_<?php echo esc_attr( $field['id'] ); ?>" class="frm_inline_label frm_help" title="<?php esc_attr_e( 'Auto Height: Automatically expand the height of the field when the text reaches the maximum rows', 'formidable' ); ?>" >
+					<input type="checkbox" id="frm_auto_height_field_<?php echo esc_attr( $field['id'] ); ?>" name="field_options[auto_height_<?php echo esc_attr( $field['id'] ); ?>]" value="1" <?php checked( $field['auto_height'], 1 ); ?>/>
+					<?php esc_html_e( 'Auto Height', 'formidable' ); ?>
+				</label>
+				<?php
+			}
 			do_action( 'frm_field_options_form_top', $field, $display, $values );
 			?>
 		</p>


### PR DESCRIPTION
This PR is linked to https://github.com/Strategy11/formidable-pro/pull/3351 that adds the `Auto Height` field for TextArea