### PR TITLE
Remove underscore from register controls function (Elementor widget)

### DIFF
--- a/classes/widgets/FrmElementorWidget.php
+++ b/classes/widgets/FrmElementorWidget.php
@@ -22,7 +22,7 @@ if ( class_exists( '\Elementor\Widget_Base' ) ) {
 			return array( 'general' );
 		}
 
-		protected function _register_controls() {
+		protected function register_controls() {
 			$this->start_controls_section(
 				'section_form_dropdown',
 				array(


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3487

Found a thread on this deprecation on the Elementor forums.

https://forum.elementor.com/fixing-common-issues-33/deprecated-register-controls-is-deprecated-since-version-3-1-0-11123/index2.html

The majority of comments were people who didn't understand the issue until I came across this comment.

<img width="718" alt="Screen Shot 2022-03-29 at 9 32 57 AM" src="https://user-images.githubusercontent.com/9134515/160612034-de7bf07f-e5d2-47c8-9678-41e3af2f37e7.png">

Easy fix. The same function exists just without the underscore.