### PR TITLE
Ignore pointer events on tooltips

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7432,6 +7432,7 @@ iframe#dyncontent_ifr {
 
 	/* Custom rules */
 	z-index: 9999999;
+	pointer-events: none;
 }
 
 .tooltip.show {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3870

The tooltip is flickering when the pointer is hovering on the tooltip. This is happening because the item triggering the tooltip is covered by the tooltip in some cases because there isn't enough space for it to fit normally, cancelling the hover event on the target element.

<img width="336" alt="Screen Shot 2022-10-14 at 9 25 09 AM" src="https://user-images.githubusercontent.com/9134515/195846358-326e646a-cdff-4a8c-825e-46c9172247d5.png">
