### PR TITLE
Check if array keys exist in init_user_info function

### DIFF
--- a/classes/models/FrmEntryValues.php
+++ b/classes/models/FrmEntryValues.php
@@ -252,19 +252,17 @@ class FrmEntryValues {
 			);
 		}
 
-		$ip = array(
+		$ip      = array(
 			'label' => __( 'IP Address', 'formidable' ),
 			'value' => $this->entry->ip,
 		);
-
 		$browser = array(
 			'label' => __( 'User-Agent (Browser/OS)', 'formidable' ),
-			'value' => FrmEntriesHelper::get_browser( $entry_description['browser'] ),
+			'value' => isset( $entry_description['browser'] ) ? FrmEntriesHelper::get_browser( $entry_description['browser'] ) : '',
 		);
-
 		$referrer = array(
 			'label' => __( 'Referrer', 'formidable' ),
-			'value' => $entry_description['referrer'],
+			'value' => isset( $entry_description['referrer'] ) ? $entry_description['referrer'] : '',
 		);
 
 		$this->user_info = array(


### PR DESCRIPTION
I noticed these two warnings when I viewed an entry that I created from a Post. Because it doesn't get submitted normally, the description is just "Copied from Post" and these array keys don't exist.

<img width="831" alt="Screen Shot 2022-09-06 at 11 25 39 AM" src="https://user-images.githubusercontent.com/9134515/188662385-53cd51cd-b22b-4981-9cfa-cf0612ae2e23.png">
