### PR TITLE
Add a PHPStan workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,6 +26,7 @@ package.json export-ignore
 phpcs.xml export-ignore
 phpunit.xml export-ignore
 psalm.stubs.php export-ignore
+phpstan.stubs.php export-ignore
 psalm.xml export-ignore
 readme.md export-ignore
 tests export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -26,8 +26,9 @@ package.json export-ignore
 phpcs.xml export-ignore
 phpunit.xml export-ignore
 psalm.stubs.php export-ignore
-phpstan.stubs.php export-ignore
 psalm.xml export-ignore
+phpstan.stubs.php export-ignore
+phpstan.neon export-ignore
 readme.md export-ignore
 tests export-ignore
 webpack.config.js export-ignore

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,17 @@
+on: [push]
+
+name: PHPStan Code Analysis
+jobs:
+  phpstan:
+    name: PHPStan
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+
+    - name: PHPStan
+      uses: docker://oskarstark/phpstan-ga
+      with:
+        args: analyse ./ --level=max

--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -56,6 +56,7 @@ zip -r $zipname $destination \
 	-x "*/phpcs.xml" \
 	-x "*/phpunit.xml" \
 	-x "*/psalm.stubs.php" \
+	-x "*/phpstan.stubs.php" \
 	-x "*/psalm.xml" \
 	-x "*/readme.md" \
 	-x "*/README.md" \

--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -56,8 +56,9 @@ zip -r $zipname $destination \
 	-x "*/phpcs.xml" \
 	-x "*/phpunit.xml" \
 	-x "*/psalm.stubs.php" \
-	-x "*/phpstan.stubs.php" \
 	-x "*/psalm.xml" \
+	-x "*/phpstan.stubs.php" \
+	-x "*/phpstan.neon" \
 	-x "*/readme.md" \
 	-x "*/README.md" \
 	-x "*/tests/*" \

--- a/classes/helpers/FrmListHelper.php
+++ b/classes/helpers/FrmListHelper.php
@@ -1148,14 +1148,6 @@ class FrmListHelper {
 
 			if ( 'cb' === $column_name ) {
 				echo '<th scope="row" class="check-column"></th>';
-			} elseif ( method_exists( $this, '_column_' . $column_name ) ) {
-				echo call_user_func( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					array( $this, '_column_' . $column_name ),
-					$item,
-					$classes,
-					$data,
-					$primary
-				);
 			} else {
 				echo '<td ';
 				FrmAppHelper::array_to_html_params( $params, true );

--- a/classes/models/FrmEntryFormatter.php
+++ b/classes/models/FrmEntryFormatter.php
@@ -701,7 +701,7 @@ class FrmEntryFormatter {
 	 *
 	 * @since 2.04
 	 *
-	 * @param FrmProFieldValue $field_value
+	 * @param FrmFieldValue $field_value
 	 * @param string $content
 	 */
 	protected function add_standard_row( $field_value, &$content ) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,10 +2,6 @@ parameters:
 	reportUnmatchedIgnoredErrors: false
 	bootstrapFiles:
 		- phpstan.stubs.php
-	scanFiles:
-		- formidable.php
-	scanDirectories:
-		- classes
 	excludePaths:
 		- */node_modules/*
 		- */tests/*
@@ -15,6 +11,7 @@ parameters:
 		- */languages/*
 		- */js/*
 		- */vendor/*
+		- */fonts/*
 	ignoreErrors:
 		- '#@return has invalid value#'
 		- '#Access to an undefined property#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,59 @@
+parameters:
+	reportUnmatchedIgnoredErrors: false
+	bootstrapFiles:
+		- phpstan.stubs.php
+	scanFiles:
+		- formidable.php
+	scanDirectories:
+		- classes
+	excludePaths:
+		- */node_modules/*
+		- */tests/*
+		- */deprecated*
+		- */bin/*
+		- */images/*
+		- */languages/*
+		- */js/*
+		- */vendor/*
+	ignoreErrors:
+		- '#@return has invalid value#'
+		- '#Access to an undefined property#'
+		- '#Call to an undefined method object::#'
+		- '#Call to an undefined static method (FrmAppHelper::compare_for_update|FrmProFormsController::add_other_option)+#'
+		- '#Call to (function is_callable|protected method)+#'
+		- '#Call to function compact\(\) contains possibly undefined variable#'
+		- '#Call to function compact\(\) contains undefined variable#'
+		- '#Call to function unset\(\) contains undefined variable#'
+		- '#Call to private static method user_shortcodes\(\) of class FrmFormsController.#'
+		- '#Cannot access (offset|property)+#'
+		- '#Cannot (call method|cast|assign offset)+#'
+		- '#Constant (COOKIEPATH|COOKIE_DOMAIN|COOKIEHASH|WP_PLUGIN_DIR|WPINC)+ not found.#'
+		- '#Else branch is unreachable#'
+		- '#Empty array passed to foreach.#'
+		- '#FrmAppHelper::is_admin\(\) invoked with 1 parameter, 0 required.#'
+		- '#FrmField::get_option\(\) invoked with 3 parameters, 2 required.#'
+		- '#Function (remove_filter|remove_action|apply_filters)+ invoked with#'
+		- '#Function (w3tc_flush_all|wp_cache_clean_cache|WP_Optimize|wp_mail_smtp|akismet_test_mode|load_formidable_pro)+ not found.#'
+		- '#Instantiated class PHPMailer not found.#'
+		- '#Possibly invalid array key type#'
+		- '#Static call to instance method FrmListHelper::get_param\(\).#'
+		- '#always exists and is not nullable.#'
+		- '#code above always terminates.#'
+		- '#does not (accept|exist on)+#'
+		- '#expects (array|string|int|callable|object|stdClass|float|bool|resource)+#'
+		- '#has (an unused parameter|invalid type)+#'
+		- '#is always (false|true)+.#'
+		- '#is incompatible with#'
+		- '#might not be defined.#'
+		- '#never returns#'
+		- '#no (typehint|value type|return typehint)+ specified.#'
+		- '#of echo cannot be converted to string.#'
+		- '#on an unknown class#'
+		- '#only iterables are supported#'
+		- '#outside of class scope.#'
+		- '#results in an error.#'
+		- '#should return#'
+		- '#will always evaluate to#'
+		- '#PHPDoc tag @param (references unknown parameter:|has invalid valu)+#'
+		- '#array_map expects#'
+		- '#Part \$class#'

--- a/phpstan.stubs.php
+++ b/phpstan.stubs.php
@@ -1,24 +1,24 @@
 <?php
 
 namespace {
-    class FrmProEntryShortcodeFormatter extends FrmEntryShortcodeFormatter {
-    }
-    class FrmProSettings extends FrmSettings {
-    }
+	class FrmProEntryShortcodeFormatter extends FrmEntryShortcodeFormatter {
+	}
+	class FrmProSettings extends FrmSettings {
+	}
 }
 
 namespace Elementor {
 
-    abstract class Widget_Base {
+	abstract class Widget_Base {
 
-        public function start_controls_section( $section_id, array $args = [] ) {
-        }
-        public function add_control( $id, array $args, $options = [] ) {
-        }
-        public function end_controls_section() {
-        }
-        public function get_settings_for_display( $setting_key = null ) {
-        }
-    }
+		public function start_controls_section( $section_id, array $args = [] ) {
+		}
+		public function add_control( $id, array $args, $options = [] ) {
+		}
+		public function end_controls_section() {
+		}
+		public function get_settings_for_display( $setting_key = null ) {
+		}
+	}
 
 }

--- a/phpstan.stubs.php
+++ b/phpstan.stubs.php
@@ -11,9 +11,9 @@ namespace Elementor {
 
 	abstract class Widget_Base {
 
-		public function start_controls_section( $section_id, array $args = [] ) {
+		public function start_controls_section( $section_id, array $args = array() ) {
 		}
-		public function add_control( $id, array $args, $options = [] ) {
+		public function add_control( $id, array $args, $options = array() ) {
 		}
 		public function end_controls_section() {
 		}

--- a/phpstan.stubs.php
+++ b/phpstan.stubs.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace {
+    class FrmProEntryShortcodeFormatter extends FrmEntryShortcodeFormatter {
+    }
+    class FrmProSettings extends FrmSettings {
+    }
+}
+
+namespace Elementor {
+
+    abstract class Widget_Base {
+
+        public function start_controls_section( $section_id, array $args = [] ) {
+        }
+        public function add_control( $id, array $args, $options = [] ) {
+        }
+        public function end_controls_section() {
+        }
+        public function get_settings_for_display( $setting_key = null ) {
+        }
+    }
+
+}

--- a/tests/misc/test_FrmDirectFileAccess.php
+++ b/tests/misc/test_FrmDirectFileAccess.php
@@ -18,7 +18,7 @@ class test_FrmDirectFileAccess extends FrmUnitTest {
 		foreach ( $files as $key => $value ) {
 			$path = realpath( $dir . DIRECTORY_SEPARATOR . $value );
 			if ( ! is_dir( $path ) ) {
-				if ( substr( $value, strlen( $value ) - 4 ) === '.php' && ! in_array( $value, array( 'set-php-version.php', 'psalm.stubs.php' ), true ) ) {
+				if ( substr( $value, strlen( $value ) - 4 ) === '.php' && ! in_array( $value, array( 'set-php-version.php', 'psalm.stubs.php', 'phpstan.stubs.php' ), true ) ) {
 					$results[] = $path;
 				}
 			} elseif ( $value !== '.' && $value !== '..' ) {


### PR DESCRIPTION
Fixes two remaining issues. I'm hiding the rest at the moment with the goal of removing exceptions over time. But it is running at the max level already aside from those exceptions.

Runs in 7-11 seconds, significantly the fastest workflow which is nice for a few reasons - catching issues faster, using less of our GitHub allowance.

 ------ -----------------------------------
  Line   classes/helpers/FrmListHelper.php
 ------ -----------------------------------
  1156   Undefined variable: $data
 ------ -----------------------------------

I trace this error back to 6 years ago when Jamie copied the file from WordPress and missed the undefined variable https://github.com/Strategy11/formidable-forms/commit/14289c2500f3a358abbb5fbc2370da6f6bd4cb33

It's trying to call a function that starts with `_column` which we never do, so this code was never getting called. It looks like it's used in two WordPress functions `_column_blogs` and `_column_title` but since we are not extending WP_List_Table this is just extra code with an undefined variable in it. So I'm removing the condition and block of code entirely.

 ------ ----------------------------------------------------------------------------------------------------------------------------
  Line   classes/models/FrmEntryFormatter.php
 ------ ----------------------------------------------------------------------------------------------------------------------------
  711    Parameter #1 $field_value of method FrmEntryFormatter::package_value_args() expects FrmFieldValue, FrmProFieldValue given.
 ------ ----------------------------------------------------------------------------------------------------------------------------

Just required a comment update. A FrmProFieldValue value is a FrmFieldValue value anyway, because of inheritance. Nothing crazy.