### PR TITLE
Add a fallback for ctype xdigit

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3249,6 +3249,22 @@ class FrmAppHelper {
 	}
 
 	/**
+	 * Returns true if every character in text is a hexadecimal 'digit', that is a decimal digit or a character from [A-Fa-f], false otherwise.
+	 * Not every server installs the ctype extension, so use a fallback if the function does not exist.
+	 *
+	 * @since 5.0.17
+	 *
+	 * @param string $text
+	 * @return bool
+	 */
+	public static function ctype_xdigit( $text ) {
+		if ( function_exists( 'ctype_xdigit' ) ) {
+			return ctype_xdigit( $text );
+		}
+		return is_string( $text ) && '' !== $text && ! preg_match( '/[^A-Fa-f0-9]/', $text );
+	}
+
+	/**
 	 * @since 4.07
 	 * @deprecated 4.09.01
 	 */

--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -185,8 +185,8 @@ class FrmTableHTMLGenerator {
 	private function get_color_markup( $color_markup ) {
 		$color_markup = trim( $color_markup );
 
-		//check if each character in string is valid hex digit
-		if ( ctype_xdigit( $color_markup ) ) {
+		// Check if each character in string is valid hex digit
+		if ( FrmAppHelper::ctype_xdigit( $color_markup ) ) {
 			$color_markup = '#' . $color_markup;
 		}
 

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -538,4 +538,16 @@ class test_FrmAppHelper extends FrmUnitTest {
 		$this->assertTrue( strlen( $unique_key ) <= 70 );
 		$this->assertNotEquals( $super_long_form_key, $unique_key );
 	}
+
+	/**
+	 * @covers FrmAppHelper::ctype_xdigit
+	 */
+	public function test_ctype_xdigit() {
+		$this->assertTrue( FrmAppHelper::ctype_xdigit( 'fff' ) );
+		$this->assertTrue( FrmAppHelper::ctype_xdigit( 'a1a1a1' ) );
+		$this->assertTrue( FrmAppHelper::ctype_xdigit( 'FFF' ) );
+		$this->assertFalse( FrmAppHelper::ctype_xdigit( 'fgf' ) );
+		$this->assertFalse( FrmAppHelper::ctype_xdigit( 'z1z1z1' ) );
+		$this->assertFalse( FrmAppHelper::ctype_xdigit( 'FGF' ) );
+	}
 }


### PR DESCRIPTION
We had this ticket come up about a month ago for it, it’s not very common but it happens. It seems common with upgrades to PHP 7.4. The "fix" is install ctype, but I'd like to avoid the errors in the first place since it isn't difficult to.
https://secure.helpscout.net/conversation/1727655661/87904/

I was looking over the Symfony components the other day and noticed that they have polyfills for these functions as it seems to be pretty likely that they may not be available on every server.

I took this function from there (https://github.com/symfony/polyfill-ctype/blob/main/Ctype.php) but I left out the part that calls "convert_int_to_char_for_ctype", we only use this on strings so I don't think this is important in our use case.

It looks like it happens in other plugins quite often, you can find tickets all over the place when you google for this issue. Our customers often don't know how to fix an issue like this, and end up having to come to multiple support teams to solve the issue.
Happening in WPML support https://wpml.org/forums/topic/fatal-error-call-to-undefined-function-ctype_alpha/
Happening in Jetpack support https://wordpress.org/support/topic/problem-upgradng-to-php-7-4/

We only use a ctype function here in one place, which is sort of surprising. PHP recommends using them since they are faster (they use c functions) over functions like is_string so it may be worth adding more of these helper functions as well (though the extra overhead might outweigh it at that point).