### PR TITLE
Declare frmDom as window var

### DIFF
--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -1,5 +1,3 @@
-let frmDom;
-
 ( function() {
 	/** globals frmGlobal */
 
@@ -536,5 +534,5 @@ let frmDom;
 		element.appendChild( child );
 	}
 
-	frmDom = { tag, div, span, a, img, svg, setAttributes, modal, ajax, bootstrap, autocomplete, search, util };
+	window.frmDom = { tag, div, span, a, img, svg, setAttributes, modal, ajax, bootstrap, autocomplete, search, util };
 }() );


### PR DESCRIPTION
Pretty positive this fixes https://secure.helpscout.net/conversation/1953381559/103981/ but it's tough to test against their caching.

You can see this behaviour if you try `eval( 'var testVariable = "testValue";' );` vs `eval( 'let testVariable = "testValue";' );`. The let example won't declare testVariable globally.

