### PR TITLE
Add a static installed bool for PHPUnit

### DIFF
--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -85,16 +85,17 @@ class FrmUnitTest extends WP_UnitTestCase {
 			define( 'WP_IMPORTING', false );
 		}
 
-		if ( ! self::$installed ) {
-			FrmHooksController::trigger_load_hook( 'load_admin_hooks' );
-			FrmAppController::install();
-			self::do_tables_exist();
+		if ( self::$installed ) {
 			self::import_xml();
-			self::create_files();
-			self::$installed = true;
-		} else {
-			self::import_xml();
+			return;
 		}
+
+		FrmHooksController::trigger_load_hook( 'load_admin_hooks' );
+		FrmAppController::install();
+		self::do_tables_exist();
+		self::import_xml();
+		self::create_files();
+		self::$installed = true;
 	}
 
 	public static function get_table_names() {

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -57,8 +57,6 @@ class FrmUnitTest extends WP_UnitTestCase {
 		$this->factory->form  = new Form_Factory( $this );
 		$this->factory->field = new Field_Factory( $this );
 		$this->factory->entry = new Entry_Factory( $this );
-
-		$this->create_users();
 	}
 
 	/**
@@ -575,10 +573,12 @@ class FrmUnitTest extends WP_UnitTestCase {
 	 * Create an administrator, editor, and subscriber
 	 *
 	 * @since 2.0
+	 *
+	 * @return void
 	 */
-	private function create_users() {
+	protected function create_users() {
 		$has_user = get_user_by( 'email', 'admin@mail.com' );
-		if ( ! empty( $has_user ) ) {
+		if ( $has_user ) {
 			return;
 		}
 

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -137,6 +137,8 @@ class FrmUnitTest extends WP_UnitTestCase {
 			return;
 		}
 
+		add_filter( 'frm_should_import_files', '__return_true' );
+
 		$single_file_upload_field = FrmField::getOne( 'single-file-upload-field' );
 		$multi_file_upload_field = FrmField::getOne( 'multi-file-upload-field' );
 
@@ -193,15 +195,24 @@ class FrmUnitTest extends WP_UnitTestCase {
 			),
 		);
 
-		$_REQUEST['csv_files'] = 1;
-		$uploads_dir           = wp_upload_dir()['basedir'] . '/formidable/';
-		$test                  = new FrmUnitTest();
+		$uploads_dir = wp_upload_dir()['basedir'] . '/formidable/';
+		$test        = new FrmUnitTest();
 		foreach ( $file_urls as $values ) {
 			$vals      = (array) $values['val'];
 			$media_ids = false;
 			foreach ( $vals as $val ) {
 				$filename = basename( $val );
 				$path     = $uploads_dir . $filename;
+
+				if ( ! file_exists ( $path ) && is_object( $values['field'] ) ) {
+					// File may be in formidable folder or it may be in the form_id folder so check the form as well.
+					$form_id_path = $uploads_dir . $values['field']->form_id . '/' . $filename;
+					if ( file_exists( $form_id_path ) ) {
+						copy( $form_id_path, $path );
+					}
+					unset( $form_id_path );
+				}
+
 				if ( file_exists( $path ) ) {
 					if ( ! is_array( $media_ids ) ) {
 						$media_ids = array();

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -89,11 +89,12 @@ class FrmUnitTest extends WP_UnitTestCase {
 			FrmHooksController::trigger_load_hook( 'load_admin_hooks' );
 			FrmAppController::install();
 			self::do_tables_exist();
+			self::import_xml();
 			self::create_files();
 			self::$installed = true;
+		} else {
+			self::import_xml();
 		}
-
-		self::import_xml();		
 	}
 
 	public static function get_table_names() {

--- a/tests/entries/test_FrmPersonalData.php
+++ b/tests/entries/test_FrmPersonalData.php
@@ -5,6 +5,11 @@
  */
 class test_FrmPersonalData extends FrmUnitTest {
 
+	public function setUp(): void {
+		parent::setUp();
+		$this->create_users();
+	}
+
 	/**
 	 * @covers FrmPersonalData::get_user_entries
 	 */

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -4,6 +4,12 @@
  * @group forms
  */
 class test_FrmForm extends FrmUnitTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->create_users();
+	}
+
 	/**
 	 * @covers FrmForm::create
 	 */

--- a/tests/misc/test_FrmAppController.php
+++ b/tests/misc/test_FrmAppController.php
@@ -3,6 +3,12 @@
  * @group app
  */
 class test_FrmAppController extends FrmUnitTest {
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->create_users();
+	}
+
 	public function test_class_is_tested() {
 		$this->assertTrue( true );
 	}

--- a/tests/misc/test_FrmAppController.php
+++ b/tests/misc/test_FrmAppController.php
@@ -172,6 +172,8 @@ class test_FrmAppController extends FrmUnitTest {
 	 * @covers FrmAppController::api_install
 	 */
 	public function test_api_install() {
+		delete_option( 'frm_install_running' );
+
 		if ( FrmAppHelper::doing_ajax() ) {
 			$this->markTestSkipped( 'Run without ajax' );
 		}

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -4,6 +4,11 @@
  */
 class test_FrmAppHelper extends FrmUnitTest {
 
+	public function setUp(): void {
+		parent::setUp();
+		$this->create_users();
+	}
+
 	/**
 	 * @covers FrmAppHelper::plugin_version
 	 */


### PR DESCRIPTION
- Checks if the install functions have been called yet, and avoid calling them a second time.
- Adds a second check for file path in case the file isn't in the formidable folder but in a formidable/form_id folder instead.
- Only try to create users for the unit tests that require users to pass.