### PR TITLE
Stop disabling summary fields

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5817,7 +5817,8 @@ ul.start_divider {
 	cursor: not-allowed;
 }
 
-.edit_field_type_summary .frm_clone_field {
+/* Hide the Duplicate summary option because we are missing the logic that also adds a new page */
+.edit_field_type_summary .frm_more_options_li:nth-child(2) {
 	display: none !important;
 }
 


### PR DESCRIPTION
Following up on a Slack conversation from last week.

> I think we decided we shouldn't prevent it. That code must have been missed when we removed the limitation.

I kept the error handling that shows a pop up but renamed the function and removed the unneeded parameters required for summary field checks. There was quite a bit of old code left in here, lots to remove 🥳

<img width="325" alt="Screen Shot 2022-08-29 at 10 53 44 AM" src="https://user-images.githubusercontent.com/9134515/187217746-0d0918b2-c0e1-4e2c-b633-0003d550d00c.png">

I also switched from using `var` to `let/const` in more code so we can keep reducing our vars-on-top warnings. Only about 140 to go 😅.

I also updated a style rule. I noticed the clone option for summary fields is disabled. I removed the rule for a moment but it doesn't look too straight forward to enforce the "insert a page break" logic in there as well. Maybe that isn't important if two summary fields are on the same page anyway but I went with hiding it still for now.

**Before**
<img width="253" alt="(ID 1202) +" src="https://user-images.githubusercontent.com/9134515/187217979-67e6be37-34c5-4603-add1-4988cd5086ad.png">

**After**
<img width="183" alt="Screen Shot 2022-08-29 at 10 57 24 AM" src="https://user-images.githubusercontent.com/9134515/187218234-0c382db5-5daa-4d21-84db-746f180e61ad.png">