### PR TITLE
add textarea height to popup options top offset.

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8558,8 +8558,8 @@ Responsive Design
 }
 
 .frm-custom-field-group-layout:hover,
-.frm-break-field-group:hover, .tracking-date {
-	background-color: #f5f5f5;
+.frm-break-field-group:hover {
+	background-color: #f5f5f5f5;
 }
 
 .frm-custom-field-group-layout svg,

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -777,9 +777,13 @@ p.frm_has_shortcodes {
 
 .frm-nav-tabs a {
 	color: var(--dark-grey);
-	padding: 5px 1px;
+	padding: 10px 1px;
 	margin: 0 9px;
 	border-bottom: 2px solid transparent;
+}
+
+.frm_form_settings .frm-nav-tabs a {
+	padding-top: 5px 1px;
 }
 
 .frm-nav-tabs.frm-compact-nav a {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -652,6 +652,9 @@ p.frm_has_shortcodes {
 	min-height: 200px;
 	overflow-y: scroll;
 	z-index: 100;
+	box-shadow: 0px 12px 24px rgb(72 78 84 / 20%);
+	border-radius: 4px;
+	border: none;
 }
 
 #form_global_settings .columns-2 .frm-right-panel,
@@ -745,7 +748,7 @@ p.frm_has_shortcodes {
 	position: -webkit-sticky;
 	position: sticky;
 	top: 0;
-	background-color: var(--sidebar-color);
+	background-color: #fff;
 	z-index: 98; /* must be < 99 */
 	margin-top: 0;
 	padding-top: 5px;
@@ -769,7 +772,7 @@ p.frm_has_shortcodes {
 
 .frm-nav-tabs a {
 	color: var(--dark-grey);
-	padding: 10px 1px;
+	padding: 5px 1px;
 	margin: 0 9px;
 	border-bottom: 2px solid transparent;
 }
@@ -784,13 +787,14 @@ p.frm_has_shortcodes {
 }
 
 #frm_adv_info .frm-nav-tabs a {
-	color: var(--dark-grey);
+	color: rgba(40, 47, 54, 0.45);
 }
 
 .frm-nav-tabs a:hover,
 .frm-nav-tabs .frm-tabs a {
 	color: var(--primary-color) !important;
 	border-color: var(--primary-color);
+	font-weight: 600;
 }
 
 #frm-bulk-modal .howto,
@@ -6473,6 +6477,10 @@ i.frm-show-inline-modal,
 	padding: 0 10px 0 5px;
 }
 
+.frm_form_settings .frm-with-right-icon .frmsvg{
+	bottom: -3px;
+}
+
 .frmsvg.frm-show-box,
 .frmsvg.frm-show-inline-modal,
 i.frm-show-box,
@@ -8550,8 +8558,8 @@ Responsive Design
 }
 
 .frm-custom-field-group-layout:hover,
-.frm-break-field-group:hover {
-	background-color: #f5f5f5f5;
+.frm-break-field-group:hover, .tracking-date {
+	background-color: #f5f5f5;
 }
 
 .frm-custom-field-group-layout svg,

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -783,7 +783,7 @@ p.frm_has_shortcodes {
 }
 
 .frm_form_settings #frm_adv_info .frm-nav-tabs a {
-	padding-top: 5px 1px;
+	padding: 5px 1px;
 }
 
 .frm-nav-tabs.frm-compact-nav a {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6495,6 +6495,7 @@ i.frm-show-inline-modal,
 
 .frm_form_settings .frm-with-right-icon .frmsvg{
 	bottom: -3px;
+	margin-right: 10px;
 }
 
 .frmsvg.frm-show-box,

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -652,7 +652,7 @@ p.frm_has_shortcodes {
 	min-height: 200px;
 	overflow-y: scroll;
 	z-index: 100;
-	box-shadow: 0px 12px 24px rgb(72 78 84 / 20%);
+	box-shadow: 0px 12px 24px rgba( 72, 78, 84, 0.2 );
 	border-radius: 4px;
 	border: none;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -748,10 +748,15 @@ p.frm_has_shortcodes {
 	position: -webkit-sticky;
 	position: sticky;
 	top: 0;
-	background-color: #fff;
+	background-color: var(--sidebar-color);
 	z-index: 98; /* must be < 99 */
 	margin-top: 0;
 	padding-top: 5px;
+}
+
+.frm_form_settings #frm_adv_info #frm-nav-tabs {
+	background-color: #fff;
+	margin-top: 0;
 }
 
 .frm-inline-modal .frm-nav-tabs,
@@ -794,6 +799,9 @@ p.frm_has_shortcodes {
 .frm-nav-tabs .frm-tabs a {
 	color: var(--primary-color) !important;
 	border-color: var(--primary-color);
+}
+
+.frm_form_settings .frm-nav-tabs .frm-tabs a {
 	font-weight: 600;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -796,7 +796,8 @@ p.frm_has_shortcodes {
 }
 
 #frm_adv_info .frm-nav-tabs a {
-	color: var(--dark-grey);}
+	color: var(--dark-grey);
+}
 
 .frm_form_settings #frm_adv_info .frm-nav-tabs a {
 	color: rgba(40, 47, 54, 0.45);

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -782,7 +782,7 @@ p.frm_has_shortcodes {
 	border-bottom: 2px solid transparent;
 }
 
-.frm_form_settings .frm-nav-tabs a {
+.frm_form_settings #frm_adv_info .frm-nav-tabs a {
 	padding-top: 5px 1px;
 }
 
@@ -809,7 +809,7 @@ p.frm_has_shortcodes {
 	border-color: var(--primary-color);
 }
 
-.frm_form_settings .frm-nav-tabs .frm-tabs a {
+.frm_form_settings #frm_adv_info .frm-nav-tabs .frm-tabs a {
 	font-weight: 600;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -759,6 +759,10 @@ p.frm_has_shortcodes {
 	margin-top: 0;
 }
 
+.frm_form_settings span.frm-with-right-icon {
+	display: block;
+}
+
 .frm-inline-modal .frm-nav-tabs,
 #frm_adv_info .frm-nav-tabs {
 	margin: 5px 0 10px;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -796,6 +796,9 @@ p.frm_has_shortcodes {
 }
 
 #frm_adv_info .frm-nav-tabs a {
+	color: var(--dark-grey);}
+
+.frm_form_settings #frm_adv_info .frm-nav-tabs a {
 	color: rgba(40, 47, 54, 0.45);
 }
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7370,7 +7370,7 @@ function frmAdminBuildJS() {
 	/**
 	 * Get the input box for the selected ... icon.
 	 */
-     function getInputForIcon( moreIcon ) {
+	function getInputForIcon( moreIcon ) {
 		var input = moreIcon.nextElementSibling;
 
 		while ( input !== null && input.tagName !== 'INPUT' && input.tagName !== 'TEXTAREA' ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7172,7 +7172,7 @@ function frmAdminBuildJS() {
 					showShortcodeBox( moreIcon, 'nofocus' );
 				}
 			} else if ( ! moreIcon.classList.contains( 'frm_close_icon' ) ) {
-				showShortcodeBox( moreIcon, 'nofocus' );
+				showShortcodeBox( moreIcon, 'nofocus', input.clientHeight );
 			}
 		}
 	}
@@ -7185,7 +7185,7 @@ function frmAdminBuildJS() {
 		showShortcodeBox( this );
 	}
 
-	function showShortcodeBox( moreIcon, shouldFocus ) {
+	function showShortcodeBox( moreIcon, shouldFocus, inputHeight ) {
 		var pos = moreIcon.getBoundingClientRect(),
 			input = getInputForIcon( moreIcon ),
 			box = document.getElementById( 'frm_adv_info' ),
@@ -7202,7 +7202,7 @@ function frmAdminBuildJS() {
 		if ( classes.indexOf( 'frm_close_icon' ) !== -1 ) {
 			hideShortcodes( box );
 		} else {
-			box.style.top = ( pos.top - parentPos.top + 32 ) + 'px';
+			box.style.top = ( pos.top - parentPos.top + inputHeight ) + 'px';
 			box.style.left = ( pos.left - parentPos.left - 257 ) + 'px';
 
 			jQuery( '.frm_code_list a' ).removeClass( 'frm_noallow' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7385,6 +7385,7 @@ function frmAdminBuildJS() {
 	 */
 	function getIconForInput( input ) {
 		var moreIcon = input.previousElementSibling;
+
 		while ( moreIcon !== null && moreIcon.tagName !== 'I' && moreIcon.tagName !== 'svg' ) {
 			moreIcon = getIconForInput( moreIcon );
 		}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7172,7 +7172,7 @@ function frmAdminBuildJS() {
 					showShortcodeBox( moreIcon, 'nofocus' );
 				}
 			} else if ( ! moreIcon.classList.contains( 'frm_close_icon' ) ) {
-				showShortcodeBox( moreIcon, 'nofocus', input.clientHeight );
+				showShortcodeBox( moreIcon, 'nofocus' );
 			}
 		}
 	}
@@ -7185,7 +7185,7 @@ function frmAdminBuildJS() {
 		showShortcodeBox( this );
 	}
 
-	function showShortcodeBox( moreIcon, shouldFocus, inputHeight ) {
+	function showShortcodeBox( moreIcon, shouldFocus ) {
 		var pos = moreIcon.getBoundingClientRect(),
 			input = getInputForIcon( moreIcon ),
 			box = document.getElementById( 'frm_adv_info' ),
@@ -7202,7 +7202,7 @@ function frmAdminBuildJS() {
 		if ( classes.indexOf( 'frm_close_icon' ) !== -1 ) {
 			hideShortcodes( box );
 		} else {
-			box.style.top = ( pos.top - parentPos.top + 30 ) + 'px';
+			box.style.top = ( pos.top - parentPos.top + 32 ) + 'px';
 			box.style.left = ( pos.left - parentPos.left - 257 ) + 'px';
 
 			jQuery( '.frm_code_list a' ).removeClass( 'frm_noallow' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7370,12 +7370,13 @@ function frmAdminBuildJS() {
 	/**
 	 * Get the input box for the selected ... icon.
 	 */
-	function getInputForIcon( moreIcon ) {
+     function getInputForIcon( moreIcon ) {
 		var input = moreIcon.nextElementSibling;
-		if ( input !== null && input.tagName !== 'INPUT' && input.tagName !== 'TEXTAREA' ) {
-			// Workaround for 1Password.
-			input = input.nextElementSibling;
+
+		while ( input !== null && input.tagName !== 'INPUT' && input.tagName !== 'TEXTAREA' ) {
+			input = getInputForIcon( input );
 		}
+
 		return input;
 	}
 
@@ -7384,9 +7385,10 @@ function frmAdminBuildJS() {
 	 */
 	function getIconForInput( input ) {
 		var moreIcon = input.previousElementSibling;
-		if ( moreIcon !== null && moreIcon.tagName !== 'I' && moreIcon.tagName !== 'svg' ) {
-			moreIcon = moreIcon.previousElementSibling;
+		while ( moreIcon !== null && moreIcon.tagName !== 'I' && moreIcon.tagName !== 'svg' ) {
+			moreIcon = getIconForInput( moreIcon );
 		}
+
 		return moreIcon;
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7202,7 +7202,7 @@ function frmAdminBuildJS() {
 		if ( classes.indexOf( 'frm_close_icon' ) !== -1 ) {
 			hideShortcodes( box );
 		} else {
-			box.style.top = ( pos.top - parentPos.top + inputHeight ) + 'px';
+			box.style.top = ( pos.top - parentPos.top + 30 ) + 'px';
 			box.style.left = ( pos.left - parentPos.left - 257 ) + 'px';
 
 			jQuery( '.frm_code_list a' ).removeClass( 'frm_noallow' );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3757
This is just a quick fix to make sure the advanced options box doesn't overlap with the textarea content, adding the textarea height to the popup's top offset.

Before:
![image](https://user-images.githubusercontent.com/41271840/186608591-a23de633-782f-4925-b309-862aab0a059d.png)

With this update:
![image](https://user-images.githubusercontent.com/41271840/186608540-9eac3ccf-410e-4b59-b78a-69d1ef663c82.png)
