### PR TITLE
Do not exit early for empty content on denylist check

### DIFF
--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -502,6 +502,7 @@ class FrmEntriesHelper {
 	 * Add submitted values to a string for spam checking.
 	 *
 	 * @param array $values
+	 * @return string
 	 */
 	public static function entry_array_to_string( $values ) {
 		$content = '';

--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -360,9 +360,6 @@ class FrmEntryValidate {
 		}
 
 		$content = FrmEntriesHelper::entry_array_to_string( $values );
-		if ( empty( $content ) ) {
-			return false;
-		}
 
 		self::prepare_values_for_spam_check( $values );
 		$ip         = FrmAppHelper::get_ip_address();


### PR DESCRIPTION
I mentioned this in Slack. Not sure to it, just removing the content check so it always does the blacklist check on the other fields like IP address.