### PR TITLE
New function postToAjaxUrl

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -684,9 +684,9 @@ function frmFrontFormJS() {
 		var ajaxUrl, action, ajaxParams;
 
 		ajaxUrl = frm_js.ajax_url;
+		action = form.getAttribute( 'action' );
 
-		if ( form.getAttribute( 'action' ) ) {
-			action = form.getAttribute( 'action' );
+		if ( action ) {			
 			if ( action && 'string' === typeof action && -1 !== action.indexOf( '?action=frm_forms_preview' ) ) {
 				ajaxUrl = action.split( '?action=frm_forms_preview' )[0];
 			}

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -686,10 +686,8 @@ function frmFrontFormJS() {
 		ajaxUrl = frm_js.ajax_url;
 		action = form.getAttribute( 'action' );
 
-		if ( action ) {			
-			if ( action && 'string' === typeof action && -1 !== action.indexOf( '?action=frm_forms_preview' ) ) {
-				ajaxUrl = action.split( '?action=frm_forms_preview' )[0];
-			}
+		if ( 'string' === typeof action && -1 !== action.indexOf( '?action=frm_forms_preview' ) ) {
+			ajaxUrl = action.split( '?action=frm_forms_preview' )[0];
 		}
 
 		ajaxParams = {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -677,13 +677,21 @@ function frmFrontFormJS() {
 			object.submit();
 		};
 
-		postToAjaxUrl( data, success, error );
+		postToAjaxUrl( object, data, success, error );
 	}
 
-	function postToAjaxUrl( data, success, error ) {
-		var ajaxUrl, ajaxParams;
+	function postToAjaxUrl( form, data, success, error ) {
+		var ajaxUrl, action, ajaxParams;
 
-		ajaxUrl = frm_js.ajax_url; // TODO do not use this url.
+		ajaxUrl = frm_js.ajax_url;
+
+		if ( form.getAttribute( 'action' ) ) {
+			action = form.getAttribute( 'action' );
+			if ( action && 'string' === typeof action && -1 !== action.indexOf( '?action=frm_forms_preview' ) ) {
+				ajaxUrl = action.split( '?action=frm_forms_preview' )[0];
+			}
+		}
+
 		ajaxParams = {
 			type: 'POST',
 			url: ajaxUrl,
@@ -921,7 +929,9 @@ function frmFrontFormJS() {
 		}
 		label.append( '<span class="frm-wait"></span>' );
 
+		form = document.getElementById( 'frm_form_' + formId + '_container' ).querySelector( 'form' );
 		postToAjaxUrl(
+			form,
 			{
 				action: 'frm_entries_send_email',
 				entry_id: entryId,
@@ -1493,8 +1503,11 @@ function frmAfterRecaptcha( token ) {
 }
 
 function frmUpdateField( entryId, fieldId, value, message, num ) {
+	var form;
 	jQuery( document.getElementById( 'frm_update_field_' + entryId + '_' + fieldId + '_' + num ) ).html( '<span class="frm-loading-img"></span>' );
+	form = jQuery( document.getElementById( 'frm_field_' + fieldId + '_container' ) ).closest( 'form' ).get( 0 );
 	postToAjaxUrl(
+		form,
 		{
 			action: 'frm_entries_update_field_ajax',
 			entry_id: entryId,


### PR DESCRIPTION
This is part of https://github.com/Strategy11/formidable-pro/issues/3396

This covers every non-deprecated call that uses frm_js.ajax_url in the free plugin, which is only 3 places so this wasn't too difficult.

I've moved the call to `jQuery.ajax` into the function and cleaned this all up a bit. The shared details (that it's a POST request, that it uses the ajax url, have all been moved into the function.

The new function is pretty straight forward. The first parameter is `form`, the element of the `<form>` tag which needs to be passed to every call to this function to determine whether or not the target form is an API form or not.

In my testing, a form loaded with the API includes an action attribute that uses the ajax url, just pointed to the preview page instead. So it's easy to parse this URL and use the AJAX url already available in the HTML.

Otherwise we just fallback to the frm_js.ajax_url so it functions the same as it always did if it's not loaded by the API add on.