### PR TITLE
Avoid fatal error when setting up a field with string field options

### DIFF
--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -34,6 +34,10 @@ class FrmEntriesHelper {
 
 			FrmFieldsHelper::prepare_new_front_field( $field_array, $field, $args );
 
+			if ( ! is_array( $field->field_options ) ) {
+				$field->field_options = array();
+			}
+
 			$field_array = array_merge( $field->field_options, $field_array );
 
 			$values['fields'][] = $field_array;


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2016033128/110605/

![image](https://user-images.githubusercontent.com/9134515/191580597-f8ead810-05e1-451a-b8c2-38f3e5d5114d.png)

I'm not too sure how they have a string `field_options`. But I figure it's best to be on the safe side and avoid calling `array_merge` on a string.