### PR TITLE
Remove builder update js for scale fields

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5229,35 +5229,6 @@ function frmAdminBuildJS() {
 		}
 	}
 
-	function setScaleValues() {
-		/*jshint validthis:true */
-		var isMin = this.id.indexOf( 'minnum' ) !== -1;
-		var fieldID = this.id.replace( 'scale_maxnum_', '' ).replace( 'scale_minnum_', '' );
-		var min = this.value;
-		var max = this.value;
-		if ( isMin ) {
-			max = document.getElementById( 'scale_maxnum_' + fieldID ).value;
-		} else {
-			min = document.getElementById( 'scale_minnum_' + fieldID ).value;
-		}
-
-		updateScaleValues( parseInt( min, 10 ), parseInt( max, 10 ), fieldID );
-	}
-
-	function updateScaleValues( min, max, fieldID ) {
-		var container = jQuery( '#field_' + fieldID + '_inner_container .frm_form_fields' );
-		container.html( '' );
-
-		if ( min >= max ) {
-			max = min + 1;
-		}
-
-		for ( var i = min; i <= max; i++ ) {
-			container.append( '<div class="frm_scale"><label><input type="hidden" name="field_options[options_' + fieldID + '][' + i + ']" value="' + i + '"> <input type="radio" name="item_meta[' + fieldID + ']" value="' + i + '"> ' + i + ' </label></div>' );
-		}
-		container.append( '<div class="clear"></div>' );
-	}
-
 	function getFieldValues() {
 		/*jshint validthis:true */
 		var isTaxonomy,
@@ -9418,7 +9389,6 @@ function frmAdminBuildJS() {
 			$builderForm.on( 'click', '.frm_add_watch_lookup_row', addWatchLookupRow );
 			$builderForm.on( 'change', '.frm_get_values_form', updateGetValueFieldSelection );
 			$builderForm.on( 'change', '.frm_logic_field_opts', getFieldValues );
-			$builderForm.on( 'change', '.scale_maxnum, .scale_minnum', setScaleValues );
 			$builderForm.on( 'change', '.radio_maxnum', setStarValues );
 			$builderForm.on( 'frm-multiselect-changed', 'select[name^="field_options[admin_only_"]', adjustVisibilityValuesForEveryoneValues );
 


### PR DESCRIPTION
Requires https://github.com/Strategy11/formidable-pro/pull/3838

If the versions get out of sync, the scale fields won't update live in the builder. I think that's a fine price to get rid of the code where it doesn't belong.