### PR TITLE
Views/reports tabs not faded out when using lite fix

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -348,7 +348,10 @@ ul.frm_form_nav > li:last-of-type {
 .frm_form_nav > li > a {
 	font-size: 13px;
 	text-transform: uppercase;
-	opacity: .8;
+}
+
+.frm_form_nav > li > a:not(.frm_noallow) {
+	opacity: 0.8;
 }
 
 .frm_form_nav > li > a:hover {


### PR DESCRIPTION
Noticed when using lite only that views/reports don't ever fade out anymore.

Checked git blame and it looks like it happened about 8 months ago when field search was added https://github.com/Strategy11/formidable-forms/commit/aebf5b4ea080ef30b1efadea9a6e550debe1afa8

**Before**
<img width="533" alt="Screen Shot 2022-07-04 at 10 56 05 AM" src="https://user-images.githubusercontent.com/9134515/177169894-77ea5d2e-b0bb-46ac-a6ad-fdf5f9795f6a.png">

**After**
<img width="535" alt="Screen Shot 2022-07-04 at 10 55 53 AM" src="https://user-images.githubusercontent.com/9134515/177169866-e3a37337-d198-4e1a-b20b-0f9cc7ed2f0e.png">
