### PR TITLE
Update unit test to cover enhancements to add_aria_description function

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1096,7 +1096,7 @@ DEFAULT_HTML;
 
 		if ( $aria_describedby_exists ) {
 			$input_html = preg_replace( '/aria-describedby=\"[^\"]*\"/', 'aria-describedby="' . $describedby . '"', $input_html );
-		} elseif ( ! empty( $describedby ) ) {
+		} elseif ( $describedby ) {
 			$input_html .= ' aria-describedby="' . esc_attr( trim( $describedby ) ) . '"';
 		}
 

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1069,7 +1069,9 @@ DEFAULT_HTML;
 		$custom_desc_fields  = preg_grep( '/frm_desc_field_*/', $describedby );
 
 		if ( $custom_desc_fields && $custom_error_fields ) {
-			if ( array_key_first( $custom_error_fields ) > array_key_first( $custom_desc_fields ) ) {
+			reset( $custom_error_fields );
+			reset( $custom_desc_fields );
+			if ( key( $custom_error_fields ) > key( $custom_desc_fields ) ) {
 				$error_comes_first = false;
 			}
 		}

--- a/tests/fields/test_FrmFieldType.php
+++ b/tests/fields/test_FrmFieldType.php
@@ -238,10 +238,13 @@ class test_FrmFieldType extends FrmUnitTest {
 
 		$input_html_actual_expected = array(
 			' data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="Name is invalid" aria-describedby="my_custom_aria_describedby" aria-invalid="true" ' =>
-			' data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="Name is invalid" aria-describedby="my_custom_aria_describedby frm_desc_2 frm_error_2" aria-invalid="true" ',
+			' data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="Name is invalid" aria-describedby="frm_error_2 my_custom_aria_describedby frm_desc_2" aria-invalid="true" ',
 
 			' data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="Name is invalid" aria-invalid="true"' =>
-			' data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="Name is invalid" aria-invalid="true" aria-describedby="frm_desc_2 frm_error_2"',
+			' data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="Name is invalid" aria-invalid="true" aria-describedby="frm_error_2 frm_desc_2"',
+
+			' data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="Name is invalid" aria-describedby="frm_desc_field_custom frm_error_field_custom" aria-invalid="true"' =>
+			' data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="Name is invalid" aria-describedby="frm_desc_2 frm_desc_field_custom frm_error_field_custom" aria-invalid="true" data-error-first="0"',
 		);
 
 		foreach ( $input_html_actual_expected as $actual => $expected ) {


### PR DESCRIPTION
Related to [https://github.com/Strategy11/formidable-pro/issues/3637](https://github.com/Strategy11/formidable-pro/issues/3637), a [PR](https://github.com/Strategy11/formidable-forms/pull/802) has been created to implement additional checks in `FrmFieldType::add_aria_description` function but the unit test for this function was not updated yet to cover the new changes to the function. This PR is targeted at updating the unit test that covers this so that the expected values are based on the new logic.