### PR TITLE
add function that returns the list of field translatable strings.

### DIFF
--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -1146,4 +1146,23 @@ class FrmField {
 
 		return ! empty( $field_type_obj->is_combo_field );
 	}
+
+	/**
+	 * Get a list of all field settings that should be translated
+	 * on a multilingual site.
+	 *
+	 * @since x.xx
+	 * @param object $field - The field object
+	 */
+	public static function translatable_strings( $field ) {
+		$strings = array(
+			'name',
+			'description',
+			'blank',
+			'conf_msg',
+			'invalid',
+		);
+
+		return apply_filters( 'frm_field_strings', $strings, $field );
+	}
 }


### PR DESCRIPTION
It might be a good idea to create a function that returns the list of translatable strings for a given field pretty much like `FrmForm::translatable_strings` to keep things consistent. We need similar functionality for fields to fix [https://github.com/Strategy11/formidable-wpml/issues/3](https://github.com/Strategy11/formidable-wpml/issues/3)