### PR TITLE
Only include class on dropdown option if other option

### DIFF
--- a/classes/views/frm-fields/front-end/dropdown-field.php
+++ b/classes/views/frm-fields/front-end/dropdown-field.php
@@ -23,16 +23,18 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' &&
 
 	$placeholder = FrmFieldsController::add_placeholder_to_select( $field );
 
-	$skipped = false;
-	$other_opt = false;
+	$skipped       = false;
+	$other_opt     = false;
 	$other_checked = false;
+
 	if ( empty( $field['options'] ) ) {
 		$field['options'] = array();
 	}
+
 	foreach ( $field['options'] as $opt_key => $opt ) {
 		$field_val = FrmFieldsHelper::get_value_from_array( $opt, $opt_key, $field );
-		$opt = FrmFieldsHelper::get_label_from_array( $opt, $opt_key, $field );
-		$selected = FrmAppHelper::check_selected( $field['value'], $field_val );
+		$opt       = FrmFieldsHelper::get_label_from_array( $opt, $opt_key, $field );
+		$selected  = FrmAppHelper::check_selected( $field['value'], $field_val );
 		if ( $other_opt === false ) {
 			$other_args = FrmFieldsHelper::prepare_other_input( compact( 'field', 'field_name', 'opt_key' ), $other_opt, $selected );
 			if ( FrmFieldsHelper::is_other_opt( $opt_key ) && $selected ) {
@@ -44,11 +46,24 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' &&
 			$skipped = true;
 			continue;
 		}
+
+		$option_params = array(
+			'value' => $field_val,
+		);
+		if ( $selected ) {
+			$option_params['selected'] = 'selected';
+		}
+		if ( FrmFieldsHelper::is_other_opt( $opt_key ) ) {
+			$option_params['class'] = 'frm_other_trigger';
+		}
 		?>
-		<option value="<?php echo esc_attr( $field_val ); ?>" <?php echo $selected ? ' selected="selected"' : ''; ?> class="<?php echo esc_attr( FrmFieldsHelper::is_other_opt( $opt_key ) ? 'frm_other_trigger' : '' ); ?>">
+		<option <?php FrmAppHelper::array_to_html_params( $option_params, true ); ?>>
 			<?php echo esc_html( $opt == '' ? ' ' : $opt ); ?>
 		</option>
-	<?php } ?>
+		<?php
+		unset( $option_params );
+	}
+	?>
 	</select>
 	<?php
 
@@ -57,12 +72,12 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' &&
 			array(
 				'other_opt' => $other_opt,
 				'read_only' => $read_only,
-				'checked' => $other_checked,
-				'name'    => $other_args['name'],
-				'value'   => $other_args['value'],
-				'field'   => $field,
-				'html_id' => $html_id,
-				'opt_key' => false,
+				'checked'   => $other_checked,
+				'name'      => $other_args['name'],
+				'value'     => $other_args['value'],
+				'field'     => $field,
+				'html_id'   => $html_id,
+				'opt_key'   => false,
 			)
 		);
 	}


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/1775519188/91384/

The other trigger has a special class "frm_other_trigger" but every other option in the dropdown is showing `class=""` which is a lot of unnecessary HTML getting printed to the page. 

**Before**
![image](https://user-images.githubusercontent.com/9134515/152158550-12e41045-a2bb-4186-875b-ca6757746e20.png)

**After**
![Screen Shot 2022-02-02 at 9 02 08 AM](https://user-images.githubusercontent.com/9134515/152158825-a610a843-fa92-47e8-a66c-92fbaadac53d.png)