### PR TITLE
Avoid empty error pop up when aborting jquery

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1485,8 +1485,8 @@ function frmAdminBuildJS() {
 				}
 				toggleSectionHolder();
 			},
-			error: function( jqXHR, textStatus, errorThrown ) {
-				maybeReenableSummaryBtnAfterAJAX( fieldType, addBtn, fieldButton, errorThrown );
+			error: function( jqXHR, _, errorThrown ) {
+				maybeReenableSummaryBtnAfterAJAX( fieldType, addBtn, fieldButton, errorThrown, jqXHR );
 			}
 		});
 	}
@@ -1709,8 +1709,8 @@ function frmAdminBuildJS() {
 				$newFields.append( wrapFieldLi( msg ) );
 				afterAddField( msg, true );
 			},
-			error: function( jqXHR, textStatus, errorThrown ) {
-				maybeReenableSummaryBtnAfterAJAX( fieldType, $thisObj, $button, errorThrown );
+			error: function( jqXHR, _, errorThrown ) {
+				maybeReenableSummaryBtnAfterAJAX( fieldType, $thisObj, $button, errorThrown, jqXHR );
 			}
 		});
 		return false;
@@ -1742,12 +1742,19 @@ function frmAdminBuildJS() {
 		addFieldLink.addClass( 'disabled' );
 	}
 
-	function maybeReenableSummaryBtnAfterAJAX( fieldType, addBtn, fieldButton, errorThrown ) {
-		infoModal( errorThrown + '. Please try again.' );
+	function maybeReenableSummaryBtnAfterAJAX( fieldType, addBtn, fieldButton, errorThrown, jqXHR ) {
+		if ( ! jqXHRAborted( jqXHR ) ) {
+			infoModal( errorThrown + '. Please try again.' );
+		}
+
 		if ( 'summary' === fieldType ) {
 			addBtn.removeClass( 'disabled' );
 			fieldButton.draggable( 'enable' );
 		}
+	}
+
+	function jqXHRAborted( jqXHR ) {
+		return jqXHR.status === 0 || jqXHR.readyState === 0;
 	}
 
 	function formHasSummaryField() {


### PR DESCRIPTION
This pop up happens if you try to insert a field and then click save and try to leave the page before the field has inserted. It triggers the AJAX error function as it's aborted. Checking for a status code of 0 is the closest I could find to checking for that.

It's the third answer here but I don't think either of the first two are perfect either. The biggest criticism it has is that it will catch some other types of errors as well.
https://stackoverflow.com/questions/4807572/jquery-ajax-error-handling-to-ignore-aborted#answer-5958734

![image](https://user-images.githubusercontent.com/9134515/186480983-0668e7d3-472e-43b3-9cf1-0b45bf390af9.png)

I tested the pop up with an error by failing the nonce check. It still works great. And the summary field re-enables fine. However I'm seeing other issues that can lead to 2 summary fields that I plan to look into as well.

<img width="329" alt="Screen Shot 2022-08-24 at 2 10 43 PM" src="https://user-images.githubusercontent.com/9134515/186481624-d7671d5a-594e-49a1-ae5c-baa05d25ab74.png">