### PR TITLE
Do not hide update button on styles2 page

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8518,7 +8518,8 @@ Responsive Design
 	}
 }
 
-.frm-admin-page-styles #frm-publishing #save_menu_header {
+.frm-admin-page-styles #frm-publishing #save_menu_header,
+.frm-admin-page-styles2 #frm-publishing #save_menu_header {
 	display: inline-block;
 }
 


### PR DESCRIPTION
Looking at our full screen code I noticed "styles2" being referenced in a few places. I eventually figured out that's there's a "Forms" link from the Appearance menu item that uses this.

I noticed that there's still an old WP 5.7+ bug here on this page because the CSS was only targeting the one page. https://github.com/Strategy11/formidable-forms/pull/361

It seems like no one may really use this page if this hasn't come up in support after all this time. Do we actually think people are visiting this page? Do we track that? It may make sense to remove the secondary URL.