### PR TITLE
Maybe match exploded arrays to values

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1622,12 +1622,23 @@ class FrmAppHelper {
 		}
 	}
 
+	/**
+	 * Check if current value matches.
+	 *
+	 * @param array  $values
+	 * @param string $current
+	 * @return bool
+	 */
 	public static function check_selected( $values, $current ) {
 		$values  = self::recursive_function_map( $values, 'trim' );
 		$values  = self::recursive_function_map( $values, 'htmlspecialchars_decode' );
 		$current = htmlspecialchars_decode( trim( $current ) );
 
-		return ( is_array( $values ) && in_array( $current, $values ) ) || ( ! is_array( $values ) && $values == $current );
+		if ( is_array( $values ) ) {
+			return in_array( $current, $values ) || implode( ', ', $values ) === $current;
+		}
+
+		return $values == $current;
 	}
 
 	public static function recursive_function_map( $value, $function ) {


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/1803938901/93581/

Trying to set a single checkbox item by a URL param is not working if the option includes a comma. It seems to be breaking it up.

So it's comparing an exploded array to a string, but they're the same value.
![image](https://user-images.githubusercontent.com/9134515/159994863-72a671d6-c3bb-4a75-9752-31454b6e084a.png)

<img width="642" alt="Screen Shot 2022-03-24 at 4 25 29 PM" src="https://user-images.githubusercontent.com/9134515/159994772-e1830b5a-e500-49be-a95c-143c26ea5f9d.png">

http://docker.for.mac.localhost:8889/wp-admin/admin-ajax.php?action=frm_forms_preview&form=p9qnt&resources[]=Streaming%20Services%20(Remote%20hits,%20Feed%20ingest,%20LiveU,%20Tentpole%20Events)

@stephywells do you think this makes sense? It's a little funny of a solution but it does solve the issue.