### PR TITLE
Add hooks for accessibility features

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2706,17 +2706,19 @@ class FrmAppHelper {
 		$ajax_url = apply_filters( 'frm_ajax_url', $ajax_url );
 
 		$script_strings = array(
-			'ajax_url'     => $ajax_url,
-			'images_url'   => self::plugin_url() . '/images',
-			'loading'      => __( 'Loading&hellip;', 'formidable' ),
-			'remove'       => __( 'Remove', 'formidable' ),
-			'offset'       => apply_filters( 'frm_scroll_offset', 4 ),
-			'nonce'        => wp_create_nonce( 'frm_ajax' ),
-			'id'           => __( 'ID', 'formidable' ),
-			'no_results'   => __( 'No results match', 'formidable' ),
-			'file_spam'    => __( 'That file looks like Spam.', 'formidable' ),
-			'calc_error'   => __( 'There is an error in the calculation in the field with key', 'formidable' ),
-			'empty_fields' => __( 'Please complete the preceding required fields before uploading a file.', 'formidable' ),
+			'ajax_url'           => $ajax_url,
+			'images_url'         => self::plugin_url() . '/images',
+			'loading'            => __( 'Loading&hellip;', 'formidable' ),
+			'remove'             => __( 'Remove', 'formidable' ),
+			'offset'             => apply_filters( 'frm_scroll_offset', 4 ),
+			'nonce'              => wp_create_nonce( 'frm_ajax' ),
+			'id'                 => __( 'ID', 'formidable' ),
+			'no_results'         => __( 'No results match', 'formidable' ),
+			'file_spam'          => __( 'That file looks like Spam.', 'formidable' ),
+			'calc_error'         => __( 'There is an error in the calculation in the field with key', 'formidable' ),
+			'empty_fields'       => __( 'Please complete the preceding required fields before uploading a file.', 'formidable' ),
+			'focus_first_error'  => self::should_focus_first_error(),
+			'include_alert_role' => self::should_include_alert_role_on_field_errors(),
 		);
 
 		$data = $wp_scripts->get_data( 'formidable', 'data' );
@@ -2784,6 +2786,28 @@ class FrmAppHelper {
 				wp_localize_script( 'formidable_admin', 'frm_admin_js', $admin_script_strings );
 			}
 		}
+	}
+
+	/**
+	 * Returns whether or not the first errored input should be auto-focused (default true).
+	 *
+	 * @since 5.2.05
+	 *
+	 * @return bool
+	 */
+	private static function should_focus_first_error() {
+		return (bool) apply_filters( 'frm_focus_first_error', true );
+	}
+
+	/**
+	 * Returns whether or not field errors should include role="alert" (default true).
+	 *
+	 * @since 5.2.05
+	 *
+	 * @return bool
+	 */
+	public static function should_include_alert_role_on_field_errors() {
+		return (bool) apply_filters( 'frm_include_alert_role_on_field_errors', true );
 	}
 
 	/**

--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -231,7 +231,7 @@ class FrmFieldFormHtml {
 		$this->maybe_add_error_id();
 		$error = isset( $this->pass_args['errors'][ 'field' . $this->field_id ] ) ? $this->pass_args['errors'][ 'field' . $this->field_id ] : false;
 
-		if ( ! empty( $error ) && false === strpos( $this->html, 'role="alert"' ) ) {
+		if ( ! empty( $error ) && false === strpos( $this->html, 'role="alert"' ) && FrmAppHelper::should_include_alert_role_on_field_errors() ) {
 			$error_body = self::get_error_body( $this->html );
 			if ( is_string( $error_body ) && false === strpos( $error_body, 'role=' ) ) {
 				$new_error_body = preg_replace( '/class="frm_error/', 'role="alert" class="frm_error', $error_body, 1 );

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -771,7 +771,7 @@ function frmFrontFormJS() {
 	}
 
 	function addFieldError( $fieldCont, key, jsErrors ) {
-		var input, id, describedBy;
+		var input, id, describedBy, roleString;
 		if ( $fieldCont.length && $fieldCont.is( ':visible' ) ) {
 			$fieldCont.addClass( 'frm_blank_field' );
 			input = $fieldCont.find( 'input, select, textarea' );
@@ -786,7 +786,8 @@ function frmFrontFormJS() {
 						jsErrors[key]
 					);
 				} else {
-					$fieldCont.append( '<div class="frm_error" role="alert" id="' + id + '">' + jsErrors[key] + '</div>' );
+					roleString = frm_js.include_alert_role ? 'role="alert"' : '';
+					$fieldCont.append( '<div class="frm_error" ' + roleString + ' id="' + id + '">' + jsErrors[key] + '</div>' );
 				}
 
 				if ( typeof describedBy === 'undefined' ) {
@@ -1095,6 +1096,10 @@ function frmFrontFormJS() {
 
 	function checkForErrorsAndMaybeSetFocus() {
 		var errors, element, timeoutCallback;
+
+		if ( ! frm_js.focus_first_error ) {
+			return;
+		}
 
 		errors = document.querySelectorAll( '.frm_form_field .frm_error' );
 		if ( ! errors.length ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3507

This update adds two new simple filters that allow you to turn off specific accessibility features (as requested by this user).

```
add_filter( 'frm_focus_first_error', '__return_false' );
add_filter( 'frm_include_alert_role_on_field_errors', '__return_false' );
```

It should work with both JavaScript validation and without. If the role="alert" is included in custom HTML, it will be included anyway but this will prevent any forced insertion.