### PR TITLE
Fix Duplicator Pro conflict

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -459,9 +459,9 @@ class FrmAppController {
 			$dependecies[] = 'wp-color-picker';
 		}
 
+		self::register_popper1();
 		wp_register_script( 'formidable_admin', FrmAppHelper::plugin_url() . '/js/formidable_admin.js', $dependecies, $version, true );
 		wp_register_style( 'formidable-admin', FrmAppHelper::plugin_url() . '/css/frm_admin.css', array(), $version );
-		wp_register_script( 'popper', FrmAppHelper::plugin_url() . '/js/popper.min.js', array( 'jquery' ), '1.16.0', true );
 		wp_register_script( 'bootstrap_tooltip', FrmAppHelper::plugin_url() . '/js/bootstrap.min.js', array( 'jquery', 'popper' ), '4.6.1', true );
 		wp_register_style( 'formidable-grids', FrmAppHelper::plugin_url() . '/css/frm_grids.css', array(), $version );
 

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -534,7 +534,7 @@ class FrmAppController {
 	/**
 	 * Fix a Duplicator Pro conflict because it uses Popper 2. See issue #3459.
 	 *
-	 * @since 5.2.03
+	 * @since 5.2.02.01
 	 *
 	 * @return void
 	 */

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -459,6 +459,8 @@ class FrmAppController {
 			$dependecies[] = 'wp-color-picker';
 		}
 
+		self::maybe_deregister_popper2();
+
 		wp_register_script( 'formidable_admin', FrmAppHelper::plugin_url() . '/js/formidable_admin.js', $dependecies, $version, true );
 		wp_register_style( 'formidable-admin', FrmAppHelper::plugin_url() . '/css/frm_admin.css', array(), $version );
 		wp_register_script( 'popper', FrmAppHelper::plugin_url() . '/js/popper.min.js', array( 'jquery' ), '1.16.0', true );
@@ -527,6 +529,26 @@ class FrmAppController {
 		}
 
 		self::maybe_force_formidable_block_on_gutenberg_page();
+	}
+
+	/**
+	 * Fix a Duplicator Pro conflict because it uses Popper 2. See issue #3459.
+	 *
+	 * @since 5.2.03
+	 *
+	 * @return void
+	 */
+	private static function maybe_deregister_popper2() {
+		global $wp_scripts;
+
+		if ( ! array_key_exists( 'popper', $wp_scripts->registered ) ) {
+			return;
+		}
+
+		$popper = $wp_scripts->registered['popper'];
+		if ( version_compare( $popper->ver, '2.0', '>=' ) ) {
+			wp_deregister_script( 'popper' );
+		}
 	}
 
 	/**

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -459,8 +459,6 @@ class FrmAppController {
 			$dependecies[] = 'wp-color-picker';
 		}
 
-		self::maybe_deregister_popper2();
-
 		wp_register_script( 'formidable_admin', FrmAppHelper::plugin_url() . '/js/formidable_admin.js', $dependecies, $version, true );
 		wp_register_style( 'formidable-admin', FrmAppHelper::plugin_url() . '/css/frm_admin.css', array(), $version );
 		wp_register_script( 'popper', FrmAppHelper::plugin_url() . '/js/popper.min.js', array( 'jquery' ), '1.16.0', true );
@@ -486,6 +484,7 @@ class FrmAppController {
 
 			wp_enqueue_script( 'admin-widgets' );
 			wp_enqueue_style( 'widgets' );
+			self::maybe_deregister_popper2();
 			wp_enqueue_script( 'formidable_admin' );
 			FrmAppHelper::localize_script( 'admin' );
 
@@ -521,6 +520,7 @@ class FrmAppController {
 			if ( $post_type === 'frm_display' ) {
 				wp_enqueue_style( 'formidable-grids' );
 				wp_enqueue_script( 'jquery-ui-draggable' );
+				self::maybe_deregister_popper2();
 				wp_enqueue_script( 'formidable_admin' );
 				wp_enqueue_style( 'formidable-admin' );
 				FrmAppHelper::localize_script( 'admin' );
@@ -548,7 +548,19 @@ class FrmAppController {
 		$popper = $wp_scripts->registered['popper'];
 		if ( version_compare( $popper->ver, '2.0', '>=' ) ) {
 			wp_deregister_script( 'popper' );
+			self::register_popper1();
 		}
+	}
+
+	/**
+	 * Register Popper required for Bootstrap 4.
+	 *
+	 * @since 5.2.02.01
+	 *
+	 * @return void
+	 */
+	private static function register_popper1() {
+		wp_register_script( 'popper', FrmAppHelper::plugin_url() . '/js/popper.min.js', array( 'jquery' ), '1.16.0', true );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3459

They use Popper 2 but Bootstrap 4 uses Popper 1. De-registering it so it registers our popper js instead fixes the issue.