### PR TITLE
Update readme for 5.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,105 +1,106 @@
 == Changelog ==
 = 5.2 =
-- New: Added a new Embed Form modal and a new Embed button that appears in the form builder and form settings pages beside Preview and Update. Now a form can be embedded into a new page or an existing page with just a few clicks.
-- Fix: A Notice was being logged that wp_enqueue_script() was called incorrectly when loading the new Widgets editor since WordPress 5.8.
-- Fix: An unexpected array value in form data would cause some text fields to break in PHP8.
-- Fix: Some AJAX calls for API loaded forms were occasionally targeting the wrong site, causing unwanted redirects.
-- Fix: Dropdown field options were including redundant class="" HTML that has been removed.
+* Increased WP version requirement to 5.2.
+* New: Added a new Embed Form modal and a new Embed button that appears in the form builder and form settings pages beside Preview and Update. Now a form can be embedded into a new page or an existing page with just a few clicks.
+* Fix: A Notice was being logged that wp_enqueue_script() was called incorrectly when loading the new Widgets editor since WordPress 5.8.
+* Fix: An unexpected array value in form data would cause some text fields to break in PHP8.
+* Fix: Some AJAX calls for API loaded forms were occasionally targeting the wrong site, causing unwanted redirects.
+* Fix: Dropdown field options were including redundant class="" HTML that has been removed.
 
 = 5.1 =
-- Updated Bootstrap Multiselect to version 1.1.1, fixing issues with the accessibility of backend multiselect dropdowns for blind users.
-- New: Inputs with errors will now add the aria-describedby attribute during JavaScript validation for more accessible errors.
-- New: Form errors will now always include the role="alert" attribute for more accessible errors. New fields will now also include role="alert" in custom field HTML.
-- New: Added a new frm_entries_column_value filter hook.
+* Updated Bootstrap Multiselect to version 1.1.1, fixing issues with the accessibility of backend multiselect dropdowns for blind users.
+* New: Inputs with errors will now add the aria-describedby attribute during JavaScript validation for more accessible errors.
+* New: Form errors will now always include the role="alert" attribute for more accessible errors. New fields will now also include role="alert" in custom field HTML.
+* New: Added a new frm_entries_column_value filter hook.
 
 = 5.0.17 =
-- The embedded CodeMirror code for compatibility with versions of WordPress before 4.9 has been removed.
-- New: The ctype PHP extension is no longer a requirement.
-- Fix: The custom CSS page would appear without any textarea on some configurations where CodeMirror may be disabled.
-- Fix: Removed padding styles from radio buttons because of a conflict with the Sensational theme.
+* The embedded CodeMirror code for compatibility with versions of WordPress before 4.9 has been removed.
+* New: The ctype PHP extension is no longer a requirement.
+* Fix: The custom CSS page would appear without any textarea on some configurations where CodeMirror may be disabled.
+* Fix: Removed padding styles from radio buttons because of a conflict with the Sensational theme.
 
 = 5.0.16 =
-- New: Field shortcodes now support sanitize_url=1 and sanitize=1 options which were previously only processed in Pro. For more information on how these options work, see https://formidableforms.com/knowledgebase/advanced/#kb-sanitize-url
-- New: The sanitize_url=1 option will now be inserted automatically when inserting most field shortcodes to a redirect url. This is to avoid issues with redirects stripping characters like ' and @ which may cause a redirect to fail in some cases.
-- New: Updated styling for radio buttons and checkboxes, with improvements to appearance on mobile devices as well.
-- New: Extended the FrmCSVExportHelper::generate_csv function so it has the option to generate a CSV file in a temporary directory, and pass along an array of meta information to most CSV filter hooks.
-- New: A new action_id variable has been added to the arguments passed to the frm_notification_attachment filter to make it easier to filter attachments by email action ID.
-- New: Added new frm_entry_formatter_class, frm_prepend_and_or_where, frm_entry_formatter_format, frm_formatted_entry_values_content, and frm_entries_show_args filter hooks.
-- New: Allow more colors in the styler to be transparent including background colors and border colors for active, hovered, and disabled inputs.
-- Fix: Selected radio buttons were appearing incorrectly when using the Twenty Twenty One theme in Chrome or Safari.
-- Fix: Radio buttons and checkboxes were appearing overlapped with labels when using the H-Code theme.
-- Fix: Field pop ups were displaying upgrade messages even for licenses that had access to the add on.
+* New: Field shortcodes now support sanitize_url=1 and sanitize=1 options which were previously only processed in Pro. For more information on how these options work, see https://formidableforms.com/knowledgebase/advanced/#kb-sanitize-url
+* New: The sanitize_url=1 option will now be inserted automatically when inserting most field shortcodes to a redirect url. This is to avoid issues with redirects stripping characters like ' and @ which may cause a redirect to fail in some cases.
+* New: Updated styling for radio buttons and checkboxes, with improvements to appearance on mobile devices as well.
+* New: Extended the FrmCSVExportHelper::generate_csv function so it has the option to generate a CSV file in a temporary directory, and pass along an array of meta information to most CSV filter hooks.
+* New: A new action_id variable has been added to the arguments passed to the frm_notification_attachment filter to make it easier to filter attachments by email action ID.
+* New: Added new frm_entry_formatter_class, frm_prepend_and_or_where, frm_entry_formatter_format, frm_formatted_entry_values_content, and frm_entries_show_args filter hooks.
+* New: Allow more colors in the styler to be transparent including background colors and border colors for active, hovered, and disabled inputs.
+* Fix: Selected radio buttons were appearing incorrectly when using the Twenty Twenty One theme in Chrome or Safari.
+* Fix: Radio buttons and checkboxes were appearing overlapped with labels when using the H-Code theme.
+* Fix: Field pop ups were displaying upgrade messages even for licenses that had access to the add on.
 
 = 5.0.15 =
-- New: Added a v3 reCAPTCHA type option and reCAPTCHA threshold slider to global reCAPTCHA settings. When using v3 the score will be compared to the threshold and marked as spam if it is lower than the threshold. The default value is 0.5. For more information on setting a score, see https://developers.google.com/recaptcha/docs/v3#interpreting_the_score
+* New: Added a v3 reCAPTCHA type option and reCAPTCHA threshold slider to global reCAPTCHA settings. When using v3 the score will be compared to the threshold and marked as spam if it is lower than the threshold. The default value is 0.5. For more information on setting a score, see https://developers.google.com/recaptcha/docs/v3#interpreting_the_score
 
 = 5.0.14 =
-- New: HTML field descriptions now use a rich text editor instead of a plain textarea.
-- New: Added a new array_separator option to entry shortcodes. This can be used with the [default-message] like [default-message array_separator="<br/>"] shortcode to change the separator used for multiple checkbox or dropdown values. It also works with the [frm-show-entry] shortcode in pro.
-- New: Added tooltips to honeypot and JavaScript token spam settings.
-- Fix: The adjusted color used for .frm-alt-table stripes was not calculating properly when the border color was set as an RGBA value in the style manager.
+* New: HTML field descriptions now use a rich text editor instead of a plain textarea.
+* New: Added a new array_separator option to entry shortcodes. This can be used with the [default-message] like [default-message array_separator="<br/>"] shortcode to change the separator used for multiple checkbox or dropdown values. It also works with the [frm-show-entry] shortcode in pro.
+* New: Added tooltips to honeypot and JavaScript token spam settings.
+* Fix: The adjusted color used for .frm-alt-table stripes was not calculating properly when the border color was set as an RGBA value in the style manager.
 
 = 5.0.13.1 =
-- Fix: Too much HTML was being stripped from filtered icons preventing the ellipses icon from opening the pop up to add layout classes.
+* Fix: Too much HTML was being stripped from filtered icons preventing the ellipses icon from opening the pop up to add layout classes.
 
 = 5.0.13 =
-- FrmAppHelper::jquery_ui_base_url and an unused dropdown view file have been deprecated.
-- Security: Back end form settings will now always filter on render when the DISALLOW_UNFILTERED_HTML constant is on.
-- Security: Added additional sanitizing when saving a custom style, added additional filtering to icons, and improved how some content is escaped.
-- New: Added a new frm_disallow_unfiltered_html filter that will always filter back form settings without having to set the DISALLOW_UNFILTERED_HTML constant.
-- New: A name field will always be used when sending comment author information to Akismet if one is set to avoid false positives that could cause another field value to possibly get sent instead.
-- Fix: When importing a grid or table view, [/if x] and [/foreach x] shortcodes were not properly being replaced.
-- Fix: Too much was being stripped from custom submit button HTML for underpriveleged users or when disallowing unfiltered html.
-- Fix: Too many calls were being made to Akismet for forms with multiple pages.
-- Fix: A conflict with WooCommerce was sometimes triggering an error when checking for addon updates.
-- Fix: The comment author information sent to Akismet was not getting set if the author information was set in a name field.
+* FrmAppHelper::jquery_ui_base_url and an unused dropdown view file have been deprecated.
+* Security: Back end form settings will now always filter on render when the DISALLOW_UNFILTERED_HTML constant is on.
+* Security: Added additional sanitizing when saving a custom style, added additional filtering to icons, and improved how some content is escaped.
+* New: Added a new frm_disallow_unfiltered_html filter that will always filter back form settings without having to set the DISALLOW_UNFILTERED_HTML constant.
+* New: A name field will always be used when sending comment author information to Akismet if one is set to avoid false positives that could cause another field value to possibly get sent instead.
+* Fix: When importing a grid or table view, [/if x] and [/foreach x] shortcodes were not properly being replaced.
+* Fix: Too much was being stripped from custom submit button HTML for underpriveleged users or when disallowing unfiltered html.
+* Fix: Too many calls were being made to Akismet for forms with multiple pages.
+* Fix: A conflict with WooCommerce was sometimes triggering an error when checking for addon updates.
+* Fix: The comment author information sent to Akismet was not getting set if the author information was set in a name field.
 
 = 5.0.12 =
-- New: When the frm_inline_submit class is added to custom Submit Button HTML if frm_inline_form is missing from the form it will now be automatically added to allow for the submit button to become inline.
-- Fix: Many Formidable addons were not properly displaying update details from the plugins page.
-- Fix: Fewer API requests will be sent to Formidable when inbox notice cached results expire and when a request results in an error.
-- Fix: Added additional validation to CSV export so it fails more gracefully when the form does not exist.
-- Fix: The style setting for Margin under Field Settings as been renamed to Bottom Margin to avoid confusion as it only updates one margin value.
+* New: When the frm_inline_submit class is added to custom Submit Button HTML if frm_inline_form is missing from the form it will now be automatically added to allow for the submit button to become inline.
+* Fix: Many Formidable addons were not properly displaying update details from the plugins page.
+* Fix: Fewer API requests will be sent to Formidable when inbox notice cached results expire and when a request results in an error.
+* Fix: Added additional validation to CSV export so it fails more gracefully when the form does not exist.
+* Fix: The style setting for Margin under Field Settings as been renamed to Bottom Margin to avoid confusion as it only updates one margin value.
 
 = 5.0.11 =
-- Fix: Required credit cards were causing an issue with JavaScript validation.
-- Fix: Empty required appointment fields were not properly validating with JavaScript.
+* Fix: Required credit cards were causing an issue with JavaScript validation.
+* Fix: Empty required appointment fields were not properly validating with JavaScript.
 
 = 5.0.10 =
-- Security: Improved how data is sanitized when previewing in the style manager.
-- Fix: Prevent a warning when trying to get inbox messages from the API when no messages are being returned.
-- Fix: The frm_alignright class was being stripped in the form builder, preventing the right alignment from appearing in the back end.
-- Fix: The frm_alignright class was causing fields to shift to the wrong row. The style definition has been updated so it will stay in the same row as other fields.
-- Fix: Required messages were not properly appearing for empty radio buttons when an other option was selected but left empty and JavaScript validation was on.
+* Security: Improved how data is sanitized when previewing in the style manager.
+* Fix: Prevent a warning when trying to get inbox messages from the API when no messages are being returned.
+* Fix: The frm_alignright class was being stripped in the form builder, preventing the right alignment from appearing in the back end.
+* Fix: The frm_alignright class was causing fields to shift to the wrong row. The style definition has been updated so it will stay in the same row as other fields.
+* Fix: Required messages were not properly appearing for empty radio buttons when an other option was selected but left empty and JavaScript validation was on.
 
 = 5.0.09 =
-- The option to check entries for spam using JavaScript is now on by default for all new forms. We recommend turning this on for older forms that may be receiving spam entries, especially forms that include file uploads. After turning this feature on, make sure to also clear any caching plugins to avoid issues with cached pages with missing tokens.
-- New: Pre-determined option data will no longer be sent to Akismet to help reduce the number of false positive results.
-- Fix: Significantly reduced the amount of memory required to load form settings for websites with fewer than 50 pages with a lot of data.
-- Fix: Author email, url, or name are no longer included in comment info when sending data to Akismet so that duplicate information is not sent.
-- Fix: Field groups could not be moved because of a missing class on the drag handle.
+* The option to check entries for spam using JavaScript is now on by default for all new forms. We recommend turning this on for older forms that may be receiving spam entries, especially forms that include file uploads. After turning this feature on, make sure to also clear any caching plugins to avoid issues with cached pages with missing tokens.
+* New: Pre-determined option data will no longer be sent to Akismet to help reduce the number of false positive results.
+* Fix: Significantly reduced the amount of memory required to load form settings for websites with fewer than 50 pages with a lot of data.
+* Fix: Author email, url, or name are no longer included in comment info when sending data to Akismet so that duplicate information is not sent.
+* Fix: Field groups could not be moved because of a missing class on the drag handle.
 
 = 5.0.08 =
-- Deprecated: Calls to FrmFormsController::preview will no longer try to load WordPress if it is not already initialized. This could cause issues for users that still use old preview links (see https://formidableforms.com/knowledgebase/php-examples/#kb-use-the-old-preview-links for an example).
-- Security: Unsafe HTML will now be stripped from global message defaults, whitelabel settings, and when importing forms and fields with XML if the user saving HTML does not have the unfiltered_html permission or if the DISALLOW_UNFILTERED_HTML constant is set.
-- Updated Bootstrap used in back end to version 3.4.1.
-- A few images that were being loaded from S3 and CDN urls are now included in the plugin instead.
+* Deprecated: Calls to FrmFormsController::preview will no longer try to load WordPress if it is not already initialized. This could cause issues for users that still use old preview links (see https://formidableforms.com/knowledgebase/php-examples/#kb-use-the-old-preview-links for an example).
+* Security: Unsafe HTML will now be stripped from global message defaults, whitelabel settings, and when importing forms and fields with XML if the user saving HTML does not have the unfiltered_html permission or if the DISALLOW_UNFILTERED_HTML constant is set.
+* Updated Bootstrap used in back end to version 3.4.1.
+* A few images that were being loaded from S3 and CDN urls are now included in the plugin instead.
 
 = 5.0.07 =
-- Security: Unsafe HTML will now be stripped from field labels, descriptions, and custom HTML, as well as form titles, descriptions, custom submit text, custom submit HTML, before HTML, after HTML, and success message if the user saving HTML does not have the unfiltered_html permission or if the DISALLOW_UNFILTERED_HTML constant is set.
-- New: Added new frm_akismet_values filter to help improve Akismet integration.
-- Fix: The Akismet API was getting called if Akismet was set up even if the form had Akismet turned off.
-- Fix: Updated the styling when a field option is being dragged and dropped.
+* Security: Unsafe HTML will now be stripped from field labels, descriptions, and custom HTML, as well as form titles, descriptions, custom submit text, custom submit HTML, before HTML, after HTML, and success message if the user saving HTML does not have the unfiltered_html permission or if the DISALLOW_UNFILTERED_HTML constant is set.
+* New: Added new frm_akismet_values filter to help improve Akismet integration.
+* Fix: The Akismet API was getting called if Akismet was set up even if the form had Akismet turned off.
+* Fix: Updated the styling when a field option is being dragged and dropped.
 
 = 5.0.06 =
-- New: Added new frm_export_csv_headings filter to make it easier to add and remove exported CSV headings.
-- New: When clicking an inactive action that requires pro, the required pro license will be properly shown in the popup.
-- New: Added new frm_fields_to_validate, frm_submit_button_html, and frm_fields_for_csv_export filters.
-- Fix: Improved the accessibility of field group dropdowns and field group row layout pop ups.
-- Fix: The caret icon on the dropdown was not positioned properly for the Formidable Gutenberg block.
-- Fix: When clicking the Formidable media button in Elementor, the pop up was appearing as empty with no content.
-- Fix: Required radio, checkbox, and name fields were not including the aria-required="true" attribute or the aria-invalid attribute when JavaScript validation was enabled.
-- Fix: Required name fields were not showing error messages when JavaScript validation was enabled.
+* New: Added new frm_export_csv_headings filter to make it easier to add and remove exported CSV headings.
+* New: When clicking an inactive action that requires pro, the required pro license will be properly shown in the popup.
+* New: Added new frm_fields_to_validate, frm_submit_button_html, and frm_fields_for_csv_export filters.
+* Fix: Improved the accessibility of field group dropdowns and field group row layout pop ups.
+* Fix: The caret icon on the dropdown was not positioned properly for the Formidable Gutenberg block.
+* Fix: When clicking the Formidable media button in Elementor, the pop up was appearing as empty with no content.
+* Fix: Required radio, checkbox, and name fields were not including the aria-required="true" attribute or the aria-invalid attribute when JavaScript validation was enabled.
+* Fix: Required name fields were not showing error messages when JavaScript validation was enabled.
 
 = 5.0.05 =
 * Deprecated the option to disable CSS Grids in form layouts.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 == Changelog ==
-= 5.1.01 =
+= 5.2 =
 - New: Added a new Embed Form modal and a new Embed button that appears in the form builder and form settings pages beside Preview and Update. Now a form can be embedded into a new page or an existing page with just a few clicks.
 - Fix: A Notice was being logged that wp_enqueue_script() was called incorrectly when loading the new Widgets editor since WordPress 5.8.
 - Fix: An unexpected array value in form data would cause some text fields to break in PHP8.

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -530,7 +530,7 @@ class FrmAppController {
 	/**
 	 * Automatically insert a Formidable block when loading Gutenberg with a $_GET['frmForm'] value set.
 	 *
-	 * @since 5.1.01
+	 * @since 5.2
 	 *
 	 * @return void
 	 */
@@ -782,7 +782,7 @@ class FrmAppController {
 	/**
 	 * Include icons on page for Embed Form modal.
 	 *
-	 * @since 5.1.01
+	 * @since 5.2
 	 *
 	 * @return void
 	 */

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2288,7 +2288,7 @@ class FrmFormsController {
 	/**
 	 * Create a page with an embedded formidable Gutenberg block.
 	 *
-	 * @since 5.1.01
+	 * @since 5.2
 	 *
 	 * @return never
 	 */

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -466,7 +466,7 @@ class FrmStylesController {
 		/**
 		 * The API needs to load font icons through a custom URL.
 		 *
-		 * @since 5.1.01
+		 * @since 5.2
 		 *
 		 * @param string $output
 		 */

--- a/readme.txt
+++ b/readme.txt
@@ -439,22 +439,23 @@ See all <a href="https://zapier.com/apps/formidable/integrations">Formidable Zap
 
 == Changelog ==
 = 5.2 =
-- New: Added a new Embed Form modal and a new Embed button that appears in the form builder and form settings pages beside Preview and Update. Now a form can be embedded into a new page or an existing page with just a few clicks.
-- Fix: A Notice was being logged that wp_enqueue_script() was called incorrectly when loading the new Widgets editor since WordPress 5.8.
-- Fix: An unexpected array value in form data would cause some text fields to break in PHP8.
-- Fix: Some AJAX calls for API loaded forms were occasionally targeting the wrong site, causing unwanted redirects.
-- Fix: Dropdown field options were including redundant class="" HTML that has been removed.
+* Increased WP version requirement to 5.2.
+* New: Added a new Embed Form modal and a new Embed button that appears in the form builder and form settings pages beside Preview and Update. Now a form can be embedded into a new page or an existing page with just a few clicks.
+* Fix: A Notice was being logged that wp_enqueue_script() was called incorrectly when loading the new Widgets editor since WordPress 5.8.
+* Fix: An unexpected array value in form data would cause some text fields to break in PHP8.
+* Fix: Some AJAX calls for API loaded forms were occasionally targeting the wrong site, causing unwanted redirects.
+* Fix: Dropdown field options were including redundant class="" HTML that has been removed.
 
 = 5.1 =
-- Updated Bootstrap Multiselect to version 1.1.1, fixing issues with the accessibility of backend multiselect dropdowns for blind users.
-- New: Inputs with errors will now add the aria-describedby attribute during JavaScript validation for more accessible errors.
-- New: Form errors will now always include the role="alert" attribute for more accessible errors. New fields will now also include role="alert" in custom field HTML.
-- New: Added a new frm_entries_column_value filter hook.
+* Updated Bootstrap Multiselect to version 1.1.1, fixing issues with the accessibility of backend multiselect dropdowns for blind users.
+* New: Inputs with errors will now add the aria-describedby attribute during JavaScript validation for more accessible errors.
+* New: Form errors will now always include the role="alert" attribute for more accessible errors. New fields will now also include role="alert" in custom field HTML.
+* New: Added a new frm_entries_column_value filter hook.
 
 = 5.0.17 =
-- The embedded CodeMirror code for compatibility with versions of WordPress before 4.9 has been removed.
-- New: The ctype PHP extension is no longer a requirement.
-- Fix: The custom CSS page would appear without any textarea on some configurations where CodeMirror may be disabled.
-- Fix: Removed padding styles from radio buttons because of a conflict with the Sensational theme.
+* The embedded CodeMirror code for compatibility with versions of WordPress before 4.9 has been removed.
+* New: The ctype PHP extension is no longer a requirement.
+* Fix: The custom CSS page would appear without any textarea on some configurations where CodeMirror may be disabled.
+* Fix: Removed padding styles from radio buttons because of a conflict with the Sensational theme.
 
 <a href="https://raw.githubusercontent.com/Strategy11/formidable-forms/master/changelog.txt">See changelog for all versions</a>

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Plugin Name: Formidable Forms - Contact Form, Survey & Quiz Forms Plugin for WordPress
 Contributors: formidableforms, sswells, srwells
 Tags: forms, contact form, form builder, survey, free, form maker, form creator, paypal form, paypal, stripe, stripe form, aweber, aweber form, getresponse, getresponse form, calculator, price calculator, quote form, contact button, form manager, Akismet, payment form, survey form, donation form, email subscription, contact form widget, user registration form, wordpress registration, wordpress login form, constant contact, mailpoet, active campaign, salesforce, hubspot, campaign monitor, quiz builder, quiz, feedback form, mailchimp form
-Requires at least: 5.0
+Requires at least: 5.2
 Tested up to: 5.9
 Requires PHP: 5.6
-Stable tag: 5.1.01
+Stable tag: 5.2
 
 The most advanced WordPress forms plugin. Go beyond contact forms with our drag & drop form builder for surveys, quizzes, and more.
 
@@ -438,7 +438,7 @@ Using our Zapier integration, you can easily connect Formidable with over 1000+ 
 See all <a href="https://zapier.com/apps/formidable/integrations">Formidable Zapier Integrations</a>.
 
 == Changelog ==
-= 5.1.01 =
+= 5.2 =
 - New: Added a new Embed Form modal and a new Embed button that appears in the form builder and form settings pages beside Preview and Update. Now a form can be embedded into a new page or an existing page with just a few clicks.
 - Fix: A Notice was being logged that wp_enqueue_script() was called incorrectly when loading the new Widgets editor since WordPress 5.8.
 - Fix: An unexpected array value in form data would cause some text fields to break in PHP8.


### PR DESCRIPTION
Changing a few extra things.

- Going with 5.2 instead of 5.1.01 so changed some version tags.
- Bumping the minimum WordPress version to 5.2 now.
- Noticed I switched from asterisks to dashes a while ago without noticing. They used to be asterisks, I change them back for consistency.