### PR TITLE
No more hooks for issue 3850

### DIFF
--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -93,22 +93,6 @@ class FrmFormActionsController {
 	}
 
 	/**
-	 * Update email message.
-	 *
-	 * @since 5.5.2
-	 *
-	 * @param string $message
-	 * @return string
-	 */
-	public static function update_email_message( $message, $atts ) {
-		$message = html_entity_decode( $message );
-		if ( ! $atts['plain_text'] ) {
-			$message = wpautop( $message, false );
-		}
-		return $message;
-	}
-
-	/**
 	 * Add unknown actions to a group.
 	 *
 	 * @since 4.0

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -142,9 +142,6 @@ class FrmHooksController {
 		// Forms Model.
 		add_action( 'frm_after_duplicate_form', 'FrmForm::after_duplicate', 10, 2 );
 
-		// Email Model
-		add_filter( 'frm_email_message', 'FrmFormActionsController::update_email_message', 10, 2 );
-
 		// Inbox Controller.
 		add_action( 'admin_menu', 'FrmInboxController::menu', 50 );
 

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -390,6 +390,9 @@ class FrmEmail {
 
 		if ( $this->is_plain_text ) {
 			$this->message = wp_specialchars_decode( strip_tags( $this->message ), ENT_QUOTES );
+		} else {
+			$message = html_entity_decode( $message ); // The decode is to support [default-html] shortcodes.
+			$message = wpautop( $message, false ); // HTML emails should use autop.
 		}
 
 		$this->message = apply_filters( 'frm_email_message', $this->message, $this->package_atts() );

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -361,7 +361,11 @@ class FrmEmail {
 	 * @since 2.03.04
 	 */
 	private function set_message() {
-		$this->message = FrmFieldsHelper::basic_replace_shortcodes( $this->settings['email_message'], $this->form, $this->entry );
+		if ( ! $this->is_plain_text ) {
+			$this->message = html_entity_decode( $this->settings['email_message'] ); // The decode is to support [default-html] shortcodes.
+		}
+
+		$this->message = FrmFieldsHelper::basic_replace_shortcodes( $this->message, $this->form, $this->entry );
 
 		$prev_mail_body = $this->message;
 		$pass_entry     = clone $this->entry; // make a copy to prevent changes by reference
@@ -391,7 +395,6 @@ class FrmEmail {
 		if ( $this->is_plain_text ) {
 			$this->message = wp_specialchars_decode( strip_tags( $this->message ), ENT_QUOTES );
 		} else {
-			$this->message = html_entity_decode( $this->message ); // The decode is to support [default-html] shortcodes.
 			$this->message = wpautop( $this->message, false ); // HTML emails should use autop.
 		}
 

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -361,8 +361,10 @@ class FrmEmail {
 	 * @since 2.03.04
 	 */
 	private function set_message() {
+		$this->message = $this->settings['email_message'];
+
 		if ( ! $this->is_plain_text ) {
-			$this->message = html_entity_decode( $this->settings['email_message'] ); // The decode is to support [default-html] shortcodes.
+			$this->message = html_entity_decode( $this->message ); // The decode is to support [default-html] shortcodes.
 		}
 
 		$this->message = FrmFieldsHelper::basic_replace_shortcodes( $this->message, $this->form, $this->entry );

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -391,8 +391,8 @@ class FrmEmail {
 		if ( $this->is_plain_text ) {
 			$this->message = wp_specialchars_decode( strip_tags( $this->message ), ENT_QUOTES );
 		} else {
-			$message = html_entity_decode( $message ); // The decode is to support [default-html] shortcodes.
-			$message = wpautop( $message, false ); // HTML emails should use autop.
+			$this->message = html_entity_decode( $this->message ); // The decode is to support [default-html] shortcodes.
+			$this->message = wpautop( $this->message, false ); // HTML emails should use autop.
 		}
 
 		$this->message = apply_filters( 'frm_email_message', $this->message, $this->package_atts() );

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -626,6 +626,11 @@ class test_FrmEmail extends FrmUnitTest {
 			'Original message'   => 'Original message',
 			'[' . $name_id . ']' => $this->entry->metas[ $name_id ],
 		);
+
+		foreach ( $settings as $key => $expected ) {
+			$settings[ $key ] = wpautop( $expected, false );
+		}
+
 		$this->check_private_properties( $settings, 'email_message', 'message' );
 	}
 
@@ -695,10 +700,6 @@ class test_FrmEmail extends FrmUnitTest {
 			$action->post_content[ $setting_name ] = $setting;
 			$email                                 = new FrmEmail( $action, $this->entry, $this->contact_form );
 			$actual                                = $this->get_private_property( $email, $property );
-			if ( $property === 'message' ) {
-				$expected = apply_filters( 'frm_email_message', $expected, array( 'plain_text' => 0 ) );
-			}
-
 			$this->assertEquals( $expected, $actual );
 		}
 	}


### PR DESCRIPTION
After merging https://github.com/Strategy11/formidable-forms/pull/927 and https://github.com/Strategy11/formidable-forms/pull/928 I have another thought.

The filter is already in lite so it makes sense to just make it part of `set_message`. We don't want to always use a hook, just when we need to.

@AbdiTolesa Do you see any issues with my update? I figured `html_entity_decode` only needs to be called for non-plain text so I moved it into the one condition.

I also moved it higher, to the top. I don't think we want to call `html_entity_decode` on any form data. That could be problematic. Ideally we could avoid this.

That should be fine right?
And do you have any ideas how it could work without the encoded data? I tried it out myself and I see why it's complicated. So if this is the best we can do, I think this is fine.

Thanks!