### PR TITLE
Switch api form source

### DIFF
--- a/classes/views/frm-forms/new-form-overlay/leave-email.php
+++ b/classes/views/frm-forms/new-form-overlay/leave-email.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <div class="frmcenter">
-	<div id="frmapi-email-form" class="frmapi-form frm_hidden" data-url="https://community.formidableforms.com/wp-json/frm/v2/forms/freetemplates?return=html">
+	<div id="frmapi-email-form" class="frmapi-form frm_hidden" data-url="https://sandbox.formidableforms.com/api/wp-json/frm/v2/forms/freetemplates?return=html&exclude_script=jquery&exclude_style=formidable-css">
 		<span class="frm-wait"></span>
 	</div>
 	<img src="<?php echo esc_url( FrmAppHelper::plugin_url() . '/images/leave-email.svg' ); ?>" />

--- a/classes/views/shared/review.php
+++ b/classes/views/shared/review.php
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<div class="frm-feedback-request frm_hidden">
 		<p><?php esc_html_e( 'Sorry to hear you aren\'t enjoying building with Formidable. We would love a chance to improve. Could you take a minute and let us know what we can do better?', 'formidable' ); ?></p>
 
-		<div id="frmapi-feedback" class="frmapi-form" data-url="https://community.formidableforms.com/wp-json/frm/v2/forms/feedback?return=html">
+		<div id="frmapi-feedback" class="frmapi-form" data-url="https://sandbox.formidableforms.com/api/wp-json/frm/v2/forms/feedback?return=html&exclude_script=jquery&exclude_style=formidable-css">
 			<span class="frm-wait frm_visible_spinner"></span>
 		</div>
 	</div>
@@ -89,8 +89,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			url:frmcont.data('url'),
 			success:function(json){
 				var form = json.renderedHtml;
-				form = form.replace(/<script\b[^<]*(community.formidableforms.com\/wp-includes\/js\/jquery\/jquery)[^<]*><\/script>/gi, '' );
-				form = form.replace(/<link\b[^>]*(formidableforms.css)[^>]*>/gi, '' );
+				form = form.replace(/<link\b[^>]*(formidableforms.css|action=frmpro_css)[^>]*>/gi, '' );
 				frmcont.html(form);
 			}
 		});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8162,8 +8162,7 @@ function frmAdminBuildJS() {
 				url: formContainer.getAttribute( 'data-url' ),
 				success: function( json ) {
 					var form = json.renderedHtml;
-					form = form.replace( /<script\b[^<]*(community.formidableforms.com\/wp-includes\/js\/jquery\/jquery)[^<]*><\/script>/gi, '' );
-					form = form.replace( /<link\b[^>]*(formidableforms.css)[^>]*>/gi, '' );
+					form = form.replace( /<link\b[^>]*(formidableforms.css|action=frmpro_css)[^>]*>/gi, '' );
 					formContainer.innerHTML = form;
 				}
 			});


### PR DESCRIPTION
This switches the free template form and the feedback form from the comminuty site to the same site the demo forms are hosted.

To see the feedback form:
- when a review is requested, select "not really".
- To force the review request to appear, a few lines of code need to be commented out in FrmReviews.php:
//if ( empty( $dismissed ) && $week_ago ) {
			$this->review();
//}
And any "return;" line in review()

To see the form template form:
- Clear the saved license key
- Deactivate Pro