### PR TITLE
Update bootstrap multiselect

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2934,9 +2934,11 @@ class FrmAppHelper {
 
 	/**
 	 * Output HTML containing reference text for accessibility
+	 *
+	 * @deprecated x.x
 	 */
 	public static function multiselect_accessibility() {
-		include_once self::plugin_path() . '/classes/views/frm-forms/multiselect-accessibility.php';
+		_deprecated_function( __METHOD__, 'x.x' );
 	}
 
 	public static function get_menu_icon_class() {

--- a/classes/views/frm-forms/form.php
+++ b/classes/views/frm-forms/form.php
@@ -64,4 +64,3 @@ if ( ! defined( 'ABSPATH' ) ) {
 </div>
 <?php
 FrmFieldsHelper::bulk_options_overlay();
-FrmAppHelper::multiselect_accessibility();

--- a/classes/views/frm-forms/multiselect-accessibility.php
+++ b/classes/views/frm-forms/multiselect-accessibility.php
@@ -2,9 +2,4 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
-?>
-<div class="hidden">
-	<div id="frm_press_space_checked"><?php esc_html_e( 'Checked. To uncheck this option, press Space or Enter', 'formidable' ); ?></div>
-	<div id="frm_press_space_unchecked"><?php esc_html_e( 'Unchecked. To check this option, press Space or Enter', 'formidable' ); ?></div>
-	<div id="frm_multiselect_button"><?php esc_html_e( 'You are on a Custom List of Checkboxes. To open, press Enter. Use Up and Down arrow keys to switch between options', 'formidable' ); ?></div>
-</div>
+_deprecated_file( esc_html( basename( __FILE__ ) ), 'x.x' );

--- a/classes/views/frm-forms/settings.php
+++ b/classes/views/frm-forms/settings.php
@@ -64,6 +64,3 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	</form>
 </div>
-
-<?php
-FrmAppHelper::multiselect_accessibility();

--- a/classes/views/frm-settings/permissions.php
+++ b/classes/views/frm-settings/permissions.php
@@ -14,12 +14,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 		?>
 		<tr>
 			<td class="frm_left_label">
-				<label id="for_<?php echo esc_attr( str_replace( '[]', '', $role_field_name ) ); ?>"><?php echo esc_html( $frm_role_description ); ?></label>
+				<label id="for_<?php echo esc_attr( str_replace( '[]', '', $role_field_name ) ); ?>" for="<?php echo esc_attr( $role_field_name ); ?>"><?php echo esc_html( $frm_role_description ); ?></label>
 			</td>
 			<td><?php FrmAppHelper::wp_roles_dropdown( $role_field_name, $frm_settings->$frm_role, 'multiple' ); ?></td>
 		</tr>
 	<?php } ?>
 </table>
-
-<?php
-FrmAppHelper::multiselect_accessibility();

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2889,6 +2889,7 @@ a.frm_option_icon:hover::before {
 	margin: 0;
 	padding: 0;
 	width: 100%;
+	max-width: 250px;
 }
 
 .multiselect-container button.multiselect-option {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2883,68 +2883,34 @@ a.frm_option_icon:hover::before {
 	font-family: "s11-fp" !important;
 }
 
-.multiselect-container.frm-dropdown-menu input[type=radio] {
-	display: none;
-}
-
 .multiselect-container {
 	position: absolute;
 	list-style-type: none;
 	margin: 0;
-	padding: 0
-}
-
-.multiselect-container .input-group {
-	margin: 5px
-}
-
-.multiselect-container > li {
 	padding: 0;
-	margin: 0;
+	width: 100%;
 }
 
-.multiselect-container > li > a.multiselect-all label {
-	font-weight: 700
-}
-
-.multiselect-container > li > label.multiselect-group {
-	margin: 0;
-	padding: 3px 20px;
-	height: 100%;
-	font-weight: 700
-}
-
-.frm-dropdown-menu.multiselect-container > li > a {
-	padding: 0
-}
-
-.multiselect-container > li > a > label {
-	margin: 0;
-	padding: 3px 25px;
-	height: 100%;
-	cursor: pointer;
-	font-weight: 400;
+.multiselect-container button.multiselect-option {
 	display: block;
+	width: 100%;
+	text-align: left;
+	background: none;
+	border: none;
+	padding: 5px 0 5px 15px;
 }
 
-.accordion-container .multiselect-container > li > a > label {
+.multiselect-container button.multiselect-option label {
+	margin-left: 5px;
+}
+
+.accordion-container .multiselect-container label {
 	padding: 3px 19px 3px 7px;
 }
 
 .frm-btn-group.btn-group > .btn-group:nth-child(2) > .multiselect.btn {
 	border-top-left-radius: 4px;
 	border-bottom-left-radius: 4px
-}
-
-.form-inline .multiselect-container label.checkbox,
-.form-inline .multiselect-container label.radio {
-	padding: 3px 20px;
-}
-
-.form-inline .multiselect-container li a label.checkbox input[type=checkbox],
-.form-inline .multiselect-container li a label.radio input[type=radio] {
-	margin-left: -20px;
-	margin-right: 0;
 }
 
 .frm-btn-group.btn-group, .frm-btn-group.btn-group-vertical {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7609,9 +7609,9 @@ function frmAdminBuildJS() {
 			labelledBy = id && labelledBy.length ? 'aria-labelledby="' + labelledBy.attr( 'id' ) + '"' : '';
 			$select.multiselect({
 				templates: {
-					ul: '<ul class="multiselect-container frm-dropdown-menu"></ul>',
-					li: '<li><a tabindex="0"><label></label></a></li>',
-					button: '<button type="button" class="multiselect dropdown-toggle" data-toggle="dropdown" aria-describedby="frm_multiselect_button" ' + labelledBy + '><span class="multiselect-selected-text"></span> <b class="caret"></b></button>'
+					popupContainer: '<div class="multiselect-container frm-dropdown-menu"></div>',
+					option: '<button type="button" class="multiselect-option dropdown-item frm_no_style_button"></button>',
+					button: '<button type="button" class="multiselect dropdown-toggle btn" data-toggle="dropdown" aria-describedby="frm_multiselect_button" ' + labelledBy + '><span class="multiselect-selected-text"></span> <b class="caret"></b></button>'
 				},
 				buttonContainer: '<div class="btn-group frm-btn-group dropdown" />',
 				nonSelectedText: '',

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5401,7 +5401,7 @@ function frmAdminBuildJS() {
 
 	function onEveryoneOptionSelected( $select ) {
 		$select.val( '' );
-		$select.next( '.btn-group' ).find( '.multiselect-container li input[value!=""]' ).prop( 'checked', false );
+		$select.next( '.btn-group' ).find( '.multiselect-container input[value!=""]' ).prop( 'checked', false );
 	}
 
 	function unselectEveryoneOptionIfSelected( $select ) {
@@ -5409,7 +5409,7 @@ function frmAdminBuildJS() {
 			index;
 
 		if ( selectedValues === null ) {
-			$select.next( '.btn-group' ).find( '.multiselect-container li input[value=""]' ).prop( 'checked', true );
+			$select.next( '.btn-group' ).find( '.multiselect-container input[value=""]' ).prop( 'checked', true );
 			onEveryoneOptionSelected( $select );
 			return;
 		}
@@ -5418,7 +5418,7 @@ function frmAdminBuildJS() {
 		if ( index >= 0 ) {
 			selectedValues.splice( index, 1 );
 			$select.val( selectedValues );
-			$select.next( '.btn-group' ).find( '.multiselect-container li input[value=""]' ).prop( 'checked', false );
+			$select.next( '.btn-group' ).find( '.multiselect-container input[value=""]' ).prop( 'checked', false );
 		}
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8653,6 +8653,33 @@ function frmAdminBuildJS() {
 		w.off( 'beforeunload.edit-post' );
 	}
 
+	function addMultiselectLabelListener() {
+		const clickListener = ( e ) => {
+			if ( 'LABEL' !== e.target.nodeName ) {
+				return;
+			}
+
+			const labelFor = e.target.getAttribute( 'for' );
+			if ( ! labelFor ) {
+				return;
+			}
+
+			const input = document.getElementById( labelFor );
+			if ( ! input || ! input.nextElementSibling ) {
+				return;
+			}
+
+			const buttonToggle = input.nextElementSibling.querySelector( 'button.dropdown-toggle.multiselect' );
+			if ( ! buttonToggle ) {
+				return;
+			}
+
+			const triggerMultiselectClick = () => buttonToggle.click();
+			setTimeout( triggerMultiselectClick, 0 );
+		};
+		document.addEventListener( 'click', clickListener );
+	}
+
 	function maybeChangeEmbedFormMsg() {
 		var fieldId = jQuery( this ).closest( '.frm-single-settings' ).data( 'fid' );
 		var fieldItem = document.getElementById( 'frm_field_id_' + fieldId );
@@ -8983,6 +9010,8 @@ function frmAdminBuildJS() {
 
 			// prevent annoying confirmation message from WordPress
 			jQuery( 'button, input[type=submit]' ).on( 'click', removeWPUnload );
+
+			addMultiselectLabelListener();
 		},
 
 		buildInit: function() {


### PR DESCRIPTION
Bootstrap multiselect is now on version 1.1.1.

The new version is more accessible so I removed some accessibility updates I had added before that are no longer required.

Fixes https://github.com/Strategy11/formidable-pro/issues/3257
Fixes https://github.com/Strategy11/formidable-pro/issues/3394

This applies to all of the back end multiselect dropdowns. There are quite a few:

**In actions**
<img width="484" alt="Screen Shot 2022-01-19 at 11 31 16 AM" src="https://user-images.githubusercontent.com/9134515/150162776-f708ce41-6118-40f2-8124-1c68f757e9bd.png">

**Field visibility**
<img width="424" alt="Screen Shot 2022-01-19 at 11 31 02 AM" src="https://user-images.githubusercontent.com/9134515/150162895-01298d90-97ee-441a-820e-ece40e949723.png">

**Global Permissions**
<img width="598" alt="Screen Shot 2022-01-19 at 11 30 45 AM" src="https://user-images.githubusercontent.com/9134515/150162929-6b1f2f69-357d-4163-8e48-9c2fcb7708e8.png">

**Other Role Dropdowns in Form Settings**
<img width="717" alt="Screen Shot 2022-01-19 at 11 33 31 AM" src="https://user-images.githubusercontent.com/9134515/150163154-6a2f2c73-4fb6-4510-a3ce-7948a14b503d.png">

<img width="695" alt="Screen Shot 2022-01-19 at 11 33 56 AM" src="https://user-images.githubusercontent.com/9134515/150163091-18887bce-56a0-4f4d-8a09-2caf8d550745.png">