### PR TITLE
Fixes PHPStan broken workflow adding composer/installer to allow-plugins rule.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,10 @@
     "require-dev": {
 		"yoast/phpunit-polyfills": "^1.0",
 		"php-stubs/wordpress-stubs": "^5.7.0"
-    }
+    },
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true
+		}
+	}
 }


### PR DESCRIPTION
This PR fixes the PHPStan broken workflow issue as described in [https://github.com/Strategy11/formidable-pro/issues/3663](https://github.com/Strategy11/formidable-pro/issues/3663).