### PR TITLE
Truncate super long entry names

### DIFF
--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -150,7 +150,8 @@ class FrmEntryValidate {
 		}
 
 		if ( false !== $item_name ) {
-			$_POST['item_name'] = $item_name;
+			// Item name has a max length of 255 characters so truncate it so it doesn't fail to save in the database.
+			$_POST['item_name'] = substr( $item_name, 0, 255 );
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3819

This is the first thing I tried to fix this. The item name has a length limit of 255, the example string was too long. Worked like a charm 🥳