### PR TITLE
Set the global post object when querying for random page to avoid PHP…

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -318,7 +318,6 @@ class FrmFormsController {
 		}
 
 		$random_page = get_posts( $page_query );
-
 		if ( ! $random_page ) {
 			return;
 		}
@@ -330,6 +329,23 @@ class FrmFormsController {
 				'page_id'   => $random_page->ID,
 			)
 		);
+
+		// Fixes Pro issue #3004. Prevent an undefined $post object.
+		// Otherwise WordPress themes will trigger a warning "Attempt to read property "comment_count" on null".
+		self::set_post_global( $random_page );
+	}
+
+	/**
+	 * Set the WP $post global object. Used for in-theme preview when defining a page.
+	 *
+	 * @since 5.5.2
+	 *
+	 * @param WP_Post $post
+	 * @return void
+	 */
+	private static function set_post_global( $page ) {
+		global $post;
+		$post = $page; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
 	}
 
 	/**


### PR DESCRIPTION
… warnings when loading theme comments

Fixes https://github.com/Strategy11/formidable-pro/issues/3004

Before working on https://github.com/Strategy11/formidable-forms/pull/912 I didn't realize we actually queried for a page on in-theme preview. Since we're already doing this, I think we should also set the global `$post` object.

This way we don't trigger the `PHP Warning:  Attempt to read property "comment_count" on null in wp-includes/general-template.php on line 3159` warning that happens when it tries to display comments.

I tried replicating the other console errors from the issue, and they no longer appear to happen, at least not for me with my current environment.