### PR TITLE
Repeater-entry-style

### DIFF
--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -54,6 +54,14 @@ class FrmTableHTMLGenerator {
 	protected $td_style = '';
 
 	/**
+	 * Used to add a class in tables. Set in Pro.
+	 *
+	 * @var bool
+	 * @since x.x
+	 */
+	public $is_child = false;
+
+	/**
 	 * FrmTableHTMLGenerator constructor.
 	 *
 	 * @param string $type
@@ -271,9 +279,7 @@ class FrmTableHTMLGenerator {
 	 */
 	public function generate_two_cell_table_row( $label, $value ) {
 		$row = '<tr' . $this->tr_style();
-		if ( $value === '' ) {
-			$row .= ' class="frm-empty-row"';
-		}
+		$row .= $this->add_row_class( $value === '' );
 		$row .= '>';
 
 		$label = '<th' . $this->td_style . '>' . wp_kses_post( $label ) . '</th>';
@@ -304,12 +310,35 @@ class FrmTableHTMLGenerator {
 	 * @return string
 	 */
 	public function generate_single_cell_table_row( $value ) {
-		$row = '<tr' . $this->tr_style() . '>';
+		$row = '<tr' . $this->tr_style();
+		$row .= $this->add_row_class();
+		$row .= '>';
 		$row .= '<td colspan="2"' . $this->td_style . '>' . $value . '</td>';
 		$row .= '</tr>' . "\r\n";
 
 		$this->switch_odd();
 
 		return $row;
+	}
+
+	/**
+	 * Add classes to the tr.
+	 *
+	 * @since x.x
+	 * @param bool $empty If the value in the row is blank.
+	 */
+	protected function add_row_class( $empty = false ) {
+		$class = '';
+		if ( $empty ) {
+			// Only add this class on two cell rows.
+			$class .= ' frm-empty-row';
+		}
+		if ( $this->is_child ) {
+			$class .= ' frm-child-row';
+		}
+		if ( $class ) {
+			$class = ' class="' . $class . '"';
+		}
+		return $class;
 	}
 }

--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -59,7 +59,7 @@ class FrmTableHTMLGenerator {
 	 * @var bool
 	 * @since x.x
 	 */
-	//public $is_child = false;
+	public $is_child = false;
 
 	/**
 	 * FrmTableHTMLGenerator constructor.

--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -59,7 +59,7 @@ class FrmTableHTMLGenerator {
 	 * @var bool
 	 * @since x.x
 	 */
-	public $is_child = false;
+	//public $is_child = false;
 
 	/**
 	 * FrmTableHTMLGenerator constructor.
@@ -337,7 +337,7 @@ class FrmTableHTMLGenerator {
 			$class .= ' frm-child-row';
 		}
 		if ( $class ) {
-			$class = ' class="' . $class . '"';
+			$class = ' class="' . trim( $class ) . '"';
 		}
 		return $class;
 	}

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -493,7 +493,7 @@ ul.frm_form_nav > li:last-of-type {
 }
 
 .frm-child-row {
-	box-shadow: 5px 0px 0px 0px inset var(--grey-border);
+	box-shadow: 5px 0px 0px 0px inset var(--sidebar-hover);
 }
 
 .frm_animate_bg {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -492,6 +492,10 @@ ul.frm_form_nav > li:last-of-type {
 	display: none;
 }
 
+.frm-child-row {
+	box-shadow: 5px 0px 0px 0px inset var(--grey-border);
+}
+
 .frm_animate_bg {
 	transition: background 200ms linear, color 200ms linear;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3698,6 +3698,10 @@ label input[type="checkbox"], label input[type="radio"] {
 	background-color: var(--sidebar-color);
 }
 
+.frm-alt-table h3 {
+	margin-bottom: 0;
+}
+
 .form-field .frm_cb_button {
 	height: 22px;
 	line-height: 20px;


### PR DESCRIPTION
This updates the styling of a single entry in a table, based on the design here:
https://www.figma.com/file/K3L40rJTHXwjNeBA3LoWBr/%E2%9C%85-PDF?node-id=604%3A296

Requires https://github.com/Strategy11/formidable-pro/pull/3658

After:
<img width="954" alt="Screen Shot 2022-07-12 at 6 25 37 PM" src="https://user-images.githubusercontent.com/1116876/178623162-ca1e7ed6-2700-4d8b-b5cd-8f10054a8210.png">

