### PR TITLE
Replace sortable with draggable

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6106,7 +6106,7 @@ tr.frm_options_heading td {
 	border: 1px dashed var(--grey-border);
 }
 
-.drop-me + .frm_no_fields {
+.ui-droppable-active ~ .frm_no_fields {
 	border-style: solid;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3859,19 +3859,19 @@ li.sortable-placeholder {
 }
 
 .edit_field_type_divider + li.sortable-placeholder {
-	box-shadow: 2px 5px 0 1px var(--primary-color);
+	box-shadow: 2px 5px 0 2px var(--primary-color);
 }
 
 .start_divider li.sortable-placeholder {
-	box-shadow: 2px -5px 0 1px var(--primary-color);
+	box-shadow: 2px -5px 0 2px var(--primary-color);
+}
+
+.frm-is-collapsed + .sortable-placeholder {
+	box-shadow: 2px 15px 0 2px var(--primary-color);
 }
 
 .frm_single_option.ui-sortable-placeholder {
 	box-shadow: 0 0 1px 1px var(--primary-color);
-}
-
-.frm-is-collapsed + .sortable-placeholder {
-	box-shadow: 2px 15px 0 1px var(--primary-color);
 }
 
 .frm_sorting > li.edit_field_type_end_divider:first-child,

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8693,7 +8693,3 @@ Responsive Design
 .frm-ready-made-solution img {
 	max-width: 100%;
 }
-
-.frm-dragging-field {
-	pointer-events: none;
-}

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3807,7 +3807,6 @@ li.sortable-placeholder {
 	position: relative;
 }
 
-#frm_form_editor_container > ul > li > ul > .frm_single_option.ui-sortable-placeholder,
 #frm_form_editor_container > ul > li > ul > li.sortable-placeholder,
 #frm_form_editor_container ul.start_divider > li > ul > li.sortable-placeholder {
 	position: absolute;
@@ -8693,6 +8692,3 @@ Responsive Design
 	max-width: 100%;
 }
 
-#frm_drag_placeholder {
-	transform: translateY(5px);
-}

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8669,6 +8669,11 @@ Responsive Design
 	pointer-events: none;
 }
 
+.frm-sortable-helper {
+	/* Make sure the item being dragged appears above other form builder fields */
+	z-index: 99;
+}
+
 #frm_banner {
 	width: 100%;
 	color: #fff;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5873,8 +5873,8 @@ li.selected .divider_section_only:before {
 .frm_sorting li.ui-state-default.edit_field_type_divider {
 	overflow: visible;
 	position: relative;
-	padding: 0 0 0 20px;
-	margin: 25px 0 0 -20px;
+	padding: 0 0 0 5px;
+	margin: 25px 0 0 -5px;
 	border-left: 1px solid var(--primary-hover);
 	transition: border 0.7s ease-out;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8693,3 +8693,7 @@ Responsive Design
 .frm-ready-made-solution img {
 	max-width: 100%;
 }
+
+.frm-dragging-field {
+	pointer-events: none;
+}

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3381,7 +3381,12 @@ li.ui-state-default.selected > .frm_inner_field_container > label {
 	cursor: grabbing !important;
 }
 
-.frm-dragging .divider_section_only {
+.frm-drag-fade {
+	opacity: 0.5;
+}
+
+.frm-dragging .divider_section_only,
+.frm-dragging .frm_field_box {
 	pointer-events: none;
 }
 
@@ -7179,6 +7184,7 @@ input[disabled],
 	color: var(--dark-grey) !important;
 	box-sizing: border-box;
 	border: 1px solid var(--grey-border);
+	box-shadow: 0 0 8px rgba(0,0,0,.3);
 }
 
 .frmbutton.ui-draggable-dragging span {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3833,7 +3833,6 @@ li.sortable-placeholder {
 
 .frm_sorting > li.edit_field_type_end_divider:first-child,
 .frm_sorting > .frmbutton + .sortable-placeholder, /* hide for first field */
-.no-drop-placeholder,
 .frm-show-click,
 li.ui-state-default.edit_field_type_divider .frm-show-click {
 	display: none;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3382,7 +3382,12 @@ li.ui-state-default.selected > .frm_inner_field_container > label {
 }
 
 .frm-drag-fade {
-	opacity: 0.5;
+	background-color: var(--lightest-grey) !important;
+	border-radius: 4px;
+}
+
+.frm-drag-fade * {
+	opacity: 0;
 }
 
 .frm-dragging .divider_section_only,

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3377,6 +3377,10 @@ li.ui-state-default.selected > .frm_inner_field_container > label {
 	max-width: calc(100% - 100px);
 }
 
+.frm-dragging .divider_section_only {
+	pointer-events: none;
+}
+
 .frm_form_settings #op-popup, /* 1Password */
 .frm_form_settings com-1password-op-button,
 .frm_conf_below .frm_conf_field_container .frm_primary_label,
@@ -5898,7 +5902,7 @@ li.selected .divider_section_only:before {
 .frm_sorting li.ui-state-default.edit_field_type_divider {
 	overflow: visible;
 	position: relative;
-	padding: 0 0 0 5px;
+	padding: 0 0 0 20px;
 	margin: 25px 0 0 -5px;
 	border-left: 1px solid var(--primary-hover);
 	transition: border 0.7s ease-out;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8692,3 +8692,7 @@ Responsive Design
 .frm-ready-made-solution img {
 	max-width: 100%;
 }
+
+#frm_drag_placeholder {
+	transform: translateY(5px);
+}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1497,9 +1497,11 @@ function frmAdminBuildJS() {
 
 				if ( ! $siblings.length ) {
 					makeDroppable( replaceWith.get( 0 ).querySelector( 'ul.frm_sorting' ) );
+					makeDraggable( replaceWith.get( 0 ).querySelector( 'li.form-field' ), '.frm-move' );
+				} else {
+					makeDraggable( replaceWith.get( 0 ), '.frm-move' );
 				}
 
-				makeDraggable( replaceWith.get( 0 ).querySelector( 'li' ), '.frm-move' );
 			},
 			error: handleInsertFieldError
 		});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1010,7 +1010,13 @@ function frmAdminBuildJS() {
 			if ( insertAtIndex === $children.length ) {
 				const $lastChild = jQuery( $children.get( insertAtIndex - 1 ) );
 				top = $lastChild.offset().top + $lastChild.outerHeight();
-				$list.append( placeholder ); // TODO do not put it after the end divider.
+				$list.append( placeholder );
+
+				// Make sure nothing gets inserted after the end divider.
+				const $endDivider = $list.children( '.edit_field_type_end_divider' );
+				if ( $endDivider.length ) {
+					$list.append( $endDivider );
+				}
 			} else {
 				top = jQuery( $children.get( insertAtIndex ) ).offset().top;
 				jQuery( $children.get( insertAtIndex ) ).before( placeholder );
@@ -1655,7 +1661,6 @@ function frmAdminBuildJS() {
 		return allowMoveFieldToGroup( draggable, droppable );
 	}
 
-	// TODO I cannot drag a field group anywhere.
 	function allowMoveFieldGroup( fieldGroup, droppable ) {
 		if ( droppable.classList.contains( 'start_divider' ) && null === fieldGroup.querySelector( '.start_divider' ) ) {
 			// Allow a field group with no section inside of a section.

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -820,6 +820,11 @@ function frmAdminBuildJS() {
 			list => {
 				makeDroppable( list );
 				Array.from( list.children ).forEach( child => makeDraggable( child, '.frm-move' ) );
+
+				const $sectionTitle = jQuery( list ).children( '[data-type="divider"]' ).children( '.divider_section_only' );
+				if ( $sectionTitle.length ) {
+					makeDroppable( $sectionTitle );
+				}
 			}
 		);
 		setupFieldOptionSorting( jQuery( '#frm_builder_page' ) );
@@ -836,7 +841,7 @@ function frmAdminBuildJS() {
 	}
 
 	function onDragOverDroppable( event, ui ) {
-		const droppable = event.target;
+		const droppable = getDroppableForOnDragOver( event.target );
 		const draggable = ui.draggable[0];
 
 		if ( ! allowDrop( draggable, droppable ) ) {
@@ -848,6 +853,20 @@ function frmAdminBuildJS() {
 		document.querySelectorAll( '.frm-over-droppable' ).forEach( droppable => droppable.classList.remove( 'frm-over-droppable' ) );
 		droppable.classList.add( 'frm-over-droppable' );
 		jQuery( droppable ).parents( 'ul.frm_sorting' ).addClass( 'frm-over-droppable' );
+	}
+
+	/**
+	 * Maybe change the droppable.
+	 * Section titles are made droppable, but are not a list, so we need to change the droppable to the section's list instead.
+	 *
+	 * @param {Element} droppable 
+	 * @returns {Element}
+	 */
+	function getDroppableForOnDragOver( droppable ) {
+		if ( droppable.classList.contains( 'divider_section_only' ) ) {
+			droppable = jQuery( droppable ).nextAll( '.start_divider.frm_sorting' ).get( 0 );
+		}
+		return droppable;
 	}
 
 	function onDraggableLeavesDroppable( event ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1129,11 +1129,22 @@ function frmAdminBuildJS() {
 	}
 
 	function getFieldsInRow( $row ) {
-		return $row.children( 'li.form-field' ).not( '.edit_field_type_end_divider' ).filter(
-			function() {
-				return 'none' !== this.style.display;
+		let $fields = jQuery();
+		Array.from( $row.get( 0 ).children ).forEach(
+			child => {
+				if ( 'none' === child.style.display ) {
+					return;
+				}
+
+				const classes = child.classList;
+				if ( ! classes.contains( 'form-field' ) || classes.contains( 'edit_field_type_end_divider' ) || classes.contains( 'frm-sortable-helper' ) ) {
+					return;
+				}
+
+				$fields = $fields.add( child );
 			}
 		);
+		return $fields;
 	}
 
 	function determineIndexBasedOffOfMousePositionInRow( $row, x ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -840,7 +840,6 @@ function frmAdminBuildJS() {
 			helper: 'clone',
 			revert: 'invalid',
 			delay: 10,
-			cancel: '.frm-dropdown-menu',
 			start: handleDragStart,
 			stop: handleDragStop,
 			drag: handleDrag

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -859,7 +859,7 @@ function frmAdminBuildJS() {
 			delay: 10,
 			start: handleDragStart,
 			stop: handleDragStop,
-			drag: handleDrag,
+			drag: handleDrag
 		};
 		if ( 'string' === typeof handle ) {
 			settings.handle = handle;
@@ -1082,7 +1082,7 @@ function frmAdminBuildJS() {
 	function fixUnwrappedListItems() {
 		const lists = document.querySelectorAll( 'ul#frm-show-fields, ul.start_divider' );
 		lists.forEach(
-			list => {				
+			list => {
 				list.childNodes.forEach(
 					child => {
 						if ( 'undefined' === typeof child.classList ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -827,7 +827,8 @@ function frmAdminBuildJS() {
 			accept: '.frmbutton, li.frm_field_box',
 			deactivate: handleFieldDrop,
 			over: onDragOverDroppable,
-			tolerance: 'touch'
+			out: onDraggableLeavesDroppable,
+			tolerance: 'pointer'
 		});
 	}
 
@@ -836,12 +837,19 @@ function frmAdminBuildJS() {
 		const draggable = ui.draggable[0];
 
 		if ( ! allowDrop( draggable, droppable ) ) {
-			list.classList.remove( 'frm-over-droppable' )
+			droppable.classList.remove( 'frm-over-droppable' );
+			jQuery( droppable ).parents( 'ul.frm_sorting' ).addClass( 'frm-over-droppable' );
 			return;
 		}
 
 		document.querySelectorAll( '.frm-over-droppable' ).forEach( droppable => droppable.classList.remove( 'frm-over-droppable' ) );
 		droppable.classList.add( 'frm-over-droppable' );
+		jQuery( droppable ).parents( 'ul.frm_sorting' ).addClass( 'frm-over-droppable' );
+	}
+
+	function onDraggableLeavesDroppable( event ) {
+		const droppable = event.target;
+		droppable.classList.remove( 'frm-over-droppable' );
 	}
 
 	function makeDraggable( draggable, handle ) {
@@ -873,6 +881,7 @@ function frmAdminBuildJS() {
 		deleteEmptyDividerWrappers();
 		maybeRemoveGroupHoverTarget();
 		closeOpenFieldDropdowns();
+		deleteTooltips();
 	}
 
 	function handleDragStop() {
@@ -1037,8 +1046,6 @@ function frmAdminBuildJS() {
 	}
 
 	function syncAfterDragAndDrop() {
-		maybeRemoveNewCancelledFields();
-		maybeUncancelFields();
 		fixUnwrappedListItems();
 		toggleSectionHolder();
 		maybeFixEndDividers();
@@ -1061,24 +1068,10 @@ function frmAdminBuildJS() {
 		);
 	}
 
-	function maybeRemoveNewCancelledFields() {
-		Array.from( document.getElementById( 'frm-show-fields' ).children ).forEach(
-			function( fieldBox ) {
-				if ( fieldBox.classList.contains( 'frmbutton' ) && fieldBox.classList.contains( 'ui-draggable' ) ) {
-					fieldBox.remove();
-				}
-			}
-		);
-	}
-
-	function maybeUncancelFields() {
-		document.querySelectorAll( '.frm_cancel_sort' ).forEach( field => field.classList.remove( 'frm_cancel_sort' ) );
-	}
-
 	function fixUnwrappedListItems() {
 		const lists = document.querySelectorAll( 'ul#frm-show-fields, ul.start_divider' );
 		lists.forEach(
-			list => {
+			list => {				
 				list.childNodes.forEach(
 					child => {
 						if ( 'undefined' === typeof child.classList ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -859,7 +859,7 @@ function frmAdminBuildJS() {
 	 * Maybe change the droppable.
 	 * Section titles are made droppable, but are not a list, so we need to change the droppable to the section's list instead.
 	 *
-	 * @param {Element} droppable 
+	 * @param {Element} droppable
 	 * @returns {Element}
 	 */
 	function getDroppableForOnDragOver( droppable ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -825,14 +825,23 @@ function frmAdminBuildJS() {
 	function makeDroppable( list ) {
 		jQuery( list ).droppable({
 			accept: '.frmbutton, li.frm_field_box',
-			deactivate: handleFieldDrop
+			deactivate: handleFieldDrop,
+			over: onDragOverDroppable,
+			tolerance: 'touch'
 		});
-		list.addEventListener( 'mouseover', function() {
-			list.classList.add( 'frm-over-droppable' );
-		});
-		list.addEventListener( 'mouseleave', function() {
-			list.classList.remove( 'frm-over-droppable' );
-		});
+	}
+
+	function onDragOverDroppable( event, ui ) {
+		const droppable = event.target;
+		const draggable = ui.draggable[0];
+
+		if ( ! allowDrop( draggable, droppable ) ) {
+			list.classList.remove( 'frm-over-droppable' )
+			return;
+		}
+
+		document.querySelectorAll( '.frm-over-droppable' ).forEach( droppable => droppable.classList.remove( 'frm-over-droppable' ) );
+		droppable.classList.add( 'frm-over-droppable' );
 	}
 
 	function makeDraggable( draggable, handle ) {
@@ -873,9 +882,6 @@ function frmAdminBuildJS() {
 	}
 
 	function handleDrag( event ) {
-		// Unset any frm-over-droppable classes from draggable to so an object never tries to embed into itself.
-		event.target.querySelectorAll( '.frm-over-droppable' ).forEach( element => element.classList.remove( 'frm-over-droppable' ) );
-
 		const draggable = event.target;
 		const droppable = getDroppableTarget();
 
@@ -1619,7 +1625,6 @@ function frmAdminBuildJS() {
 		return true;
 	}
 
-	// TODO I was allowed to move an embed form into a field group in a section.
 	function allowMoveFieldToGroup( draggable, group ) {
 		const groupIncludesBreakOrHidden = null !== group.querySelector( '.edit_field_type_break, .edit_field_type_hidden' );
 		if ( groupIncludesBreakOrHidden ) {
@@ -1634,9 +1639,10 @@ function frmAdminBuildJS() {
 		}
 
 		const draggableIncludesASection = draggable.classList.contains( 'edit_field_type_divider' ) || draggable.querySelector( '.edit_field_type_divider' );
+		const draggableIsEmbedField     = draggable.classList.contains( 'edit_field_type_form' );
 		const groupIsInASection         = null !== group.closest( '.start_divider' );
-		if ( groupIsInASection && draggableIncludesASection ) {
-			// Do not allow a setcion inside of a section.
+		if ( groupIsInASection && ( draggableIncludesASection || draggableIsEmbedField ) ) {
+			// Do not allow a section or an embed field inside of a section.
 			return false;
 		}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -927,10 +927,7 @@ function frmAdminBuildJS() {
 			}
 		}
 
-		// TODO fallback.
-		return div({
-			className: 'frmbutton'
-		});
+		return div({ className: 'frmbutton' });
 	}
 
 	function handleDragStart( event, ui ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1049,6 +1049,10 @@ function frmAdminBuildJS() {
 		} else {
 			left = jQuery( $children.get( insertAtIndex ) ).offset().left;
 			jQuery( $children.get( insertAtIndex ) ).before( placeholder );
+
+			if ( 0 !== insertAtIndex ) {
+				left -= 8; // Offset the placeholder slightly so it appears between two fields.
+			}
 		}
 
 		left -= $row.offset().left;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -958,6 +958,12 @@ function frmAdminBuildJS() {
 			placeholder.parentNode.insertBefore( draggable, placeholder );
 		}
 
+		const previousSection = ui.helper.closest( 'ul.frm_sorting' ).get( 0 );
+		const newSection      = placeholder.closest( 'ul.frm_sorting' );
+
+		const previousSectionId = previousSection.classList.contains( 'start_divider' ) ? parseInt( previousSection.closest( '.edit_field_type_divider' ).getAttribute( 'data-fid' ) ) : 0;
+		const newSectionId      = newSection.classList.contains( 'start_divider' ) ? parseInt( newSection.closest( '.edit_field_type_divider' ).getAttribute( 'data-fid' ) ) : 0;
+
 		placeholder.remove();
 		ui.helper.remove();
 
@@ -979,7 +985,10 @@ function frmAdminBuildJS() {
 			syncLayoutClasses( jQuery( draggable ) );
 		}
 
-		updateFieldAfterMovingBetweenSections( jQuery( draggable ) ); // TODO check if it actually moved between sections first.
+		if ( previousSectionId !== newSectionId ) {
+			updateFieldAfterMovingBetweenSections( jQuery( draggable ) );
+		}
+
 		syncAfterDragAndDrop();
 	}
 
@@ -1905,6 +1914,7 @@ function frmAdminBuildJS() {
 				updateFieldOrder();
 				afterAddField( msg, false );
 				maybeDuplicateUnsavedSettings( fieldId, msg );
+				toggleSectionHolder();
 			}
 		});
 		return false;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1130,7 +1130,13 @@ function frmAdminBuildJS() {
 
 	function getFieldsInRow( $row ) {
 		let $fields = jQuery();
-		Array.from( $row.get( 0 ).children ).forEach(
+
+		const row = $row.get( 0 );
+		if ( ! row.children ) {
+			return $fields;
+		}
+
+		Array.from( row.children ).forEach(
 			child => {
 				if ( 'none' === child.style.display ) {
 					return;
@@ -1501,6 +1507,10 @@ function frmAdminBuildJS() {
 					replaceWith = wrapFieldLi( msg );
 				} else {
 					replaceWith = msgAsjQueryObject( msg );
+					if ( ! $placeholder.get( 0 ).parentNode.parentNode.classList.contains( 'ui-draggable' ) ) {
+						// If a field group wasn't draggable because it only had a single field, make it draggable.
+						makeDraggable( $placeholder.get( 0 ).parentNode.parentNode, '.frm-move' );
+					}
 				}
 				$placeholder.replaceWith( replaceWith );
 				updateFieldOrder();

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1474,7 +1474,9 @@ function frmAdminBuildJS() {
 					// if dragging into a new row, we need to wrap the li first.
 					replaceWith = wrapFieldLi( msg );
 				} else {
-					replaceWith = msg;
+					const element = div();
+					element.innerHTML = msg;
+					replaceWith = jQuery( element.firstChild );
 				}
 				$placeholder.replaceWith( replaceWith );
 				updateFieldOrder();
@@ -1483,6 +1485,12 @@ function frmAdminBuildJS() {
 					syncLayoutClasses( $siblings.first() );
 				}
 				toggleSectionHolder();
+
+				if ( ! $siblings.length ) {
+					makeDroppable( replaceWith.get( 0 ).querySelector( 'ul.frm_sorting' ) );
+				}
+
+				makeDraggable( replaceWith.get( 0 ) );
 			},
 			error: handleInsertFieldError
 		});
@@ -1752,8 +1760,11 @@ function frmAdminBuildJS() {
 			},
 			success: function( msg ) {
 				document.getElementById( 'frm_form_editor_container' ).classList.add( 'frm-has-fields' );
-				$newFields.append( wrapFieldLi( msg ) );
+				const replaceWith = wrapFieldLi( msg );
+				$newFields.append( replaceWith );
 				afterAddField( msg, true );
+				makeDroppable( replaceWith.get( 0 ).querySelector( 'ul.frm_sorting' ) );
+				makeDraggable( replaceWith.get( 0 ) );
 			},
 			error: handleInsertFieldError
 		});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -925,7 +925,7 @@ function frmAdminBuildJS() {
 		const $previousFieldContainer = ui.helper.parent();
 
 		if ( draggable.classList.contains( 'frmbutton' ) ) {
-			insertNewFieldByDragging( jQuery( draggable ) );
+			insertNewFieldByDragging( draggable.id );
 		} else {
 			placeholder.parentNode.insertBefore( draggable, placeholder );
 		}
@@ -1412,27 +1412,25 @@ function frmAdminBuildJS() {
 	/**
 	 * Add a new field by dragging and dropping it from the Fields sidebar
 	 *
-	 * @param {object} selectedItem
+	 * @param {string} fieldType
 	 */
-	function insertNewFieldByDragging( fieldButton ) {
-		const fieldType   = fieldButton.attr( 'id' );
+	function insertNewFieldByDragging( fieldType ) {
 		const placeholder = document.getElementById( 'frm_drag_placeholder' );
 		const loadingID   = fieldType.replace( '|', '-' ) + '_' + getAutoId();
-		const loading     = tag( 'li', {
-			id: loadingID,
-			className: 'frm-wait frmbutton_loadingnow'
-		});
-		const $placeholder = jQuery( loading )
+		const loading     = tag(
+			'li',
+			{
+				id: loadingID,
+				className: 'frm-wait frmbutton_loadingnow'
+			}
+		);
+		const $placeholder = jQuery( loading );
+		const currentItem  = jQuery( placeholder );
+		const section      = getSectionForFieldPlacement( currentItem );
+		const formId       = getFormIdForFieldPlacement( section );
+		const sectionId    = getSectionIdForFieldPlacement( section );
 
-		placeholder.parentNode.insertBefore( $placeholder.get( 0 ), placeholder );
-
-		const insertAtIndex = determineIndexBasedOffOfMousePositionInRow( jQuery( placeholder ).parent(), jQuery( placeholder ).offset().left );
-		jQuery( getFieldsInRow( jQuery( placeholder ).parent() ).get( insertAtIndex ) ).before( placeholder );
-
-		const section   = getSectionForFieldPlacement( jQuery( placeholder ) );
-		const formId    = getFormIdForFieldPlacement( section );
-		const sectionId = getSectionIdForFieldPlacement( section );
-
+		placeholder.parentNode.insertBefore( loading, placeholder );
 		placeholder.remove();
 		syncLayoutClasses( $placeholder );
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -953,7 +953,7 @@ function frmAdminBuildJS() {
 			syncLayoutClasses( jQuery( draggable ) );
 		}
 
-		updateFieldAfterMovingBetweenSections( jQuery( draggable ) );
+		updateFieldAfterMovingBetweenSections( jQuery( draggable ) ); // TODO check if it actually moved between sections first.
 		syncAfterDragAndDrop();
 	}
 
@@ -1389,8 +1389,6 @@ function frmAdminBuildJS() {
 	 * @param {object} currentItem
 	 */
 	function updateFieldAfterMovingBetweenSections( currentItem ) {
-		console.log({ currentItem });
-
 		if ( ! currentItem.hasClass( 'form-field' ) ) {
 			// currentItem is a field group. Call for children recursively.
 			getFieldsInRow( jQuery( currentItem.get( 0 ).firstChild ) ).each(
@@ -1405,8 +1403,6 @@ function frmAdminBuildJS() {
 		const section   = getSectionForFieldPlacement( currentItem );
 		const formId    = getFormIdForFieldPlacement( section );
 		const sectionId = getSectionIdForFieldPlacement( section );
-
-		// TODO exit if section id does not actually change.
 
 		jQuery.ajax({
 			type: 'POST',

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -992,6 +992,9 @@ function frmAdminBuildJS() {
 		while ( droppable.querySelector( '.frm-over-droppable' ) ) {
 			droppable = droppable.querySelector( '.frm-over-droppable' );
 		}
+		if ( 'frm-show-fields' === droppable.id && ! droppable.classList.contains( 'frm-over-droppable' ) ) {
+			droppable = false;
+		}
 		return droppable;
 	}
 
@@ -1682,6 +1685,11 @@ function frmAdminBuildJS() {
 	// Don't allow field groups in field groups.
 	// Don't allow hidden fields inside of field groups but allow them in sections.
 	function allowDrop( draggable, droppable ) {
+		if ( false === droppable ) {
+			// Don't show drop placeholder if dragging somewhere off of the droppable area.
+			return false;
+		}
+
 		if ( droppable.closest( '.frm-sortable-helper' ) ) {
 			// Do not allow drop into draggable.
 			return false;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -933,12 +933,14 @@ function frmAdminBuildJS() {
 		});
 	}
 
-	function handleDragStart( _, ui ) {
+	function handleDragStart( event, ui ) {
 		const container = document.getElementById( 'post-body-content' );
 		container.classList.add( 'frm-dragging-field' );
 
 		document.body.classList.add( 'frm-dragging' );
 		ui.helper.addClass( 'frm-sortable-helper' );
+
+		event.target.classList.add( 'frm-drag-fade' );
 
 		unselectFieldGroups();
 		deleteEmptyDividerWrappers();
@@ -951,6 +953,11 @@ function frmAdminBuildJS() {
 		const container = document.getElementById( 'post-body-content' );
 		container.classList.remove( 'frm-dragging-field' );
 		document.body.classList.remove( 'frm-dragging' );
+
+		const fade = document.querySelector( '.frm-drag-fade' );
+		if ( fade ) {
+			fade.classList.remove( 'frm-drag-fade' );
+		}
 	}
 
 	function handleDrag( event ) {
@@ -1156,9 +1163,8 @@ function frmAdminBuildJS() {
 			left = jQuery( $children.get( insertAtIndex ) ).offset().left;
 			jQuery( $children.get( insertAtIndex ) ).before( placeholder );
 
-			if ( 0 !== insertAtIndex ) {
-				left -= 8; // Offset the placeholder slightly so it appears between two fields.
-			}
+			const amountToOffsetLeftBy = 0 === insertAtIndex ? 4 : 8; // Offset by 8 in between rows, but only 4 for the first item in a group.
+			left -= amountToOffsetLeftBy; // Offset the placeholder slightly so it appears between two fields.
 		}
 
 		left -= $row.offset().left;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -943,16 +943,7 @@ function frmAdminBuildJS() {
 
 		const $previousFieldContainer = ui.helper.parent();
 
-		if ( placeholder.previousElementSibling && placeholder.previousElementSibling.classList.contains( 'frm-is-collapsed' ) ) {
-			// If a page if collapsed, expand it before dragging since only the page break will move.
-			const $pageBreakField = jQuery( placeholder ).prevUntil( '[data-type="break"]' );
-			if ( $pageBreakField.length ) {
-				const collapseButton = $pageBreakField.find( '.frm-collapse-page' ).get( 0 );
-				if ( collapseButton ) {
-					collapseButton.click();
-				}
-			}
-		}
+		maybeOpenCollapsedPage( placeholder );
 
 		const previousSection = ui.helper.get( 0 ).closest( 'ul.frm_sorting' );
 		const newSection      = placeholder.closest( 'ul.frm_sorting' );
@@ -993,6 +984,28 @@ function frmAdminBuildJS() {
 		}
 
 		debouncedSyncAfterDragAndDrop();
+	}
+
+	/**
+	 * If a page if collapsed, expand it before dragging since only the page break will move.
+	 *
+	 * @param {Element} placeholder
+	 * @returns {void}
+	 */
+	function maybeOpenCollapsedPage( placeholder ) {
+		if ( ! placeholder.previousElementSibling || ! placeholder.previousElementSibling.classList.contains( 'frm-is-collapsed' ) ) {
+			return;
+		}
+
+		const $pageBreakField = jQuery( placeholder ).prevUntil( '[data-type="break"]' );
+		if ( ! $pageBreakField.length ) {
+			return;
+		}
+
+		const collapseButton = $pageBreakField.find( '.frm-collapse-page' ).get( 0 );
+		if ( collapseButton ) {
+			collapseButton.click();
+		}
 	}
 
 	function handleDragOverYAxis({ droppable, y, placeholder }) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2139,9 +2139,14 @@ function frmAdminBuildJS() {
 		return option;
 	}
 
-	function wrapFieldLi( fieldHtml ) {
+	function wrapFieldLi( field ) {
 		const wrapper = div();
-		wrapper.innerHTML = fieldHtml;
+
+		if ( 'string' === typeof field ) {
+			wrapper.innerHTML = field;
+		} else {
+			wrapper.appendChild( field );
+		}
 
 		let result = jQuery();
 		Array.from( wrapper.children ).forEach(
@@ -3892,12 +3897,14 @@ function frmAdminBuildJS() {
 	}
 
 	function breakRow( row ) {
-		getFieldsInRow( jQuery( row ) ).each(
+		const $row = jQuery( row );
+		getFieldsInRow( $row ).each(
 			function( index ) {
+				const field = this;
 				if ( 0 !== index ) {
-					jQuery( row ).closest( 'li' ).after( wrapFieldLi( this ) );
+					$row.parent().after( wrapFieldLi( field ) );
 				}
-				stripLayoutFromFields( jQuery( this ) );
+				stripLayoutFromFields( jQuery( field ) );
 			}
 		);
 	}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1474,9 +1474,7 @@ function frmAdminBuildJS() {
 					// if dragging into a new row, we need to wrap the li first.
 					replaceWith = wrapFieldLi( msg );
 				} else {
-					const element = div();
-					element.innerHTML = msg;
-					replaceWith = jQuery( element.firstChild );
+					replaceWith = msgAsjQueryObject( msg );
 				}
 				$placeholder.replaceWith( replaceWith );
 				updateFieldOrder();
@@ -1490,10 +1488,16 @@ function frmAdminBuildJS() {
 					makeDroppable( replaceWith.get( 0 ).querySelector( 'ul.frm_sorting' ) );
 				}
 
-				makeDraggable( replaceWith.get( 0 ) );
+				makeDraggable( replaceWith.get( 0 ).querySelector( 'li' ), '.frm-move' );
 			},
 			error: handleInsertFieldError
 		});
+	}
+
+	function msgAsjQueryObject( msg ) {
+		const element = div();
+		element.innerHTML = msg;
+		return jQuery( element.firstChild );
 	}
 
 	function handleInsertFieldError( jqXHR, _, errorThrown ) {
@@ -1764,7 +1768,7 @@ function frmAdminBuildJS() {
 				$newFields.append( replaceWith );
 				afterAddField( msg, true );
 				makeDroppable( replaceWith.get( 0 ).querySelector( 'ul.frm_sorting' ) );
-				makeDraggable( replaceWith.get( 0 ) );
+				makeDraggable( replaceWith.get( 0 ).querySelector( '.form-field' ), '.frm-move' );
 			},
 			error: handleInsertFieldError
 		});
@@ -1820,10 +1824,14 @@ function frmAdminBuildJS() {
 			success: function( msg ) {
 				var newRow;
 
+				let replaceWith;
+
 				if ( null !== newRowId ) {
 					newRow = document.getElementById( newRowId );
 					if ( null !== newRow ) {
-						jQuery( newRow ).append( msg );
+						replaceWith = msgAsjQueryObject( msg );
+						jQuery( newRow ).append( replaceWith );
+						makeDraggable( replaceWith.get( 0 ), '.frm-move' );
 						if ( null !== fieldOrder ) {
 							newRow.lastElementChild.setAttribute( 'frm-field-order', fieldOrder );
 						}
@@ -1840,10 +1848,15 @@ function frmAdminBuildJS() {
 				}
 
 				if ( $field.siblings( 'li.form-field' ).length ) {
-					$field.after( msg );
+					replaceWith = msgAsjQueryObject( msg );
+					$field.after( replaceWith );
 					syncLayoutClasses( $field );
+					makeDraggable( replaceWith.get( 0 ), '.frm-move' );
 				} else {
-					$field.parent().parent().after( wrapFieldLi( msg ) );
+					replaceWith = wrapFieldLi( msg );
+					$field.parent().parent().after( replaceWith );
+					makeDroppable( replaceWith.get( 0 ).querySelector( 'ul.frm_sorting' ) );
+					makeDraggable( replaceWith.get( 0 ).querySelector( 'li.form-field' ), '.frm-move' );
 				}
 
 				updateFieldOrder();

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -940,6 +940,17 @@ function frmAdminBuildJS() {
 
 		const $previousFieldContainer = ui.helper.parent();
 
+		if ( placeholder.previousElementSibling && placeholder.previousElementSibling.classList.contains( 'frm-is-collapsed' ) ) {
+			// If a page if collapsed, expand it before dragging since only the page break will move.
+			const $pageBreakField = jQuery( placeholder ).prevUntil( '[data-type="break"]' );
+			if ( $pageBreakField.length ) {
+				const collapseButton = $pageBreakField.find( '.frm-collapse-page' ).get( 0 );
+				if ( collapseButton ) {
+					collapseButton.click();
+				}
+			}
+		}
+
 		if ( draggable.classList.contains( 'frmbutton' ) ) {
 			insertNewFieldByDragging( draggable.id );
 		} else {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -324,7 +324,7 @@ function frmAdminBuildJS() {
 		drag: svg({ href: '#frm_drag_icon', classList: [ 'frm_drag_icon', 'frm-drag' ] })
 	};
 
-	var $newFields = jQuery( document.getElementById( 'frm-show-fields' ) ),
+	let $newFields = jQuery( document.getElementById( 'frm-show-fields' ) ),
 		builderForm = document.getElementById( 'new_fields' ),
 		thisForm = document.getElementById( 'form_id' ),
 		copyHelper = false,
@@ -332,8 +332,10 @@ function frmAdminBuildJS() {
 		thisFormId = 0,
 		autoId = 0,
 		optionMap = {},
-		lastNewActionIdReturned = 0,
-		__ = wp.i18n.__;
+		lastNewActionIdReturned = 0;
+
+	const { __ } = wp.i18n;
+	let debouncedSyncAfterDragAndDrop;
 
 	if ( thisForm !== null ) {
 		thisFormId = thisForm.value;
@@ -934,7 +936,7 @@ function frmAdminBuildJS() {
 
 		if ( ! placeholder ) {
 			ui.helper.remove();
-			syncAfterDragAndDrop();
+			debouncedSyncAfterDragAndDrop();
 			return;
 		}
 
@@ -951,6 +953,9 @@ function frmAdminBuildJS() {
 			}
 		}
 
+		const previousSection = ui.helper.get( 0 ).closest( 'ul.frm_sorting' );
+		const newSection      = placeholder.closest( 'ul.frm_sorting' );
+
 		if ( draggable.classList.contains( 'frmbutton' ) ) {
 			insertNewFieldByDragging( draggable.id );
 		} else {
@@ -958,10 +963,7 @@ function frmAdminBuildJS() {
 			placeholder.parentNode.insertBefore( draggable, placeholder );
 		}
 
-		const previousSection = ui.helper.closest( 'ul.frm_sorting' ).get( 0 );
-		const newSection      = placeholder.closest( 'ul.frm_sorting' );
-
-		const previousSectionId = previousSection.classList.contains( 'start_divider' ) ? parseInt( previousSection.closest( '.edit_field_type_divider' ).getAttribute( 'data-fid' ) ) : 0;
+		const previousSectionId = previousSection && previousSection.classList.contains( 'start_divider' ) ? parseInt( previousSection.closest( '.edit_field_type_divider' ).getAttribute( 'data-fid' ) ) : 0;
 		const newSectionId      = newSection.classList.contains( 'start_divider' ) ? parseInt( newSection.closest( '.edit_field_type_divider' ).getAttribute( 'data-fid' ) ) : 0;
 
 		placeholder.remove();
@@ -989,7 +991,7 @@ function frmAdminBuildJS() {
 			updateFieldAfterMovingBetweenSections( jQuery( draggable ) );
 		}
 
-		syncAfterDragAndDrop();
+		debouncedSyncAfterDragAndDrop();
 	}
 
 	function handleDragOverYAxis({ droppable, y, placeholder }) {
@@ -1914,7 +1916,6 @@ function frmAdminBuildJS() {
 				updateFieldOrder();
 				afterAddField( msg, false );
 				maybeDuplicateUnsavedSettings( fieldId, msg );
-				toggleSectionHolder();
 			}
 		});
 		return false;
@@ -9496,7 +9497,9 @@ function frmAdminBuildJS() {
 		},
 
 		buildInit: function() {
-			var loadFieldId, $builderForm, builderArea;
+			let loadFieldId, $builderForm, builderArea;
+
+			debouncedSyncAfterDragAndDrop = debounce( syncAfterDragAndDrop, 10 );
 
 			if ( jQuery( '.frm_field_loading' ).length ) {
 				loadFieldId = jQuery( '.frm_field_loading' ).first().attr( 'id' );
@@ -9515,7 +9518,7 @@ function frmAdminBuildJS() {
 			jQuery( 'a.edit-form-status' ).on( 'click', slideDown );
 			jQuery( '.cancel-form-status' ).on( 'click', slideUp );
 			jQuery( '.save-form-status' ).on( 'click', function() {
-				var newStatus = jQuery( document.getElementById( 'form_change_status' ) ).val();
+				const newStatus = jQuery( document.getElementById( 'form_change_status' ) ).val();
 				jQuery( 'input[name="new_status"]' ).val( newStatus );
 				jQuery( document.getElementById( 'form-status-display' ) ).html( newStatus );
 				jQuery( '.cancel-form-status' ).trigger( 'click' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4269,7 +4269,7 @@ function frmAdminBuildJS() {
 	function deleteAllSelectedFieldGroups( deleteFieldIds ) {
 		deleteFieldIds.forEach(
 			function( fieldId ) {
-				deleteField( fieldId );
+				deleteFields( fieldId );
 			}
 		);
 	}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -916,7 +916,7 @@ function frmAdminBuildJS() {
 			return;
 		}
 
-		placeholder.style.top = 0;
+		placeholder.style.top = '';
 		handleDragOverFieldGroup({ droppable, x: event.clientX, placeholder });
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -924,7 +924,12 @@ function frmAdminBuildJS() {
 		const droppable = placeholder.parentNode;
 		const $previousFieldContainer = ui.helper.parent();
 
-		placeholder.parentNode.insertBefore( draggable, placeholder );
+		if ( draggable.classList.contains( 'frmbutton' ) ) {
+			insertNewFieldByDragging( jQuery( draggable ) );
+		} else {
+			placeholder.parentNode.insertBefore( draggable, placeholder );
+		}
+
 		placeholder.remove();
 
 		ui.helper.remove();
@@ -1408,24 +1413,27 @@ function frmAdminBuildJS() {
 	 * Add a new field by dragging and dropping it from the Fields sidebar
 	 *
 	 * @param {object} selectedItem
-	 * @param {object} fieldButton
-	 * @param {object} opts
 	 */
-	function insertNewFieldByDragging( selectedItem, fieldButton ) {
-		const fieldType = fieldButton.attr( 'id' );
+	function insertNewFieldByDragging( fieldButton ) {
+		const fieldType   = fieldButton.attr( 'id' );
+		const placeholder = document.getElementById( 'frm_drag_placeholder' );
+		const loadingID   = fieldType.replace( '|', '-' ) + '_' + getAutoId();
+		const loading     = tag( 'li', {
+			id: loadingID,
+			className: 'frm-wait frmbutton_loadingnow'
+		});
+		const $placeholder = jQuery( loading )
 
-		const sortableData = jQuery( selectedItem ).data().uiSortable;
-		const currentItem = sortableData.currentItem;
-		const insertAtIndex = determineIndexBasedOffOfMousePositionInRow( currentItem.parent(), currentItem.offset().left );
-		jQuery( getFieldsInRow( currentItem.parent() ).get( insertAtIndex ) ).before( currentItem );
-		const section = getSectionForFieldPlacement( currentItem );
-		const formId = getFormIdForFieldPlacement( section );
+		placeholder.parentNode.insertBefore( $placeholder.get( 0 ), placeholder );
+
+		const insertAtIndex = determineIndexBasedOffOfMousePositionInRow( jQuery( placeholder ).parent(), jQuery( placeholder ).offset().left );
+		jQuery( getFieldsInRow( jQuery( placeholder ).parent() ).get( insertAtIndex ) ).before( placeholder );
+
+		const section   = getSectionForFieldPlacement( jQuery( placeholder ) );
+		const formId    = getFormIdForFieldPlacement( section );
 		const sectionId = getSectionIdForFieldPlacement( section );
 
-		const loadingID    = fieldType.replace( '|', '-' ) + '_' + getAutoId();
-		const $placeholder = jQuery( '<li class="frm-wait frmbutton_loadingnow" id="' + loadingID + '" ></li>' );
-		currentItem.replaceWith( $placeholder );
-
+		placeholder.remove();
 		syncLayoutClasses( $placeholder );
 
 		let hasBreak = 0;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -914,8 +914,6 @@ function frmAdminBuildJS() {
 		const draggable = ui.draggable[0];
 		const placeholder = document.getElementById( 'frm_drag_placeholder' );
 
-		console.log( 'handle drop' );
-
 		if ( ! placeholder ) {
 			syncAfterDragAndDrop();
 			return;
@@ -927,12 +925,13 @@ function frmAdminBuildJS() {
 		if ( draggable.classList.contains( 'frmbutton' ) ) {
 			insertNewFieldByDragging( draggable.id );
 		} else {
+			// Moving a field that already exists in the form.
 			placeholder.parentNode.insertBefore( draggable, placeholder );
 		}
 
 		placeholder.remove();
-
 		ui.helper.remove();
+
 		if ( $previousFieldContainer.length ) {
 			const $previousContainerFields = getFieldsInRow( $previousFieldContainer );
 			if ( ! $previousContainerFields.length ) {
@@ -946,25 +945,23 @@ function frmAdminBuildJS() {
 			}
 		}
 
-		if ( 'frm-show-fields' === droppable.id ) {
-			handleFieldDropIntoFrmListFields( draggable );
-		} else if ( droppable.classList.contains( 'start_divider' ) ) {
-			handleFieldDropIntoSection( draggable );
-		} else {
+		const dropType = getDropType( droppable );
+		if ( 'group' === dropType ) {
 			handleFieldDropIntoGroup( draggable, ui );
 		}
 
 		updateFieldAfterMovingBetweenSections( jQuery( draggable ) );
-
 		syncAfterDragAndDrop();
 	}
 
-	function handleFieldDropIntoFrmListFields( draggable ) {
-
-	}
-
-	function handleFieldDropIntoSection( draggable ) {
-
+	function getDropType( droppable ) {
+		if ( 'frm-show-fields' === droppable.id ) {
+			return 'list';
+		}
+		if ( droppable.classList.contains( 'start_divider' ) ) {
+			return 'section';
+		}
+		return 'group';
 	}
 
 	function handleFieldDropIntoGroup( draggable ) {
@@ -1415,9 +1412,9 @@ function frmAdminBuildJS() {
 	 * @param {string} fieldType
 	 */
 	function insertNewFieldByDragging( fieldType ) {
-		const placeholder = document.getElementById( 'frm_drag_placeholder' );
-		const loadingID   = fieldType.replace( '|', '-' ) + '_' + getAutoId();
-		const loading     = tag(
+		const placeholder  = document.getElementById( 'frm_drag_placeholder' );
+		const loadingID    = fieldType.replace( '|', '-' ) + '_' + getAutoId();
+		const loading      = tag(
 			'li',
 			{
 				id: loadingID,

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -998,7 +998,7 @@ function frmAdminBuildJS() {
 		}
 
 		if ( $previousContainerFields.length ) {
-			syncLayoutClasses( $previousContainerFields.first() );		
+			syncLayoutClasses( $previousContainerFields.first() );
 		} else {
 			maybeDeleteAnEmptyFieldGroup( $previousFieldContainer.get( 0 ) );
 		}
@@ -1013,7 +1013,7 @@ function frmAdminBuildJS() {
 	/**
 	 * Remove an empty field group, but don't remove an empty section.
 	 *
-	 * @param {Element} previousFieldContainer 
+	 * @param {Element} previousFieldContainer
 	 * @returns {void}
 	 */
 	function maybeDeleteAnEmptyFieldGroup( previousFieldContainer ) {
@@ -1756,7 +1756,7 @@ function frmAdminBuildJS() {
 
 	function loadFields( fieldId ) {
 		const thisField      = document.getElementById( fieldId );
-		const $thisField     = jQuery( thisField );		
+		const $thisField     = jQuery( thisField );
 		const field          = [];
 		const addHtmlToField = element => {
 			const frmHiddenFdata = element.querySelector( '.frm_hidden_fdata' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -898,8 +898,6 @@ function frmAdminBuildJS() {
 			});
 		}
 
-		droppable.appendChild( placeholder );
-
 		if ( 'frm-show-fields' === droppable.id || droppable.classList.contains( 'start_divider' ) ) {
 			placeholder.style.left = 0;
 			handleDragOverYAxis({ droppable, y: event.clientY, placeholder });
@@ -932,6 +930,8 @@ function frmAdminBuildJS() {
 		placeholder.remove();
 		ui.helper.remove();
 
+//		const dropType = getDropType( droppable );
+
 		if ( $previousFieldContainer.length ) {
 			const $previousContainerFields = getFieldsInRow( $previousFieldContainer );
 			if ( ! $previousContainerFields.length ) {
@@ -942,18 +942,15 @@ function frmAdminBuildJS() {
 				}
 			} else {
 				syncLayoutClasses( $previousContainerFields.first() );
+				syncLayoutClasses( jQuery( draggable ) );
 			}
-		}
-
-		const dropType = getDropType( droppable );
-		if ( 'group' === dropType ) {
-			handleFieldDropIntoGroup( draggable, ui );
 		}
 
 		updateFieldAfterMovingBetweenSections( jQuery( draggable ) );
 		syncAfterDragAndDrop();
 	}
 
+	/*
 	function getDropType( droppable ) {
 		if ( 'frm-show-fields' === droppable.id ) {
 			return 'list';
@@ -962,11 +959,7 @@ function frmAdminBuildJS() {
 			return 'section';
 		}
 		return 'group';
-	}
-
-	function handleFieldDropIntoGroup( draggable ) {
-		syncLayoutClasses( jQuery( draggable ) );
-	}
+	}*/
 
 	function handleDragOverYAxis({ droppable, y, placeholder }) {
 		const $list = jQuery( droppable );
@@ -1067,9 +1060,16 @@ function frmAdminBuildJS() {
 	}
 
 	function fixUnwrappedListItems() {
-		document.querySelectorAll( 'ul.start_divider > li.form-field:not(.edit_field_type_end_divider)' ).forEach(
-			function( field ) {
-				wrapFieldLiInPlace( field );
+		const lists = document.querySelectorAll( 'ul#frm-show-fields, ul.start_divider' );
+		lists.forEach(
+			list => {
+				list.childNodes.forEach(
+					child => {
+						if ( 'undefined' !== typeof child.classList && child.classList.contains( 'form-field' ) ) {
+							wrapFieldLiInPlace( child );
+						}
+					}
+				);
 			}
 		);
 	}
@@ -1376,10 +1376,6 @@ function frmAdminBuildJS() {
 		section = getSectionForFieldPlacement( currentItem );
 		formId = getFormIdForFieldPlacement( section );
 		sectionId = getSectionIdForFieldPlacement( section );
-
-		if ( currentItem.parent().hasClass( 'start_divider' ) ) {
-			wrapFieldLiInPlace( currentItem );
-		}
 
 		currentItem[0].addEventListener( 'click', function() {
 			maybeAddSaveAndDragIcons( this.dataset.fid );
@@ -2033,7 +2029,25 @@ function frmAdminBuildJS() {
 	}
 
 	function wrapFieldLiInPlace( li ) {
-		jQuery( li ).wrap( '<li class="frm_field_box"><ul class="frm_grid_container frm_sorting"></ul></li>' );
+		const ul      = tag(
+			'ul',
+			{
+				className: 'frm_grid_container frm_sorting'
+			}
+		);
+		const wrapper = tag(
+			'li',
+			{
+				className: 'frm_field_box',
+				child: ul
+			}
+		);
+
+		li.replaceWith( wrapper );
+		ul.appendChild( li );
+
+		makeDroppable( ul );
+		makeDraggable( wrapper, '.frm-move' );
 	}
 
 	function afterAddField( msg, addFocus ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1780,8 +1780,13 @@ function frmAdminBuildJS() {
 				const replaceWith = wrapFieldLi( msg );
 				$newFields.append( replaceWith );
 				afterAddField( msg, true );
-				makeDroppable( replaceWith.get( 0 ).querySelector( 'ul.frm_sorting' ) );
-				makeDraggable( replaceWith.get( 0 ).querySelector( '.form-field' ), '.frm-move' );
+
+				replaceWith.each(
+					function() {
+						makeDroppable( this.querySelector( 'ul.frm_sorting' ) );
+						makeDraggable( this.querySelector( '.form-field' ), '.frm-move' );
+					}
+				);
 			},
 			error: handleInsertFieldError
 		});
@@ -2119,12 +2124,24 @@ function frmAdminBuildJS() {
 		return option;
 	}
 
-	function wrapFieldLi( li ) {
-		return jQuery( '<li>' )
-			.addClass( 'frm_field_box' )
-			.html(
-				jQuery( '<ul>' ).addClass( 'frm_grid_container frm_sorting' ).append( li )
-			);
+	function wrapFieldLi( fieldHtml ) {
+		const wrapper = div();
+		wrapper.innerHTML = fieldHtml;
+
+		let result = jQuery();
+		Array.from( wrapper.children ).forEach(
+			li => {
+				result = result.add(
+					jQuery( '<li>' )
+						.addClass( 'frm_field_box' )
+						.html(
+							jQuery( '<ul>' ).addClass( 'frm_grid_container frm_sorting' ).append( li )
+						)
+				);
+			}
+		);
+
+		return result;
 	}
 
 	function wrapFieldLiInPlace( li ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -812,12 +812,11 @@ function frmAdminBuildJS() {
 		}
 	}
 
-	/* Form Builder */
 	function setupSortable( sortableSelector ) {
 		document.querySelectorAll( sortableSelector ).forEach(
 			list => {
 				makeDroppable( list );
-				Array.from( list.children ).forEach( child => makeDraggable( child, '.frm-move' ) )
+				Array.from( list.children ).forEach( child => makeDraggable( child, '.frm-move' ) );
 			}
 		);
 		setupFieldOptionSorting( jQuery( '#frm_builder_page' ) );
@@ -866,17 +865,11 @@ function frmAdminBuildJS() {
 		deleteEmptyDividerWrappers();
 		maybeRemoveGroupHoverTarget();
 		closeOpenFieldDropdowns();
-
-//		if ( ui.item[0].classList.contains( 'frm-page-collapsed' ) ) {
-			// If a page if collapsed, expand it before dragging since only the page break will move.
-//			toggleCollapsePage( jQuery( ui.item[0]) );
-//		}
 	}
 
-	function handleDragStop( event, ui ) {
+	function handleDragStop() {
 		const container = document.getElementById( 'post-body-content' );
 		container.classList.remove( 'frm-dragging-field' );
-
 		document.body.classList.remove( 'frm-dragging' );
 	}
 
@@ -917,7 +910,6 @@ function frmAdminBuildJS() {
 			return;
 		}
 
-		const droppable = placeholder.parentNode;
 		const $previousFieldContainer = ui.helper.parent();
 
 		if ( draggable.classList.contains( 'frmbutton' ) ) {
@@ -929,8 +921,6 @@ function frmAdminBuildJS() {
 
 		placeholder.remove();
 		ui.helper.remove();
-
-//		const dropType = getDropType( droppable );
 
 		if ( $previousFieldContainer.length ) {
 			const $previousContainerFields = getFieldsInRow( $previousFieldContainer );
@@ -949,17 +939,6 @@ function frmAdminBuildJS() {
 		updateFieldAfterMovingBetweenSections( jQuery( draggable ) );
 		syncAfterDragAndDrop();
 	}
-
-	/*
-	function getDropType( droppable ) {
-		if ( 'frm-show-fields' === droppable.id ) {
-			return 'list';
-		}
-		if ( droppable.classList.contains( 'start_divider' ) ) {
-			return 'section';
-		}
-		return 'group';
-	}*/
 
 	function handleDragOverYAxis({ droppable, y, placeholder }) {
 		const $list = jQuery( droppable );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3175

The drag/drop code has been rewritten to work better with sections and field groups.

This also fixes a bug with deleted groups. When sections were deleted, the children fields weren't also being deleted when using the delete group option.

And it fixes a couple of items from https://github.com/Strategy11/formidable-pro/issues/3118 including:
- "I added a summary field and the grouping that happened is odd. It should wrap the page break and the summary separately."

It also appears to resolve this issue I can appear to replicate on master when I drop a field into a row really quickly. It won't sync my layout but will set the layout class value to a double class like `frm6 frm6`, looking like this as a result:
<img width="721" alt="Screen Shot 2022-09-15 at 4 26 49 PM" src="https://user-images.githubusercontent.com/9134515/190492106-7ae665f6-ddd0-4d04-b0d0-5fccdc37391b.png">

**Recording**
![QRx9245Dl8](https://user-images.githubusercontent.com/9134515/189980700-72bd9784-94ca-4870-9e61-1ac7724f6d66.gif)

**Completed**
- [x] Do we want class `this.classList.add( 'drop-me' );`?
- [x] A new dragged in field is not draggable.
- [x] Dragging does not work yet between rows.
- [x] Don’t lose any logic from updateFieldAfterMovingBetweenSections
    - [x] And insertNewFieldByDragging
- [x] Do I still need to maintain a $previousFieldContainer variable?
- [x] Only if the previous container had other sibling fields, remove the previous layout class.
- [x] Never place anything after the edit_field_type_end_divider.
- [x] Call allowDrop to make sure that some field types can’t be dragged into a section (see comment don't allow some field types inside section in sortable change function. It uses classes no-drop-placeholder and sortable-placeholder
- [x] Dragging a group into/out of a section should assign the whole group.
- [x] There are issues right now with dragging field groups.
- [x] There's code that tries to update a collapsed page when you drag a field. This doesn't appear to actually happen.
- [x] Page break+summary doesn’t init properly.
- [x] Reduce the negative margin on sections.
- [x] Trying to place a field beside itself back into it's original field group is weird when it in the only item in the group. The placeholder follows the edge of the field as it drags around.
- [x] Break into rows didn’t break into new groups properly
- [x] I can't move around a field within the group it was just in.
- [x] I don’t think sections properly delete in bulk-delete. The child fields seem to get left behind.
- [x] Right now it's calling frm_update_field_after_move too often (after after time a field is dragged). Only call it when section id changes.
- [x] It breaks when you load a long form with AJAX. The loaded items do not become draggable or droppable.
- [x] The field being dragged has an inconsistent z-index.