### PR TITLE
Treat single field in group as selected group for multiselect

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3831,28 +3831,27 @@ function frmAdminBuildJS() {
 	}
 
 	function fieldGroupClick( e ) {
-		var hoverTarget, ctrlOrCmdKeyIsDown, shiftKeyIsDown, groupIsActive, $selectedFieldGroups, numberOfSelectedGroups, selectedField, $firstGroup, $range;
-
 		if ( 'ul' !== e.originalEvent.target.nodeName.toLowerCase() ) {
 			// only continue if the group itself was clicked / ignore when a field is clicked.
 			return;
 		}
 
-		hoverTarget = document.querySelector( '.frm-field-group-hover-target' );
-		if ( hoverTarget === null ) {
+		const hoverTarget = document.querySelector( '.frm-field-group-hover-target' );
+		if ( ! hoverTarget ) {
 			return;
 		}
 
-		ctrlOrCmdKeyIsDown = e.ctrlKey || e.metaKey;
-		shiftKeyIsDown = e.shiftKey;
-		groupIsActive = hoverTarget.classList.contains( 'frm-selected-field-group' );
-		$selectedFieldGroups = jQuery( '.frm-selected-field-group' );
-		numberOfSelectedGroups = $selectedFieldGroups.length;
+		const ctrlOrCmdKeyIsDown   = e.ctrlKey || e.metaKey;
+		const shiftKeyIsDown       = e.shiftKey;
+		const groupIsActive        = hoverTarget.classList.contains( 'frm-selected-field-group' );
+		const $selectedFieldGroups = getSelectedFieldGroups();
+
+		let numberOfSelectedGroups = $selectedFieldGroups.length;
 
 		if ( ctrlOrCmdKeyIsDown || shiftKeyIsDown ) {
 			// multi-selecting
 
-			selectedField = document.querySelector( 'li.form-field.selected' );
+			const selectedField = getSelectedField();
 			if ( null !== selectedField && ! jQuery( selectedField ).siblings( 'li.form-field' ).length ) {
 				// count a selected field on its own as a selected field group when multiselecting.
 				selectedField.parentNode.classList.add( 'frm-selected-field-group' );
@@ -3871,8 +3870,9 @@ function frmAdminBuildJS() {
 				}
 			} else if ( shiftKeyIsDown && ! groupIsActive ) {
 				++numberOfSelectedGroups; // include the one we're selecting right now.
-				$firstGroup = $selectedFieldGroups.first();
+				const $firstGroup = $selectedFieldGroups.first();
 
+				let $range;
 				if ( $firstGroup.parent().index() < jQuery( hoverTarget.parentNode ).index() ) {
 					$range = $firstGroup.parent().nextUntil( hoverTarget.parentNode );
 				} else {
@@ -3903,6 +3903,29 @@ function frmAdminBuildJS() {
 
 		jQuery( document ).off( 'click', unselectFieldGroups );
 		jQuery( document ).on( 'click', unselectFieldGroups );
+	}
+
+	function getSelectedField() {
+		return document.getElementById( 'frm-show-fields' ).querySelector( 'li.form-field.selected' );
+	}
+
+	function getSelectedFieldGroups() {
+		const $fieldGroups = jQuery( '.frm-selected-field-group' );
+		if ( $fieldGroups.length ) {
+			return $fieldGroups;
+		}
+
+		const selectedField = getSelectedField();
+		if ( selectedField ) {
+			// If there is only one field in a group and the field is selected, consider the field's group as selected for multi-select.
+			const selectedFieldGroup = selectedField.closest( 'ul' );
+			if ( selectedFieldGroup && 1 === getFieldsInRow( jQuery( selectedFieldGroup ) ).length ) {
+				selectedFieldGroup.classList.add( 'frm-selected-field-group' );
+				return jQuery( selectedFieldGroup );
+			}
+		}
+
+		return jQuery();
 	}
 
 	function syncAfterMultiSelect( numberOfSelectedGroups ) {


### PR DESCRIPTION
This is just a small enhancement for side-by-side fields.

The way the multi-select works when you're holding the shift key, it would only consider the field group as selected if the actual field group was. Since a single field fills in the whole group it isn't very easy to click on the field's group without clicking on the field.

This means that when you shift+click it would just work like the `Cmd`/`Ctrl` key and just select another field group without using the shift rule of selecting all groups in between as well.

**Before**
![ROIAU5cVdr](https://user-images.githubusercontent.com/9134515/188687354-a83bb62a-36e7-4930-aa48-b993523f8ee4.gif)

**After**
![yTDLS2BO2e](https://user-images.githubusercontent.com/9134515/188687587-967d4150-e5fc-4bd5-8ae3-c816761edb42.gif)
