### PR TITLE
Exclude field options from Akismet comment data

### DIFF
--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -630,12 +630,61 @@ class FrmEntryValidate {
 	 * @param array $values Entry values.
 	 */
 	private static function skip_adding_values_to_akismet( &$values ) {
-		$skipped_field_ids = self::get_akismet_skipped_field_ids( $values );
-		foreach ( $skipped_field_ids as $field_id ) {
-			if ( isset( $values['item_meta'][ $field_id ] ) ) {
-				unset( $values['item_meta'][ $field_id ] );
+		$skipped_fields = self::get_akismet_skipped_field_ids( $values );
+		foreach ( $skipped_fields as $skipped_field ) {
+			if ( ! isset( $values['item_meta'][ $skipped_field->id ] ) ) {
+				continue;
+			}
+
+			if ( self::should_really_skip_field( $skipped_field, $values ) ) {
+				unset( $values['item_meta'][ $skipped_field->id ] );
+				if ( isset( $values['item_meta']['other'][ $skipped_field->id ] ) ) {
+					unset( $values['item_meta']['other'][ $skipped_field->id ] );
+				}
 			}
 		}
+	}
+
+	/**
+	 * Checks if a skip field should be really skipped.
+	 *
+	 * @since 5.02.04
+	 *
+	 * @param object $field_data Object contains `id` and `options`.
+	 * @param array  $values     Entry values.
+	 * @return bool
+	 */
+	private static function should_really_skip_field( $field_data, $values ) {
+		if ( empty( $field_data->options ) ) { // This is skipped field types.
+			return true;
+		}
+
+		FrmAppHelper::unserialize_or_decode( $field_data->options );
+		if ( ! $field_data->options ) { // Check if an error happens when unserializing.
+			return false;
+		}
+
+		$last_key = array_key_last( $field_data->options );
+
+		// If a choice field has no Other option.
+		if ( is_numeric( $last_key ) || 0 !== strpos( $last_key, 'other_' ) ) {
+			return true;
+		}
+
+		// If a choice field has Other option, but Other is not selected.
+		if ( empty( $values['item_meta']['other'][ $field_data->id ] ) ) {
+			return true;
+		}
+
+		// Check if submitted value is same as one of field option.
+		foreach ( $field_data->options as $option ) {
+			$option_value = ! is_array( $option ) ? $option : ( isset( $option['value'] ) ? $option['value'] : '' );
+			if ( $values['item_meta']['other'][ $field_data->id ] === $option_value ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -643,6 +692,7 @@ class FrmEntryValidate {
 	 *
 	 * @since 5.0.09
 	 * @since 5.0.13 Move out get_all_form_ids_and_flatten_meta() call and get `form_ids` from `$values`.
+	 * @since 5.2.04 This method returns array of object contains `id` and `options` instead of array of `id` only.
 	 *
 	 * @param array $values Entry values after running through {@see FrmEntryValidate::prepare_values_for_spam_check()}.
 	 * @return array
@@ -658,18 +708,11 @@ class FrmEntryValidate {
 		$where = array(
 			array(
 				'form_id' => $values['form_ids'],
-				array(
-					array(
-						'field_options not like' => ';s:5:"other";s:1:"1"',
-						'type'                   => $has_other_types,
-					),
-					'or'   => 1,
-					'type' => $skipped_types,
-				),
+				'type'    => array_merge( $skipped_types, $has_other_types ),
 			),
 		);
 
-		return FrmDb::get_col( 'frm_fields', $where );
+		return FrmDb::get_results( 'frm_fields', $where, 'id,options' );
 	}
 
 	/**

--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -660,8 +660,8 @@ class FrmEntryValidate {
 		}
 
 		FrmAppHelper::unserialize_or_decode( $field_data->options );
-		if ( ! $field_data->options ) { // Check if an error happens when unserializing.
-			return false;
+		if ( ! $field_data->options ) { // Check if an error happens when unserializing, or empty options.
+			return true;
 		}
 
 		$last_key = array_key_last( $field_data->options );

--- a/tests/entries/test_FrmEntryValidate.php
+++ b/tests/entries/test_FrmEntryValidate.php
@@ -169,6 +169,6 @@ class test_FrmEntryValidate extends FrmUnitTest {
 		foreach ( array( 'radio', 'select', 'scale', 'star', 'range', 'toggle' ) as $field_type ) {
 			$this->assertFalse( isset( $values['item_meta'][ $fields[ $field_type ]->id ] ) );
 		}
-		$this->assertTrue( isset( $values['item_meta'][ $fields['checkbox']->id ] ) );
+		$this->assertFalse( isset( $values['item_meta'][ $fields['checkbox']->id ] ) );
 	}
 }

--- a/tests/entries/test_FrmEntryValidate.php
+++ b/tests/entries/test_FrmEntryValidate.php
@@ -141,6 +141,7 @@ class test_FrmEntryValidate extends FrmUnitTest {
 		$form   = $this->factory->form->create_and_get();
 		$fields = array();
 
+		// These types are skipped.
 		foreach ( array( 'radio', 'checkbox', 'select', 'scale', 'star', 'range', 'toggle' ) as $field_type ) {
 			$fields[ $field_type ] = $this->factory->field->create_and_get(
 				array(
@@ -150,10 +151,56 @@ class test_FrmEntryValidate extends FrmUnitTest {
 			);
 		}
 
-		$fields['checkbox']->field_options['other'] = '1';
-		FrmField::update( $fields['checkbox']->id, array( 'field_options' => $fields['checkbox']->field_options ) );
+		// Radio field, has Other, but no options.
+		$fields['radio_2'] = $this->factory->field->create_and_get(
+			array(
+				'form_id'       => $form->id,
+				'type'          => 'radio',
+				'field_options' => array( 'other' => '1' ),
+			)
+		);
+
+		/*
+		 * Radio_3: has Other and options, value is one of option. Skip this from values.
+		 * Radio_4: has Other and options, value is Other and same as one of options. Skip this from values.
+		 * Radio_5: has Other and options, value is Other and different from one of option. Do not skip this.
+		 */
+		$options = array(
+			array(
+				'label' => 'Option 1',
+				'value' => 'option-1',
+			),
+			array(
+				'label' => 'Option 2',
+				'value' => 'option-2',
+			),
+			array(
+				'label' => 'Option 3',
+				'value' => 'option-3',
+			),
+			'other_3' => 'Other',
+		);
+
+		foreach ( array( 'radio_3', 'radio_4', 'radio_5' ) as $key ) {
+			$fields[ $key ] = $this->factory->field->create_and_get(
+				array(
+					'form_id'       => $form->id,
+					'type'          => 'radio',
+					'field_options' => array( 'other' => '1' ),
+					'options'       => $options,
+				)
+			);
+		}
 
 		$values = $this->factory->field->generate_entry_array( $form );
+
+		$values['item_meta'][ $fields['radio_3']->id ] = 'option-2';
+		$values['item_meta'][ $fields['radio_4']->id ] = 'Other';
+		$values['item_meta'][ $fields['radio_5']->id ] = 'Other';
+		$values['item_meta']['other'] = array(
+			$fields['radio_4']->id => 'option-3',
+			$fields['radio_5']->id => 'another-value',
+		);
 
 		$values['form_ids'] = $this->run_private_method(
 			array( 'FrmEntryValidate', 'get_all_form_ids_and_flatten_meta' ),
@@ -166,9 +213,10 @@ class test_FrmEntryValidate extends FrmUnitTest {
 		);
 
 		// Checkbox field shouldn't be skipped.
-		foreach ( array( 'radio', 'select', 'scale', 'star', 'range', 'toggle' ) as $field_type ) {
-			$this->assertFalse( isset( $values['item_meta'][ $fields[ $field_type ]->id ] ) );
+		foreach ( array( 'radio', 'radio_2', 'radio_3', 'radio_4', 'checkbox', 'select', 'scale', 'star', 'range', 'toggle' ) as $key ) {
+			$this->assertFalse( isset( $values['item_meta'][ $fields[ $key ]->id ] ) );
 		}
-		$this->assertFalse( isset( $values['item_meta'][ $fields['checkbox']->id ] ) );
+
+		$this->assertTrue( isset( $values['item_meta'][ $fields['radio_5']->id ] ) );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3482

In the previous version, we get the field IDs of choice fields that don't have `Other` option. In this version, I get the field ID and options of all choice fields, then loop through to check.