### PR TITLE
Remove font icons from css

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -16,7 +16,7 @@ class FrmAppHelper {
 	/**
 	 * @since 2.0
 	 */
-	public static $plug_version = '5.5';
+	public static $plug_version = '5.5.1';
 
 	/**
 	 * @since 1.07.02

--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -491,6 +491,38 @@ class FrmStylesHelper {
 	}
 
 	/**
+	 * @since 5.5.1
+	 * @return void
+	 */
+	public static function maybe_include_font_icon_css() {
+		$signature_add_on_is_active = class_exists( 'FrmSigAppHelper', false );
+
+		if ( ! FrmAppHelper::pro_is_installed() && ! $signature_add_on_is_active ) {
+			// If Pro and Signatures are both not active, there is no need to include the font icon CSS in lite.
+			return;
+		}
+
+		$pro_version_will_handle_loading = false;
+
+		if ( class_exists( 'FrmProDb', false ) ) {
+			$pro_version_that_includes_font_icons_css = '5.5.1';
+
+			// Include font icons in Lite for backward compatibility with older version of Pro.
+			$pro_version_will_handle_loading = version_compare( FrmProDb::$plug_version, $pro_version_that_includes_font_icons_css, '>=' );
+		}
+
+		$load_it_here = false;
+		if ( ! $pro_version_will_handle_loading ) {
+			// If Pro is not handling it, we still need to include it for the Signature add on.
+			$load_it_here = $signature_add_on_is_active;
+		}
+
+		if ( $load_it_here ) {
+			readfile( FrmAppHelper::plugin_path() . '/css/font_icons.css' );
+		}
+	}
+
+	/**
 	 * @deprecated 3.01
 	 * @codeCoverageIgnore
 	 */

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -1570,7 +1570,7 @@ select.frm_loading_lookup{
 
 <?php
 if ( FrmAppHelper::pro_is_installed() && class_exists( 'FrmProDb', false ) ) {
-	$pro_version_that_includes_font_icons_css = '5.5.2';
+	$pro_version_that_includes_font_icons_css = '5.5.1';
 	if ( version_compare( FrmProDb::$plug_version, $pro_version_that_includes_font_icons_css, '<' ) ) {
 		// Include font icons in Lite for backward compatibility with older version of Pro.
 		// This isn't required for the Lite add on.

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -1568,7 +1568,25 @@ select.frm_loading_lookup{
 	margin-bottom: 0 !important;
 }
 
-<?php do_action( 'frm_include_front_css', compact( 'defaults' ) ); ?>
+<?php
+if ( FrmAppHelper::pro_is_installed() && class_exists( 'FrmProDb', false ) ) {
+	$pro_version_that_includes_font_icons_css = '5.5.2';
+	if ( version_compare( FrmProDb::$plug_version, $pro_version_that_includes_font_icons_css, '<' ) ) {
+		// Include font icons in Lite for backward compatibility with older version of Pro.
+		// This isn't required for the Lite add on.
+		readfile( FrmAppHelper::plugin_path() . '/css/font_icons.css' );
+	}
+}
+
+/**
+ * Call action so other plugins can add additional CSS.
+ *
+ * @param array $args {
+ *     @type array $defaults
+ * }
+ */
+do_action( 'frm_include_front_css', compact( 'defaults' ) );
+?>
 
 /* Responsive */
 

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -1569,14 +1569,7 @@ select.frm_loading_lookup{
 }
 
 <?php
-if ( FrmAppHelper::pro_is_installed() && class_exists( 'FrmProDb', false ) ) {
-	$pro_version_that_includes_font_icons_css = '5.5.1';
-	if ( version_compare( FrmProDb::$plug_version, $pro_version_that_includes_font_icons_css, '<' ) ) {
-		// Include font icons in Lite for backward compatibility with older version of Pro.
-		// This isn't required for the Lite add on.
-		readfile( FrmAppHelper::plugin_path() . '/css/font_icons.css' );
-	}
-}
+FrmStylesHelper::maybe_include_font_icon_css();
 
 /**
  * Call action so other plugins can add additional CSS.

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -1568,8 +1568,6 @@ select.frm_loading_lookup{
 	margin-bottom: 0 !important;
 }
 
-/* Fonts */
-<?php readfile( FrmAppHelper::plugin_path() . '/css/font_icons.css' ); ?>
 <?php do_action( 'frm_include_front_css', compact( 'defaults' ) ); ?>
 
 /* Responsive */


### PR DESCRIPTION
Part of https://github.com/Strategy11/formidable-pro/pull/3829

Lite doesn't require the font icons CSS. And Pro should be loading it. So in v5.5.1 I'm moving this to Pro (with https://github.com/Strategy11/formidable-pro/pull/3831).

If Pro is not active, this will still load the CSS if the Signatures add on is active. Otherwise the icons for signature fields also break. I added an issue in Signatures to switch to SVGs there as well. Eventually we can add a version check for Signatures too but it's harder to time that release https://github.com/Strategy11/formidable-signature/issues/84

**Size of formidable.css before**
<img width="542" alt="Screen Shot 2022-09-26 at 2 19 43 PM" src="https://user-images.githubusercontent.com/9134515/192340457-f6b0cda8-9349-4cf6-b722-5ed78afe65b0.png">

**Size of formidable.css after**
<img width="549" alt="Screen Shot 2022-09-26 at 2 20 06 PM" src="https://user-images.githubusercontent.com/9134515/192340447-453ab5bf-b8bf-4184-97e3-5805a5896f06.png">

Saving around 11.5KB.