### PR TITLE
Recalculate [auto_id] on entry duplicate.

### DIFF
--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -672,6 +672,25 @@ class FrmEntriesController {
 	}
 
 	/**
+	 * If a field default value matches [auto_id] patterns, evaluate the shortcode again and assign it to the new field entry meta.
+	 *
+	 * @since x.x
+	 *
+	 * @param array $meta The field entry meta
+	 */
+	public static function autoincrement_on_duplicate( &$meta ) {
+		$field = FrmField::getOne( $meta->field_id );
+		if ( ! preg_match( '/\[auto_id[^\]]*\]/', $field->default_value ) ) {
+			return;
+		}
+
+		$value = $field->default_value;
+
+		FrmProFieldsHelper::replace_non_standard_formidable_shortcodes( array( 'field' => $field ), $value );
+		$meta->meta_value = $value;
+	}
+
+	/**
 	 * @deprecated 4.0
 	 */
 	public static function contextual_help( $help, $screen_id, $screen ) {

--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -672,25 +672,6 @@ class FrmEntriesController {
 	}
 
 	/**
-	 * If a field default value matches [auto_id] patterns, evaluate the shortcode again and assign it to the new field entry meta.
-	 *
-	 * @since x.x
-	 *
-	 * @param array $meta The field entry meta
-	 */
-	public static function autoincrement_on_duplicate( &$meta ) {
-		$field = FrmField::getOne( $meta->field_id );
-		if ( ! preg_match( '/\[auto_id[^\]]*\]/', $field->default_value ) ) {
-			return;
-		}
-
-		$value = $field->default_value;
-
-		FrmProFieldsHelper::replace_non_standard_formidable_shortcodes( array( 'field' => $field ), $value );
-		$meta->meta_value = $value;
-	}
-
-	/**
 	 * @deprecated 4.0
 	 */
 	public static function contextual_help( $help, $screen_id, $screen ) {

--- a/classes/models/FrmEntryMeta.php
+++ b/classes/models/FrmEntryMeta.php
@@ -166,6 +166,14 @@ class FrmEntryMeta {
 
 	public static function duplicate_entry_metas( $old_id, $new_id ) {
 		$metas = self::get_entry_meta_info( $old_id );
+
+		/**
+		 * Allows changing entry duplicate values before save.
+		 *
+		 * @since x.x
+		 *
+		 * @param array $metas The list of entry meta values.
+		 */
 		$metas = apply_filters( 'frm_before_duplicate_entry_values', $metas );
 		foreach ( $metas as $meta ) {
 			self::add_entry_meta( $new_id, $meta->field_id, '', $meta->meta_value );

--- a/classes/models/FrmEntryMeta.php
+++ b/classes/models/FrmEntryMeta.php
@@ -166,8 +166,8 @@ class FrmEntryMeta {
 
 	public static function duplicate_entry_metas( $old_id, $new_id ) {
 		$metas = self::get_entry_meta_info( $old_id );
+		$metas = apply_filters( 'frm_before_duplicate_entry_values', $metas );
 		foreach ( $metas as $meta ) {
-			FrmEntriesController::autoincrement_on_duplicate( $meta );
 			self::add_entry_meta( $new_id, $meta->field_id, '', $meta->meta_value );
 			unset( $meta );
 		}

--- a/classes/models/FrmEntryMeta.php
+++ b/classes/models/FrmEntryMeta.php
@@ -167,6 +167,7 @@ class FrmEntryMeta {
 	public static function duplicate_entry_metas( $old_id, $new_id ) {
 		$metas = self::get_entry_meta_info( $old_id );
 		foreach ( $metas as $meta ) {
+			FrmEntriesController::autoincrement_on_duplicate( $meta );
 			self::add_entry_meta( $new_id, $meta->field_id, '', $meta->meta_value );
 			unset( $meta );
 		}


### PR DESCRIPTION
Fields with [auto_id] are not currently incrementing when an entry is duplicating, resulting in entries with the same value and that defeats the purpose of having unique values for a given field with the help of the shortcode.

This PR aims to make sure that field values with [auto-id] gets updated when duplicating an entry.