### PR TITLE
Add form name shortcode to email actions

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1442,6 +1442,7 @@ class FrmFormsController {
 			$entry_shortcodes['default-message'] = __( 'Default Msg', 'formidable' );
 			$entry_shortcodes['default-html']    = __( 'Default HTML', 'formidable' );
 			$entry_shortcodes['default-plain']   = __( 'Default Plain', 'formidable' );
+			$entry_shortcodes['form_name']       = __( 'Form Name', 'formidable' );
 		}
 
 		/**

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1530,7 +1530,7 @@ class FrmFormsController {
 	 * @param stdClass|string|int $form
 	 * @return string
 	 */
-	private static function replace_form_name_shortcodes( $string, $form ) {
+	public static function replace_form_name_shortcodes( $string, $form ) {
 		if ( false === strpos( $string, '[form_name]' ) ) {
 			return $string;
 		}

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1497,11 +1497,19 @@ class FrmFormsController {
 		wp_die();
 	}
 
+	/**
+	 * @param string                    $content
+	 * @param stdClass|string|int       $form
+	 * @param stdClass|string|int|false $entry
+	 * @return string
+	 */
 	public static function filter_content( $content, $form, $entry = false ) {
 		self::get_entry_by_param( $entry );
 		if ( ! $entry ) {
 			return $content;
 		}
+
+		$content = self::replace_form_name_shortcodes( $content, $form );
 
 		if ( is_object( $form ) ) {
 			$form = $form->id;
@@ -1513,6 +1521,31 @@ class FrmFormsController {
 		return $content;
 	}
 
+	/**
+	 * Replace any [form_name] shortcodes in a string.
+	 *
+	 * @since x.x
+	 *
+	 * @param string              $string
+	 * @param stdClass|string|int $form
+	 * @return string
+	 */
+	private static function replace_form_name_shortcodes( $string, $form ) {
+		if ( false === strpos( $string, '[form_name]' ) ) {
+			return $string;
+		}
+
+		if ( ! is_object( $form ) ) {
+			$form = FrmForm::getOne( $form );
+		}
+
+		return str_replace( '[form_name]', $form->name, $string );
+	}
+
+	/**
+	 * @param stdClass|string|int|false $entry
+	 * @return void
+	 */
 	private static function get_entry_by_param( &$entry ) {
 		if ( ! $entry || ! is_object( $entry ) ) {
 			if ( ! $entry || ! is_numeric( $entry ) ) {

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1504,12 +1504,12 @@ class FrmFormsController {
 	 * @return string
 	 */
 	public static function filter_content( $content, $form, $entry = false ) {
+		$content = self::replace_form_name_shortcodes( $content, $form );
+
 		self::get_entry_by_param( $entry );
 		if ( ! $entry ) {
 			return $content;
 		}
-
-		$content = self::replace_form_name_shortcodes( $content, $form );
 
 		if ( is_object( $form ) ) {
 			$form = $form->id;

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1539,7 +1539,8 @@ class FrmFormsController {
 			$form = FrmForm::getOne( $form );
 		}
 
-		return str_replace( '[form_name]', $form->name, $string );
+		$form_name = is_object( $form ) ? $form->name : '';
+		return str_replace( '[form_name]', $form_name, $string );
 	}
 
 	/**

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -250,12 +250,35 @@ class FrmFormsHelper {
 		return apply_filters( 'frm_invalid_error_message', $invalid_msg, $args );
 	}
 
+	/**
+	 * @param array $atts {
+	 *     @type string   $message
+	 *     @type stdClass $form
+	 *     @type int      $entry_id
+	 *     @type string   $class
+	 * }
+	 * @return string
+	 */
 	public static function get_success_message( $atts ) {
-		$message = apply_filters( 'frm_content', $atts['message'], $atts['form'], $atts['entry_id'] );
+		$message = self::replace_form_name_shortcodes( $atts['message'], $atts['form'] );
+		$message = apply_filters( 'frm_content', $message, $atts['form'], $atts['entry_id'] );
 		$message = do_shortcode( FrmAppHelper::use_wpautop( $message ) );
 		$message = '<div class="' . esc_attr( $atts['class'] ) . '" role="status">' . $message . '</div>';
 
 		return $message;
+	}
+
+	/**
+	 * Replace any [form_name] shortcodes in a string.
+	 *
+	 * @since x.x
+	 *
+	 * @param string   $string
+	 * @param stdClass $form
+	 * @return string
+	 */
+	public static function replace_form_name_shortcodes( $string, $form ) {
+		return str_replace( '[form_name]', $form->name, $string );
 	}
 
 	/**

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -260,25 +260,10 @@ class FrmFormsHelper {
 	 * @return string
 	 */
 	public static function get_success_message( $atts ) {
-		$message = self::replace_form_name_shortcodes( $atts['message'], $atts['form'] );
-		$message = apply_filters( 'frm_content', $message, $atts['form'], $atts['entry_id'] );
+		$message = apply_filters( 'frm_content', $atts['message'], $atts['form'], $atts['entry_id'] );
 		$message = do_shortcode( FrmAppHelper::use_wpautop( $message ) );
 		$message = '<div class="' . esc_attr( $atts['class'] ) . '" role="status">' . $message . '</div>';
-
 		return $message;
-	}
-
-	/**
-	 * Replace any [form_name] shortcodes in a string.
-	 *
-	 * @since x.x
-	 *
-	 * @param string   $string
-	 * @param stdClass $form
-	 * @return string
-	 */
-	public static function replace_form_name_shortcodes( $string, $form ) {
-		return str_replace( '[form_name]', $form->name, $string );
 	}
 
 	/**

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -229,12 +229,14 @@ class FrmEmail {
 	 * @since 2.03.04
 	 *
 	 * @param array $user_id_args
+	 * @return void
 	 */
 	private function set_from( $user_id_args ) {
 		if ( empty( $this->settings['from'] ) ) {
 			$from = get_option( 'admin_email' );
 		} else {
-			$from = $this->prepare_email_setting( $this->settings['from'], $user_id_args );
+			$from = $this->replace_form_name_shortcode( $this->settings['from'] );
+			$from = $this->prepare_email_setting( $from, $user_id_args );
 		}
 
 		$this->from = $this->format_from( $from );

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -235,8 +235,7 @@ class FrmEmail {
 		if ( empty( $this->settings['from'] ) ) {
 			$from = get_option( 'admin_email' );
 		} else {
-			$from = $this->replace_form_name_shortcode( $this->settings['from'] );
-			$from = $this->prepare_email_setting( $from, $user_id_args );
+			$from = $this->prepare_email_setting( $this->settings['from'], $user_id_args );
 		}
 
 		$this->from = $this->format_from( $from );
@@ -342,7 +341,6 @@ class FrmEmail {
 			$this->subject = sprintf( __( '%1$s Form submitted on %2$s', 'formidable' ), $this->form->name, '[sitename]' );
 		} else {
 			$this->subject = $this->settings['email_subject'];
-			$this->subject = $this->replace_form_name_shortcode( $this->subject );
 		}
 
 		// This also replaces [sitename] shortcode in default.
@@ -363,8 +361,7 @@ class FrmEmail {
 	 * @since 2.03.04
 	 */
 	private function set_message() {
-		$this->message = $this->replace_form_name_shortcode( $this->settings['email_message'] );
-		$this->message = FrmFieldsHelper::basic_replace_shortcodes( $this->message, $this->form, $this->entry );
+		$this->message = FrmFieldsHelper::basic_replace_shortcodes( $this->settings['email_message'], $this->form, $this->entry );
 
 		$prev_mail_body = $this->message;
 		$pass_entry     = clone $this->entry; // make a copy to prevent changes by reference
@@ -396,14 +393,6 @@ class FrmEmail {
 		}
 
 		$this->message = apply_filters( 'frm_email_message', $this->message, $this->package_atts() );
-	}
-
-	/**
-	 * @param string $string
-	 * @return string
-	 */
-	private function replace_form_name_shortcode( $string ) {
-		return FrmFormsHelper::replace_form_name_shortcodes( $string, $this->form );
 	}
 
 	private function maybe_add_ip( &$mail_body ) {

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -331,6 +331,8 @@ class FrmEmail {
 	 * Set the subject
 	 *
 	 * @since 2.03.04
+	 *
+	 * @return void
 	 */
 	private function set_subject() {
 		if ( empty( $this->settings['email_subject'] ) ) {
@@ -338,9 +340,9 @@ class FrmEmail {
 			$this->subject = sprintf( __( '%1$s Form submitted on %2$s', 'formidable' ), $this->form->name, '[sitename]' );
 		} else {
 			$this->subject = $this->settings['email_subject'];
+			$this->subject = $this->replace_form_name_shortcode( $this->subject );
+			$this->subject = FrmFieldsHelper::basic_replace_shortcodes( $this->subject, $this->form, $this->entry );
 		}
-
-		$this->subject = FrmFieldsHelper::basic_replace_shortcodes( $this->subject, $this->form, $this->entry );
 
 		$args          = array(
 			'form'      => $this->form,
@@ -348,7 +350,6 @@ class FrmEmail {
 			'email_key' => $this->email_key,
 		);
 		$this->subject = apply_filters( 'frm_email_subject', $this->subject, $args );
-
 		$this->subject = wp_specialchars_decode( strip_tags( stripslashes( $this->subject ) ), ENT_QUOTES );
 	}
 
@@ -358,7 +359,8 @@ class FrmEmail {
 	 * @since 2.03.04
 	 */
 	private function set_message() {
-		$this->message = FrmFieldsHelper::basic_replace_shortcodes( $this->settings['email_message'], $this->form, $this->entry );
+		$this->message = $this->replace_form_name_shortcode( $this->settings['email_message'] );
+		$this->message = FrmFieldsHelper::basic_replace_shortcodes( $this->message, $this->form, $this->entry );
 
 		$prev_mail_body = $this->message;
 		$pass_entry     = clone $this->entry; // make a copy to prevent changes by reference
@@ -390,6 +392,14 @@ class FrmEmail {
 		}
 
 		$this->message = apply_filters( 'frm_email_message', $this->message, $this->package_atts() );
+	}
+
+	/**
+	 * @param string $string
+	 * @return string
+	 */
+	private function replace_form_name_shortcode( $string ) {
+		return str_replace( '[form_name]', $this->form->name, $string );
 	}
 
 	private function maybe_add_ip( &$mail_body ) {

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -341,8 +341,10 @@ class FrmEmail {
 		} else {
 			$this->subject = $this->settings['email_subject'];
 			$this->subject = $this->replace_form_name_shortcode( $this->subject );
-			$this->subject = FrmFieldsHelper::basic_replace_shortcodes( $this->subject, $this->form, $this->entry );
 		}
+
+		// This also replaces [sitename] shortcode in default.
+		$this->subject = FrmFieldsHelper::basic_replace_shortcodes( $this->subject, $this->form, $this->entry );
 
 		$args          = array(
 			'form'      => $this->form,

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -403,7 +403,7 @@ class FrmEmail {
 	 * @return string
 	 */
 	private function replace_form_name_shortcode( $string ) {
-		return str_replace( '[form_name]', $this->form->name, $string );
+		return FrmFormsHelper::replace_form_name_shortcodes( $string, $this->form );
 	}
 
 	private function maybe_add_ip( &$mail_body ) {


### PR DESCRIPTION
I went through the feature requests more today and found this one.

https://team.strategy11.com/feature-requests/2021/04/30/form-name-shortcode-for-emails/?modal=1

> I need to include the form name in the email message admin receives.
> I can't get [form_name] to work.

It has 10 upvotes and it is a pretty small task so I gave it a go.

This update adds support for the `[form_name]` shortcode in email subject and in email message.

**Before**
<img width="265" alt="Screen Shot 2022-09-02 at 3 38 18 PM" src="https://user-images.githubusercontent.com/9134515/188218310-2dcfea2b-8191-43b6-9e0c-115cdbd0d391.png">
<img width="385" alt="Screen Shot 2022-09-02 at 3 38 15 PM" src="https://user-images.githubusercontent.com/9134515/188218311-92c27aa3-2e21-4e1c-832a-72aec6698cca.png">

**After**
<img width="303" alt="Screen Shot 2022-09-02 at 3 43 17 PM" src="https://user-images.githubusercontent.com/9134515/188218337-eacf6427-f1da-4abc-a3a5-e3cafca0fc63.png">
<img width="412" alt="Screen Shot 2022-09-02 at 3 43 16 PM" src="https://user-images.githubusercontent.com/9134515/188218339-ab8a36fc-7193-4c25-a8ef-1902130c29ed.png">
