### PR TITLE
A bit more styling on the default modals

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1905,7 +1905,7 @@ h2.frm-h2 + .howto {
 }
 
 .frm_modal_footer {
-	padding: 20px 30px;
+	padding: 15px 30px;
 	text-align: right;
 	border-top: 1px solid var(--sidebar-hover);
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1849,7 +1849,7 @@ h2.frm-h2 + .howto {
 
 .frm-modal .postbox .frm_modal_top,
 .frm-dialog .frm_common_modal .postbox > div:first-child {
-	padding: 30px 30px 10px;
+	padding: 25px 30px 20px;
 	position: relative;
 }
 
@@ -1861,7 +1861,7 @@ h2.frm-h2 + .howto {
 .frm-dialog .frm_common_modal .postbox > div:first-child > div:first-child  {
 	display: inline-block;
 	font-size: 24px;
-	color: #282F36;
+	color: var(--darkest-grey);
 }
 
 .frm-inline-modal > a.dismiss,
@@ -1883,7 +1883,7 @@ h2.frm-h2 + .howto {
 .frm-modal .postbox .frm-modal-title + div:last-child a,
 .frm-modal a.dismiss .frmsvg,
 .frm_common_modal .frm_modal_top a .frmsvg {
-	color: var(--grey);
+	color: var(--darkest-grey);
 }
 
 .frm-modal .frm_modal_content > div.inside,
@@ -1891,6 +1891,7 @@ h2.frm-h2 + .howto {
 	padding: 20px 30px;
 	margin: 0;
 	font-size: 14px;
+	color: var(--dark-grey);
 }
 
 .frm_common_modal .postbox {
@@ -1905,7 +1906,7 @@ h2.frm-h2 + .howto {
 }
 
 .frm_modal_footer {
-	padding: 15px 30px;
+	padding: 17px 30px 20px;
 	text-align: right;
 	border-top: 1px solid var(--sidebar-hover);
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1888,7 +1888,7 @@ h2.frm-h2 + .howto {
 
 .frm-modal .frm_modal_content > div.inside,
 .frm_common_modal .frm_modal_content > div.inside {
-	padding: 20px 30px;
+	padding: 24px 30px;
 	margin: 0;
 	font-size: 14px;
 	color: var(--dark-grey);
@@ -1906,7 +1906,7 @@ h2.frm-h2 + .howto {
 }
 
 .frm_modal_footer {
-	padding: 17px 30px 20px;
+	padding: 18px 30px 20px;
 	text-align: right;
 	border-top: 1px solid var(--sidebar-hover);
 }
@@ -7325,7 +7325,7 @@ h2 .frm-sub-label {
 	left: 0;
 	right: 0;
 	bottom: 0;
-	background: var(--grey-border);
+	background: var(--grey);
 	z-index: 2;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1888,8 +1888,9 @@ h2.frm-h2 + .howto {
 
 .frm-modal .frm_modal_content > div.inside,
 .frm_common_modal .frm_modal_content > div.inside {
-	padding: 10px 30px;
+	padding: 20px 30px;
 	margin: 0;
+	font-size: 14px;
 }
 
 .frm_common_modal .postbox {
@@ -1904,7 +1905,7 @@ h2.frm-h2 + .howto {
 }
 
 .frm_modal_footer {
-	padding: 15px 30px;
+	padding: 20px 30px;
 	text-align: right;
 	border-top: 1px solid var(--sidebar-hover);
 }


### PR DESCRIPTION
Related to https://github.com/Strategy11/formidable-googlespreadsheet/issues/12

This gets us a bit closer to the design with a bit bigger font size and more padding for the inside.

Design:
<img width="664" alt="Screen Shot 2022-09-23 at 11 18 35 AM" src="https://user-images.githubusercontent.com/1116876/192020090-225be3ae-f944-4de2-816f-85de7bb6e670.png">


Before:
<img width="563" alt="Screen Shot 2022-09-23 at 11 15 44 AM" src="https://user-images.githubusercontent.com/1116876/192018572-c6e3cc18-b09e-4299-82b5-a7869c8b0c7f.png">

After:
<img width="562" alt="Screen Shot 2022-09-23 at 11 31 24 AM" src="https://user-images.githubusercontent.com/1116876/192024478-42b99820-f78d-4baf-a8cc-449d48139172.png">
