### PR TITLE
Drag and drop enhancements

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3390,10 +3390,6 @@ li.ui-state-default.selected > .frm_inner_field_container > label {
 	max-width: calc(100% - 100px);
 }
 
-.frm-dragging * {
-	cursor: grabbing !important;
-}
-
 .frm-drag-fade {
 	background-color: var(--lightest-grey) !important;
 	border-radius: 4px;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1775,6 +1775,12 @@ function frmAdminBuildJS() {
 			return allowMoveFieldToSection( draggable );
 		}
 
+		const isHiddenField = draggable.classList.contains( 'edit_field_type_hidden' );
+		if ( isHiddenField ) {
+			// Hidden fields should not be added to field groups since they're not shown and don't make sense with the grid distribution.
+			return false;
+		}
+
 		return allowMoveFieldToGroup( draggable, droppable );
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1717,6 +1717,7 @@ function frmAdminBuildJS() {
 	}
 
 	// Don't allow a new page break or hidden field in a field group.
+	// Don't allow a new field into a field group that includes a page break or hidden field.
 	// Don't allow a new section inside of a section.
 	// Don't allow an embedded form in a section.
 	function allowNewFieldDrop( draggable, droppable ) {
@@ -1725,6 +1726,16 @@ function frmAdminBuildJS() {
 		const newHiddenField    = classes.contains( 'frm_thidden' );
 		const newSectionField   = classes.contains( 'frm_tdivider' );
 		const newEmbedField     = classes.contains( 'frm_tform' );
+
+		const newFieldWillBeAddedToAGroup = ! ( 'frm-show-fields' === droppable.id || droppable.classList.contains( 'start_divider' ) );
+		if ( newFieldWillBeAddedToAGroup ) {
+			if ( groupIncludesBreakOrHidden( droppable ) ) {
+				// Never allow any field beside a page break or a hidden field.
+				return false;
+			}
+
+			return ! newHiddenField && ! newPageBreakField;
+		}
 
 		const fieldTypeIsAlwaysAllowed = ! newPageBreakField && ! newHiddenField && ! newSectionField && ! newEmbedField;
 		if ( fieldTypeIsAlwaysAllowed ) {
@@ -1735,11 +1746,6 @@ function frmAdminBuildJS() {
 		if ( newFieldWillBeAddedToASection ) {
 			// Don't allow a section or an embedded form in a section.
 			return ! newEmbedField && ! newSectionField;
-		}
-
-		const newFieldWillBeAddedToAGroup = ! ( 'frm-show-fields' === droppable.id || droppable.classList.contains( 'start_divider' ) );
-		if ( newFieldWillBeAddedToAGroup ) {
-			return ! newHiddenField && ! newPageBreakField;
 		}
 
 		return true;
@@ -1792,8 +1798,7 @@ function frmAdminBuildJS() {
 	}
 
 	function allowMoveFieldToGroup( draggable, group ) {
-		const groupIncludesBreakOrHidden = null !== group.querySelector( '.edit_field_type_break, .edit_field_type_hidden' );
-		if ( groupIncludesBreakOrHidden ) {
+		if ( groupIncludesBreakOrHidden( group ) ) {
 			// Never allow any field beside a page break or a hidden field.
 			return false;
 		}
@@ -1813,6 +1818,10 @@ function frmAdminBuildJS() {
 		}
 
 		return true;
+	}
+
+	function groupIncludesBreakOrHidden( group ) {
+		return null !== group.querySelector( '.edit_field_type_break, .edit_field_type_hidden' );
 	}
 
 	function groupCanFitAnotherField( fieldsInRow, $field ) {


### PR DESCRIPTION
- It was possible to drag a new field into a field group with a page break or a hidden field. I'm preventing this the other way (no adding a new page break or a hidden field to a group), but missed this check on the other end.
- Steve commented about issues with dragging. It looks like cursorAt doesn't really sync with scroll events. I've fixed this with a `transform: translateY( offset )` style that calculates based on the container's scroll position.
- I swapped the cursor setting to the JavaScript and removed it from CSS. I didn't realize `cursor` was a draggable setting until reading more into the documentation today.

**Before**
![dHfHigkxYa](https://user-images.githubusercontent.com/9134515/195887125-2395d6a1-b533-4cb9-b6d8-525d0ceb8502.gif)

**After**
![JcwZad88G0](https://user-images.githubusercontent.com/9134515/195886961-0a069686-eb5d-490a-8b82-9e10aa07b53f.gif)
