### PR TITLE
New frm_after_destroy_entry_hook

### DIFF
--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -251,6 +251,12 @@ class FrmEntry {
 		return $query_results;
 	}
 
+	/**
+	 * Delete an entry.
+	 *
+	 * @param string|int $id
+	 * @return bool True on success, false if nothing was deleted.
+	 */
 	public static function destroy( $id ) {
 		global $wpdb;
 		$id = (int) $id;
@@ -258,16 +264,32 @@ class FrmEntry {
 		$entry = self::getOne( $id );
 		if ( ! $entry ) {
 			$result = false;
-
 			return $result;
 		}
 
+		/**
+		 * Trigger an action to run custom logic before the entry is deleted.
+		 *
+		 * @param int      $id    The id of the entry that was destroyed.
+		 * @param stdClass $entry The entry object.
+		 */
 		do_action( 'frm_before_destroy_entry', $id, $entry );
 
 		$wpdb->query( $wpdb->prepare( 'DELETE FROM ' . $wpdb->prefix . 'frm_item_metas WHERE item_id=%d', $id ) );
 		$result = $wpdb->query( $wpdb->prepare( 'DELETE FROM ' . $wpdb->prefix . 'frm_items WHERE id=%d', $id ) );
 
 		self::clear_cache();
+
+		/**
+		 * Trigger an action to run custom logic after the entry is deleted.
+		 * Use this hook if you need to update caching after an entry is deleted.
+		 *
+		 * @since 5.4.1
+		 *
+		 * @param int      $id    The id of the entry that was destroyed.
+		 * @param stdClass $entry The entry object.
+		 */
+		do_action( 'frm_after_destroy_entry', $id, $entry );
 
 		return $result;
 	}


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/1924502130/101690/

There isn't a very practical way to hook into after these get deleted, just before. In this customer's case they want to build their cache after the deleting happens, which doesn't really work if you try to trigger it beforehand.

I opted to still pass the deleted entry so you can check it for specific things like form_id or post_id associated with the entry as well.

Example use.
```
add_action(
	'frm_after_destroy_entry',
	function( $entry_id, $entry ) {
		$target_form_id = 294; // change this.
		if ( $target_form_id !== (int) $entry->form_id ) {
			return;
		}

		// Handle deleted entry for target form.
	},
	10,
	2
);
```