### PR TITLE
Implode array values in prepare_esc_value function

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -859,9 +859,14 @@ DEFAULT_HTML;
 	 * If the value includes intentional entities, don't lose them.
 	 *
 	 * @since 4.03.01
+	 *
+	 * @return string
 	 */
 	protected function prepare_esc_value() {
 		$value = $this->field['value'];
+		if ( is_array( $value ) ) {
+			$value = implode( ', ', $value );
+		}
 		if ( strpos( $value, '&lt;' ) !== false ) {
 			$value = htmlentities( $value );
 		}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3408

This code only expects a string value but `$this->field['value']` is certainly not guaranteed to be an array, so I implode on the spot to avoid the error.