### PR TITLE
Applications compatibility fix with wp 5.6

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -494,6 +494,7 @@ class FrmAppController {
 			'bootstrap_tooltip',
 			'bootstrap-multiselect',
 			'wp-i18n',
+			'wp-hooks', // Required in WP versions older than 5.7
 			'formidable_dom',
 			'formidable_embed',
 		);

--- a/classes/controllers/FrmApplicationsController.php
+++ b/classes/controllers/FrmApplicationsController.php
@@ -171,6 +171,7 @@ class FrmApplicationsController {
 
 		$js_dependencies = array(
 			'wp-i18n',
+			'wp-hooks', // This prevents a console error "wp.hooks is undefined" in WP versions older than 5.7.
 			'formidable_dom',
 		);
 		wp_register_script( 'formidable_applications', $plugin_url . '/js/admin/applications.js', $js_dependencies, $version, true );


### PR DESCRIPTION
Fixes https://secure.helpscout.net/conversation/1980393108/106481/

Fixes `Uncaught TypeError: wp.hooks is undefined` in Applications.
Fixes `Uncaught TypeError: hooks is undefined` in the Form Builder.

The "View All Applications" page also requires https://github.com/Strategy11/formidable-pro/pull/3759