### PR TITLE
Phpstan rule fix - custom css void is used

### DIFF
--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -326,6 +326,9 @@ class FrmStylesController {
 		include FrmAppHelper::plugin_path() . '/classes/views/styles/custom_css.php';
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function save_css() {
 		$frm_style = new FrmStyle();
 
@@ -337,7 +340,7 @@ class FrmStylesController {
 			$message = __( 'Your styling settings have been saved.', 'formidable' );
 		}
 
-		return self::custom_css( $message );
+		self::custom_css( $message );
 	}
 
 	public static function route() {

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3289,7 +3289,7 @@ class FrmAppHelper {
 				$params['medium'] = $plugin;
 			}
 		} else {
-			$params['requires'] = FrmFormsHelper::get_plan_required( $link, false );
+			$params['requires'] = FrmFormsHelper::get_plan_required( $link );
 		}
 
 		return $params;


### PR DESCRIPTION
Running some tests with phpstan, I noticed these small issues. Easy fixes.

 ------ ---------------------------------------------------------------------------
  Line   classes/controllers/FrmStylesController.php
 ------ ---------------------------------------------------------------------------
  340    Result of static method FrmStylesController::custom_css() (void) is used.
 ------ ---------------------------------------------------------------------------

------ ------------------------------------------------------------------------------------------
  Line   classes/helpers/FrmAppHelper.php
 ------ ------------------------------------------------------------------------------------------
  3292   Static method FrmFormsHelper::get_plan_required() invoked with 2 parameters, 1 required.
 ------ ------------------------------------------------------------------------------------------