### PR TITLE
TinyMCE Email Actions + Shortcode popup fix

### DIFF
--- a/classes/views/frm-form-actions/_email_settings.php
+++ b/classes/views/frm-form-actions/_email_settings.php
@@ -79,7 +79,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php
 	$editor_args = array(
 		'textarea_name' => $this->get_field_name( 'email_message' ),
-		'textarea_rows' => 8,
+		'textarea_rows' => 6,
 		'editor_class'  => 'frm_not_email_message',
 	);
 	wp_editor(

--- a/classes/views/frm-form-actions/_email_settings.php
+++ b/classes/views/frm-form-actions/_email_settings.php
@@ -76,7 +76,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<label for="<?php echo esc_attr( $this->get_field_id( 'email_message' ) ); ?>">
 		<?php esc_html_e( 'Message', 'formidable' ); ?>
 	</label>
-	<textarea name="<?php echo esc_attr( $this->get_field_name( 'email_message' ) ); ?>" class="frm_not_email_message frm_long_input" id="<?php echo esc_attr( $this->get_field_id( 'email_message' ) ); ?>" cols="50" rows="5"><?php echo FrmAppHelper::esc_textarea( $form_action->post_content['email_message'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></textarea>
+	<?php
+	$editor_args = array(
+		'textarea_name' => $this->get_field_name( 'email_message' ),
+		'textarea_rows' => 8,
+		'editor_class'  => 'frm_not_email_message',
+	);
+	wp_editor(
+		$form_action->post_content['email_message'],
+		$this->get_field_id( 'email_message' ),
+		$editor_args
+	);
+	?>
 </p>
 
 <label for="<?php echo esc_attr( $this->get_field_id( 'inc_user_info' ) ); ?>">

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -627,7 +627,7 @@ p.frm_has_shortcodes {
 }
 
 .frm_has_shortcodes .frmsvg,
-.frm_has_shortcodes i {
+.frm_has_shortcodes i:not([class*=mce-]) {
 	position: absolute;
 	color: var(--primary-color);
 	border-radius: 50%;
@@ -1032,7 +1032,7 @@ h2 .frm-button-primary {
 .frm-white-body .button-primary,
 .frm-white-body .button-secondary,
 .wp-core-ui.frm-white-body .button:not(.button-small),
-.frm-white-body button:not(.wp-switch-editor):not(.dropdown-toggle):not(.media-menu-item):not(.media-modal-close):not(.frm_no_style_button){
+.frm-white-body button:not(.wp-switch-editor):not(.dropdown-toggle):not(.media-menu-item):not(.media-modal-close):not(.frm_no_style_button):not([id^=mceu]){
 	text-shadow: none;
 	box-shadow: none;
 	border-radius: 30px;
@@ -6476,7 +6476,7 @@ ul.frm-category-tabs {
 i.frm-show-box,
 i.frm-show-inline-modal,
 .frm-with-left-icon i,
-.frm-with-right-icon i,
+.frm-with-right-icon i:not([class*=mce-]),
 .frmsvg.frm-show-box,
 .frmsvg.frm-show-inline-modal,
 .frm-with-left-icon .frmsvg,
@@ -6493,7 +6493,7 @@ i.frm-show-inline-modal,
 }
 
 .frm-with-right-icon .frmsvg,
-.frm-with-right-icon i {
+.frm-with-right-icon i:not([class*=mce-]) {
 	right: 0;
 	top: -3px;
 	left: auto;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6501,7 +6501,7 @@ i.frm-show-inline-modal,
 }
 
 .frm_form_settings .frm-with-right-icon .frmsvg{
-	bottom: -3px;
+	bottom: -7px;
 	margin-right: 10px;
 }
 

--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -389,7 +389,7 @@
 	};
 
 	const wysiwyg = {
-		init( editor, { setupCallback } = {}) {
+		init( editor, { setupCallback, height } = {}) {
 			if ( isTinyMceActive() ) {
 				setTimeout( resetTinyMce, 0 );
 			} else {
@@ -430,6 +430,9 @@
 
 				if ( setupCallback ) {
 					settings.setup = setupCallback;
+				}
+				if ( height ) {
+					settings.height = height;
 				}
 
 				tinymce.init( settings );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7521,7 +7521,10 @@ function frmAdminBuildJS() {
 	function onEmailActionLoaded( settings ) {
 		const wysiwyg = settings.querySelector( '.wp-editor-area' );
 		if ( wysiwyg ) {
-			frmDom.wysiwyg.init( wysiwyg, { height: 160 } );
+			frmDom.wysiwyg.init(
+				wysiwyg,
+				{ height: 160 }
+			);
 		}
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7523,9 +7523,23 @@ function frmAdminBuildJS() {
 		if ( wysiwyg ) {
 			frmDom.wysiwyg.init(
 				wysiwyg,
-				{ height: 160 }
+				{ setupCallback: addFocusEvents, height: 160 }
 			);
 		}
+	}
+
+	function addFocusEvents( editor ) {
+		editor.on( 'focusin', function() {
+			jQuery( editor.targetElm ).trigger( 'focusin' );
+			editor.off( 'focusin', '**' );
+		});
+
+		editor.on( 'focusout', function( e ) {
+			editor.on( 'focusin', function() {
+				jQuery( editor.targetElm ).trigger( 'focusin' );
+				editor.off( 'focusin', '**' );
+			});
+		});
 	}
 
 	/* Styling */

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7521,7 +7521,7 @@ function frmAdminBuildJS() {
 	function onEmailActionLoaded( settings ) {
 		const wysiwyg = settings.querySelector( '.wp-editor-area' );
 		if ( wysiwyg ) {
-			frmDom.wysiwyg.init( wysiwyg );
+			frmDom.wysiwyg.init( wysiwyg, { height: 160 } );
 		}
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9576,7 +9576,7 @@ function frmAdminBuildJS() {
 			formSettings.on( 'mouseup', '*:not(.frm-show-box)', function( e ) {
 				e.stopPropagation();
 
-				if ( e.target.classList.contains( 'frm-show-box' ) ) {
+				if ( e.target.classList.contains( 'frm-show-box' )  || e.target.parentElement.classList.contains( 'frm-show-box' ) ) {
 					return;
 				}
 
@@ -9590,6 +9590,7 @@ function frmAdminBuildJS() {
 				}
 
 				const isChild = jQuery( e.target ).closest( '#frm_adv_info' ).length > 0;
+
 				if ( ! isChild && sidebar.display !== 'none' ) {
 					hideShortcodes( sidebar );
 				}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -686,16 +686,17 @@ function frmAdminBuildJS() {
 
 	function clickWidget( event, b ) {
 		/*jshint validthis:true */
-		var target = event.target;
 		if ( typeof b === 'undefined' ) {
 			b = this;
 		}
 
 		popCalcFields( b, false );
 
-		var cont = jQuery( b ).closest( '.frm_form_action_settings' );
+		const cont   = jQuery( b ).closest( '.frm_form_action_settings' );
+		const target = event.target;
+
 		if ( cont.length && typeof target !== 'undefined' ) {
-			var className = target.parentElement.className;
+			const className = target.parentElement.className;
 			if ( 'string' === typeof className ) {
 				if ( className.indexOf( 'frm_email_icons' ) > -1 || className.indexOf( 'frm_toggle' ) > -1 ) {
 					// clicking on delete icon shouldn't open it
@@ -705,11 +706,11 @@ function frmAdminBuildJS() {
 			}
 		}
 
-		var inside = cont.children( '.widget-inside' );
+		let inside = cont.children( '.widget-inside' );
 
 		if ( cont.length && inside.find( 'p, div, table' ).length < 1 ) {
-			var actionId = cont.find( 'input[name$="[ID]"]' ).val();
-			var actionType = cont.find( 'input[name$="[post_excerpt]"]' ).val();
+			const actionId = cont.find( 'input[name$="[ID]"]' ).val();
+			const actionType = cont.find( 'input[name$="[post_excerpt]"]' ).val();
 			if ( actionType ) {
 				inside.html( '<span class="frm-wait frm_spinner"></span>' );
 				cont.find( '.spinner' ).fadeIn( 'slow' );
@@ -728,6 +729,11 @@ function frmAdminBuildJS() {
 						showInputIcon( '#' + cont.attr( 'id' ) );
 						frmDom.autocomplete.initAutocomplete( 'page', inside );
 						jQuery( b ).trigger( 'frm-action-loaded' );
+
+						const editor = inside.get( 0 ).querySelector( '.wp-editor-area' );
+						if ( editor ) {
+							frmDom.wysiwyg.init( editor );
+						}
 					}
 				});
 			}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7529,16 +7529,15 @@ function frmAdminBuildJS() {
 	}
 
 	function addFocusEvents( editor ) {
-		editor.on( 'focusin', function() {
+		function focusInCallback() {
 			jQuery( editor.targetElm ).trigger( 'focusin' );
 			editor.off( 'focusin', '**' );
-		});
+		}
 
-		editor.on( 'focusout', function( e ) {
-			editor.on( 'focusin', function() {
-				jQuery( editor.targetElm ).trigger( 'focusin' );
-				editor.off( 'focusin', '**' );
-			});
+		editor.on( 'focusin', focusInCallback );
+
+		editor.on( 'focusout', function() {
+			editor.on( 'focusin', focusInCallback );
 		});
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7193,7 +7193,11 @@ function frmAdminBuildJS() {
 			}
 
 			if ( shouldFocus !== 'nofocus' ) {
-				input.focus();
+				if ( 'none' !== input.style.display ) {
+					input.focus();
+				} else {
+					jQuery( tinymce.get( input.id ) ).trigger( 'focus' );
+				}
 			}
 		}
 	}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -729,11 +729,6 @@ function frmAdminBuildJS() {
 						showInputIcon( '#' + cont.attr( 'id' ) );
 						frmDom.autocomplete.initAutocomplete( 'page', inside );
 						jQuery( b ).trigger( 'frm-action-loaded' );
-
-						const editor = inside.get( 0 ).querySelector( '.wp-editor-area' );
-						if ( editor ) {
-							frmDom.wysiwyg.init( editor );
-						}
 					}
 				});
 			}
@@ -7516,6 +7511,20 @@ function frmAdminBuildJS() {
 		jQuery( '.' + switchTo ).addClass( 'current' );
 	}
 
+	function onActionLoaded( event ) {
+		const settings = event.target.closest( '.frm_form_action_settings' );
+		if ( settings && settings.classList.contains( 'frm_single_email_settings' ) ) {
+			onEmailActionLoaded( settings );
+		}
+	}
+
+	function onEmailActionLoaded( settings ) {
+		const wysiwyg = settings.querySelector( '.wp-editor-area' );
+		if ( wysiwyg ) {
+			frmDom.wysiwyg.init( wysiwyg );
+		}
+	}
+
 	/* Styling */
 	function setPosClass() {
 		/*jshint validthis:true */
@@ -9672,6 +9681,8 @@ function frmAdminBuildJS() {
 
             // Page Selection Autocomplete
 			initSelectionAutocomplete();
+
+			jQuery( document ).on( 'frm-action-loaded', onActionLoaded );
 		},
 
 		panelInit: function() {

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -202,7 +202,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 				$filename = basename( $val );
 				$path     = $uploads_dir . $filename;
 
-				if ( ! file_exists ( $path ) && is_object( $values['field'] ) ) {
+				if ( ! file_exists( $path ) && is_object( $values['field'] ) ) {
 					// File may be in formidable folder or it may be in the form_id folder so check the form as well.
 					$form_id_path = $uploads_dir . $values['field']->form_id . '/' . $filename;
 					if ( file_exists( $form_id_path ) ) {


### PR DESCRIPTION
Includes https://github.com/Strategy11/formidable-forms/pull/885
And includes an update from Abdi that supports this update https://github.com/Strategy11/formidable-forms/pull/873

Fixes https://github.com/Strategy11/formidable-pro/issues/3737
Fixes https://github.com/Strategy11/formidable-pro/issues/3757

This update adds support for a rich text editor in email actions, which is a fairly highly voted feature request https://team.strategy11.com/feature-requests/2021/04/30/wysiwyg-email-editor/?modal=1

The shortcode popup will now appear directly below the text areas so it doesn't get in the way of seeing the content.
https://github.com/Strategy11/formidable-pro/issues/3757