### PR TITLE
Force postbox to display block in new form modal

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7879,6 +7879,13 @@ function frmAdminBuildJS() {
 		jQuery( document ).on( 'click', '.frm-trigger-new-form-modal', triggerNewFormModal );
 		$modal = initModal( '#frm_new_form_modal', '600px' );
 
+		setTimeout(
+			function() {
+				$modal.get( 0 ).querySelector( '.postbox' ).style.display = 'block'; // Fixes pro issue #3508, prevent a conflict that hides the postbox in modal.
+			},
+			0
+		);
+
 		installFormTrigger = document.createElement( 'a' );
 		installFormTrigger.classList.add( 'frm-install-template', 'frm_hidden' );
 		document.body.appendChild( installFormTrigger );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3508

Tested it on the customer's site. Without the timeout it still wasn't working so whatever is hiding the postbox is hooking into the modal opening or something.

Long term it should be possible to try drawing this modal with JavaScript instead. Other modals like the new view/new application ones all appear to be fine, so I think it might have to do something with this modal existing already on page load.