### PR TITLE
Allow for custom field key separators

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1816,8 +1816,19 @@ class FrmAppHelper {
 
 		if ( $key_check || is_numeric( $key_check ) ) {
 			$key = self::maybe_truncate_key_before_appending( $column, $key );
+
+			/**
+			 * Allow for a custom separator between the attempted key and the generated suffix.
+			 *
+			 * @since 5.2.03
+			 *
+			 * @param string $separator. Default empty.
+			 * @param string $key the key without the added suffix.
+			 */
+			$separator = apply_filters( 'frm_unique_' . $column . '_separator', '', $key );
+
 			// Create a unique field id if it has already been used.
-			$key = $key . substr( md5( microtime() . rand() ), 0, 10 );
+			$key = $key . $separator . substr( md5( microtime() . rand() ), 0, 10 );
 		}
 
 		return $key;

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1814,12 +1814,9 @@ class FrmAppHelper {
 			$column
 		);
 
-		$key_check = false;
-		foreach ( $similar_keys as $similar_key ) {
-			if ( $key === $similar_key  ) {
-				$key_check = $similar_key;
-				break;
-			}
+		$key_check = array_search( $key, $similar_keys, true );
+		if ( false !== $key_check ) {
+			$key_check = $key;
 		}
 
 		// Create a unique field id if it has already been used.

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1853,6 +1853,9 @@ class FrmAppHelper {
 			$max_key_length_before_truncating = 60;
 			if ( strlen( $key ) > $max_key_length_before_truncating ) {
 				$key = substr( $key, 0, $max_key_length_before_truncating );
+				if ( is_numeric( $key ) ) {
+					$key .= 'a';
+				}
 			}
 		}
 		return $key;

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1828,9 +1828,10 @@ class FrmAppHelper {
 			 */
 			$separator = apply_filters( 'frm_unique_' . $column . '_separator', '', $key );
 
+			$suffix = 2;
 			do {
-				$suffix    = substr( md5( microtime() . rand() ), 0, 5 );
 				$key_check = $key . $separator . $suffix;
+				++$suffix;
 			} while ( in_array( $key_check, $similar_keys, true ) );
 
 			$key = $key_check;

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1814,13 +1814,8 @@ class FrmAppHelper {
 			$column
 		);
 
-		$key_check = array_search( $key, $similar_keys, true );
-		if ( false !== $key_check ) {
-			$key_check = $key;
-		}
-
 		// Create a unique field id if it has already been used.
-		if ( $key_check || is_numeric( $key_check ) ) {
+		if ( in_array( $key, $similar_keys, true ) ) {
 			$key = self::maybe_truncate_key_before_appending( $column, $key );
 
 			/**

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -538,23 +538,23 @@ class test_FrmAppHelper extends FrmUnitTest {
 
 		$name    = 'examplefieldkey';
 		$form_id = $this->factory->form->create();
-		$this->factory->field->create(
-			array(
-				'type'      => 'text',
-				'field_key' => $name,
-				'form_id'   => $form_id,
-			)
-		);
+		$this->add_field_to_form( $form_id, $name );
 		$key = FrmAppHelper::get_unique_key( $name, $table_name, $column );
 		$this->assertNotEquals( $name, $key, 'Field key should be unique' );
-		$this->assertEquals( strlen( $name ) + 5, strlen( $key ), 'Field key should be the previous key + 5 random characters' );
+		$this->assertEquals( strlen( $name ) + 1, strlen( $key ), 'Field key should be the previous key + "2" incremented counter value' );
+		$this->assertEquals( $name . 2, $key, 'Key value should increment' );
+
+		$this->add_field_to_form( $form_id, $key );
+		$key = FrmAppHelper::get_unique_key( $name, $table_name, $column );
+		$this->assertEquals( $name . 3, $key, 'Key value should increment' );
 
 		add_filter( 'frm_unique_field_key_separator', array( __CLASS__, 'underscore_key_separator' ) );
 
 		$key = FrmAppHelper::get_unique_key( $name, $table_name, $column );
 		$this->assertNotEquals( $name, $key, 'Field key should be unique' );
 		$this->assertStringContainsString( '___', $key, 'Field key should contain custom separator' );
-		$this->assertEquals( strlen( $name ) + 8, strlen( $key ), 'Field key should be the previous key + 3 character separator + 5 random characters' );
+		$this->assertEquals( strlen( $name ) + 4, strlen( $key ), 'Field key should be the previous key + 3 character separator + "2" incremented counter value' );
+		$this->assertEquals( $name . '___2', $key );
 
 		remove_filter( 'frm_unique_field_key_separator', array( __CLASS__, 'underscore_key_separator' ) );
 
@@ -564,6 +564,11 @@ class test_FrmAppHelper extends FrmUnitTest {
 		$unique_key = FrmAppHelper::get_unique_key( $super_long_form_key, $table_name, $column );
 		$this->assertTrue( strlen( $unique_key ) <= 70 );
 		$this->assertNotEquals( $super_long_form_key, $unique_key );
+	}
+
+	private function add_field_to_form( $form_id, $field_key ) {
+		$type = 'text';
+		$this->factory->field->create( compact( 'type', 'form_id', 'field_key' ) );
 	}
 
 	public static function underscore_key_separator() {

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -513,7 +513,9 @@ class test_FrmAppHelper extends FrmUnitTest {
 	 */
 	public function test_get_unique_key() {
 		global $wpdb;
-		$table_name = $wpdb->prefix . 'frm_fields';
+
+		// Test field keys
+		$table_name = 'frm_fields';
 		$column     = 'field_key';
 
 		$name = 'lrk2p3994ed7b17086290a2b7c3ca5e65c944451f9c2d457602cae34661ec7f32998cc21b037a67695662e4b9fb7e177a5b28a6c0f';
@@ -534,9 +536,38 @@ class test_FrmAppHelper extends FrmUnitTest {
 			array( 'form_key' => $super_long_form_key )
 		);
 
-		$unique_key = FrmAppHelper::get_unique_key( $super_long_form_key, 'frm_forms', 'form_key' );
+		$name    = 'examplefieldkey';
+		$form_id = $this->factory->form->create();
+		$this->factory->field->create(
+			array(
+				'type'      => 'text',
+				'field_key' => $name,
+				'form_id'   => $form_id,
+			)
+		);
+		$key = FrmAppHelper::get_unique_key( $name, $table_name, $column );
+		$this->assertNotEquals( $name, $key, 'Field key should be unique' );
+		$this->assertEquals( strlen( $name ) + 5, strlen( $key ), 'Field key should be the previous key + 5 random characters' );
+
+		add_filter( 'frm_unique_field_key_separator', array( __CLASS__, 'underscore_key_separator' ) );
+
+		$key = FrmAppHelper::get_unique_key( $name, $table_name, $column );
+		$this->assertNotEquals( $name, $key, 'Field key should be unique' );
+		$this->assertStringContainsString( '___', $key, 'Field key should contain custom separator' );
+		$this->assertEquals( strlen( $name ) + 8, strlen( $key ), 'Field key should be the previous key + 3 character separator + 5 random characters' );
+
+		remove_filter( 'frm_unique_field_key_separator', array( __CLASS__, 'underscore_key_separator' ) );
+
+		// Test form keys
+		$table_name = 'frm_forms';
+		$column     = 'form_key';
+		$unique_key = FrmAppHelper::get_unique_key( $super_long_form_key, $table_name, $column );
 		$this->assertTrue( strlen( $unique_key ) <= 70 );
 		$this->assertNotEquals( $super_long_form_key, $unique_key );
+	}
+
+	public static function underscore_key_separator() {
+		return '___';
 	}
 
 	/**


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/1814896451/94441

> If you could add "___" to me before each random string, it would solve all my problems.

It seems like the easiest solution to their issue. Seems like a nice enhancement to add as well.

Example use.
```
function use_custom_field_key_separator() {
	return '___';
}
add_filter( 'frm_unique_field_key_separator', 'use_custom_field_key_separator' );
```

Also supports `add_filter( 'frm_unique_form_key_separator', 'use_custom_form_key_separator' );`, etc. I figure passing the column in the filter name makes the most sense in this case.

But I'm open for suggestions to a different solution as well.