### PR TITLE
Add extra checks for data in actions

### DIFF
--- a/classes/models/FrmFormAction.php
+++ b/classes/models/FrmFormAction.php
@@ -106,7 +106,7 @@ class FrmFormAction {
 			$action_options['color'] = 'var(--' . reset( $colors ) . ')';
 		}
 
-		$upgrade_class = $action_options['classes'] === 'frm_show_upgrade';
+		$upgrade_class = isset( $action_options['classes'] ) && $action_options['classes'] === 'frm_show_upgrade';
 		if ( $action_options['group'] === $id_base ) {
 			$upgrade_class = strpos( $action_options['classes'], 'frm_show_upgrade' ) !== false;
 			$action_options['classes'] = $group['icon'];
@@ -420,17 +420,23 @@ class FrmFormAction {
 	 * If the status of the action has changed, update it
 	 *
 	 * @since 3.04
+	 *
+	 * @param array          $new_instance
+	 * @param stdClass|array $old_instance
+	 * @return void
 	 */
 	protected function maybe_update_status( $new_instance, $old_instance ) {
-		if ( $new_instance['post_status'] !== $old_instance->post_status ) {
-			self::clear_cache();
-			wp_update_post(
-				array(
-					'ID'          => $new_instance['ID'],
-					'post_status' => $new_instance['post_status'],
-				)
-			);
+		if ( ! is_object( $old_instance ) || $new_instance['post_status'] === $old_instance->post_status ) {
+			return;
 		}
+
+		self::clear_cache();
+		wp_update_post(
+			array(
+				'ID'          => $new_instance['ID'],
+				'post_status' => $new_instance['post_status'],
+			)
+		);
 	}
 
 	public function save_settings( $settings ) {

--- a/tests/forms/test_FrmFormAction.php
+++ b/tests/forms/test_FrmFormAction.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @group forms
+ */
+class test_FrmFormAction extends FrmUnitTest {
+
+	/**
+	 * @covers FrmFormAction::update_callback
+	 */
+	public function test_update_callback() {
+		$form_id               = $this->factory->form->create();
+		$id_base               = 'email';
+		$option_name           = 'frm_' . $id_base . '_action';
+		$number                = -1;
+		$new_post_id           = $this->factory->post->create(
+			array(
+				'post_type'    => FrmFormActionsController::$action_post_type,
+				'menu_order'   => $form_id,
+				'post_excerpt' => $id_base,
+				'post_status'  => 'publish',
+			)
+		);
+		$_POST[ $option_name ] = array(
+			$number => array(
+				'ID'          => $new_post_id,
+				'post_status' => 'publish',
+			),
+		);
+		$action                = new FrmFormAction( $id_base, 'Email' );
+		$action_ids            = $action->update_callback( $form_id );
+
+		$this->assertIsArray( $action_ids );
+		$this->assertEquals( array( $new_post_id ), $action_ids );
+		$this->assertTrue( $action->updated );
+	}
+}


### PR DESCRIPTION
Referencing a comment from Garret https://github.com/Strategy11/formidable-quizzes/pull/133#issuecomment-1212400320

He mentioned an issue.
```
PHP Notice: Trying to get property 'post_status' of non-object in wp-content\plugins\formidable\classes\models\FrmFormAction.php on line 425
```

I added a unit test to replicate the issue. I'm not sure how to get it to happen on the front end exactly. I'm just adding a few extra type checks.

The problem is really that there's a line in the code here.

`$old_instance = isset( $all_instances[ $number ] ) ? $all_instances[ $number ] : array();`.

That if `$all_instances[ $number ]` is not set will all back to an array rather than an object. But the status update function is assuming that `$old_instance` is never an array.

The unit test catches this. Though in PHPUnit the error I see instead is "Attempt to read property "post_status" on array".

I also added a check for the `classes` key in the action option. I was seeing `Undefined array key "classes"` as well. The variable tries to set an `array()` default so this is a bug as well.