### PR TITLE
Update checkUniqueOpt

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
+    types: [ opened, labeled, synchronize ]
 
 name: Inspections
 jobs:
   runPHPCSInspection:
+    if: contains(github.event.pull_request.labels.*.name, 'run analysis')
     name: Run PHPCS inspection
     runs-on: ubuntu-latest
     steps:

--- a/classes/views/frm-fields/single-option.php
+++ b/classes/views/frm-fields/single-option.php
@@ -7,13 +7,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php FrmAppHelper::icon_by_class( 'frmfont frm_drag_icon frm-drag' ); ?>
 	<input type="<?php echo esc_attr( $default_type ); ?>" name="<?php echo esc_attr( $field_name ); ?>" <?php echo ( isset( $checked ) && $checked ? 'checked="checked"' : '' ); ?> value="<?php echo esc_attr( $field_val ); ?>"/>
 
-	<input type="text" name="field_options[options_<?php echo esc_attr( $field['id'] ); ?>][<?php echo esc_attr( $opt_key ); ?>][label]" value="<?php echo esc_attr( $opt ); ?>" class="field_<?php echo esc_attr( $field['id'] ); ?>_option <?php echo esc_attr( $field['separate_value'] ? 'frm_with_key' : '' ); ?>" id="<?php echo esc_attr( $html_id . '-' . $opt_key . '-label' ); ?>" data-frmchange="trim,updateOption" />
+	<input type="text" name="field_options[options_<?php echo esc_attr( $field['id'] ); ?>][<?php echo esc_attr( $opt_key ); ?>][label]" value="<?php echo esc_attr( $opt ); ?>" class="field_<?php echo esc_attr( $field['id'] ); ?>_option <?php echo esc_attr( $field['separate_value'] ? 'frm_with_key' : '' ); ?>" id="<?php echo esc_attr( $html_id . '-' . $opt_key . '-label' ); ?>" data-frmchange="trim,updateOption,checkUniqueOpt" />
 
 	<a href="javascript:void(0)" class="frm_icon_font frm_remove_tag" data-fid="<?php echo esc_attr( $field['id'] ); ?>" data-removeid="frm_delete_field_<?php echo esc_attr( $field['id'] . '-' . $opt_key ); ?>_container" data-removemore="#frm_<?php echo esc_attr( $default_type . '_' . $field['id'] . '-' . $opt_key ); ?>" data-showlast="#frm_add_opt_<?php echo esc_attr( $field['id'] ); ?>"></a>
 
 	<span class="frm_option_key frm-with-right-icon field_<?php echo esc_attr( $field['id'] ); ?>_option_key<?php echo esc_attr( $field['separate_value'] ? '' : ' frm_hidden' ); ?>">
 		<input type="<?php echo esc_attr( $default_type ); ?>" class="frm_invisible" />
-		<input type="text" name="field_options[options_<?php echo esc_attr( $field['id'] ); ?>][<?php echo esc_attr( $opt_key ); ?>][value]" id="field_key_<?php echo esc_attr( $field['id'] . '-' . $opt_key ); ?>" value="<?php echo esc_attr( $field_val ); ?>" placeholder="<?php esc_attr_e( 'Saved Value', 'formidable' ); ?>" data-frmchange="trim,updateDefault" />
+		<input type="text" name="field_options[options_<?php echo esc_attr( $field['id'] ); ?>][<?php echo esc_attr( $opt_key ); ?>][value]" id="field_key_<?php echo esc_attr( $field['id'] . '-' . $opt_key ); ?>" value="<?php echo esc_attr( $field_val ); ?>" placeholder="<?php esc_attr_e( 'Saved Value', 'formidable' ); ?>" data-frmchange="trim,updateDefault,checkUniqueOpt" />
 		<?php FrmAppHelper::icon_by_class( 'frmfont frm_save_icon' ); ?>
 	</span>
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5184,17 +5184,28 @@ function frmAdminBuildJS() {
 		}
 	}
 
-	/* TODO: Is this still used? */
-	function checkUniqueOpt( id, text ) {
-		if ( id.indexOf( 'field_key_' ) === 0 ) {
-			var a = id.split( '-' );
-			jQuery.each( jQuery( 'label[id^="' + a[0] + '"]' ), function( k, v ) {
-				var c = false;
-				if ( ! c && jQuery( v ).attr( 'id' ) != id && jQuery( v ).html() == text ) {
-					c = true;
-					infoModal( 'Saved values cannot be identical.' );
-				}
-			});
+	function checkUniqueOpt( event ) {
+		const targetInput = event.target;
+		const settingsContainer = targetInput.closest( '.frm-single-settings' );
+
+		const fieldId = settingsContainer.getAttribute( 'data-fid' );
+		const areValuesSeparate = settingsContainer.querySelector( '[name="field_options[separate_value_' + fieldId + ']"]' ).checked;
+
+		if ( areValuesSeparate && ! targetInput.name.endsWith( '[value]' ) ) {
+			return;
+		}
+
+		const container = document.getElementById( 'frm_field_' + fieldId + '_opts' );
+		const inputs = Array.from( container.querySelectorAll( 'input[type="text"]' ) ).filter(
+			input => input !== targetInput && areValuesSeparate === input.name.endsWith( '[value]' )
+		);
+
+		const length = inputs.length;
+		for ( let index = 0; index < length; ++index ) {
+			if ( inputs[ index ].value === targetInput.value ) {
+				infoModal( __( 'Duplicate dropdown item value "%s" detected', 'formidable' ).replace( '%s', targetInput.value ) );
+				break;
+			}
 		}
 	}
 
@@ -9390,6 +9401,9 @@ function frmAdminBuildJS() {
 
 			jQuery( document ).on( 'submit', '#frm_js_build_form', buildSubmittedNoAjax );
 			jQuery( document ).on( 'change', '#frm_builder_page input:not(.frm-search-input):not(.frm-custom-grid-size-input), #frm_builder_page select, #frm_builder_page textarea', fieldUpdated );
+
+			jQuery( document ).on( 'change', '#frm_builder_page input:not(.frm-search-input):not(.frm-custom-grid-size-input), #frm_builder_page select, #frm_builder_page textarea', fieldUpdated );
+			jQuery( document ).on( 'change', '#frm_builder_page .frm_single_option input', checkUniqueOpt );
 
 			popAllProductFields();
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5203,7 +5203,7 @@ function frmAdminBuildJS() {
 		const length = inputs.length;
 		for ( let index = 0; index < length; ++index ) {
 			if ( inputs[ index ].value === targetInput.value ) {
-				infoModal( __( 'Duplicate dropdown item value "%s" detected', 'formidable' ).replace( '%s', targetInput.value ) );
+				infoModal( __( 'Duplicate option value "%s" detected', 'formidable' ).replace( '%s', targetInput.value ) );
 				break;
 			}
 		}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5184,10 +5184,8 @@ function frmAdminBuildJS() {
 		}
 	}
 
-	function checkUniqueOpt( event ) {
-		const targetInput = event.target;
+	function checkUniqueOpt( targetInput ) {
 		const settingsContainer = targetInput.closest( '.frm-single-settings' );
-
 		const fieldId = settingsContainer.getAttribute( 'data-fid' );
 		const areValuesSeparate = settingsContainer.querySelector( '[name="field_options[separate_value_' + fieldId + ']"]' ).checked;
 
@@ -5540,6 +5538,8 @@ function frmAdminBuildJS() {
 				changeHiddenSeparateValue( this );
 			} else if ( action[i] === 'updateDefault' ) {
 				changeDefaultRadioValue( this );
+			} else if ( action[i] === 'checkUniqueOpt' ) {
+				checkUniqueOpt( this );
 			} else {
 				this.value = this.value[ action[i] ]();
 			}
@@ -9418,9 +9418,6 @@ function frmAdminBuildJS() {
 
 			jQuery( document ).on( 'submit', '#frm_js_build_form', buildSubmittedNoAjax );
 			jQuery( document ).on( 'change', '#frm_builder_page input:not(.frm-search-input):not(.frm-custom-grid-size-input), #frm_builder_page select, #frm_builder_page textarea', fieldUpdated );
-
-			jQuery( document ).on( 'change', '#frm_builder_page input:not(.frm-search-input):not(.frm-custom-grid-size-input), #frm_builder_page select, #frm_builder_page textarea', fieldUpdated );
-			jQuery( document ).on( 'change', '#frm_builder_page .frm_single_option input', checkUniqueOpt );
 
 			popAllProductFields();
 


### PR DESCRIPTION
Related Slack conversation https://strategy11.slack.com/archives/C799A2R61/p1658910750598379

> Would there be any way to include a warning in-plugin if identical values are detected, telling users that separate values MUST be unique?

I got it working again, removed the jQuery, added support for separate values, and made the error message more helpful.

<img width="375" alt="Screen Shot 2022-07-27 at 3 30 16 PM" src="https://user-images.githubusercontent.com/9134515/181345709-cc2d1105-c5c1-4cfb-aa55-cfa9cb7f0a7a.png">

_Branching off of https://github.com/Strategy11/formidable-forms/pull/835 as I forgot to checkout master first. That shouldn't be a real issue as I hope to include both of these in next release._