### PR TITLE
Move unlocked application templates to the front

### DIFF
--- a/classes/controllers/FrmApplicationsController.php
+++ b/classes/controllers/FrmApplicationsController.php
@@ -70,7 +70,17 @@ class FrmApplicationsController {
 		$api          = new FrmApplicationApi();
 		$applications = $api->get_api_info();
 		$applications = array_filter( $applications, 'is_array' );
-		$applications = self::sort_templates( $applications );
+
+		$unlocked_templates = array();
+		$locked_templates   = array();
+		foreach ( $applications as $application ) {
+			if ( ! empty( $application['url'] ) ) {
+				$unlocked_templates[] = $application;
+			} else {
+				$locked_templates[] = $application;
+			}
+		}
+		$applications = array_merge( self::sort_templates( $unlocked_templates ), self::sort_templates( $locked_templates ) );
 
 		FrmApplicationTemplate::init();
 


### PR DESCRIPTION
Following up from a comment the other day.

> How complicated would it be to move allowed applications to the front of the list, and alphabetic each group separately?

<img width="1109" alt="Screen Shot 2022-05-26 at 2 45 42 PM" src="https://user-images.githubusercontent.com/9134515/170545734-7dcd8412-3141-42aa-a6e8-b5172ac34498.png">