### PR TITLE
Add filter for gmt offset to avoid fatal error in php8

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -4,9 +4,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class FrmAppHelper {
-	public static $db_version = 98; // Version of the database we are moving to.
+	public static $db_version     = 98; // Version of the database we are moving to.
 	public static $pro_db_version = 37; //deprecated
-	public static $font_version = 7;
+	public static $font_version   = 7;
+
+	/**
+	 * @var bool $added_gmt_offset_filter
+	 */
+	private static $added_gmt_offset_filter = false;
 
 	/**
 	 * @since 2.0
@@ -3447,6 +3452,33 @@ class FrmAppHelper {
 		}
 
 		return strlen( $parts[ count( $parts ) - 1 ] );
+	}
+
+	/**
+	 * Prevent a fatal error in PHP8 if gmt_offset happens to be set any empty string.
+	 *
+	 * @since 5.3.1
+	 *
+	 * @return int
+	 */
+	public static function filter_gmt_offset() {
+		if ( self::$added_gmt_offset_filter ) {
+			// Avoid adding twice.
+			return;
+		}
+
+		add_filter(
+			'option_gmt_offset',
+			function( $offset ) {
+				if ( ! is_string( $offset ) || is_numeric( $offset ) ) {
+					// Leave a valid value alone.
+					return $offset;
+				}
+
+				return 0;
+			}
+		);
+		self::$added_gmt_offset_filter = true;
 	}
 
 	/**

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3455,11 +3455,13 @@ class FrmAppHelper {
 	}
 
 	/**
-	 * Prevent a fatal error in PHP8 if gmt_offset happens to be set any empty string.
+	 * Prevent a fatal error in PHP8 if gmt_offset happens to be set an empty string.
+	 * This is a bug in WordPress. It isn't safe to call current_time( 'timestamp' ) without this with an empty string offset.
+	 * In the future this might be safe to remove. Keep an eye on the current_time function in functions.php.
 	 *
 	 * @since 5.3.1
 	 *
-	 * @return int
+	 * @return void
 	 */
 	public static function filter_gmt_offset() {
 		if ( self::$added_gmt_offset_filter ) {

--- a/classes/models/FrmFormApi.php
+++ b/classes/models/FrmFormApi.php
@@ -166,6 +166,8 @@ class FrmFormApi {
 	protected function get_cached() {
 		$cache = get_option( $this->cache_key );
 
+		self::filter_gmt_offset();
+
 		if ( empty( $cache ) || empty( $cache['timeout'] ) || current_time( 'timestamp' ) > $cache['timeout'] ) {
 			return false; // Cache is expired
 		}
@@ -184,6 +186,8 @@ class FrmFormApi {
 	 * @since 3.06
 	 */
 	protected function set_cached( $addons ) {
+		self::filter_gmt_offset();
+
 		$data = array(
 			'timeout' => strtotime( $this->cache_timeout, current_time( 'timestamp' ) ),
 			'value'   => json_encode( $addons ),
@@ -191,6 +195,27 @@ class FrmFormApi {
 		);
 
 		update_option( $this->cache_key, $data, 'no' );
+	}
+
+	/**
+	 * Prevent a fatal error in PHP8 if gmt_offset happens to be set any empty string.
+	 *
+	 * @since 5.3.1
+	 *
+	 * @return int
+	 */
+	private function filter_gmt_offset() {
+		add_filter(
+			'option_gmt_offset',
+			function( $offset ) {
+				if ( ! is_string( $offset ) || is_numeric( $offset ) ) {
+					// Leave a valid value alone.
+					return $offset;
+				}
+
+				return 0;
+			}
+		);
 	}
 
 	/**

--- a/classes/models/FrmFormApi.php
+++ b/classes/models/FrmFormApi.php
@@ -166,7 +166,7 @@ class FrmFormApi {
 	protected function get_cached() {
 		$cache = get_option( $this->cache_key );
 
-		self::filter_gmt_offset();
+		FrmAppHelper::filter_gmt_offset();
 
 		if ( empty( $cache ) || empty( $cache['timeout'] ) || current_time( 'timestamp' ) > $cache['timeout'] ) {
 			return false; // Cache is expired
@@ -186,7 +186,7 @@ class FrmFormApi {
 	 * @since 3.06
 	 */
 	protected function set_cached( $addons ) {
-		self::filter_gmt_offset();
+		FrmAppHelper::filter_gmt_offset();
 
 		$data = array(
 			'timeout' => strtotime( $this->cache_timeout, current_time( 'timestamp' ) ),
@@ -195,27 +195,6 @@ class FrmFormApi {
 		);
 
 		update_option( $this->cache_key, $data, 'no' );
-	}
-
-	/**
-	 * Prevent a fatal error in PHP8 if gmt_offset happens to be set any empty string.
-	 *
-	 * @since 5.3.1
-	 *
-	 * @return int
-	 */
-	private function filter_gmt_offset() {
-		add_filter(
-			'option_gmt_offset',
-			function( $offset ) {
-				if ( ! is_string( $offset ) || is_numeric( $offset ) ) {
-					// Leave a valid value alone.
-					return $offset;
-				}
-
-				return 0;
-			}
-		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://secure.helpscout.net/conversation/1900124057/100035/

It happens when a call to `current_time( 'timestamp' )` is made if the `gmt_offset` WordPress setting is an empty string.

It's failing on this WordPress code.

```
time() + (int) ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS );
```

Technically this is more or a WordPress bug and we could probably remove this in the future. But it's causing fatal errors as soon as you load the admin pages if gmt_offset is set to an empty string. It's possible to fix on our end with this filter, and that probably makes sense while the issue exists in WordPress.

I made it public because it looks like pro uses `current_time( 'timestamp' )` as well so I think I may add an update there as well.