### PR TITLE
Set opacity:1 to firefox placeholder style

### DIFF
--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -186,6 +186,7 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 .<?php echo esc_html( $style_class ); ?> input::-moz-placeholder,
 .<?php echo esc_html( $style_class ); ?> textarea::-moz-placeholder{
 	color: <?php echo esc_html( $text_color_disabled . $important ); ?>;
+	opacity: 1;
 }
 .<?php echo esc_html( $style_class ); ?> input:-ms-input-placeholder,
 <?php echo esc_html( $style_class ); ?> textarea:-ms-input-placeholder{


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/1920249527/101307/

The Read Only Text Color setting is used for placeholders. On Chrome, it uses the color. In Firefox, you need to specify `opacity: 1` or it appears as a more faded out alpha transparency.

Related Stack Overflow question https://stackoverflow.com/questions/19621306/css-placeholder-text-color-on-firefox#answer-19621642

**Before**
<img width="407" alt="Screen Shot 2022-06-14 at 10 38 41 AM" src="https://user-images.githubusercontent.com/9134515/173591243-a23afe82-8397-4c25-976b-7c8e3b47b554.png">

**After**
<img width="275" alt="Screen Shot 2022-06-14 at 10 38 32 AM" src="https://user-images.githubusercontent.com/9134515/173591251-e03176ad-cc2b-48bc-9aaf-c9e7d913bebf.png">

