### PR TITLE
Stop showing autoresponder upsell for action types with no autoresponder support

### DIFF
--- a/classes/views/frm-form-actions/_action_inside.php
+++ b/classes/views/frm-form-actions/_action_inside.php
@@ -79,7 +79,7 @@ if ( ! FrmAppHelper::pro_is_installed() ) {
 }
 
 // Show Form Action Automation indicator.
-if ( ! function_exists( 'load_frm_autoresponder' ) && in_array( $form_action->post_excerpt, apply_filters( 'frm_autoresponder_allowed_actions', array( 'email', 'twilio', 'api', 'register' ), true ) ) ) {
+if ( ! function_exists( 'load_frm_autoresponder' ) && in_array( $form_action->post_excerpt, apply_filters( 'frm_autoresponder_allowed_actions', array( 'email', 'twilio', 'api', 'register' ) ), true ) ) {
 	$upgrading = FrmAddonsController::install_link( 'autoresponder' );
 	$params    = array(
 		'href'         => 'javascript:void(0)',

--- a/classes/views/frm-form-actions/_action_inside.php
+++ b/classes/views/frm-form-actions/_action_inside.php
@@ -79,7 +79,7 @@ if ( ! FrmAppHelper::pro_is_installed() ) {
 }
 
 // Show Form Action Automation indicator.
-if ( ! function_exists( 'load_frm_autoresponder' ) ) {
+if ( ! function_exists( 'load_frm_autoresponder' ) && in_array( $form_action->post_excerpt, apply_filters( 'frm_autoresponder_allowed_actions', array( 'email', 'twilio', 'api', 'register' ), true ) ) ) {
 	$upgrading = FrmAddonsController::install_link( 'autoresponder' );
 	$params    = array(
 		'href'         => 'javascript:void(0)',


### PR DESCRIPTION
This becomes pretty apparent one you start trying to add a bunch of outcome quiz actions. The extra up-sell on every one takes up a lot of space.

I got confused by this before, when I went to install an autoresponder from this trigger only to refresh the action and see the settings didn't exist for my action type. I think it could be a misleading up-sell that could get customers frustrated thinking something supports automation when it doesn't.

This removes it from all quiz actions and others that aren't 'email', 'twilio', 'api', 'register', or 'zapier'.

**Before**
<img width="812" alt="Screen Shot 2022-07-14 at 2 30 11 PM" src="https://user-images.githubusercontent.com/9134515/179045840-c625f6f5-4fc4-48f4-994b-0360c24110a3.png">

**After**
<img width="820" alt="Screen Shot 2022-07-14 at 2 33 04 PM" src="https://user-images.githubusercontent.com/9134515/179046282-3f85df1f-8a89-438e-a5ac-30e89ad4ade8.png">