### PR TITLE
Add LIBXML_COMPACT | LIBXML_PARSEHUGE options to loadXML function call

### DIFF
--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -36,8 +36,10 @@ class FrmXMLHelper {
 			return new WP_Error( 'SimpleXML_parse_error', __( 'Your server does not have XML enabled', 'formidable' ), libxml_get_errors() );
 		}
 
-		$dom     = new DOMDocument();
-		$success = $dom->loadXML( file_get_contents( $file ) );
+		$dom = new DOMDocument();
+		// LIBXML_COMPACT activates small nodes allocation optimization.
+		// Use LIBXML_PARSEHUGE to avoid "parser error : internal error: Huge input lookup" for large (300MB) files.
+		$success = $dom->loadXML( file_get_contents( $file ), LIBXML_COMPACT | LIBXML_PARSEHUGE );
 		if ( ! $success ) {
 			return new WP_Error( 'SimpleXML_parse_error', __( 'There was an error when reading this XML file', 'formidable' ), libxml_get_errors() );
 		}


### PR DESCRIPTION
I tried to import a very large XML file to test an issue on a customer's website. Around 250MB.

That didn't work out very well at first. I hit this `parser error : internal error: Huge input lookup` error.

**Before**
<img width="1134" alt="Screen Shot 2022-10-14 at 11 10 52 AM" src="https://user-images.githubusercontent.com/9134515/195868432-9330ca15-b910-4dd6-a3ee-cbd9851b84cc.png">

**After**
<img width="1136" alt="Screen Shot 2022-10-14 at 11 10 16 AM" src="https://user-images.githubusercontent.com/9134515/195868925-d80a7b49-8ef3-4f16-a042-4628dbb51ef1.png">

`loadXML` has a second parameter `$options`. It accepts constants from https://www.php.net/manual/en/libxml.constants.php

I've added two for now. It should optimize it, and allow for huge files now.

>  LIBXML_COMPACT (int)
>     Activate small nodes allocation optimization. This may speed up your application without needing to change the code. 

> LIBXML_PARSEHUGE (int)
>     Sets XML_PARSE_HUGE flag, which relaxes any hardcoded limit from the parser. This affects limits like maximum depth of a document or the entity recursion, as well as limits of the size of text nodes. 