### PR TITLE
Remove title and description options from embed examples

### DIFF
--- a/js/admin/embed.js
+++ b/js/admin/embed.js
@@ -377,13 +377,13 @@
 		let examples = [
 			{
 				label: __( 'WordPress shortcode', 'formidable' ),
-				example: '[formidable id=' + formId + ' title=true description=true]',
+				example: '[formidable id=' + formId + ']',
 				link: 'https://formidableforms.com/knowledgebase/publish-a-form/#kb-insert-the-shortcode-manually',
 				linkLabel: __( 'How to use shortcodes in WordPress', 'formidable' )
 			},
 			{
 				label: __( 'Use PHP code', 'formidable' ),
-				example: '<?php echo FrmFormsController::get_form_shortcode( array( \'id\' => ' + formId + ', \'title\' => true, \'description\' => true ) ); ?>'
+				example: '<?php echo FrmFormsController::get_form_shortcode( array( \'id\' => ' + formId + ' ) ); ?>'
 			}
 		];
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3852

Since these are settings now, it make sense not to have the options set by default in the embed examples since they override the setting. It seemed to confuse a customer, and I think we can avoid future support tickets by having it rely on the options in settings by default.

<img width="444" alt="Screen Shot 2022-10-05 at 10 31 11 AM" src="https://user-images.githubusercontent.com/9134515/194072939-a9c1eb6a-ec03-48ab-a28f-e526f12df85b.png">
