### PR TITLE
New function FrmAppHelper::get_plugins that adds missing file

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -321,10 +321,7 @@ class FrmAddonsController {
 
 		$transient->last_checked = time();
 
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-		$wp_plugins = get_plugins();
+		$wp_plugins = FrmAppHelper::get_plugins();
 
 		foreach ( $version_info as $id => $plugin ) {
 			$plugin = (object) $plugin;
@@ -369,12 +366,7 @@ class FrmAddonsController {
 	 * @return bool - True if installed
 	 */
 	protected static function is_installed( $plugin ) {
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
-		$all_plugins = get_plugins();
-
+		$all_plugins = FrmAppHelper::get_plugins();
 		return isset( $all_plugins[ $plugin ] );
 	}
 

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3582,6 +3582,20 @@ class FrmAppHelper {
 	}
 
 	/**
+	 * Safely call get_plugins, importing the required files if they are not yet loaded.
+	 *
+	 * @since x.x
+	 *
+	 * @return array
+	 */
+	public static function get_plugins() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		return get_plugins();
+	}
+
+	/**
 	 * @since 4.08
 	 * @deprecated 4.09.01
 	 */

--- a/classes/models/FrmPluginSearch.php
+++ b/classes/models/FrmPluginSearch.php
@@ -333,13 +333,12 @@ class FrmPluginSearch {
 		return $links;
 	}
 
+	/**
+	 * @param string $plugin
+	 * @return bool
+	 */
 	protected function is_installed( $plugin ) {
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
-		$all_plugins = get_plugins();
-
+		$all_plugins = FrmAppHelper::get_plugins();
 		return isset( $all_plugins[ $plugin ] );
 	}
 

--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -94,7 +94,7 @@ class FrmUsage {
 	 * @return array
 	 */
 	private function plugins() {
-		$plugin_list = get_plugins();
+		$plugin_list = FrmAppHelper::get_plugins();
 
 		$plugins = array();
 		foreach ( $plugin_list as $slug => $info ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3802

This exact issue is fixed all over the place. I added a new helper function that handles this check to reduce the copied/pasted checks we have all over.