### PR TITLE
Menu position should always be an integer

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -15,8 +15,11 @@ class FrmAppController {
 		add_menu_page( 'Formidable', $menu_name, 'frm_view_forms', 'formidable', 'FrmFormsController::route', self::menu_icon(), self::get_menu_position() );
 	}
 
+	/**
+	 * @return int
+	 */
 	private static function get_menu_position() {
-		return apply_filters( 'frm_menu_position', '29.3' );
+		return (int) apply_filters( 'frm_menu_position', 29 );
 	}
 
 	/**


### PR DESCRIPTION
I've switched to using the WordPress 6.0.0 beta locally.

It's logging a new deprecation.

> PHP Notice:  Function add_menu_page was called <strong>incorrectly</strong>. The seventh parameter passed to <code>add_menu_page()</code> should be an integer representing menu position. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.0.0.) in /var/www/src/wp-includes/functions.php on line 5768

I'm not totally sure why these are strings at the moment or why they are using decimals. But it looks like WordPress wants integers (non-decimal values), so I rounded down to 29 instead. Same position as before (under comments).

I looked at the last commit that changed this three years ago. It mentions that it should be "below comments" so I think the rounded value is probably fine. https://github.com/Strategy11/formidable-forms/commit/2239413a30f390b6ea85f3b6a2ecacfd4f570d6d 