### PR TITLE
Exclude license types from application categories

### DIFF
--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -1340,6 +1340,8 @@ BEFORE_HTML;
 
 	/**
 	 * @since 4.03.01
+	 *
+	 * @return array<string>
 	 */
 	public static function ignore_template_categories() {
 		return array( 'Business', 'Elite', 'Personal', 'Creator', 'Basic', 'free' );

--- a/classes/models/FrmApplicationTemplate.php
+++ b/classes/models/FrmApplicationTemplate.php
@@ -80,11 +80,27 @@ class FrmApplicationTemplate {
 	 */
 	private static function populate_category_information( $categories ) {
 		foreach ( $categories as $category ) {
-			if ( false !== strpos( $category, '+Views' ) || in_array( $category, self::$categories, true ) ) {
+			if ( self::category_matches_a_license_type( $category ) ) {
+				continue;
+			}
+			if ( in_array( $category, self::$categories, true ) ) {
 				continue;
 			}
 			self::$categories[] = $category;
 		}
+	}
+
+	/**
+	 * @since 5.5.2
+	 *
+	 * @param string $category
+	 * @return bool
+	 */
+	private static function category_matches_a_license_type( $category ) {
+		if ( false !== strpos( $category, '+Views' ) ) {
+			return true;
+		}
+		return in_array( $category, FrmFormsHelper::ignore_template_categories(), true );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3857

I'm just including a check against `FrmFormsHelper::ignore_template_categories` which is used for this with other templates already.

**Before**
<img width="367" alt="Screen Shot 2022-10-12 at 1 32 42 PM" src="https://user-images.githubusercontent.com/9134515/195399020-c621962b-fd82-4011-86db-0046eda6a9c3.png">

**After**
<img width="287" alt="Screen Shot 2022-10-12 at 1 32 47 PM" src="https://user-images.githubusercontent.com/9134515/195399013-b6982e15-6352-4906-a5c9-27713e6eaa6f.png">