### PR TITLE
Check for simplexml_load_string function, show form install error in …

### DIFF
--- a/classes/controllers/FrmXMLController.php
+++ b/classes/controllers/FrmXMLController.php
@@ -35,10 +35,19 @@ class FrmXMLController {
 	 * Use the template link to install the XML template
 	 *
 	 * @since 3.06
+	 * @return void
 	 */
 	public static function install_template() {
 		FrmAppHelper::permission_check( 'frm_edit_forms' );
 		check_ajax_referer( 'frm_ajax', 'nonce' );
+
+		if ( ! function_exists( 'simplexml_load_string' ) ) {
+			$response = array(
+				'message' => __( 'Your server is missing the Simple XML extension. This is required to install a template.', 'formidable' ),
+			);
+			echo wp_json_encode( $response );
+			wp_die();
+		}
 
 		$url = FrmAppHelper::get_param( 'xml', '', 'post', 'esc_url_raw' );
 
@@ -51,7 +60,7 @@ class FrmXMLController {
 
 		if ( ! $xml ) {
 			$response = array(
-				'message' => __( 'There was an error reading the form template', 'formidable' ),
+				'message' => __( 'There was an error reading the form template.', 'formidable' ),
 			);
 			echo wp_json_encode( $response );
 			wp_die();

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8645,16 +8645,25 @@ function frmAdminBuildJS() {
 				jQuery( '.spinner' ).css( 'visibility', 'hidden' );
 
 				// Show response.message
-				if ( response.message && typeof form.elements.show_response !== 'undefined' ) {
-					const showError = document.getElementById( form.elements.show_response.value );
-					if ( showError !== null ) {
-						showError.innerHTML = response.message;
-						showError.classList.remove( 'frm_hidden' );
-					}
+				if ( 'string' === typeof response.message ) {
+					showInstallFormErrorModal( response.message );
 				}
 			}
 			button.classList.remove( 'frm_loading_button' );
 		});
+	}
+
+	function showInstallFormErrorModal( message ) {
+		const modalContent = div( message );
+		modalContent.style.padding = '20px 40px';
+		const modal = frmDom.modal.maybeCreateModal(
+			'frmInstallFormErrorModal',
+			{
+				title: __( 'Unable to install template', 'formidable' ),
+				content: modalContent
+			}
+		);
+		modal.classList.add( 'frm_common_modal' );
 	}
 
 	function handleCaptchaTypeChange( e ) {


### PR DESCRIPTION
…modal

Related ticket https://secure.helpscout.net/conversation/2029422497/112116/

It turns out that it tries to show the error on "form.elements.show_response.value" `show_response` doesn't exist in this context. It looks like it exists in FrmSolution, though it's in a hidden input so I don't understand what it's intention there is anyway.

I'm creating a modal on modal now instead. And I added a new error message to check that `simplexml_load_string` actually exists.

Otherwise they hit an unexpected fatal error:
```
PHP Fatal error:  Uncaught Error: Call to undefined function simplexml_load_string() in /var/www/html/wp-content/plugins/formidable/classes/controllers/FrmXMLController.php:50
Stack trace:
```

<img width="493" alt="Screen Shot 2022-10-06 at 9 13 09 AM" src="https://user-images.githubusercontent.com/9134515/194310126-bc2c952a-32ac-441a-8df1-be64358e15e6.png">
<img width="489" alt="Screen Shot 2022-10-06 at 9 13 32 AM" src="https://user-images.githubusercontent.com/9134515/194310130-5246b1e1-215b-4d15-8b20-7b5dce8da8e7.png">
