### PR TITLE
Broken embed button after bootstrap update fix

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8326,7 +8326,7 @@ function frmAdminBuildJS() {
 				} else {
 					const previewDrop = document.getElementById( 'frm-previewDrop' );
 					if ( previewDrop ) {
-						formKey = previewDrop.nextElementSibling.querySelector( 'li a' ).getAttribute( 'href' ).split( 'form=' )[1];
+						formKey = previewDrop.nextElementSibling.querySelector( '.dropdown-item a' ).getAttribute( 'href' ).split( 'form=' )[1];
 					}
 				}
 			}


### PR DESCRIPTION
The `li a` check isn't accurate anymore.

![httplocalhost8889wp-contentpluginsformidablejsformidable_admin jsver=5 2 018292](https://user-images.githubusercontent.com/9134515/157268168-dc12e854-90d8-4721-b7e7-9f292d4fac92.png)