### PR TITLE
Fix issue with checkbox styling in enfold

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -791,7 +791,7 @@ a.frm_save_draft{
 	appearance: none;
 	background-color: var(--bg-color);
 	flex: none;
-	display:inline-block;
+	display:inline-block !important;
 	margin: 0 5px 0 0;
 	color: var(--border-color);
 	width: 18px;


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3397

Took a while figuring out how to reliably replicate this without enfold. I ended up copying the CSS from their demo into a blank HTML file and pulled in a new API form 😂.

The issue is actually pretty simple, just annoying to debug. Enfold includes this rule on checkboxes, `#top input[type="checkbox"]{display:inline}`. Because of the `#top` reference it beats our CSS rule and forces the checkbox to inline instead of inline-block. Since it's targeting by id, I think our best bet here is to just use `!important`.