### PR TITLE
Move "add focus events" logic for wysiwys to domjs

### DIFF
--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -389,7 +389,7 @@
 	};
 
 	const wysiwyg = {
-		init( editor, { setupCallback, height } = {}) {
+		init( editor, { setupCallback, height, addFocusEvents } = {}) {
 			if ( isTinyMceActive() ) {
 				setTimeout( resetTinyMce, 0 );
 			} else {
@@ -428,9 +428,24 @@
 					}
 				);
 
-				if ( setupCallback ) {
-					settings.setup = setupCallback;
-				}
+				settings.setup = editor => {
+					if ( addFocusEvents ) {
+						function focusInCallback() {
+							jQuery( editor.targetElm ).trigger( 'focusin' );
+							editor.off( 'focusin', '**' );
+						}
+				
+						editor.on( 'focusin', focusInCallback );
+				
+						editor.on( 'focusout', function() {
+							editor.on( 'focusin', focusInCallback );
+						});
+					}
+					if ( setupCallback ) {
+						setupCallback( editor );
+					}
+				};
+
 				if ( height ) {
 					settings.height = height;
 				}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7535,23 +7535,9 @@ function frmAdminBuildJS() {
 		const wysiwyg = settings.querySelector( '.wp-editor-area' );
 		if ( wysiwyg ) {
 			frmDom.wysiwyg.init(
-				wysiwyg,
-				{ setupCallback: addFocusEvents, height: 160 }
+				wysiwyg, { height: 160, addFocusEvents: true }
 			);
 		}
-	}
-
-	function addFocusEvents( editor ) {
-		function focusInCallback() {
-			jQuery( editor.targetElm ).trigger( 'focusin' );
-			editor.off( 'focusin', '**' );
-		}
-
-		editor.on( 'focusin', focusInCallback );
-
-		editor.on( 'focusout', function() {
-			editor.on( 'focusin', focusInCallback );
-		});
 	}
 
 	/* Styling */


### PR DESCRIPTION
Rather than copying/pasting this logic for quiz outcomes I think it makes more sense to just re-use it from Lite so I'm moving it into the dom.js file as a wysiwyg init option instead.

Without this update, it won't trigger the pop up when you focus on the visual tab for Quiz Outcomes. Otherwise it should still work fine (and will still trigger when you click the ... as well).