### PR TITLE
Do not set data-message if it is empty

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1852,8 +1852,22 @@ class FrmFieldsHelper {
 			}
 		}
 
+		$li_params = array(
+			'class'         => 'frmbutton frm6 ' . $args['no_allow_class'] . $single_no_allow . ' frm_t' . str_replace( '|', '-', $field_key ),
+			'id'            => $field_key,
+			'data-upgrade'  => $upgrade_label,
+			'data-link'     => $link,
+			'data-medium'   => 'builder',
+			'data-oneclick' => $install_data,
+			'data-content'  => $field_key,
+			'data-requires' => $requires,
+		);
+
+		if ( $upgrade_message ) {
+			$li_params['data-message'] = $upgrade_message;
+		}
 		?>
-		<li class="frmbutton frm6 <?php echo esc_attr( $args['no_allow_class'] . $single_no_allow . ' frm_t' . str_replace( '|', '-', $field_key ) ); ?>" id="<?php echo esc_attr( $field_key ); ?>" data-upgrade="<?php echo esc_attr( $upgrade_label ); ?>" data-message="<?php echo esc_attr( $upgrade_message ); ?>" data-link="<?php echo esc_attr( $link ); ?>" data-medium="builder" data-oneclick="<?php echo esc_attr( $install_data ); ?>" data-content="<?php echo esc_attr( $field_key ); ?>" data-requires="<?php echo esc_attr( $requires ); ?>">
+		<li <?php FrmAppHelper::array_to_html_params( $li_params, true ); ?>>
 		<?php
 		if ( $run_filter ) {
 			$field_label = apply_filters( 'frmpro_field_links', $field_label, $args['id'], $field_key );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3354

It looks like back in January 2020 there was a commit https://github.com/Strategy11/formidable-forms/commit/81d916fa94cd6b8555a903f4d6af6fcdddd4f52d

That added the `data-message` in always. Before, it was never there. So it looks like it was broken one way (it was never appearing), and then broken another way (always appearing).

That line of code is really long. I broke it up into an array and I'm calling `FrmAppHelper::array_to_html_params` now. I've kept the JavaScript the same.