### PR TITLE
New draggable helper function

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7175,7 +7175,7 @@ input[disabled],
 	height: 25px !important;
 	width: 140px;
 	text-align: center;
-	display: block !important;
+	display: inline !important;
 	background-color: var(--lightest-grey) !important;
 	border-radius: 35px !important;
 	padding: 5px 20px !important;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3378,7 +3378,7 @@ li.ui-state-default.selected > .frm_inner_field_container > label {
 }
 
 .frm-dragging * {
-	cursor: move !important;
+	cursor: grabbing !important;
 }
 
 .frm-dragging .divider_section_only {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7183,7 +7183,6 @@ input[disabled],
 }
 
 #frm-show-fields .frmbutton.ui-sortable-helper i,
-.frmbutton.ui-sortable-helper span,
 .frmbutton.ui-draggable-dragging i,
 .frmbutton.ui-draggable-dragging .frmsvg {
 	color: #fff !important;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3828,7 +3828,7 @@ li.sortable-placeholder {
 	border: none;
 	margin: 0;
 	visibility: visible !important;
-	box-shadow: 2px -10px 0 1px var(--primary-color);
+	box-shadow: 2px -10px 0 2px var(--primary-color);
 }
 
 #frm_form_editor_container > ul > .frm_single_option.ui-sortable-placeholder,
@@ -5455,7 +5455,7 @@ a.frm_action_icon:hover {
 }
 
 .frm-move {
-	cursor: move;
+	cursor: grab;
 }
 
 span.howto {
@@ -7173,11 +7173,12 @@ input[disabled],
 	flex-direction: row;
 	justify-content: center;
 	align-items: center;
-	background-color: var(--lightest-grey) !important;
+	background-color: var(--sidebar-color) !important;
 	border-radius: 35px !important;
 	padding: 5px 10px !important;
 	color: var(--dark-grey) !important;
 	box-sizing: border-box;
+	border: 1px solid var(--border-color);
 }
 
 .frmbutton.ui-draggable-dragging span {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7178,7 +7178,7 @@ input[disabled],
 	padding: 5px 10px !important;
 	color: var(--dark-grey) !important;
 	box-sizing: border-box;
-	border: 1px solid var(--border-color);
+	border: 1px solid var(--grey-border);
 }
 
 .frmbutton.ui-draggable-dragging span {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7165,21 +7165,19 @@ input[disabled],
 	pointer-events: none;
 }
 
-.frmbutton.ui-draggable-dragging,
-.frmbutton.ui-draggable-dragging a {
-	cursor: move;
-}
-
 .frmbutton.ui-draggable-dragging a {
 	text-decoration: none;
-	height: 25px !important;
-	width: 140px;
-	text-align: center;
-	display: inline !important;
+	height: 40px;
+	width: 180px;
+	display: inline-flex !important;
+	flex-direction: row;
+	justify-content: center;
+	align-items: center;
 	background-color: var(--lightest-grey) !important;
 	border-radius: 35px !important;
-	padding: 5px 20px !important;
+	padding: 5px 10px !important;
 	color: var(--dark-grey) !important;
+	box-sizing: border-box;
 }
 
 .frmbutton.ui-draggable-dragging span {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7225,6 +7225,13 @@ input[disabled],
 	opacity: 0;
 }
 
+.frm-field-group-count {
+	background-color: gray;
+	padding: 5px;
+	color: #fff !important;
+	border-radius: 10px;
+}
+
 /* End dragging */
 
 .field_type_list .frm_icon_font:before {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7164,34 +7164,22 @@ input[disabled],
 	color: var(--dark-grey);
 }
 
-.frmbutton.ui-draggable-dragging {
-	width: auto !important;
-}
-
 /* Icon while dragging */
 .frmbutton.ui-draggable-dragging,
 .frmbutton.ui-draggable-dragging a {
 	cursor: move;
 }
 
-.frmbutton.ui-sortable-helper a,
 .frmbutton.ui-draggable-dragging a:hover,
 .frmbutton.ui-draggable-dragging a {
 	text-decoration: none;
 	height: 25px !important;
-	width: 180px;
+	width: 140px;
 	text-align: center;
 	display: block !important;
-	background-color: var(--primary-hover) !important;
+	background-color: var(--lightest-grey) !important;
 	border-radius: 35px !important;
 	padding: 5px 20px !important;
-	color: #fff !important;
-}
-
-.frmbutton.ui-draggable-dragging:not(.ui-sortable-helper) a {
-	/* When the new field is held outside of a dropzone */
-	cursor: not-allowed;
-	background: var(--sidebar-color) !important;
 	color: var(--dark-grey) !important;
 }
 
@@ -7211,22 +7199,14 @@ input[disabled],
 	color: var(--dark-grey) !important;
 }
 
-.frmbutton.ui-draggable-dragging .frm-dropdown-menu {
-	display: none;
-}
-
 .frm_sorting li.ui-state-default.ui-sortable-helper,
 .frmbutton.ui-sortable-helper {
 	transition: opacity .2s;
 	opacity: 1;
 }
 
-.frmbutton.ui-sortable-helper:not(.ui-draggable-dragging) {
-	opacity: 0;
-}
-
 .frm-field-group-count {
-	background-color: gray;
+	background-color: var(--sidebar-hover);
 	padding: 5px;
 	color: #fff !important;
 	border-radius: 10px;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3861,17 +3861,9 @@ li.sortable-placeholder {
 }
 
 .frm_sorting > li.edit_field_type_end_divider:first-child,
-.frm_sorting > .frmbutton + .sortable-placeholder, /* hide for first field */
 .frm-show-click,
 li.ui-state-default.edit_field_type_divider .frm-show-click {
 	display: none;
-}
-
-.frm_form_field.ui-sortable-helper {
-	height: 30px !important;
-	background-color: #fff !important;
-	overflow: hidden !important;
-	box-sizing: border-box;
 }
 
 .frm_form_field.ui-sortable-helper .frm-field-action-icons,
@@ -7165,12 +7157,15 @@ input[disabled],
 }
 
 /* Icon while dragging */
+.frmbutton.ui-draggable-dragging {
+	pointer-events: none;
+}
+
 .frmbutton.ui-draggable-dragging,
 .frmbutton.ui-draggable-dragging a {
 	cursor: move;
 }
 
-.frmbutton.ui-draggable-dragging a:hover,
 .frmbutton.ui-draggable-dragging a {
 	text-decoration: none;
 	height: 25px !important;
@@ -7194,8 +7189,8 @@ input[disabled],
 	color: #fff !important;
 }
 
-.frmbutton.ui-draggable-dragging:not(.ui-sortable-helper) i,
-.frmbutton.ui-draggable-dragging:not(.ui-sortable-helper) .frmsvg {
+.frmbutton.ui-draggable-dragging i,
+.frmbutton.ui-draggable-dragging .frmsvg {
 	color: var(--dark-grey) !important;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3377,6 +3377,10 @@ li.ui-state-default.selected > .frm_inner_field_container > label {
 	max-width: calc(100% - 100px);
 }
 
+.frm-dragging * {
+	cursor: move !important;
+}
+
 .frm-dragging .divider_section_only {
 	pointer-events: none;
 }

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -894,6 +894,7 @@ function frmAdminBuildJS() {
 
 		if ( isFieldGroup( draggable ) ) {
 			const newTextFieldClone = document.getElementById( 'frm-insert-fields' ).querySelector( '.frm_ttext' ).cloneNode( true );
+			newTextFieldClone.querySelector( 'use' ).setAttributeNS( 'http://www.w3.org/1999/xlink', 'href', '#frm_field_group_layout_icon' );
 			newTextFieldClone.querySelector( 'span' ).textContent = __( 'Field Group' );
 			newTextFieldClone.classList.add( 'frm_field_box' );
 			newTextFieldClone.classList.add( 'ui-sortable-helper' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -881,7 +881,11 @@ function frmAdminBuildJS() {
 			delay: 10,
 			start: handleDragStart,
 			stop: handleDragStop,
-			drag: handleDrag
+			drag: handleDrag,
+			cursorAt: {
+				top: 0,
+				left: 0
+			}
 		};
 		if ( 'string' === typeof handle ) {
 			settings.handle = handle;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -876,7 +876,7 @@ function frmAdminBuildJS() {
 
 	function makeDraggable( draggable, handle ) {
 		const settings = {
-			helper: 'clone',
+			helper: getDraggableHelper,
 			revert: 'invalid',
 			delay: 10,
 			start: handleDragStart,
@@ -889,15 +889,37 @@ function frmAdminBuildJS() {
 		jQuery( draggable ).draggable( settings );
 	}
 
-	function handleDragStart( event, ui ) {
+	function getDraggableHelper( event ) {
+		const draggable = event.delegateTarget;
+
+		let copyTarget;
+
+		if ( draggable.classList.contains( 'frmbutton' ) ) {
+			copyTarget = draggable;
+		} else if ( draggable.hasAttribute( 'data-ftype' ) ) {
+			const fieldType = draggable.getAttribute( 'data-ftype' );
+			copyTarget = document.getElementById( 'frm-insert-fields' ).querySelector( '.frm_t' + fieldType );
+			if ( ! copyTarget ) {
+				// This may include "quiz score" when quizzes are not active as it does not appear in the list.
+			}
+		} else {
+			// Field group.
+			const newTextFieldClone = document.getElementById( 'frm-insert-fields' ).querySelector( '.frm_ttext' ).cloneNode( true );
+			const fieldCount = getFieldsInRow( jQuery( draggable ) ).length;
+			newTextFieldClone.querySelector( 'svg' ).replaceWith( tag( 'i', { className: 'frm-field-group-count', text: fieldCount.toString() }) );
+			newTextFieldClone.querySelector( 'span' ).textContent = __( 'Field Group' );
+			return newTextFieldClone;
+		}
+
+		return copyTarget.cloneNode( true );
+	}
+
+	function handleDragStart( _, ui ) {
 		const container = document.getElementById( 'post-body-content' );
 		container.classList.add( 'frm-dragging-field' );
 
 		document.body.classList.add( 'frm-dragging' );
-
-		const width = jQuery( event.target ).width();
 		ui.helper.addClass( 'frm-sortable-helper' );
-		ui.helper.css( 'width', width + 'px' );
 
 		unselectFieldGroups();
 		deleteEmptyDividerWrappers();

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -884,7 +884,7 @@ function frmAdminBuildJS() {
 			drag: handleDrag,
 			cursorAt: {
 				top: 0,
-				left: 0
+				left: 70
 			}
 		};
 		if ( 'string' === typeof handle ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -884,7 +884,7 @@ function frmAdminBuildJS() {
 			drag: handleDrag,
 			cursorAt: {
 				top: 0,
-				left: 70
+				left: 70 // The width of draggable button is 140. 70 should center the draggable on the cursor.
 			}
 		};
 		if ( 'string' === typeof handle ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -896,16 +896,17 @@ function frmAdminBuildJS() {
 			const newTextFieldClone = document.getElementById( 'frm-insert-fields' ).querySelector( '.frm_ttext' ).cloneNode( true );
 			newTextFieldClone.querySelector( 'span' ).textContent = __( 'Field Group' );
 			newTextFieldClone.classList.add( 'frm_field_box' );
+			newTextFieldClone.classList.add( 'ui-sortable-helper' );
 			return newTextFieldClone;
 		}
 
 		let copyTarget;
-
 		const isNewField = draggable.classList.contains( 'frmbutton' );
 		if ( isNewField ) {
-			copyTarget = draggable;
+			copyTarget = draggable.cloneNode( true );
+			copyTarget.classList.add( 'ui-sortable-helper' );
 			draggable.classList.add( 'frm-new-field' );
-			return copyTarget.cloneNode( true );
+			return copyTarget;
 		}
 
 		if ( draggable.hasAttribute( 'data-ftype' ) ) {
@@ -913,6 +914,8 @@ function frmAdminBuildJS() {
 			copyTarget = document.getElementById( 'frm-insert-fields' ).querySelector( '.frm_t' + fieldType );
 			copyTarget = copyTarget.cloneNode( true );
 			copyTarget.classList.add( 'form-field' );
+
+			copyTarget.classList.add( 'ui-sortable-helper' );
 
 			if ( copyTarget ) {
 				return copyTarget.cloneNode( true );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -884,7 +884,7 @@ function frmAdminBuildJS() {
 			drag: handleDrag,
 			cursorAt: {
 				top: 0,
-				left: 70 // The width of draggable button is 140. 70 should center the draggable on the cursor.
+				left: 90 // The width of draggable button is 180. 90 should center the draggable on the cursor.
 			}
 		};
 		if ( 'string' === typeof handle ) {


### PR DESCRIPTION
With this update the dragged item no longer "clones". It now always uses the "frmbutton" look for new fields. For a field group, it says "Field Group" instead.

@stephywells @srwells Is this what you had in mind? Ignore the code for now. It's still in a prototype stage.

I'm also cleaning up some styles a bit.

For now I'm using the row layout icon for field groups. Trying to get a field count is more difficult than it should be at the moment.

<img width="641" alt="Screen Shot 2022-10-05 at 2 35 33 PM" src="https://user-images.githubusercontent.com/9134515/194125053-c8bdda73-f503-4e73-8ab2-bbb99f769dec.png">

![tI4rTw6gB8](https://user-images.githubusercontent.com/9134515/194125178-3a935980-e578-4968-a5be-1b43c01f55c4.gif)
