### PR TITLE
add missing form strings.

### DIFF
--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -483,6 +483,10 @@ class FrmForm {
 			'submit_value',
 			'submit_msg',
 			'success_msg',
+			'invalid_msg',
+			'failed_msg',
+			'login_msg',
+			'admin_permission',
 		);
 
 		return apply_filters( 'frm_form_strings', $strings, $form );


### PR DESCRIPTION
I'm trying to add the missing translatable form strings, which a form duplication become incomplete without them as their respective translated strings are not copied to the new form.