### PR TITLE
Make applications more responsive, and fix position of upgrade button…

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1606,7 +1606,8 @@ class FrmFormsController {
 				if ( strpos( $action, 'bulk_' ) === 0 ) {
 					FrmAppHelper::remove_get_action();
 
-					return self::list_form();
+					self::list_form();
+					return;
 				}
 
 				self::display_forms_list();

--- a/css/admin/applications.css
+++ b/css/admin/applications.css
@@ -217,18 +217,12 @@
 	pointer-events: none;
 }
 
-.frm-admin-page-applications #frm_top_bar {
-	position: relative;
-}
-
 .frm-admin-page-applications #frm_top_bar h1 {
 	width: auto;
 }
 
 .frm-admin-page-applications #frm_top_bar .install-now {
-	position: absolute;
-	top: 50%;
-	transform: translateY(-50%);
+	vertical-align: bottom;
 }
 
 .frm-application-templates-nav .frm-search {

--- a/css/admin/applications.css
+++ b/css/admin/applications.css
@@ -217,8 +217,18 @@
 	pointer-events: none;
 }
 
+.frm-admin-page-applications #frm_top_bar {
+	position: relative;
+}
+
 .frm-admin-page-applications #frm_top_bar h1 {
 	width: auto;
+}
+
+.frm-admin-page-applications #frm_top_bar .install-now {
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
 }
 
 .frm-application-templates-nav .frm-search {
@@ -245,7 +255,17 @@
 	margin-top: 20px;
 }
 
-@media only screen and (max-width: 1050px) {
+@media only screen and (max-width: 1200px) {
+	.frm-application-card {
+		grid-column: span 4/span 4; /* treat as frm4 */
+	}
+
+	.frm-application-card:nth-child(3) ~ .frm-application-card {
+		margin-top: 20px;
+	}
+}
+
+@media only screen and (max-width: 800px) {
 	.frm-application-card {
 		grid-column: span 6/span 6; /* treat as frm6 */
 	}
@@ -255,7 +275,7 @@
 	}
 }
 
-@media only screen and (max-width: 782px) {
+@media only screen and (max-width: 600px) {
 	#frm_application_category_filter {
 		display: block;
 		margin-left: 0;

--- a/js/admin/applications.js
+++ b/js/admin/applications.js
@@ -161,7 +161,7 @@
 				tag(
 					'h2',
 					{
-						text: __( 'Formidable Applications', 'formidable' ),
+						text: __( 'Application Templates', 'formidable' ),
 						className: 'frm-h2'
 					}
 				),


### PR DESCRIPTION
…, and rename formidable applications category

I played with the widths a bit and added a 3 column view.

This update also renames the category and fixes the upgrade button position. I don't really know when it broke but I just made an issue for it today https://github.com/Strategy11/formidable-pro/issues/3589

<img width="373" alt="Screen Shot 2022-05-27 at 10 58 08 AM" src="https://user-images.githubusercontent.com/9134515/170714165-2b9ac238-8525-4390-82f4-327bafda3653.png">

![IVz4O7YJg6](https://user-images.githubusercontent.com/9134515/170713776-ba86ce97-b3a5-4cb4-b9b5-3df24e54e365.gif)

There's also a small fix in here for phpstan.

Error: Result of static method FrmFormsController::list_form() (void) is used.
 ------ ------------------------------------------------------------------- 
  Line   classes/controllers/FrmFormsController.php                         
 ------ ------------------------------------------------------------------- 
  1609   Result of static method FrmFormsController::list_form() (void) is  
         used.                                                              
 ------ ------------------------------------------------------------------- 

I might have just missed this when I added a comment. Easy fix though to separate the two lines so it's easier to tell that the function isn't actually returning anything to pass forward.