### PR TITLE
Do not call json decode on null fix

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2562,9 +2562,13 @@ class FrmAppHelper {
 	/**
 	 * Decode a JSON string.
 	 * Do not switch shortcodes like [24] to array unless intentional ie XML values.
+	 *
+	 * @param mixed $string
+	 * @param bool  $single_to_array
+	 * @return mixed
 	 */
 	public static function maybe_json_decode( $string, $single_to_array = true ) {
-		if ( is_array( $string ) ) {
+		if ( is_array( $string ) || is_null( $string ) ) {
 			return $string;
 		}
 


### PR DESCRIPTION
Noticed a PHP8+ deprecated message in this function. I'm not totally positive how I ended up with a null, I was playing with a few things.

> PHP Deprecated:  json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in /var/www/src/wp-content/plugins/formidable/classes/helpers/FrmAppHelper.php on line 2571