### PR TITLE
Only append to array, only iterate an array during csv export

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1449,7 +1449,7 @@ class FrmAppHelper {
 
 		// Do not treat the view listing as full screen when no form id is being filtered.
 		global $pagenow;
-		return 'edit.php' !== $pagenow || FrmAppHelper::simple_get( 'form' );
+		return 'edit.php' !== $pagenow || self::simple_get( 'form' );
 	}
 
 	/**

--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -477,7 +477,12 @@ class FrmCSVExportHelper {
 
 		foreach ( self::$fields_by_repeater_id[ $repeater_id ] as $repeater_child ) {
 			if ( ! isset( $metas[ $repeater_child->id ] ) ) {
-				$metas[ $repeater_child->id ]                                            = '';
+				$metas[ $repeater_child->id ] = '';
+
+				if ( ! isset( $entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ] ) || ! is_array( $entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ] ) ) {
+					$entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ] = array();
+				}
+
 				$entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ][] = '';
 			}
 		}

--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -479,11 +479,9 @@ class FrmCSVExportHelper {
 			if ( ! isset( $metas[ $repeater_child->id ] ) ) {
 				$metas[ $repeater_child->id ] = '';
 
-				if ( ! isset( $entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ] ) || ! is_array( $entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ] ) ) {
-					$entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ] = array();
+				if ( isset( $entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ] ) && is_array( $entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ] ) ) {
+					$entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ][] = '';
 				}
-
-				$entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ][] = '';
 			}
 		}
 
@@ -522,8 +520,11 @@ class FrmCSVExportHelper {
 				$label_key = $col->id . '_label';
 				if ( self::is_the_child_of_a_repeater( $col ) ) {
 					$row[ $label_key ] = array();
-					foreach ( $field_value as $value ) {
-						$row[ $label_key ][] = self::get_separate_value_label( $value, $col );
+
+					if ( is_array( $field_value ) ) {
+						foreach ( $field_value as $value ) {
+							$row[ $label_key ][] = self::get_separate_value_label( $value, $col );
+						}
 					}
 				} else {
 					$row[ $label_key ] = self::get_separate_value_label( $field_value, $col );

--- a/psalm.xml
+++ b/psalm.xml
@@ -69,5 +69,10 @@
 				<referencedFunction name="akismet_test_mode" />
 			</errorLevel>
 		</UndefinedFunction>
+		<MissingFile>
+			<errorLevel type="suppress">
+				<file name="formidable.php" />
+			</errorLevel>
+		</MissingFile>
 	</issueHandlers>
 </psalm>


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2022152412/111312

The XML file is included in one of Kristine's notes there. I'm not including it here because this is public.

This update works to remove a fatal error and a warning that I get when exporting this customer's entries as CSV.

I spent some time trying to debug the data coming through. As far as I can tell the CSV exports fine with these changes.

I ended up just adding type checks so the code won't break. I haven't really figured out the root of this issue. But I don't know if it's worth the effort either.

> PHP Fatal error:  Uncaught Error: [] operator not supported for strings in .../plugins/formidable/classes/helpers/FrmCSVExportHelper.php:481

> [18-Oct-2022 19:26:44 UTC] PHP Warning:  foreach() argument must be of type array|object, bool given in ...plugins/formidable/classes/helpers/FrmCSVExportHelper.php on line 525