### PR TITLE
Require missing function when installing an add on via API

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -903,7 +903,6 @@ class FrmAddonsController {
 		return activate_plugin( $plugin, $redirect, $network_wide, $silent );
 	}
 
-
 	/**
 	 * @since 5.0.10
 	 *


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3845

It also fixes another issue related to https://github.com/Strategy11/formidable-forms/pull/888. I added some comments as to why I need to actually avoid `FrmAppHelper::get_plugins`. This seems to be harmless when it throws an error, but I'd rather avoid it. It will continue to come up as people update from older versions to v5.5+ versions so I want to avoid those tickets. Already it looks like it's resulted in at least 2 (https://secure.helpscout.net/conversation/2009905013/109913/ when v5.5 was just released and again from a new ticket just a couple of days ago https://secure.helpscout.net/conversation/2026757775/111791/).