### PR TITLE
Update post parent id if imported page id parent matches

### DIFF
--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -799,6 +799,8 @@ class FrmXMLHelper {
 			} else {
 				if ( $post['post_type'] === 'frm_display' ) {
 					$post['post_content'] = self::maybe_prepare_json_view_content( $post['post_content'] );
+				} elseif ( 'page' === $post['post_type'] && isset( $imported['posts'][ $post['post_parent'] ] ) ) {
+					$post['post_parent'] = $imported['posts'][ $post['post_parent'] ];
 				}
 				// Create/update post now
 				$post_id = wp_insert_post( $post );


### PR DESCRIPTION
Fixes an issue mentioned in https://secure.helpscout.net/conversation/1983340821/106865/

> When pages are imported as part of an application they do not remember their parent page when it's brought across in the same application.
