### PR TITLE
Do not skip required inline datepicker in js required check

### DIFF
--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -385,7 +385,7 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 .<?php echo esc_html( $style_class ); ?> .frm_blank_field input[type=email],
 .<?php echo esc_html( $style_class ); ?> .frm_blank_field textarea,
 .<?php echo esc_html( $style_class ); ?> .frm_blank_field .mce-edit-area iframe,
-.<?php echo esc_html( $style_class ); ?> .frm_blank_field select,
+.<?php echo esc_html( $style_class ); ?> .frm_blank_field select:not(.ui-datepicker-month):not(.ui-datepicker-year),
 .frm_form_fields_error_style,
 .<?php echo esc_html( $style_class ); ?> .frm_blank_field .frm-g-recaptcha iframe,
 .<?php echo esc_html( $style_class ); ?> .frm_blank_field .g-recaptcha iframe,

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -348,7 +348,7 @@ function frmFrontFormJS() {
 	}
 
 	function isInlineDatepickerField( field ) {
-		return 'hidden' === field.type && '_alt' === field.id.substr( -4 ) && hasClass( field.nextElementSibling, 'frm_date_inline' );
+		return 'hidden' === field.type && 'string' === typeof field.id && '_alt' === field.id.substr( -4 ) && hasClass( field.nextElementSibling, 'frm_date_inline' );
 	}
 
 	function getFileVals( fileID ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -348,7 +348,7 @@ function frmFrontFormJS() {
 	}
 
 	function isInlineDatepickerField( field ) {
-		return 'hidden' === field.type && 'string' === typeof field.id && '_alt' === field.id.substr( -4 ) && hasClass( field.nextElementSibling, 'frm_date_inline' );
+		return 'hidden' === field.type && '_alt' === field.id.substr( -4 ) && hasClass( field.nextElementSibling, 'frm_date_inline' );
 	}
 
 	function getFileVals( fileID ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -262,7 +262,7 @@ function frmFrontFormJS() {
 			fieldID = '',
 			fileID = field.getAttribute( 'data-frmfile' );
 
-		if ( field.type === 'hidden' && fileID === null && ! hasClass( field, 'ssa_appointment_form_field_appointment_id' ) ) {
+		if ( field.type === 'hidden' && fileID === null && ! isAppointmentField( field ) && ! isInlineDatepickerField( field ) ) {
 			return errors;
 		}
 
@@ -341,6 +341,14 @@ function frmFrontFormJS() {
 	function isSignatureField( field ) {
 		var name = field.getAttribute( 'name' );
 		return 'string' === typeof name && '[typed]' === name.substr( -7 );
+	}
+
+	function isAppointmentField( field ) {
+		return hasClass( field, 'ssa_appointment_form_field_appointment_id' );
+	}
+
+	function isInlineDatepickerField( field ) {
+		return 'hidden' === field.type && '_alt' === field.id.substr( -4 ) && hasClass( field.nextElementSibling, 'frm_date_inline' );
 	}
 
 	function getFileVals( fileID ) {


### PR DESCRIPTION
Part of https://github.com/Strategy11/formidable-dates/pull/68

On its own it will validate and properly prevent the page from submitting but requires https://github.com/Strategy11/formidable-dates/pull/68 for an error message to be displayed.

One funny thing I was also noticing was that the error border styling happens on the month/year pickers.

![Screen Shot 2021-12-28 at 1 08 39 PM](https://user-images.githubusercontent.com/9134515/147590144-2f36bc93-abd8-4755-ac48-b20aa3576385.png)

We have this style set
![Screen Shot 2021-12-28 at 1 09 04 PM](https://user-images.githubusercontent.com/9134515/147590172-07a813be-f46c-4b4f-84fd-028b97a26e55.png)

So I added some `:not` rules to the theming so it avoids those.