### PR TITLE
Only set margin-bottom 0 for name subfields

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -1474,7 +1474,9 @@ select.frm_loading_lookup{
 	color:var(--repeat-icon-color)<?php echo esc_html( $important ); ?>;
 }
 
-.with_frm_style .frm_combo_inputs_container > .form-field {
+.with_frm_style .frm_combo_inputs_container > .frm_form_subfield-first,
+.with_frm_style .frm_combo_inputs_container > .frm_form_subfield-middle,
+.with_frm_style .frm_combo_inputs_container > .frm_form_subfield-last {
 	margin-bottom: 0 !important;
 }
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3461

@truongwp I didn't see an easier way to target these. If you have a better option moving forward, feel free to make another pull request.