### PR TITLE
Add form show title description options

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1770,11 +1770,10 @@ class FrmFormsController {
 	 * @return stdClass|false
 	 */
 	private static function maybe_get_form_by_id_or_key( $id, $key ) {
-		if ( empty( $id ) ) {
+		if ( ! $id ) {
 			$id = $key;
 		}
-
-		$form = self::maybe_get_form_to_show( $id );
+		return self::maybe_get_form_to_show( $id );
 	}
 
 	/**
@@ -1788,11 +1787,6 @@ class FrmFormsController {
 	public static function show_form( $id = '', $key = '', $title = false, $description = false, $atts = array() ) {
 		$form = self::maybe_get_form_by_id_or_key( $id, $key );
 
-		if ( empty( $id ) ) {
-			$id = $key;
-		}
-
-		$form = self::maybe_get_form_to_show( $id );
 		if ( ! $form ) {
 			return __( 'Please select a valid form', 'formidable' );
 		}

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1763,7 +1763,7 @@ class FrmFormsController {
 	}
 
 	/**
-	 * @since 5.2.1
+	 * @since 5.2.01
 	 *
 	 * @param string|int|false $id
 	 * @param string|false     $key

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1783,8 +1783,8 @@ class FrmFormsController {
 	/**
 	 * @param string|int|false $id
 	 * @param string|false     $key
-	 * @param bool             $title
-	 * @param bool             $description
+	 * @param string|int|bool  $title may be true, false, 'true', 'false', 'yes', '1', 1, '0', 0.
+	 * @param string|int|bool  $description  may be true, false, 'true', 'false', 'yes', '1', 1, '0', 0.
 	 * @param array            $atts
 	 * @return string
 	 */

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1737,8 +1737,8 @@ class FrmFormsController {
 			array(
 				'id'             => '',
 				'key'            => '',
-				'title'          => false,
-				'description'    => false,
+				'title'          => 'auto',
+				'description'    => 'auto',
 				'readonly'       => false,
 				'entry_id'       => false,
 				'fields'         => array(),
@@ -1749,21 +1749,7 @@ class FrmFormsController {
 		);
 		do_action( 'formidable_shortcode_atts', $shortcode_atts, $atts );
 
-		if ( ! isset( $atts['title'] ) || ! isset( $atts['description'] ) ) {
-			$form             = self::maybe_get_form_by_id_or_key( $shortcode_atts['id'], $shortcode_atts['key'] );
-			$show_title       = $form && ! empty( $form->options['show_title'] );
-			$show_description = $form && ! empty( $form->options['show_description'] );
-		}
-
-		if ( isset( $atts['title'] ) ) {
-			$show_title = $atts['title'];
-		}
-
-		if ( isset( $atts['description'] ) ) {
-			$show_description = $atts['description'];
-		}
-
-		return self::show_form( $shortcode_atts['id'], $shortcode_atts['key'], $show_title, $show_description, $atts );
+		return self::show_form( $shortcode_atts['id'], $shortcode_atts['key'], $shortcode_atts['title'], $shortcode_atts['description'], $atts );
 	}
 
 	/**
@@ -1783,8 +1769,8 @@ class FrmFormsController {
 	/**
 	 * @param string|int|false $id
 	 * @param string|false     $key
-	 * @param string|int|bool  $title may be true, false, 'true', 'false', 'yes', '1', 1, '0', 0.
-	 * @param string|int|bool  $description  may be true, false, 'true', 'false', 'yes', '1', 1, '0', 0.
+	 * @param string|int|bool  $title may be 'auto', true, false, 'true', 'false', 'yes', '1', 1, '0', 0.
+	 * @param string|int|bool  $description may be 'auto', true, false, 'true', 'false', 'yes', '1', 1, '0', 0.
 	 * @param array            $atts
 	 * @return string
 	 */
@@ -1793,6 +1779,14 @@ class FrmFormsController {
 
 		if ( ! $form ) {
 			return __( 'Please select a valid form', 'formidable' );
+		}
+
+		if ( 'auto' === $title ) {
+			$title = ! empty( $form->options['show_title'] );
+		}
+
+		if ( 'auto' === $description ) {
+			$description = ! empty( $form->options['show_description'] );
 		}
 
 		FrmAppController::maybe_update_styles();

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -262,9 +262,7 @@ class FrmFormsController {
 
 		$form = FrmForm::getOne( $params['form'] );
 		if ( $form ) {
-			$show_title       = ! empty( $form->options['show_title'] );
-			$show_description = ! empty( $form->options['show_description'] );
-			return self::show_form( $form->id, '', $show_title, $show_description );
+			return self::show_form( $form->id, '', 'auto', 'auto' );
 		}
 	}
 

--- a/classes/views/frm-entries/direct.php
+++ b/classes/views/frm-entries/direct.php
@@ -2,6 +2,8 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
+$show_title       = ! empty( $form->options['show_title'] );
+$show_description = ! empty( $form->options['show_description'] );
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
@@ -13,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php FrmFormsController::maybe_load_css( $form, 1, false ); ?>
 </head>
 <body class="frm_preview_page">
-	<?php echo FrmFormsController::show_form( $form->id, '', true, true ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+	<?php echo FrmFormsController::show_form( $form->id, '', $show_title, $show_description ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	<?php wp_footer(); ?>
 </body>
 </html>

--- a/classes/views/frm-entries/direct.php
+++ b/classes/views/frm-entries/direct.php
@@ -2,8 +2,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
-$show_title       = ! empty( $form->options['show_title'] );
-$show_description = ! empty( $form->options['show_description'] );
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
@@ -15,7 +13,7 @@ $show_description = ! empty( $form->options['show_description'] );
 	<?php FrmFormsController::maybe_load_css( $form, 1, false ); ?>
 </head>
 <body class="frm_preview_page">
-	<?php echo FrmFormsController::show_form( $form->id, '', $show_title, $show_description ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+	<?php echo FrmFormsController::show_form( $form->id, '', 'auto', 'auto' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	<?php wp_footer(); ?>
 </body>
 </html>

--- a/classes/views/frm-forms/settings-advanced.php
+++ b/classes/views/frm-forms/settings-advanced.php
@@ -29,6 +29,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<textarea id="frm_form_description" name="description" cols="50" rows="4"><?php echo FrmAppHelper::esc_textarea( $values['description'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></textarea>
 	</p>
 
+	<p class="frm8 frm_form_field">
+		<label for="show_title" class="frm_inline_block">
+			<input type="checkbox" name="options[show_title]" id="show_title" value="1" <?php checked( $values['show_title'], 1 ); ?> />
+			<?php esc_html_e( 'Show the form title', 'formidable' ); ?>
+		</label>
+	</p>
+
+	<p class="frm8 frm_form_field">
+		<label for="show_description" class="frm_inline_block">
+			<input type="checkbox" name="options[show_description]" id="show_description" value="1" <?php checked( $values['show_description'], 1 ); ?> />
+			<?php esc_html_e( 'Show the form description', 'formidable' ); ?>
+		</label>
+	</p>
+
 <?php if ( ! $values['is_template'] ) { ?>
 	<?php $first_h3 = ''; ?>
 


### PR DESCRIPTION
Right now I've added two new check boxes to turn on/off the visibility of the form title/description which are currently always on in previews and off but adjustable with options for an embedded form. Now it's based off of this setting, which is off by default, so the default behaviour of a preview page is changing with this update, for consistency.

<img width="444" alt="Screen Shot 2022-02-21 at 12 48 05 PM" src="https://user-images.githubusercontent.com/9134515/154997201-442cbb8f-bdc8-41ab-b6af-da188fa57bb0.png">

This has been included as part of a design we never implemented, as toggles. Right now all of our CSS for toggles is used for front end toggle fields and included in pro only, so it's a lot easier to just use checkboxes. Otherwise I'll need to pull the CSS into the free plugin and it will need to load all of the toggle styles twice.

<img width="447" alt="Show form title" src="https://user-images.githubusercontent.com/9134515/154997214-7bd1cc8f-b59d-4e95-b461-bd7dce58a88a.png">

That probably makes more sense either way since the other options on this page are currently all check boxes and the toggle would be inconsistent.

<img width="491" alt="Screen Shot 2022-02-21 at 12 49 26 PM" src="https://user-images.githubusercontent.com/9134515/154997387-4fed1249-5ba3-460a-942e-b9524789032c.png">

@garretlaxton for testing, you can try using the title=1, description=1  or title=0/description=0 options for [formidable] shortcodes, or the Gutenberg block's title/description toggles. If these are set, they should take over instead of the toggles in the settings page. If they are not specified, it should use the toggle settings instead.