### PR TITLE
Make honeypot field untabbable after first tab press

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1098,7 +1098,7 @@ function frmFrontFormJS() {
 	}
 
 	function maybeMakeHoneypotFieldsUntabbable() {
-		document.addEventListener( 'keyup', handleKeyUp );
+		document.addEventListener( 'keydown', handleKeyUp );
 
 		function handleKeyUp( event ) {
 			var code;
@@ -1111,7 +1111,7 @@ function frmFrontFormJS() {
 
 			if ( 'Tab' === code ) {
 				makeHoneypotFieldsUntabbable();
-				document.removeEventListener( 'keyup', handleKeyUp );
+				document.removeEventListener( 'keydown', handleKeyUp );
 			}
 		}
 

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1108,7 +1108,7 @@ function frmFrontFormJS() {
 			} else if ( 'undefined' !== typeof event.keyCode && 9 === event.keyCode ) {
 				code = 'Tab';
 			}
-	
+
 			if ( 'Tab' === code ) {
 				makeHoneypotFieldsUntabbable();
 				document.removeEventListener( 'keyup', handleKeyUp );

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1097,6 +1097,36 @@ function frmFrontFormJS() {
 		}
 	}
 
+	function maybeMakeHoneypotFieldsUntabbable() {
+		document.addEventListener( 'keyup', handleKeyUp );
+
+		function handleKeyUp( event ) {
+			var code;
+
+			if ( 'undefined' !== typeof event.key ) {
+				code = event.key;
+			} else if ( 'undefined' !== typeof event.keyCode && 9 === event.keyCode ) {
+				code = 'Tab';
+			}
+	
+			if ( 'Tab' === code ) {
+				makeHoneypotFieldsUntabbable();
+				document.removeEventListener( 'keyup', handleKeyUp );
+			}
+		}
+
+		function makeHoneypotFieldsUntabbable() {
+			document.querySelectorAll( '.frm_verify' ).forEach(
+				function( wrapper ) {
+					var input = wrapper.querySelector( 'input[id^=frm_email]' );
+					if ( input ) {
+						input.setAttribute( 'tabindex', -1 );
+					}
+				}
+			);
+		}
+	}
+
 	/**
 	 * Focus on the first sub field when clicking to the primary label of combo field.
 	 *
@@ -1341,6 +1371,7 @@ function frmFrontFormJS() {
 			jQuery( document ).on( 'change', '.frm-show-form input[name^="item_meta"], .frm-show-form select[name^="item_meta"], .frm-show-form textarea[name^="item_meta"]', frmFrontForm.fieldValueChanged );
 
 			jQuery( document ).on( 'change', '[id^=frm_email_]', onHoneypotFieldChange );
+			maybeMakeHoneypotFieldsUntabbable();
 
 			jQuery( document ).on( 'click', 'a[data-frmconfirm]', confirmClick );
 			jQuery( 'a[data-frmtoggle]' ).on( 'click', toggleDiv );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3856

I looked at the original suggestion, and the suggestion of adding a `-1` tabindex to the input is the best solution I can think of to handle this issue.

I figure a bot might be more likely to check for something like `tabindex="-1"` so I put it in an additional event listener first so it only happens if it detects a tab press.