### PR TITLE
Cleanup bootstrap code

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10000,17 +10000,24 @@ function frmAdminBuildJS() {
 				}
 			});
 
-			// TODO this is not working.
-			jQuery( '.multiselect-container.frm-dropdown-menu li a' ).on( 'click', function() {
-				var radio = this.children[0].children[0];
-				var btnGrp = jQuery( this ).closest( '.btn-group' );
-				var btnId = btnGrp.attr( 'id' );
-				document.getElementById( btnId.replace( '_select', '' ) ).value = radio.value;
-				btnGrp.children( 'button' ).html( radio.nextElementSibling.innerHTML + ' <b class="caret"></b>' );
+			jQuery( document ).on( 'change', '.frm-dropdown-menu input[type="radio"]', function() {
+				const radio = this;
+				const btnGrp = this.closest( '.btn-group' );
+				const btnId = btnGrp.getAttribute( 'id' );
 
-				// set active class
-				btnGrp.find( 'li.active' ).removeClass( 'active' );
-				jQuery( this ).closest( 'li' ).addClass( 'active' );
+				const select = document.getElementById( btnId.replace( '_select', '' ) );
+				if ( select ) {
+					select.value = radio.value;
+				}
+
+				jQuery( btnGrp ).children( 'button' ).html( radio.nextElementSibling.innerHTML + ' <b class="caret"></b>' );
+
+				const activeItem = btnGrp.querySelector( '.dropdown-item.active' );
+				if ( activeItem ) {
+					activeItem.classList.remove( 'active' );
+				}
+
+				this.closest( '.dropdown-item' ).classList.add( 'active' );
 			});
 
 			jQuery( '#frm_confirm_modal' ).on( 'click', '[data-resetstyle]', function( e ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7602,16 +7602,6 @@ function frmAdminBuildJS() {
 		}
 	}
 
-	function multiselectAccessibility() {
-		jQuery( '.multiselect-container' ).find( 'input[type="checkbox"]' ).each( function() {
-			var checkbox = jQuery( this );
-			checkbox.closest( 'a' ).attr(
-				'aria-describedby',
-				checkbox.is( ':checked' ) ? 'frm_press_space_checked' : 'frm_press_space_unchecked'
-			);
-		});
-	}
-
 	function initiateMultiselect() {
 		jQuery( '.frm_multiselect' ).hide().each( function() {
 			var $select = jQuery( this ),
@@ -7635,11 +7625,8 @@ function frmAdminBuildJS() {
 							}
 						});
 					}
-
-					multiselectAccessibility();
 				},
 				onChange: function( element, option ) {
-					multiselectAccessibility();
 					$select.trigger( 'frm-multiselect-changed', element, option );
 				}
 			});
@@ -9456,7 +9443,7 @@ function frmAdminBuildJS() {
 			clickTab( jQuery( '.starttab a' ), 'auto' );
 
 			// submit the search form with dropdown
-			jQuery( '#frm-fid-search-menu a' ).on( 'click', function() {
+			jQuery( document ).on( 'click', '#frm-fid-search-menu a', function() {
 				var val = this.id.replace( 'fid-', '' );
 				jQuery( 'select[name="fid"]' ).val( val );
 				triggerSubmit( document.getElementById( 'posts-filter' ) );
@@ -10013,6 +10000,7 @@ function frmAdminBuildJS() {
 				}
 			});
 
+			// TODO this is not working.
 			jQuery( '.multiselect-container.frm-dropdown-menu li a' ).on( 'click', function() {
 				var radio = this.children[0].children[0];
 				var btnGrp = jQuery( this ).closest( '.btn-group' );
@@ -10200,7 +10188,7 @@ function frmAdminBuildJS() {
 
 frmAdminBuild = frmAdminBuildJS();
 
-jQuery( document ).ready( function( $ ) {
+jQuery( document ).ready( function() {
 	frmAdminBuild.init();
 
 	updateDropdownsForBootstrap4();
@@ -10230,6 +10218,16 @@ jQuery( document ).ready( function( $ ) {
 
 			// Temporarily add dropdown-menu class so bootstrap can initialize.
 			frmDropdownMenu.classList.add( 'dropdown-menu' );
+
+			const toggle = result.querySelector( '.frm-dropdown-toggle' );
+			if ( toggle ) {
+				if ( ! toggle.hasAttribute( 'role' ) ) {
+					toggle.setAttribute( 'role', 'button' );
+				}
+				if ( ! toggle.hasAttribute( 'tabindex' ) ) {
+					toggle.setAttribute( 'tabindex', 0 );
+				}
+			}
 
 			// Convert <li> and <ul> tags.
 			if ( 'UL' === frmDropdownMenu.tagName ) {


### PR DESCRIPTION
Continuing to test bootstrap https://github.com/Strategy11/formidable-forms/pull/708

I noticed that there are these dropdowns with radio buttons in them in the style manager. There's code I missed that was syncing the icons with the button trigger. However, it looks like one of those (sections) had broken at some other point in time before the bootstrap update. So this fixes that.

I also made some other slight adjustments so events don't get stripped when the html changes with anchors inside. And added a little extra bit to try to make sure toggles are more accessible just in case. And I noticed the old `multiselectAccessibility` function in JavaScript that I missed when I pulled out the PHP code related to this. This no longer applies.

<img width="301" alt="Icon Color" src="https://user-images.githubusercontent.com/9134515/157106579-ad5bbe8e-3d6c-41f4-ab68-99459a061069.png">

**Before in version v5.2**
![VfjU3yY7Nv](https://user-images.githubusercontent.com/9134515/157109563-3096e346-ef0e-4cbd-bfe9-1deaa1a7cda7.gif)

**After**
![Yn6udyAHc1](https://user-images.githubusercontent.com/9134515/157109615-27e382e0-924f-454d-a4c3-6102e97f34f9.gif)