### PR TITLE
Remove unused function FrmFormsController::init_modal

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -81,16 +81,6 @@ class FrmFormsController {
 	}
 
 	/**
-	 * Load the scripts before a modal can be triggered.
-	 *
-	 * @since 4.0
-	 */
-	private static function init_modal() {
-		wp_enqueue_script( 'jquery-ui-dialog' );
-		wp_enqueue_style( 'jquery-ui-dialog' );
-	}
-
-	/**
 	 * Create the default email action
 	 *
 	 * @since 2.02.11


### PR DESCRIPTION
I noticed we call these two lines of code in a few places and I was refactoring it to one function.

Then I noticed one of those functions is private and never gets called so I'm removing it.