### PR TITLE
Remove old aria describedby

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7611,7 +7611,7 @@ function frmAdminBuildJS() {
 				templates: {
 					popupContainer: '<div class="multiselect-container frm-dropdown-menu"></div>',
 					option: '<button type="button" class="multiselect-option dropdown-item frm_no_style_button"></button>',
-					button: '<button type="button" class="multiselect dropdown-toggle btn" data-toggle="dropdown" aria-describedby="frm_multiselect_button" ' + labelledBy + '><span class="multiselect-selected-text"></span> <b class="caret"></b></button>'
+					button: '<button type="button" class="multiselect dropdown-toggle btn" data-toggle="dropdown" ' + labelledBy + '><span class="multiselect-selected-text"></span> <b class="caret"></b></button>'
 				},
 				buttonContainer: '<div class="btn-group frm-btn-group dropdown" />',
 				nonSelectedText: '',


### PR DESCRIPTION
Missed this when I updated bootstrap multi-select. I removed frm_multiselect_button so there's no reason to use it for `aria-describedby` anymore.