### PR TITLE
Update how stubs are excluded from zip, stop updating submodule by de…

### DIFF
--- a/bin/build-plugin.sh
+++ b/bin/build-plugin.sh
@@ -22,10 +22,10 @@ warning () {
 status "Time to release"
 
 # Update any submodules
-git submodule foreach git pull origin master
-if ! git diff --submodule=diff --exit-code > /dev/null; then
-	git commit -am 'Update submodule'
-fi
+# git submodule foreach git pull origin master
+# if ! git diff --submodule=diff --exit-code > /dev/null; then
+#	git commit -am 'Update submodule'
+# fi
 
 # Make sure there are no changes in the working tree. Release builds should be
 # traceable to a particular commit and reliably reproducible.

--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -55,10 +55,10 @@ zip -r $zipname $destination \
 	-x "*/package-lock.json" \
 	-x "*/phpcs.xml" \
 	-x "*/phpunit.xml" \
-	-x "*/psalm.stubs.php" \
 	-x "*/psalm.xml" \
-	-x "*/phpstan.stubs.php" \
 	-x "*/phpstan.neon" \
+	-x "*/*.stubs.php" \
+	-x "*/stubs.php" \
 	-x "*/readme.md" \
 	-x "*/README.md" \
 	-x "*/tests/*" \


### PR DESCRIPTION
…fault during release process

Starting to use files with just `stubs.php` as the name so I need to update how I'm excluding them. Also switching the psalm/phpstan.stubs.php to use a * so it catches anything .stubs.php.

And the update submodule only ever commits stuff I didn't want to commit by accident, even for branches without submodules in them. I'm commenting it out for now.