### PR TITLE
Fix shortcode typo in strpos check when importing views and pages

### DIFF
--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -848,7 +848,7 @@ class FrmXMLHelper {
 				continue;
 			}
 
-			if ( false !== strpos( $post['post_content'], '[frm-display-data' ) || false !== strpos( $post['post_content'], '[formidable' ) ) {
+			if ( false !== strpos( $post['post_content'], '[display-frm-data' ) || false !== strpos( $post['post_content'], '[formidable' ) ) {
 				$posts_with_shortcodes[ $post_id ] = $post;
 			}
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3866

I looked at a few other things before I realized this was just a shortcode mistake. I always mix this shortcode order up because it doesn't start with frm like everything else 😅.