### PR TITLE
turn on $br param for wpautop function

### DIFF
--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -397,7 +397,7 @@ class FrmEmail {
 		if ( $this->is_plain_text ) {
 			$this->message = wp_specialchars_decode( strip_tags( $this->message ), ENT_QUOTES );
 		} else {
-			$this->message = wpautop( $this->message, false ); // HTML emails should use autop.
+			$this->message = wpautop( $this->message ); // HTML emails should use autop.
 		}
 
 		$this->message = apply_filters( 'frm_email_message', $this->message, $this->package_atts() );

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -677,7 +677,7 @@ class test_FrmEmail extends FrmUnitTest {
 		$action->post_content['email_message'] = 'Value <br/>with HTML';
 
 		$settings = array(
-			0 => "<p>Value <br/>with HTML</p>\n", // This is testing HTML, not plain text because it's indexed by 0 which is used for the plain_text setting.
+			0 => "<p>Value <br />with HTML</p>\n", // This is testing HTML, not plain text because it's indexed by 0 which is used for the plain_text setting.
 			1 => 'Value with HTML',
 		);
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3847
This PR fixes the issue of line breaks not being ouput in html emails because the email body is passed through `wpautop` function but the second parameter was set to false.