### PR TITLE
Listen for checkbox captcha

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1103,6 +1103,24 @@ function frmFrontFormJS() {
 		} while ( element.previousSibling );
 	}
 
+	/**
+	 * @since x.x
+	 */
+	function triggerEvent( element, eventType ) {
+		var event;
+
+		if ( typeof window.CustomEvent === 'function' ) {
+			event = new CustomEvent( eventType );
+		} else if ( document.createEvent ) {
+			event = document.createEvent( 'HTMLEvents' );
+			event.initEvent( eventType, false, true );
+		} else {
+			return;
+		}
+
+		element.dispatchEvent( event );
+	}
+
 	return {
 		init: function() {
 			jQuery( document ).off( 'submit.formidable', '.frm-show-form' );
@@ -1163,6 +1181,10 @@ function frmFrontFormJS() {
 				jQuery( captcha ).closest( '.frm_form_field .frm_primary_label' ).hide();
 				params.callback = function( token ) {
 					frmFrontForm.afterRecaptcha( token, formID );
+				};
+			} else {
+				params.callback = function() {
+					triggerEvent( document, 'frmCheckboxCaptcha' );
 				};
 			}
 


### PR DESCRIPTION
I noticed that a reCAPTCHA checkbox is not triggering auto-advance, but it could.

What's stopping me currently is that I can't really hook into the success event without this update.

This update adds a new triggerEvent function so we can trigger events without needing to use jQuery.

I'm not sure if it's worth adding this for checkbox reCAPTCHAs though, or if everyone is just going to use v3 from now on.

What do you think @stephywells?