### PR TITLE
Add role alert in default html

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -743,6 +743,7 @@ class FrmFieldsController {
 		$error_body   = substr( $custom_html, $start + 10, $end - $start - 10 );
 		$default_html = array(
 			'<div class="frm_error" id="frm_error_field_[key]">[error]</div>',
+			'<div class="frm_error" role="alert" id="frm_error_field_[key]">[error]</div>',
 			'<div class="frm_error">[error]</div>',
 			'<div class="frm_error" role="alert">[error]</div>',
 		);

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -744,6 +744,7 @@ class FrmFieldsController {
 		$default_html = array(
 			'<div class="frm_error" id="frm_error_field_[key]">[error]</div>',
 			'<div class="frm_error">[error]</div>',
+			'<div class="frm_error" role="alert">[error]</div>',
 		);
 
 		if ( in_array( $error_body, $default_html, true ) ) {

--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -254,8 +254,8 @@ class FrmFieldFormHtml {
 			return false;
 		}
 
-		$end = strpos( $html, '[/if error]' );
-		if ( false === $end || $end < $start ) {
+		$end = strpos( $html, '[/if error]', $start );
+		if ( false === $end ) {
 			return false;
 		}
 

--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -232,10 +232,35 @@ class FrmFieldFormHtml {
 		$error = isset( $this->pass_args['errors'][ 'field' . $this->field_id ] ) ? $this->pass_args['errors'][ 'field' . $this->field_id ] : false;
 
 		if ( ! empty( $error ) && false === strpos( $this->html, 'role="alert"' ) ) {
-			$this->html = str_replace( 'class="frm_error', 'role="alert" class="frm_error', $this->html );
+			$error_body = self::get_error_body( $this->html );
+			if ( is_string( $error_body ) && false === strpos( $error_body, 'role=' ) ) {
+				$new_error_body = preg_replace( '/class="frm_error/', 'role="alert" class="frm_error', $error_body, 1 );
+				$this->html     = str_replace( '[if error]' . $error_body . '[/if error]', '[if error]' . $new_error_body . '[/if error]', $this->html );
+			}
 		}
 
 		FrmShortcodeHelper::remove_inline_conditions( ! empty( $error ), 'error', $error, $this->html );
+	}
+
+	/**
+	 * Pull the HTML between [if error] and [/if error] shortcodes.
+	 *
+	 * @param string $html
+	 * @return string|false
+	 */
+	private static function get_error_body( $html ) {
+		$start = strpos( $html, '[if error]' );
+		if ( false === $start ) {
+			return false;
+		}
+
+		$end = strpos( $html, '[/if error]' );
+		if ( false === $end || $end < $start ) {
+			return false;
+		}
+
+		$error_body = substr( $html, $start + 10, $end - $start - 10 );
+		return $error_body;
 	}
 
 	/**

--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -230,6 +230,11 @@ class FrmFieldFormHtml {
 	private function replace_error_shortcode() {
 		$this->maybe_add_error_id();
 		$error = isset( $this->pass_args['errors'][ 'field' . $this->field_id ] ) ? $this->pass_args['errors'][ 'field' . $this->field_id ] : false;
+
+		if ( ! empty( $error ) && false === strpos( $this->html, 'role="alert"' ) ) {
+			$this->html = str_replace( 'class="frm_error', 'role="alert" class="frm_error', $this->html );
+		}
+
 		FrmShortcodeHelper::remove_inline_conditions( ! empty( $error ), 'error', $error, $this->html );
 	}
 

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -177,7 +177,7 @@ abstract class FrmFieldType {
     </$label>
     $input
     [if description]<div class="frm_description" id="frm_desc_field_[key]">[description]</div>[/if description]
-    [if error]<div class="frm_error" id="frm_error_field_[key]">[error]</div>[/if error]
+    [if error]<div class="frm_error" role="alert" id="frm_error_field_[key]">[error]</div>[/if error]
 </div>
 DEFAULT_HTML;
 

--- a/classes/views/frm-fields/front-end/combo-field/combo-field.php
+++ b/classes/views/frm-fields/front-end/combo-field/combo-field.php
@@ -80,7 +80,7 @@ $inputs_attrs = $this->get_inputs_container_attrs();
 				// Don't show individual field errors when there is a combo field error.
 				if ( ! empty( $errors ) && isset( $errors[ 'field' . $field_id . '-' . $name ] ) && ! isset( $errors[ 'field' . $field_id ] ) ) {
 					?>
-					<div class="frm_error"><?php echo esc_html( $errors[ 'field' . $field_id . '-' . $name ] ); ?></div>
+					<div class="frm_error" role="alert"><?php echo esc_html( $errors[ 'field' . $field_id . '-' . $name ] ); ?></div>
 				<?php } ?>
 			</div>
 		<?php } ?>

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -760,7 +760,7 @@ function frmFrontFormJS() {
 						jsErrors[key]
 					);
 				} else {
-					$fieldCont.append( '<div class="frm_error" id="' + id + '">' + jsErrors[key] + '</div>' );
+					$fieldCont.append( '<div class="frm_error" role="alert" id="' + id + '">' + jsErrors[key] + '</div>' );
 				}
 
 				if ( typeof describedBy === 'undefined' ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -771,6 +771,7 @@ function frmFrontFormJS() {
 				input.attr( 'aria-describedby', describedBy );
 			}
 			input.attr( 'aria-invalid', true );
+			input.attr( 'aria-describedby', id );
 
 			jQuery( document ).trigger( 'frmAddFieldError', [ $fieldCont, key, jsErrors ]);
 		}
@@ -785,6 +786,7 @@ function frmFrontFormJS() {
 		$fieldCont.removeClass( 'frm_blank_field has-error' );
 		errorMessage.remove();
 		input.attr( 'aria-invalid', false );
+		input.removeAttr( 'aria-describedby' );
 
 		if ( typeof describedBy !== 'undefined' ) {
 			describedBy = describedBy.replace( errorId, '' );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3238

- Errors in new fields now include role="alert" so they get more screen reader attention on error.
- Old fields will inject role="alert" when it replaces the [error] shortcode even if it is missing from the custom HTML.
- JavaScript side validation now includes aria-describedby on an input on error. This was happening already with PHP-side validation, but not JavaScript validation.

There are also some small tweaks in pro https://github.com/Strategy11/formidable-pro/pull/3406 to add role="alert" to total fields by default as well.