### PR TITLE
Set a string hook suffix in set_current_screen_and_hook_suffix to avo…

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3318,6 +3318,10 @@ class FrmAppHelper {
 	 */
 	public static function set_current_screen_and_hook_suffix() {
 		global $hook_suffix;
+		if ( is_null( $hook_suffix ) ) {
+			// $hook_suffix gets used in substr so make sure it's not null. PHP8 deprecates null in substr.
+			$hook_suffix = ''; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
 		set_current_screen();
 	}
 

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3319,7 +3319,7 @@ class FrmAppHelper {
 	public static function set_current_screen_and_hook_suffix() {
 		global $hook_suffix;
 		if ( is_null( $hook_suffix ) ) {
-			// $hook_suffix gets used in substr so make sure it's not null. PHP8 deprecates null in substr.
+			// $hook_suffix gets used in substr so make sure it's not null. PHP 8.1 deprecates null in substr.
 			$hook_suffix = ''; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 		set_current_screen();


### PR DESCRIPTION
…id a PHP 8.1 null deprecation issue

> [04-Mar-2022 17:33:44 UTC] PHP Deprecated:  substr(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/src/wp-admin/includes/class-wp-screen.php on line 231

Just avoiding a deprecation. The hook suffix not only needs to exist, it can't be null.