### PR TITLE
Fix text input advanced option button style

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7776,6 +7776,7 @@ function frmAdminBuildJS() {
 		event.target.closest( '.frm_form_action_settings' ).querySelectorAll( '.frmsvg.frm-show-box' ).forEach( ( svg ) => {
 			if ( svg.nextElementSibling.type === 'text' ) {
 				svg.style.bottom = '-3px';
+				svg.style.marginRight = '0';
 			}
 		});
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7773,7 +7773,7 @@ function frmAdminBuildJS() {
 	}
 
 	function onActionLoaded( event ) {
-		event.target.querySelectorAll( '.frmsvg.frm-show-box' ).forEach( ( svg ) => {
+		event.target.closest( '.frm_form_action_settings' ).querySelectorAll( '.frmsvg.frm-show-box' ).forEach( ( svg ) => {
 			if ( svg.nextElementSibling.type === 'text' ) {
 				svg.style.bottom = '-3px';
 			}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7773,6 +7773,12 @@ function frmAdminBuildJS() {
 	}
 
 	function onActionLoaded( event ) {
+		event.target.querySelectorAll( '.frmsvg.frm-show-box' ).forEach( ( svg ) => {
+			if ( svg.nextElementSibling.type === 'text' ) {
+				svg.style.bottom = '-3px';
+			}
+		});
+
 		const settings = event.target.closest( '.frm_form_action_settings' );
 		if ( settings && settings.classList.contains( 'frm_single_email_settings' ) ) {
 			onEmailActionLoaded( settings );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3860
It looks like text inputs with advanced option are injected into the DOM when form actions are loaded but textarea fields are already loaded in different places on page loads. It might make sense to leave the css style for textarea SVGs as is but fix these for text fields when form actions are loaded.