### PR TITLE
Trigger frm-action-loaded event on new action

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6046,21 +6046,19 @@ function frmAdminBuildJS() {
 
 	function addFormAction() {
 		/*jshint validthis:true */
-		var type, actionId, formId, placeholderSetting, actionsList;
-
-		type = jQuery( this ).data( 'actiontype' );
+		const type = jQuery( this ).data( 'actiontype' );
 
 		if ( isAtLimitForActionType( type ) ) {
 			return;
 		}
 
-		actionId = getNewActionId();
-		formId = thisFormId;
+		const actionId = getNewActionId();
+		const formId = thisFormId;
 
-		placeholderSetting = document.createElement( 'div' );
+		const placeholderSetting = document.createElement( 'div' );
 		placeholderSetting.classList.add( 'frm_single_' + type + '_settings' );
 
-		actionsList = document.getElementById( 'frm_notification_settings' );
+		const actionsList = document.getElementById( 'frm_notification_settings' );
 		actionsList.appendChild( placeholderSetting );
 
 		jQuery.ajax({
@@ -6083,7 +6081,7 @@ function frmAdminBuildJS() {
 				jQuery( actionsList ).append( html );
 				jQuery( '.frm_form_action_settings' ).fadeIn( 'slow' );
 
-				var newAction = document.getElementById( 'frm_form_action_' + actionId );
+				const newAction = document.getElementById( 'frm_form_action_' + actionId );
 
 				newAction.classList.add( 'open' );
 				document.getElementById( 'post-body-content' ).scroll({
@@ -6096,6 +6094,11 @@ function frmAdminBuildJS() {
 				checkActiveAction( type );
 				initiateMultiselect();
 				showInputIcon( '#frm_form_action_' + actionId );
+
+				const widgetTop = placeholderSetting.querySelector( '.widget-top' );
+				if ( widgetTop ) {
+					jQuery( widgetTop ).trigger( 'frm-action-loaded' );
+				}
 			}
 		});
 	}


### PR DESCRIPTION
In the outcome quizzes I'm hooking into https://github.com/Strategy11/formidable-forms/blob/2e859e569972d3d1d43e28788568f37992643b3e/js/formidable_admin.js#L722 to initialize the wysiwyg editors. But when you create a new action there isn't any event that gets triggered. I figure just triggering the same action as it also is a "action loaded" type of event works best and requires nothing extra on the quizzes side.

I wonder if we'd want to handle more of this in lite though and consider a wysiwyg for emails too. The feature request has quite a few upvotes. What do you think @stephywells? If we use a wysiwyg for that, you'd be losing this pop up, but maybe that's not a big deal.

<img width="332" alt="Screen Shot 2022-08-02 at 3 10 22 PM" src="https://user-images.githubusercontent.com/9134515/182443964-ef27322b-2817-486b-98d9-112796f04a91.png">

https://team.strategy11.com/feature-requests/2021/04/30/wysiwyg-email-editor/?modal=1

I also changed a couple `var` declarations to `const` here as everything is only defined once.

_Hold off on reviewing this. I'm not sure if this is complete at this point. Question still applies though_