### PR TITLE
Update handleUpgradeClick function

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6334,9 +6334,13 @@ function frmAdminBuildJS() {
 	}
 
 	function markActionTriggersActive( triggers ) {
-		return;
 		triggers.forEach(
 			trigger => {
+				if ( trigger.querySelector( '.frm_show_upgrade' ) ) {
+					// Prevent disabled action becoming active.
+					return;
+				}
+
 				trigger.classList.remove( 'frm_inactive_action', 'frm_already_used' );
 				trigger.classList.add( 'frm_active_action' );
 			}
@@ -6344,7 +6348,6 @@ function frmAdminBuildJS() {
 	}
 
 	function markActionTriggersInactive( triggers, addAlreadyUsedClass ) {
-		return;
 		triggers.forEach(
 			trigger => {
 				trigger.classList.remove( 'frm_active_action' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5691,27 +5691,31 @@ function frmAdminBuildJS() {
 		document.addEventListener( 'click', handleUpgradeClick );
 
 		function handleUpgradeClick( event ) {
-			let element, upgradeLabel, link, content;
+			let element, link, content;
 
 			element = event.target;
-			upgradeLabel = element.dataset.upgrade;
 
-			if ( ! upgradeLabel ) {
+			if ( ! element.classList ) {
+				return;
+			}
+
+			const showExpiredModal = element.classList.contains( 'frm_show_expired_modal' ) || null !== element.querySelector( '.frm_show_expired_modal' ) || element.closest( '.frm_show_expired_modal' );
+
+			if ( ! element.dataset.upgrade ) {
 				const parent = element.closest( '[data-upgrade]' );
 				if ( ! parent ) {
 					return;
 				}
-
 				element = parent;
-				upgradeLabel = parent.dataset.upgrade;
 			}
 
-			if ( element.classList.contains( 'frm_show_expired_modal' ) ) {
+			if ( showExpiredModal ) {
 				const hookName = 'frm_show_expired_modal';
 				wp.hooks.doAction( hookName, element );
 				return;
 			}
 
+			const upgradeLabel = element.dataset.upgrade;
 			if ( ! upgradeLabel || element.classList.contains( 'frm_show_upgrade_tab' ) ) {
 				return;
 			}
@@ -6330,6 +6334,7 @@ function frmAdminBuildJS() {
 	}
 
 	function markActionTriggersActive( triggers ) {
+		return;
 		triggers.forEach(
 			trigger => {
 				trigger.classList.remove( 'frm_inactive_action', 'frm_already_used' );
@@ -6339,6 +6344,7 @@ function frmAdminBuildJS() {
 	}
 
 	function markActionTriggersInactive( triggers, addAlreadyUsedClass ) {
+		return;
 		triggers.forEach(
 			trigger => {
 				trigger.classList.remove( 'frm_active_action' );


### PR DESCRIPTION
This update helps make sure that when something with "frm_show_expired_modal" will always properly trigger the expired modal. I was seeing some inconsistency where clicking certain areas would trigger the upgrade modal instead.

It also makes sure that anything `.frm_show_upgrade` doesn't re-activate on load.

Required for https://github.com/Strategy11/formidable-pro/pull/3825