### PR TITLE
make sure autocomplete option has priority over input shortcode.

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -769,7 +769,7 @@ class FrmFieldsController {
 		}
 
 		foreach ( $field['shortcodes'] as $k => $v ) {
-			if ( 'opt' === $k || ( ! empty( $field['autocomplete'] && $k === 'autocomplete' ) ) ) {
+			if ( 'opt' === $k || ( ! empty( $field['autocomplete'] ) && $k === 'autocomplete' ) ) {
 				continue;
 			}
 

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -769,7 +769,7 @@ class FrmFieldsController {
 		}
 
 		foreach ( $field['shortcodes'] as $k => $v ) {
-			if ( 'opt' === $k ) {
+			if ( 'opt' === $k || ( ! empty( $field['autocomplete'] && $k === 'autocomplete' ) ) ) {
 				continue;
 			}
 

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -768,8 +768,12 @@ class FrmFieldsController {
 			return;
 		}
 
+		if ( ! empty( $field['autocomplete'] ) ) {
+			unset( $field['shortcodes']['autocomplete'] );
+		}
+
 		foreach ( $field['shortcodes'] as $k => $v ) {
-			if ( 'opt' === $k || ( ! empty( $field['autocomplete'] ) && $k === 'autocomplete' ) ) {
+			if ( 'opt' === $k ) {
 				continue;
 			}
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3780

This update avoids having double autocomplete html attributes in a field by making sure that the option set in the field settings override the input shortcode html.