### PR TITLE
Stop treating views index with no filtered form ID as full screen

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -499,7 +499,7 @@ class FrmAppController {
 			'formidable_embed',
 		);
 
-		if ( FrmAppHelper::is_on_style_editor() ) {
+		if ( FrmAppHelper::is_style_editor_page() ) {
 			$dependencies[] = 'wp-color-picker';
 		}
 

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -499,7 +499,7 @@ class FrmAppController {
 			'formidable_embed',
 		);
 
-		if ( FrmAppHelper::is_admin_page( 'formidable-styles' ) || FrmAppHelper::is_admin_page( 'formidable-styles2' ) ) {
+		if ( FrmAppHelper::is_on_style_editor() ) {
 			$dependencies[] = 'wp-color-picker';
 		}
 

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -51,8 +51,11 @@ class FrmStylesController {
 		add_submenu_page( 'themes.php', 'Formidable | ' . __( 'Styles', 'formidable' ), __( 'Forms', 'formidable' ), 'frm_change_settings', 'formidable-styles2', 'FrmStylesController::route' );
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function admin_init() {
-		if ( ! FrmAppHelper::is_admin_page( 'formidable-styles' ) && ! FrmAppHelper::is_admin_page( 'formidable-styles2' ) ) {
+		if ( ! FrmAppHelper::is_on_style_editor() ) {
 			return;
 		}
 

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -55,7 +55,7 @@ class FrmStylesController {
 	 * @return void
 	 */
 	public static function admin_init() {
-		if ( ! FrmAppHelper::is_on_style_editor() ) {
+		if ( ! FrmAppHelper::is_style_editor_page() ) {
 			return;
 		}
 

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1419,7 +1419,7 @@ class FrmAppHelper {
 	 */
 	public static function is_full_screen() {
 		return self::is_form_builder_page() ||
-			self::is_on_style_editor() ||
+			self::is_style_editor_page() ||
 			self::simple_get( 'frm-full', 'absint' ) ||
 			self::is_full_screen_view_builder_page();
 	}
@@ -1433,7 +1433,7 @@ class FrmAppHelper {
 	 *
 	 * @return bool
 	 */
-	public static function is_on_style_editor() {
+	public static function is_style_editor_page() {
 		return self::is_admin_page( 'formidable-styles' ) || self::is_admin_page( 'formidable-styles2' );
 	}
 

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1419,10 +1419,37 @@ class FrmAppHelper {
 	 */
 	public static function is_full_screen() {
 		return self::is_form_builder_page() ||
-			self::is_admin_page( 'formidable-styles' ) ||
-			self::is_admin_page( 'formidable-styles2' ) ||
+			self::is_on_style_editor() ||
 			self::simple_get( 'frm-full', 'absint' ) ||
-			self::is_view_builder_page();
+			self::is_full_screen_view_builder_page();
+	}
+
+	/**
+	 * Check if user is on the style editor, or the alternative URL.
+	 * The first URL is a submenu "Styles" in the Formidable menu /wp-admin/admin.php?page=formidable-styles.
+	 * The alternative URL is linked as a submenu "Forms" item of the Appearance menu /wp-admin/themes.php?page=formidable-styles2.
+	 *
+	 * @since 5.5.3
+	 *
+	 * @return bool
+	 */
+	public static function is_on_style_editor() {
+		return self::is_admin_page( 'formidable-styles' ) || self::is_admin_page( 'formidable-styles2' );
+	}
+
+	/**
+	 * @since 5.5.3
+	 *
+	 * @return bool
+	 */
+	private static function is_full_screen_view_builder_page() {
+		if ( ! self::is_view_builder_page() ) {
+			return false;
+		}
+
+		// Do not treat the view listing as full screen when no form id is being filtered.
+		global $pagenow;
+		return 'edit.php' !== $pagenow || FrmAppHelper::simple_get( 'form' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-views/issues/347

I refactored it a bit as well. Having this check for `self::is_admin_page( 'formidable-styles' ) || self::is_admin_page( 'formidable-styles2' )` everywhere felt problematic so I moved that into a new function that describes that's really going on because I wasn't even aware of this secondary URL in the theme menu. And most others must not be either if the update button was missing all of this time (see https://github.com/Strategy11/formidable-forms/pull/947 😅).