### PR TITLE
New filter "frm_rich_text_emails"

### DIFF
--- a/classes/views/frm-form-actions/_email_settings.php
+++ b/classes/views/frm-form-actions/_email_settings.php
@@ -77,16 +77,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php esc_html_e( 'Message', 'formidable' ); ?>
 	</label>
 	<?php
-	$editor_args = array(
-		'textarea_name' => $this->get_field_name( 'email_message' ),
-		'textarea_rows' => 6,
-		'editor_class'  => 'frm_not_email_message',
-	);
-	wp_editor(
-		$form_action->post_content['email_message'],
-		$this->get_field_id( 'email_message' ),
-		$editor_args
-	);
+	/**
+	 * @since 5.5.2
+	 *
+	 * @param bool  $rich_text_emails
+	 * @param array $args {
+	 *     @type stdClass $form
+	 *     @type WP_Post  $form_action
+	 * }
+	 */
+	$rich_text_emails = apply_filters( 'frm_rich_text_emails', true, compact( 'form', 'form_action' ) );
+
+	if ( $rich_text_emails ) {
+		$editor_args = array(
+			'textarea_name' => $this->get_field_name( 'email_message' ),
+			'textarea_rows' => 6,
+			'editor_class'  => 'frm_not_email_message',
+		);
+		wp_editor(
+			$form_action->post_content['email_message'],
+			$this->get_field_id( 'email_message' ),
+			$editor_args
+		);
+	} else {
+		?>
+		<textarea name="<?php echo esc_attr( $this->get_field_name( 'email_message' ) ); ?>" class="frm_not_email_message frm_long_input" id="<?php echo esc_attr( $this->get_field_id( 'email_message' ) ); ?>" cols="50" rows="5"><?php echo FrmAppHelper::esc_textarea( $form_action->post_content['email_message'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></textarea>
+		<?php
+	}
 	?>
 </p>
 

--- a/classes/views/frm-form-actions/_email_settings.php
+++ b/classes/views/frm-form-actions/_email_settings.php
@@ -77,16 +77,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php esc_html_e( 'Message', 'formidable' ); ?>
 	</label>
 	<?php
+	$rich_text_emails = empty( $form_action->post_content['plain_text'] );
+
 	/**
 	 * @since 5.5.2
 	 *
-	 * @param bool  $rich_text_emails
+	 * @param bool  $rich_text_emails True by default unless plain text is selected.
 	 * @param array $args {
 	 *     @type stdClass $form
 	 *     @type WP_Post  $form_action
 	 * }
 	 */
-	$rich_text_emails = apply_filters( 'frm_rich_text_emails', true, compact( 'form', 'form_action' ) );
+	$rich_text_emails = apply_filters( 'frm_rich_text_emails', $rich_text_emails, compact( 'form', 'form_action' ) );
 
 	if ( $rich_text_emails ) {
 		$editor_args = array(


### PR DESCRIPTION
Jonathan mentioned to me that he's seen a few tickets so far that has requested to option to turn off the new rich text emails.

It isn't completely clear why, but I know some people actually have 99+ email actions, and loading TinyMCE for all of those would probably be a bad idea, so I can understand some cases when it makes sense.

Example snippets:

```
add_filter( 'frm_rich_text_emails', '__return_false' );
add_filter( 'frm_rich_text_emails', 'disable_rich_text_email_for_specific_action', 10, 2 );
add_filter( 'frm_rich_text_emails', 'disable_rich_text_email_for_specific_form', 10, 2);

function disable_rich_text_email_for_specific_action( $rich_text_emails, $args ) {
	$target_action_id = 2381;
	if ( $target_action_id === $args['form_action']->ID ) {
		$rich_text_emails = false;
	}
	return $rich_text_emails;
}

function disable_rich_text_email_for_specific_form( $rich_text_emails, $args ) {
	$target_form_id = 338;
	if ( $target_form_id === (int) $args['form']->id ) {
		$rich_text_emails = false;
	}
	return $rich_text_emails;
}
```