### PR TITLE
Add border box box sizing to admin css buttons

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3042,7 +3042,10 @@ a.frm_option_icon:hover::before {
 
 .frm-btn-group.btn-group, .frm-btn-group.btn-group-vertical {
 	display: block;
-	vertical-align: middle;
+}
+
+.frm-btn-group.btn-group button {
+	box-sizing: border-box;
 }
 
 .frm_scale {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3004,8 +3004,9 @@ a.frm_option_icon:hover::before {
 	min-width: 40px;
 }
 
-.multiselect.dropdown-toggle {
+.frm-btn-group .multiselect.dropdown-toggle {
 	box-sizing: border-box;
+	min-height: unset;
 }
 
 .accordion-container .frm-dropdown-menu:before,

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3048,10 +3048,6 @@ a.frm_option_icon:hover::before {
 	display: block;
 }
 
-.frm-btn-group.btn-group button {
-	box-sizing: border-box;
-}
-
 .frm_scale {
 	text-align: center;
 	float: left;


### PR DESCRIPTION
I'm not totally sure when this actually was introduced. It looks like it was still happening when when I was checking out v5.0. I think it may have changed to a button when I updated bootstrap multiselect.

```
.frm-fields button.btn {
     padding: 6px 9px;
}
```

I was looking at a quiz action and noticed the multiselect dropdown is exceeding it's space, overflowing past the action container.

**Before**
<img width="1034" alt="Screen Shot 2022-03-22 at 2 20 04 PM" src="https://user-images.githubusercontent.com/9134515/159539810-074dc93b-47d2-4dd6-8408-743cbbf466af.png">
<img width="1028" alt="Screen Shot 2022-03-22 at 2 27 44 PM" src="https://user-images.githubusercontent.com/9134515/159540112-52234d44-d2a6-4afd-9d7b-55eeb9c910c9.png">

**After**
<img width="1028" alt="Screen Shot 2022-03-22 at 2 36 36 PM" src="https://user-images.githubusercontent.com/9134515/159542068-06a1150f-8d39-43a0-ae56-08e6b383d252.png">

I also dropped a `vertical-align` style because that doesn't work with `display: block`. A warning gets flagged on my IDE about it.
<img width="579" alt="Screen Shot 2022-03-22 at 2 24 46 PM" src="https://user-images.githubusercontent.com/9134515/159542079-ef36eadb-9b8c-44f8-b467-d623d83e4d30.png">

