### PR TITLE
Vertically center background images in formidable dropdowns

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -339,6 +339,7 @@ legend.frm_hidden{
 	width:<?php echo esc_html( $defaults['auto_width'] ); ?>;
 	width:var(--auto-width)<?php echo esc_html( $important ); ?>;
 	max-width:100%;
+	background-position-y: center;
 }
 
 .with_frm_style input[disabled],


### PR DESCRIPTION
This fixes a conflict with Astra.

I noticed dropdowns all look weird like this in Astra. It's easy to fix though by adding a `background-position-y: center` style to a select.

**Before**
<img width="430" alt="Screen Shot 2022-09-01 at 10 29 02 AM" src="https://user-images.githubusercontent.com/9134515/187925918-ffa795d1-f731-4857-ba92-309b90985463.png">

**After**
<img width="560" alt="Screen Shot 2022-09-01 at 10 27 38 AM" src="https://user-images.githubusercontent.com/9134515/187925927-9d92b0db-6acd-4a66-8190-76b74e559207.png">
