### PR TITLE
Get meta with entry in FrmEntry::destroy function

### DIFF
--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -261,7 +261,7 @@ class FrmEntry {
 		global $wpdb;
 		$id = (int) $id;
 
-		$entry = self::getOne( $id );
+		$entry = self::getOne( $id, true ); // Item meta is required for conditional logic in actions with 'delete' events.
 		if ( ! $entry ) {
 			$result = false;
 			return $result;


### PR DESCRIPTION
Fixes https://secure.helpscout.net/conversation/1987233335/107342/

Deleted actions do not trigger conditional logic if the conditions are based off of item meta because the item meta is missing from the object.