### PR TITLE
Exit init new form modal function early if $modal is false

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7879,6 +7879,10 @@ function frmAdminBuildJS() {
 		jQuery( document ).on( 'click', '.frm-trigger-new-form-modal', triggerNewFormModal );
 		$modal = initModal( '#frm_new_form_modal', '600px' );
 
+		if ( false === $modal ) {
+			return;
+		}
+
 		setTimeout(
 			function() {
 				$modal.get( 0 ).querySelector( '.postbox' ).style.display = 'block'; // Fixes pro issue #3508, prevent a conflict that hides the postbox in modal.


### PR DESCRIPTION
Missed that some pages that don't have the modal are calling this function. I'm adding an early exit so it doesn't add all of the new form modal event listeners if there is no modal.

![Screen Shot 2022-06-23 at 9 10 23 AM](https://user-images.githubusercontent.com/9134515/175295462-1a514797-bd0e-4550-90a0-9613413655bd.png)
