### PR TITLE
Allow name fields to be the entry name

### DIFF
--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -148,21 +148,6 @@ class FrmEntryValidate {
 			$item_name = $value;
 		}
 
-		/**
-		 * Allows modifying the item name before it's saved to database.
-		 *
-		 * @since 5.2.02
-		 *
-		 * @param string|false $item_name The item name.
-		 * @param array        $args      {
-		 *     The arguments.
-		 *
-		 *     @type object $field The current processing field.
-		 *     @type mixed  $value The value of current processing field.
-		 * }
-		 */
-		$item_name = apply_filters( 'frm_item_name', $item_name, compact( 'value', 'field' ) );
-
 		if ( false !== $item_name ) {
 			$_POST['item_name'] = $item_name;
 		}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3434

This doesn't apply to old entries unless the user updates them.
Besides the `name` and `text` fields, we can add support for more field types. I'm not sure if we should do that.