### PR TITLE
Add image src to exported image field options

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -23,4 +23,4 @@ jobs:
         run: composer install
 
       - name: "🧪 Test"
-        run: phpstan analyze ./ --level=max
+        run: phpstan analyze ./

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -1369,6 +1369,7 @@ class FrmXMLHelper {
 	 */
 	public static function prepare_field_for_export( &$field ) {
 		self::remove_default_field_options( $field );
+		self::add_image_src_to_image_options( $field );
 	}
 
 	/**
@@ -1399,6 +1400,39 @@ class FrmXMLHelper {
 		}
 
 		$field->field_options = serialize( $options );
+	}
+
+	/**
+	 * Add image "src" key to each image option so the image can be imported to another website.
+	 *
+	 * @since x.x
+	 *
+	 * @param stdClass $field
+	 * @return void
+	 */
+	private static function add_image_src_to_image_options( $field ) {
+		if ( empty( $field->options ) || false === strpos( $field->options, 'image' ) ) {
+			return;
+		}
+
+		$updated = false;
+		$options = $field->options;
+		FrmAppHelper::unserialize_or_decode( $options );
+
+		if ( ! $options || ! is_array( $options ) ) {
+			return;
+		}
+
+		foreach ( $options as $key => $option ) {
+			if ( is_array( $option ) && ! empty( $option['image'] ) ) {
+				$options[ $key ]['src'] = wp_get_attachment_url( $option['image'] );
+				$updated                = true;
+			}
+		}
+
+		if ( $updated ) {
+			$field->options = maybe_serialize( $options );
+		}
 	}
 
 	/**

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 parameters:
+	level: max
 	reportUnmatchedIgnoredErrors: false
 	bootstrapFiles:
 		- vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
@@ -71,3 +72,4 @@ parameters:
 		- '#\@param tag must not be named \$this#'
 		- '#Expected 2 \@param tags, found 4\.#'
 		- '#should always throw an exception or terminate script execution but#'
+		- '#spl_autoload_register expects#'

--- a/stubs.php
+++ b/stubs.php
@@ -28,6 +28,10 @@ namespace {
 		public static function get_required_templates_capability() {}
 		public static function get_custom_applications_capability() {}
 	}
+	class FrmProFileImport{ 
+		public static function import_attachment( $val, $field ) {
+		}
+	}	
 }
 
 namespace Elementor {

--- a/stubs.php
+++ b/stubs.php
@@ -31,7 +31,7 @@ namespace {
 	class FrmProFileImport {
 		public static function import_attachment( $val, $field ) {
 		}
-	}	
+	}
 }
 
 namespace Elementor {

--- a/stubs.php
+++ b/stubs.php
@@ -28,7 +28,7 @@ namespace {
 		public static function get_required_templates_capability() {}
 		public static function get_custom_applications_capability() {}
 	}
-	class FrmProFileImport{ 
+	class FrmProFileImport {
 		public static function import_attachment( $val, $field ) {
 		}
 	}	


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3746

This can be tested with the XML from https://github.com/Strategy11/formidable-quizzes/pull/155 as well which includes src data for both radio buttons with image options and for quiz outcomes.