### PR TITLE
Fixes Issue #3389

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,6 +50,7 @@
 		"react/no-find-dom-node": "warn",
 		"react/prop-types": "off",
 		"vars-on-top": "warn",
-		"yoda": "off"
+		"yoda": "off",
+        "linebreak-style": "off"
 	}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,6 +51,6 @@
 		"react/prop-types": "off",
 		"vars-on-top": "warn",
 		"yoda": "off",
-        "linebreak-style": "off"
+		"linebreak-style": "off"
 	}
 }

--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -1015,9 +1015,12 @@ class FrmAddonsController {
 	 * @return string
 	 */
 	private static function get_activating_page() {
-		if ( false !== strpos( FrmAppHelper::get_server_value( 'HTTP_REFERER' ), 'frm_action=settings' ) ) {
+		$referer = FrmAppHelper::get_server_value( 'HTTP_REFERER' );
+		if ( false !== strpos( $referer, 'frm_action=settings' ) ) {
 			return 'settings';
-		} elseif ( false !== strpos( FrmAppHelper::get_server_value( 'HTTP_REFERER' ), 'frm_action=edit' ) ) {
+		}
+
+		if ( false !== strpos( $referer, 'frm_action=edit' ) ) {
 			return 'form_builder';
 		}
 

--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -998,21 +998,30 @@ class FrmAddonsController {
 	 * @return array|string
 	 */
 	private static function get_addon_activation_response() {
+		$activating_page = self::get_activating_page();
+
 		$response = array(
-			'message' => __( 'Your plugin has been activated. Would you like to save and reload the page now?', 'formidable' ),
-			'saveAndReload' => 'form_builder',
+			'message'       => __( 'Your plugin has been activated. Would you like to save and reload the page now?', 'formidable' ),
+			'saveAndReload' => $activating_page,
 		);
-		if ( self::activating_from_settings_page() ) {
-			$response['saveAndReload'] = 'settings';
-		}
+
 		return $response;
 	}
 
 	/**
-	 * @return bool
+	 * Return a string that reflects the page from which the addon is being activated on,
+	 * if it is from settings or form builder, otherwise return empty string.
+	 *
+	 * @return string
 	 */
-	private static function activating_from_settings_page() {
-		return false !== strpos( FrmAppHelper::get_server_value( 'HTTP_REFERER' ), 'frm_action=settings' );
+	private static function get_activating_page() {
+		if ( false !== strpos( FrmAppHelper::get_server_value( 'HTTP_REFERER' ), 'frm_action=settings' ) ) {
+			return 'settings';
+		} elseif ( false !== strpos( FrmAppHelper::get_server_value( 'HTTP_REFERER' ), 'frm_action=edit' ) ) {
+			return 'form_builder';
+		}
+
+		return '';
 	}
 
 	/**

--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -998,13 +998,12 @@ class FrmAddonsController {
 	 * @return array|string
 	 */
 	private static function get_addon_activation_response() {
+		$response = array(
+			'message' => __( 'Your plugin has been activated. Would you like to save and reload the page now?', 'formidable' ),
+			'saveAndReload' => 'form_builder',
+		);
 		if ( self::activating_from_settings_page() ) {
-			$response = array(
-				'message'       => __( 'Your plugin has been activated. Would you like to save and reload the page now?', 'formidable' ),
-				'saveAndReload' => 'settings',
-			);
-		} else {
-			$response = __( 'Your plugin has been activated. Please reload the page to see more options.', 'formidable' );
+			$response['saveAndReload'] = 'settings';
 		}
 		return $response;
 	}

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1838,7 +1838,7 @@ h2.frm-h2 + .howto {
 	font-size: 13px;
 }
 
-#frm_save_and_reload_settings, #frm_save_and_reload_form_builder, #frm_save_and_reload_settings + .frm-button-secondary, #frm_save_and_reload_form_builder + .frm-button-secondary {
+#frm_save_and_reload, #frm_save_and_reload + .frm-button-secondary {
 	visibility: visible;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1838,7 +1838,7 @@ h2.frm-h2 + .howto {
 	font-size: 13px;
 }
 
-#frm_save_and_reload_settings, #frm_save_and_reload_settings + .frm-button-secondary {
+#frm_save_and_reload_settings, #frm_save_and_reload_form_builder, #frm_save_and_reload_settings + .frm-button-secondary, #frm_save_and_reload_form_builder + .frm-button-secondary {
 	visibility: visible;
 }
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7221,6 +7221,10 @@ function frmAdminBuildJS() {
 		}
 	}
 
+	function saveAndReloadFormBuilder() {
+		document.getElementById( 'frm_submit_side_top' ).click();
+	}
+
 	function confirmExit( event ) {
 		if ( fieldsUpdated ) {
 			event.preventDefault();
@@ -7942,23 +7946,30 @@ function frmAdminBuildJS() {
 		refreshPage = document.querySelectorAll( '.frm-admin-page-import, #frm-admin-smtp, #frm-welcome' );
 		if ( refreshPage.length > 0 ) {
 			window.location.reload();
-		} else if ( 'settings' === saveAndReload ) {
-			$addonStatus.append( getSaveAndReloadSettingsOptions() );
+		} else if ([ 'settings', 'form_builder' ].includes( saveAndReload ) ) {
+			$addonStatus.append( getSaveAndReloadSettingsOptions( saveAndReload ) );
 		}
 	}
 
-	function getSaveAndReloadSettingsOptions() {
+	function getSaveAndReloadSettingsOptions( saveAndReload ) {
 		var wrapper = div({ id: 'frm_save_and_reload_options' });
-		wrapper.appendChild( saveAndReloadSettingsButton() );
+		wrapper.appendChild( saveAndReloadSettingsButton( saveAndReload ) );
 		wrapper.appendChild( closePopupButton() );
 		return wrapper;
 	}
 
-	function saveAndReloadSettingsButton() {
+	function saveAndReloadSettingsButton( saveAndReload ) {
 		var button = document.createElement( 'button' );
-		button.id = 'frm_save_and_reload_settings';
+		button.id = 'settings' === saveAndReload ? 'frm_save_and_reload_settings' : 'frm_save_and_reload_form_builder';
 		button.classList.add( 'button', 'button-primary', 'frm-button-primary' );
 		button.textContent = __( 'Save and Reload', 'formidable' );
+		button.addEventListener( 'click', () => {
+			if ( button.id === 'frm_save_and_reload_form_builder' ) {
+				saveAndReloadFormBuilder();
+			} else if ( button.id === 'frm_save_and_reload_settings' ) {
+				saveAndReloadSettings();
+			}
+		});
 		return button;
 	}
 
@@ -9468,7 +9479,6 @@ function frmAdminBuildJS() {
 
 			jQuery( document ).on( 'submit', '.frm_form_settings', settingsSubmitted );
 			jQuery( document ).on( 'change', '#form_settings_page input:not(.frm-search-input), #form_settings_page select, #form_settings_page textarea', fieldUpdated );
-			jQuery( document ).on( 'click', '#frm_save_and_reload_settings', saveAndReloadSettings );
 
             // Page Selection Autocomplete
 			initSelectionAutocomplete();

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7960,13 +7960,13 @@ function frmAdminBuildJS() {
 
 	function saveAndReloadSettingsButton( saveAndReload ) {
 		var button = document.createElement( 'button' );
-		button.id = 'settings' === saveAndReload ? 'frm_save_and_reload_settings' : 'frm_save_and_reload_form_builder';
+		button.id = 'frm_save_and_reload';
 		button.classList.add( 'button', 'button-primary', 'frm-button-primary' );
 		button.textContent = __( 'Save and Reload', 'formidable' );
 		button.addEventListener( 'click', () => {
-			if ( button.id === 'frm_save_and_reload_form_builder' ) {
+			if ( saveAndReload === 'form_builder' ) {
 				saveAndReloadFormBuilder();
-			} else if ( button.id === 'frm_save_and_reload_settings' ) {
+			} else if ( saveAndReload === 'settings' ) {
 				saveAndReloadSettings();
 			}
 		});


### PR DESCRIPTION
issue: [#3389](https://github.com/Strategy11/formidable-pro/issues/3389)

Following from [https://github.com/Strategy11/formidable-forms/pull/511](https://github.com/Strategy11/formidable-forms/pull/511), a `Save and Reload` functionality has been added to the popup that appears when activating addons from the settings page. However, that didn't cover the same action from form builder. This PR is to extend the existing code and bring the same functionality to the form builder.

![image](https://user-images.githubusercontent.com/41271840/179725554-8edba390-63c8-4a1e-992a-3b2d4aca3857.png)

![image](https://user-images.githubusercontent.com/41271840/179725581-5c0152d1-a9d0-4de3-9922-2c971d538a9b.png)
