### PR TITLE
Reliably load frmDom before admin js

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -466,10 +466,10 @@ class FrmAppController {
 		wp_register_style( 'formidable_admin_global', $plugin_url . '/css/admin/frm_admin_global.css', array(), $version );
 		wp_enqueue_style( 'formidable_admin_global' );
 
-		wp_register_style( 'formidable-admin', $plugin_url . '/css/frm_admin.css', array(), $version );
+		wp_register_script( 'formidable_dom', $plugin_url . '/js/admin/dom.js', array( 'jquery', 'jquery-ui-dialog', 'wp-i18n' ), $version, true );
+		wp_register_style( 'formidable-admin', $plugin_url . '/css/frm_admin.css', array( 'formidable_dom' ), $version );
 		wp_register_style( 'formidable-grids', $plugin_url . '/css/frm_grids.css', array(), $version );
 
-		wp_register_script( 'formidable_dom', $plugin_url . '/js/admin/dom.js', array( 'jquery', 'jquery-ui-dialog', 'wp-i18n' ), $version, true );
 		wp_register_script( 'formidable_embed', $plugin_url . '/js/admin/embed.js', array( 'formidable_dom', 'jquery-ui-autocomplete' ), $version, true );
 		self::register_popper1();
 		wp_register_script( 'bootstrap_tooltip', $plugin_url . '/js/bootstrap.min.js', array( 'jquery', 'popper' ), '4.6.1', true );


### PR DESCRIPTION
It looks like frmDom is included as a defined global in formidable_admin.js, but it was creating a js error on some sites:

```
formidable_admin.js?ver=5.3.2:320 Uncaught ReferenceError: frmDom is not defined
at frmAdminBuildJS (formidable_admin.js?ver=5.3.2:320:37)
at formidable_admin.js?ver=5.3.2:9722:17
```

This sets frmDom as a requirement for formidable-admin.