### PR TITLE
Remove unexpected add new button on import page

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1102,6 +1102,11 @@ class FrmAppHelper {
 			return;
 		}
 
+		if ( empty( $atts['new_link'] ) && empty( $atts['trigger_new_form_modal'] ) && empty( $atts['class'] ) ) {
+			// Do not render a button if none of these attributes are set.
+			return;
+		}
+
 		$href  = ! empty( $atts['new_link'] ) ? esc_url( $atts['new_link'] ) : '#';
 		$class = 'button button-primary frm-button-primary frm-with-plus';
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3583

This came up when I refactored the add new button code. I missed that the import button calls this code without any of the expected attributes.

My solution is to just check if none of the attributes are set. If all of those are missing it expects the function to do nothing.

The alternative is trying to do something like.

```
if ( ! $atts['import_link'] ) {
    FrmAppHelper::add_new_item_link( $atts );
}
```

in the admin-header.php, or to check against `$atts['import_link']` specifically in this function but that introduces another option that isn't really related to the function.

But that would only catch the import button. This may effect other calls to `add_new_item_link`. As it's a public function I wouldn't be surprised if someone was using it in a custom flow so fixing it in-function probably makes more sense.