### PR TITLE
replace newline with <br>

### DIFF
--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -101,7 +101,7 @@ class FrmFormActionsController {
 	 */
 	public static function update_email_message( $message, $atts ) {
 		if ( ! $atts['plain_text'] ) {
-			$message = wpautop( $message );
+			$message = wpautop( $message, false );
 		}
 		return $message;
 	}

--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -93,6 +93,17 @@ class FrmFormActionsController {
 	}
 
 	/**
+	 * @since x.x
+	 *
+	 * @param string $message
+	 *
+	 * @return string
+	 */
+	public static function update_email_message( $message ) {
+		return str_replace( "\n", '<br>', $message );
+	}
+
+	/**
 	 * Add unknown actions to a group.
 	 *
 	 * @since 4.0

--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -101,7 +101,7 @@ class FrmFormActionsController {
 	 */
 	public static function update_email_message( $message, $atts ) {
 		if ( ! $atts['plain_text'] ) {
-			$message = str_replace( "\n", '<br>', $message );
+			$message = wpautop( $message );
 		}
 		return $message;
 	}

--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -99,8 +99,11 @@ class FrmFormActionsController {
 	 *
 	 * @return string
 	 */
-	public static function update_email_message( $message ) {
-		return str_replace( "\n", '<br>', $message );
+	public static function update_email_message( $message, $atts ) {
+		if ( ! $atts['plain_text'] ) {
+			$message = str_replace( "\n", '<br>', $message );
+		}
+		return $message;
 	}
 
 	/**

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -143,7 +143,7 @@ class FrmHooksController {
 		add_action( 'frm_after_duplicate_form', 'FrmForm::after_duplicate', 10, 2 );
 
 		// Email Model
-		add_filter( 'frm_email_message', 'FrmFormActionsController::update_email_message' );
+		add_filter( 'frm_email_message', 'FrmFormActionsController::update_email_message', 10, 2 );
 
 		// Inbox Controller.
 		add_action( 'admin_menu', 'FrmInboxController::menu', 50 );

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -172,9 +172,6 @@ class FrmHooksController {
 		add_action( 'admin_enqueue_scripts', 'FrmApplicationsController::dequeue_scripts', 15 );
 		add_action( 'wp_ajax_frm_get_applications_data', 'FrmApplicationsController::get_applications_data' );
 
-		// Emails
-		add_filter( 'frm_email_message', 'FrmFormActionsController::update_email_message' );
-
 		FrmSMTPController::load_hooks();
 		FrmWelcomeController::load_hooks();
 		new FrmPluginSearch();

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -142,6 +142,9 @@ class FrmHooksController {
 		// Forms Model.
 		add_action( 'frm_after_duplicate_form', 'FrmForm::after_duplicate', 10, 2 );
 
+		// Email Model
+		add_filter( 'frm_email_message', 'FrmFormActionsController::update_email_message' );
+
 		// Inbox Controller.
 		add_action( 'admin_menu', 'FrmInboxController::menu', 50 );
 

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -672,7 +672,7 @@ class test_FrmEmail extends FrmUnitTest {
 		$action->post_content['email_message'] = 'Value <br/>with HTML';
 
 		$settings = array(
-			0 => 'Value <br/>with HTML',
+			0 => '<p>Value <br/>with HTML</p>',
 			1 => 'Value with HTML',
 		);
 

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -696,9 +696,7 @@ class test_FrmEmail extends FrmUnitTest {
 			$email                                 = new FrmEmail( $action, $this->entry, $this->contact_form );
 			$actual                                = $this->get_private_property( $email, $property );
 
-			if ( $setting_name === 'email_message' ) {
-				$expected = apply_filters( 'frm_email_message', $expected, array( 'plain_text' => 0 ) );
-			}
+			$expected = apply_filters( 'frm_email_message', $expected, array( 'plain_text' => 0 ) );
 
 			$this->assertEquals( $expected, $actual );
 		}

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -695,6 +695,11 @@ class test_FrmEmail extends FrmUnitTest {
 			$action->post_content[ $setting_name ] = $setting;
 			$email                                 = new FrmEmail( $action, $this->entry, $this->contact_form );
 			$actual                                = $this->get_private_property( $email, $property );
+
+			if ( $setting_name === 'email_message' ) {
+				$expected = apply_filters( 'frm_email_message', $expected, array( 'plain_text' => 0 ) );
+			}
+
 			$this->assertEquals( $expected, $actual );
 		}
 	}

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -695,8 +695,9 @@ class test_FrmEmail extends FrmUnitTest {
 			$action->post_content[ $setting_name ] = $setting;
 			$email                                 = new FrmEmail( $action, $this->entry, $this->contact_form );
 			$actual                                = $this->get_private_property( $email, $property );
-
-			$expected = apply_filters( 'frm_email_message', $expected, array( 'plain_text' => 0 ) );
+			if ( $property === 'message' ) {
+				$expected = apply_filters( 'frm_email_message', $expected, array( 'plain_text' => 0 ) );
+			}
 
 			$this->assertEquals( $expected, $actual );
 		}


### PR DESCRIPTION
This update just uses `wpautop` to replace double line breaks with paragraphs for HTML emails.