### PR TITLE
New filter frm saved css

### DIFF
--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -448,19 +448,31 @@ class FrmStylesController {
 		$defaults  = $frm_style->get_defaults();
 		$style     = '';
 
-		include( FrmAppHelper::plugin_path() . '/css/_single_theme.css.php' );
+		include FrmAppHelper::plugin_path() . '/css/_single_theme.css.php';
 		wp_die();
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function load_saved_css() {
 		$css = get_transient( 'frmpro_css' );
 
 		ob_start();
-		include( FrmAppHelper::plugin_path() . '/css/custom_theme.css.php' );
+		include FrmAppHelper::plugin_path() . '/css/custom_theme.css.php';
 		$output = ob_get_clean();
+		$output = self::replace_relative_url( $output );
 
-		echo self::replace_relative_url( $output ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		/**
+		 * The API needs to load font icons through a custom URL.
+		 *
+		 * @since 5.1.01
+		 *
+		 * @param string $output
+		 */
+		$output = apply_filters( 'frm_saved_css', $output );
 
+		echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		wp_die();
 	}
 


### PR DESCRIPTION
I need to add this new filter so that the API add on can overwrite the path to the fonts and use an action instead.

Because of CORS blocking the fonts need to include the `Access-Control-Allow-Origin` header but in order to do that and have it work on both Apache and Nginx (since htaccess doesn't work for both) I need to do this with PHP and serve the file afterward.

Related branch https://github.com/Strategy11/formidable-api/pull/103