### PR TITLE
Fix issues with landing page upgrade tab message not reflecting license

### DIFF
--- a/classes/views/shared/upgrade_overlay.php
+++ b/classes/views/shared/upgrade_overlay.php
@@ -25,12 +25,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</h2>
 				<div class="cta-inside">
 
-					<p id="frm-oneclick" class="frm_hidden">
+					<p class="frm-oneclick frm_hidden">
 						<?php esc_html_e( 'That add-on is not installed. Would you like to install it now?', 'formidable' ); ?>
 					</p>
-					<p id="frm-addon-status"></p>
+					<p class="frm-addon-status"></p>
 
-					<a class="button button-primary frm-button-primary frm_hidden" id="frm-oneclick-button">
+					<a class="button button-primary frm-button-primary frm_hidden frm-oneclick-button">
 						<?php esc_html_e( 'Install', 'formidable' ); ?>
 					</a>
 
@@ -44,11 +44,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 					}
 					$message = sprintf( esc_html( $message ), '<span class="frm_feature_label"></span>' );
 					?>
-					<p id="frm-upgrade-message" data-default="<?php echo esc_attr( $message ); ?>">
+					<p class="frm-upgrade-message" data-default="<?php echo esc_attr( $message ); ?>">
 						<?php echo FrmAppHelper::kses( $message, array( 'span' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</p>
 					<?php if ( $is_pro ) { ?>
-						<a href="<?php echo esc_url( $default_link ); ?>" class="button button-primary frm-button-primary" id="frm-upgrade-modal-link" data-default="<?php echo esc_url( $default_link ); ?>">
+						<a href="<?php echo esc_url( $default_link ); ?>" class="button button-primary frm-button-primary frm-upgrade-link" data-default="<?php echo esc_url( $default_link ); ?>">
 							<?php
 							printf(
 								/* translators: %s: Plan name */
@@ -58,7 +58,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							?>
 						</a>
 					<?php } else { ?>
-						<a href="<?php echo esc_url( $default_link ); ?>" class="button button-primary frm-button-primary" target="_blank" rel="noopener noreferrer" id="frm-upgrade-modal-link" data-default="<?php echo esc_url( $default_link ); ?>">
+						<a href="<?php echo esc_url( $default_link ); ?>" class="button button-primary frm-button-primary frm-upgrade-link" target="_blank" rel="noopener noreferrer" data-default="<?php echo esc_url( $default_link ); ?>">
 							<?php
 							printf(
 								/* translators: %s: Plan name */

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7338,7 +7338,7 @@ h2 .frm-sub-label {
 	padding-bottom: 20px;
 }
 
-#frm-upgrade-message img {
+.frm-upgrade-message img {
 	max-width: 100%;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1778,13 +1778,18 @@ h2.frm-h2 + .howto {
 	visibility: hidden;
 }
 
-#frm_save_and_reload_options {
+.button.button-primary.frm-save-and-reload {
+	margin-right: 10px;
+}
+
+.frm-save-and-reload-options {
 	margin-top: 10px;
 	font-size: 13px;
 }
 
-#frm_save_and_reload, #frm_save_and_reload + .frm-button-secondary {
-	visibility: visible;
+.frm-save-and-reload,
+.frm-save-and-reload + .frm-button-secondary {
+	visibility: visible !important;
 }
 
 .addon-status-label {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1778,10 +1778,6 @@ h2.frm-h2 + .howto {
 	visibility: hidden;
 }
 
-.button.button-primary.frm-save-and-reload {
-	margin-right: 10px;
-}
-
 .frm-save-and-reload-options {
 	margin-top: 10px;
 	font-size: 13px;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5923,8 +5923,9 @@ function frmAdminBuildJS() {
 			hideIt = 'block';
 			oneclick = JSON.parse( oneclick );
 
-			button.className = button.className.replace( ' frm-install-addon', '' ).replace( ' frm-activate-addon', '' );
-			button.className = button.className + ' ' + oneclick.class;
+			button.className   = button.className.replace( ' frm-install-addon', '' ).replace( ' frm-activate-addon', '' );
+			button.className   = button.className + ' ' + oneclick.class;
+			button.textContent = __( 'Activate', 'formidable' );
 			button.rel = oneclick.url;
 		}
 
@@ -8054,16 +8055,21 @@ function frmAdminBuildJS() {
 
 		if ([ 'settings', 'form_builder' ].includes( saveAndReload ) ) {
 			addonStatuses.forEach(
-				addonStatus => addonStatus.appendChild( getSaveAndReloadSettingsOptions( saveAndReload ) )
+				addonStatus => {
+					const inModal = null !== addonStatus.closest( '#frm_upgrade_modal' );
+					addonStatus.appendChild( getSaveAndReloadSettingsOptions( saveAndReload, inModal ) );
+				}
 			);
 		}
 	}
 
-	function getSaveAndReloadSettingsOptions( saveAndReload ) {
-		return div({
-			className: 'frm-save-and-reload-options',
-			children: [ saveAndReloadSettingsButton( saveAndReload ), closePopupButton() ]
-		});
+	function getSaveAndReloadSettingsOptions( saveAndReload, inModal ) {
+		const className = 'frm-save-and-reload-options';
+		const children  = [ saveAndReloadSettingsButton( saveAndReload ) ];
+		if ( inModal ) {
+			children.push( closePopupButton() );
+		}
+		return div({ className, children });
 	}
 
 	function saveAndReloadSettingsButton( saveAndReload ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5816,12 +5816,12 @@ function frmAdminBuildJS() {
 
 		container.classList.add( 'frmcenter' );
 
-		const modal = document.getElementById( 'frm_upgrade_modal' );
-		container.appendChild( modal.querySelector( '.frm-oneclick' ).cloneNode( true ) );
-		container.appendChild( modal.querySelector( '.frm-addon-status' ).cloneNode( true ) );
+		const upgradeModal = document.getElementById( 'frm_upgrade_modal' );
+		cloneUpgradeModalElementAndAppendToContainer( 'frm-oneclick' );
+		cloneUpgradeModalElementAndAppendToContainer( 'frm-addon-status' );
 
-		// Borrow the call to action from the Upgrade modal which should exist on the settings page (it is still used for other upgrades including Actions).
-		const upgradeModalLink = modal.querySelector( '.frm-upgrade-link' );
+		// Borrow the call to action from the Upgrade upgradeModal which should exist on the settings page (it is still used for other upgrades including Actions).
+		const upgradeModalLink = upgradeModal.querySelector( '.frm-upgrade-link' );
 		if ( upgradeModalLink ) {
 			const upgradeButton = upgradeModalLink.cloneNode( true );
 			const level         = upgradeButton.querySelector( '.license-level' );
@@ -5832,21 +5832,23 @@ function frmAdminBuildJS() {
 
 			container.appendChild( upgradeButton );
 
-			// Maybe append the secondary "Already purchased?" link from the modal as well.
+			// Maybe append the secondary "Already purchased?" link from the upgradeModal as well.
 			if ( upgradeModalLink.nextElementSibling && upgradeModalLink.nextElementSibling.querySelector( '.frm-link-secondary' ) ) {
 				container.appendChild( upgradeModalLink.nextElementSibling.cloneNode( true ) );
 			}
 
-			const oneClickButton = document.getElementById( 'frm_upgrade_modal' ).querySelector( '.frm-oneclick-button' ).cloneNode( true );
-			oneClickButton.id = 'frm_one_click_' + getAutoId();
-			container.appendChild( oneClickButton );
+			cloneUpgradeModalElementAndAppendToContainer( 'frm-oneclick-button' );
 		}
 
-		container.appendChild( modal.querySelector( '.frm-upgrade-message' ).cloneNode( true ) );
+		cloneUpgradeModalElementAndAppendToContainer( 'frm-upgrade-message' );
 		addOneClick( element, 'tab', element.dataset.message );
 
 		if ( element.dataset.screenshot ) {
 			container.appendChild( getScreenshotWrapper( element.dataset.screenshot ) );
+		}
+
+		function cloneUpgradeModalElementAndAppendToContainer( className ) {
+			container.appendChild( upgradeModal.querySelector( '.' + className ).cloneNode( true ) );
 		}
 	}
 
@@ -8059,15 +8061,14 @@ function frmAdminBuildJS() {
 
 	function getSaveAndReloadSettingsOptions( saveAndReload ) {
 		return div({
-			id: 'frm_save_and_reload_options',
+			className: 'frm-save-and-reload-options',
 			children: [ saveAndReloadSettingsButton( saveAndReload ), closePopupButton() ]
 		});
 	}
 
 	function saveAndReloadSettingsButton( saveAndReload ) {
 		var button = document.createElement( 'button' );
-		button.id = 'frm_save_and_reload';
-		button.classList.add( 'button', 'button-primary', 'frm-button-primary' );
+		button.classList.add( 'frm-save-and-reload', 'button', 'button-primary', 'frm-button-primary' );
 		button.textContent = __( 'Save and Reload', 'formidable' );
 		button.addEventListener( 'click', () => {
 			if ( saveAndReload === 'form_builder' ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8055,7 +8055,7 @@ function frmAdminBuildJS() {
 		if ([ 'settings', 'form_builder' ].includes( saveAndReload ) ) {
 			addonStatuses.forEach(
 				addonStatus => addonStatus.appendChild( getSaveAndReloadSettingsOptions( saveAndReload ) )
-			)
+			);
 		}
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5817,8 +5817,8 @@ function frmAdminBuildJS() {
 		container.classList.add( 'frmcenter' );
 
 		const upgradeModal = document.getElementById( 'frm_upgrade_modal' );
-		cloneUpgradeModalElementAndAppendToContainer( 'frm-oneclick' );
-		cloneUpgradeModalElementAndAppendToContainer( 'frm-addon-status' );
+		appendClonedModalElementToContainer( 'frm-oneclick' );
+		appendClonedModalElementToContainer( 'frm-addon-status' );
 
 		// Borrow the call to action from the Upgrade upgradeModal which should exist on the settings page (it is still used for other upgrades including Actions).
 		const upgradeModalLink = upgradeModal.querySelector( '.frm-upgrade-link' );
@@ -5837,17 +5837,17 @@ function frmAdminBuildJS() {
 				container.appendChild( upgradeModalLink.nextElementSibling.cloneNode( true ) );
 			}
 
-			cloneUpgradeModalElementAndAppendToContainer( 'frm-oneclick-button' );
+			appendClonedModalElementToContainer( 'frm-oneclick-button' );
 		}
 
-		cloneUpgradeModalElementAndAppendToContainer( 'frm-upgrade-message' );
+		appendClonedModalElementToContainer( 'frm-upgrade-message' );
 		addOneClick( element, 'tab', element.dataset.message );
 
 		if ( element.dataset.screenshot ) {
 			container.appendChild( getScreenshotWrapper( element.dataset.screenshot ) );
 		}
 
-		function cloneUpgradeModalElementAndAppendToContainer( className ) {
+		function appendClonedModalElementToContainer( className ) {
 			container.appendChild( upgradeModal.querySelector( '.' + className ).cloneNode( true ) );
 		}
 	}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8017,7 +8017,8 @@ function frmAdminBuildJS() {
 	 * TODO stop addressing oneclick stuff by ID as this may happen in a tab as well.
 	 */
 	function afterAddonInstall( response, button, message, el, saveAndReload ) {
-		document.querySelectorAll( '.frm-addon-status' ).forEach(
+		const addonStatuses = document.querySelectorAll( '.frm-addon-status' );
+		addonStatuses.forEach(
 			addonStatus => {
 				addonStatus.textContent   = response;
 				addonStatus.style.display = 'block';
@@ -8046,16 +8047,21 @@ function frmAdminBuildJS() {
 		const refreshPage = document.querySelectorAll( '.frm-admin-page-import, #frm-admin-smtp, #frm-welcome' );
 		if ( refreshPage.length > 0 ) {
 			window.location.reload();
-		} else if ([ 'settings', 'form_builder' ].includes( saveAndReload ) ) {
-			$addonStatus.append( getSaveAndReloadSettingsOptions( saveAndReload ) );
+			return;
+		}
+
+		if ([ 'settings', 'form_builder' ].includes( saveAndReload ) ) {
+			addonStatuses.forEach(
+				addonStatus => addonStatus.appendChild( getSaveAndReloadSettingsOptions( saveAndReload ) )
+			)
 		}
 	}
 
 	function getSaveAndReloadSettingsOptions( saveAndReload ) {
-		var wrapper = div({ id: 'frm_save_and_reload_options' });
-		wrapper.appendChild( saveAndReloadSettingsButton( saveAndReload ) );
-		wrapper.appendChild( closePopupButton() );
-		return wrapper;
+		return div({
+			id: 'frm_save_and_reload_options',
+			children: [ saveAndReloadSettingsButton( saveAndReload ), closePopupButton() ]
+		});
 	}
 
 	function saveAndReloadSettingsButton( saveAndReload ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3755

Not all of the oneclick logic was being carried over. Add on statuses were missing and not getting updated, etc.

I removed all of the ID-specific stuff and made everything work with classes and allowing for multiple instances of things. The upgrade tabs still borrow from the upgrade modal but will use their own elements after the elements are initially cloned now.

More code is being re-used now. And there's a bit less jQuery and a bit more ES6 than before as well.

<img width="644" alt="Screen Shot 2022-08-16 at 12 11 46 PM" src="https://user-images.githubusercontent.com/9134515/184918483-5de8b57a-89dc-4b0c-884e-e2a77e743de9.png">
<img width="723" alt="Screen Shot 2022-08-16 at 12 32 06 PM" src="https://user-images.githubusercontent.com/9134515/184918782-b7da86c8-cef3-46ea-8a2c-9b101eaefb69.png">