### PR TITLE
Hide screen options on entry duplicate action

### DIFF
--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -24,7 +24,7 @@ class FrmEntriesController {
 	 * @since 2.05.07
 	 */
 	private static function load_manage_entries_hooks() {
-		if ( ! in_array( FrmAppHelper::simple_get( 'frm_action', 'sanitize_title' ), array( 'edit', 'show', 'new' ) ) ) {
+		if ( ! in_array( FrmAppHelper::simple_get( 'frm_action', 'sanitize_title' ), array( 'edit', 'show', 'new', 'duplicate' ), true ) ) {
 			$menu_name = FrmAppHelper::get_menu_name();
 			$base      = self::base_column_key( $menu_name );
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3880

But I also logged a new issue https://github.com/Strategy11/formidable-pro/issues/3886. I don't think this page should exist at this URL endpoint in the first place as it's problematic and causes issues like this one.

That's a larger fix though so I figure I'd still commit this fix first for now.