### PR TITLE
Fix screen meta placement

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -63,6 +63,10 @@ class FrmAppController {
 			$classes .= apply_filters( 'frm_admin_full_screen_class', ' frm-full-screen folded' );
 		}
 
+		if ( ! FrmAppHelper::pro_is_installed() ) {
+			$classes .= ' frm-lite ';
+		}
+
 		return $classes;
 	}
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -86,22 +86,23 @@ a, .widget .widget-top, .stuffbox h3, .frm-collapsed {
 	overflow: hidden;
 }
 
+.frm-white-body #wpbody-content {
+	position: relative; /* For screen meta links */
+}
+
 .post-new-php.post-type-frm_display #screen-meta-links,
 .post-php.post-type-frm_display #screen-meta-links,
 .frm-full-screen #wpfooter {
 	display: none;
 }
 
-.frm-full-screen #screen-meta-links .screen-meta-toggle {
+.frm-white-body #screen-meta-links {
 	position: absolute;
-	right: 80px;
-	box-shadow: none;
-	border-bottom-left-radius: var(--small-radius);
-	border-bottom-right-radius: var(--small-radius);
+    right: 20px;
 }
 
-.frm-white-body #screen-meta-links .show-settings {
-	box-shadow: none;
+.frm-full-screen #screen-meta-links .screen-meta-toggle {
+	right: 55px;
 }
 
 .frm-white-body #screen-meta {
@@ -8037,6 +8038,18 @@ Responsive Design
 
 	.frm-full-close .frmsvg {
 		padding: 0;
+	}
+
+	.frm-full-screen .frm_top_left {
+		padding-top: 10px
+	}
+
+	.frm-full-screen .frm_top_left h1 {
+		padding-top: 0 !important;
+	}
+
+	.frm-full-screen .frm-header-logo {
+		margin-top: 6px !important;
 	}
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -105,6 +105,10 @@ a, .widget .widget-top, .stuffbox h3, .frm-collapsed {
 	right: 55px;
 }
 
+.frm-white-body.frm-lite #screen-meta-links .screen-meta-toggle {
+	right: 125px; /* Don't cover the lite upgrade button */
+}
+
 .frm-white-body #screen-meta {
 	margin: 0;
 }

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5746,7 +5746,7 @@ function frmAdminBuildJS() {
 
 	// Move the top banner above the screen options to prevent overlap.
 	function moveTopBanner() {
-		const $banner = document.querySelector( '.frm-banner-alert' );
+		const $banner = document.querySelector( '.frm-banner-alert' ) || document.querySelector( '.frm-upgrade-bar' );
 		if ( ! $banner ) {
 			return;
 		}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5744,6 +5744,22 @@ function frmAdminBuildJS() {
 		}
 	}
 
+	// Move the top banner above the screen options to prevent overlap.
+	function moveTopBanner() {
+		const $banner = document.querySelector( '.frm-banner-alert' );
+		if ( ! $banner ) {
+			return;
+		}
+
+		const $screenMeta = document.getElementById( 'screen-meta' );
+		if ( ! $screenMeta ) {
+			return;
+		}
+
+		const $parentDiv = document.getElementById( 'wpbody-content' );
+		$parentDiv.insertBefore( $banner, $screenMeta );
+	}
+
 	function getRequiredLicenseFromTrigger( element ) {
 		if ( element.dataset.requires ) {
 			return element.dataset.requires;
@@ -9150,6 +9166,7 @@ function frmAdminBuildJS() {
 
 			loadTooltips();
 			initUpgradeModal();
+			moveTopBanner();
 
 			// used on build, form settings, and view settings
 			var $shortCodeDiv = jQuery( document.getElementById( 'frm_shortcodediv' ) );


### PR DESCRIPTION
This uses javascript to move the renew banner above the screen options in the HTML.

This also removes some css that is no longer needed.

**Before:**
(entries list)
<img width="1194" alt="Screen Shot 2022-07-26 at 12 54 02 PM" src="https://user-images.githubusercontent.com/1116876/181088878-fc96c7e6-5f7b-47b2-a2d7-92021977f8c9.png">

(forms list)
<img width="1197" alt="Screen Shot 2022-07-26 at 12 54 12 PM" src="https://user-images.githubusercontent.com/1116876/181088884-33cf8a35-e39f-4f60-a46d-bdeb54f0833a.png">

(full screen)
<img width="1320" alt="Screen Shot 2022-07-26 at 12 54 30 PM" src="https://user-images.githubusercontent.com/1116876/181088888-9543f614-91b8-4d3b-ade6-dabdae228706.png">

(lite)
<img width="1319" alt="Screen Shot 2022-07-26 at 1 24 51 PM" src="https://user-images.githubusercontent.com/1116876/181096622-c1cab297-98f2-407e-ae4c-7c0861878cad.png">


**After:**
<img width="1194" alt="Screen Shot 2022-07-26 at 12 53 25 PM" src="https://user-images.githubusercontent.com/1116876/181088964-a1559d15-19e6-4cfe-9338-b33b49d7fa70.png">
<img width="1322" alt="Screen Shot 2022-07-26 at 12 53 35 PM" src="https://user-images.githubusercontent.com/1116876/181088966-bf7d8b71-7f1e-46a5-8ba8-3cf1fcd20616.png">
<img width="1163" alt="Screen Shot 2022-07-26 at 1 35 58 PM" src="https://user-images.githubusercontent.com/1116876/181096899-dbb3c9bf-e6dc-45b5-b528-fb44fed5989a.png">

