### PR TITLE
Add show title/show description values to defaults array

### DIFF
--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -356,25 +356,30 @@ class FrmFormsHelper {
 		return $values;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function get_default_opts() {
 		$frm_settings = FrmAppHelper::get_settings();
 
 		return array(
-			'submit_value'   => $frm_settings->submit_value,
-			'success_action' => 'message',
-			'success_msg'    => $frm_settings->success_msg,
-			'show_form'      => 0,
-			'akismet'        => '',
-			'honeypot'       => 'basic',
-			'antispam'       => 0,
-			'no_save'        => 0,
-			'ajax_load'      => 0,
-			'js_validate'    => 0,
-			'form_class'     => '',
-			'custom_style'   => 1,
-			'before_html'    => self::get_default_html( 'before' ),
-			'after_html'     => '',
-			'submit_html'    => self::get_default_html( 'submit' ),
+			'submit_value'     => $frm_settings->submit_value,
+			'success_action'   => 'message',
+			'success_msg'      => $frm_settings->success_msg,
+			'show_form'        => 0,
+			'akismet'          => '',
+			'honeypot'         => 'basic',
+			'antispam'         => 0,
+			'no_save'          => 0,
+			'ajax_load'        => 0,
+			'js_validate'      => 0,
+			'form_class'       => '',
+			'custom_style'     => 1,
+			'before_html'      => self::get_default_html( 'before' ),
+			'after_html'       => '',
+			'submit_html'      => self::get_default_html( 'submit' ),
+			'show_title'       => 0,
+			'show_description' => 0,
 		);
 	}
 


### PR DESCRIPTION
Noticed a small issue with https://github.com/Strategy11/formidable-forms/pull/706

Some warnings are getting logged on the settings page.
> [22-Feb-2022 18:17:43 UTC] PHP Warning:  Undefined array key "show_title" in /var/www/src/wp-content/plugins/formidable/classes/views/frm-forms/settings-advanced.php on line 34
> [22-Feb-2022 18:17:43 UTC] PHP Warning:  Undefined array key "show_description" in /var/www/src/wp-content/plugins/formidable/classes/views/frm-forms/settings-advanced.php on line 41

I wasn't defining defaults.