### PR TITLE
Issue 3841

### DIFF
--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -95,7 +95,7 @@ class FrmFormActionsController {
 	/**
 	 * Updates email message
 	 *
-	 * @param $message
+	 * @param string $message
 	 *
 	 * @return string
 	 */

--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -93,6 +93,18 @@ class FrmFormActionsController {
 	}
 
 	/**
+	 * Updates email message
+	 *
+	 * @param $message
+	 *
+	 * @return string
+	 */
+	public static function update_email_message( $message ) {
+		$message = html_entity_decode( $message );
+		return $message;
+	}
+
+	/**
 	 * Add unknown actions to a group.
 	 *
 	 * @since 4.0

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -169,6 +169,9 @@ class FrmHooksController {
 		add_action( 'admin_enqueue_scripts', 'FrmApplicationsController::dequeue_scripts', 15 );
 		add_action( 'wp_ajax_frm_get_applications_data', 'FrmApplicationsController::get_applications_data' );
 
+		// Emails
+		add_filter( 'frm_email_message', 'FrmFormActionsController::update_email_message' );
+
 		FrmSMTPController::load_hooks();
 		FrmWelcomeController::load_hooks();
 		new FrmPluginSearch();

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7033,7 +7033,7 @@ function frmAdminBuildJS() {
 				elementId: elementId,
 				success: function( msg ) {
 					if ( rich ) {
-						tinymce.activeEditor.setContent(msg, {format: 'raw'});
+						send_to_editor( msg );
 					} else {
 						insertContent( contentBox, msg );
 					}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7043,7 +7043,11 @@ function frmAdminBuildJS() {
 			});
 		} else {
 			variable = maybeAddSanitizeUrlToShortcodeVariable( variable, element, contentBox );
-			insertContent( contentBox, variable );
+			if ( rich ) {
+				send_to_editor( variable );
+			} else {
+				insertContent( contentBox, variable );
+			}
 		}
 		return false;
 	}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7033,7 +7033,9 @@ function frmAdminBuildJS() {
 				elementId: elementId,
 				success: function( msg ) {
 					if ( rich ) {
-						send_to_editor( msg );
+						let p = document.createElement( 'p' );
+						p.innerText = msg;
+						send_to_editor( p.outerHTML );
 					} else {
 						insertContent( contentBox, msg );
 					}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7035,7 +7035,7 @@ function frmAdminBuildJS() {
 					if ( rich ) {
 						let p = document.createElement( 'p' );
 						p.innerText = msg;
-						send_to_editor( p.outerHTML );
+						send_to_editor( p.innerHTML );
 					} else {
 						insertContent( contentBox, msg );
 					}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7011,8 +7011,6 @@ function frmAdminBuildJS() {
 
 		if ( rich ) {
 			wpActiveEditor = elementId;
-			send_to_editor( variable );
-			return;
 		}
 
 		if ( ! contentBox.length ) {
@@ -7032,8 +7030,13 @@ function frmAdminBuildJS() {
 					plain_text: p,
 					nonce: frmGlobal.nonce
 				},
+				elementId: elementId,
 				success: function( msg ) {
-					insertContent( contentBox, msg );
+					if ( rich ) {
+						tinymce.activeEditor.setContent(msg, {format: 'raw'});
+					} else {
+						insertContent( contentBox, msg );
+					}
 				}
 			});
 		} else {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3841 and Fixes https://github.com/Strategy11/formidable-pro/issues/3850

Its a bit tricky to find an ideal solution for this because sending an html to tinymce editor parses it and create DOM element (table in default-html case) and the browser auto fix changes the html which in unintended side effect. This update avoids that though and is backward compatible.