### PR TITLE
add aria-label to autocomplete dropdown items.

### DIFF
--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -268,7 +268,13 @@ let frmDom;
 					if ( this.value === '' || this.nextElementSibling.value < 1 ) {
 						jQuery( this ).autocomplete( 'search', this.value );
 					}
-				});
+				})
+				.data('ui-autocomplete')._renderItem = function( ul, item ) {
+					return jQuery( '<li>' )
+					.attr( 'aria-label', item.label )
+					.append( jQuery( '<div>' ).text( item.label ) )
+					.appendTo( ul );
+				};
 			}
 		},
 


### PR DESCRIPTION
As related to this [PR](https://github.com/Strategy11/formidable-views/pull/324), the applications dropdown items id is read instead of the Application name. This pertains to the autocomplete function. This can be fixed by extending the `_renderItem` when the autocomplete is created. [https://api.jqueryui.com/autocomplete/#method-_renderItem](https://api.jqueryui.com/autocomplete/#method-_renderItem)

![image](https://user-images.githubusercontent.com/41271840/178761727-b1cecdc3-d60b-4dc8-85b4-a41fe367fbef.png)
