### PR TITLE
Trigger event instead of continuing

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -586,7 +586,7 @@ function frmFrontFormJS() {
 		fieldset.addClass( 'frm_doing_ajax' );
 
 		data               = jQuery( object ).serialize() + '&action=frm_entries_' + action + '&nonce=' + frm_js.nonce;
-		shouldTriggerEvent = null !== object.querySelector( 'input[name="frm_trigger_event"]' );
+		shouldTriggerEvent = object.classList.contains( 'frm_trigger_event_on_submit' );
 
 		success = function( response ) {
 			var defaultResponse, formID, replaceContent, pageOrder, formReturned, contSubmit, delay,
@@ -611,7 +611,7 @@ function frmFrontFormJS() {
 
 			if ( typeof response.redirect !== 'undefined' ) {
 				if ( shouldTriggerEvent ) {
-					triggerCustomEvent( object, 'frmFormEvent' );
+					triggerCustomEvent( object, 'frmSubmitEvent' );
 					return;
 				}
 
@@ -621,7 +621,7 @@ function frmFrontFormJS() {
 				// the form or success message was returned
 
 				if ( shouldTriggerEvent ) {
-					triggerCustomEvent( object, 'frmFormEvent' );
+					triggerCustomEvent( object, 'frmSubmitEvent' );
 					return;
 				}
 

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -611,7 +611,7 @@ function frmFrontFormJS() {
 
 			if ( typeof response.redirect !== 'undefined' ) {
 				if ( shouldTriggerEvent ) {
-					triggerEvent( object, 'frmFormEvent' );
+					triggerCustomEvent( object, 'frmFormEvent' );
 					return;
 				}
 
@@ -621,7 +621,7 @@ function frmFrontFormJS() {
 				// the form or success message was returned
 
 				if ( shouldTriggerEvent ) {
-					triggerEvent( object, 'frmFormEvent' );
+					triggerCustomEvent( object, 'frmFormEvent' );
 					return;
 				}
 
@@ -739,21 +739,6 @@ function frmFrontFormJS() {
 		};
 
 		postToAjaxUrl( object, data, success, error );
-	}
-
-	function triggerEvent( element, eventType ) {
-		var event;
-	
-		if ( typeof window.CustomEvent === 'function' ) {
-			event = new CustomEvent( eventType );
-		} else if ( document.createEvent ) {
-			event = document.createEvent( 'HTMLEvents' );
-			event.initEvent( eventType, false, true );
-		} else {
-			return;
-		}
-	
-		element.dispatchEvent( event );
 	}
 
 	function postToAjaxUrl( form, data, success, error ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -576,8 +576,7 @@ function frmFrontFormJS() {
 			defaultResponse = {
 				content: '',
 				errors: {},
-				pass: false,
-				doNothing: false
+				pass: false
 			};
 
 			if ( response === null ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -601,14 +601,14 @@ function frmFrontFormJS() {
 			} else if ( response.content !== '' ) {
 				// the form or success message was returned
 
-				removeSubmitLoading( jQuery( object ) );
-				if ( frm_js.offset != -1 ) {
-					frmFrontForm.scrollMsg( jQuery( object ), false );
-				}
-
 				if ( shouldTriggerEvent ) {
 					triggerEvent( object, 'frmFormEvent' );
 					return;
+				}
+
+				removeSubmitLoading( jQuery( object ) );
+				if ( frm_js.offset != -1 ) {
+					frmFrontForm.scrollMsg( jQuery( object ), false );
 				}
 
 				formID = jQuery( object ).find( 'input[name="form_id"]' ).val();

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -557,7 +557,7 @@ function frmFrontFormJS() {
 	}
 
 	function getFormErrors( object, action ) {
-		var fieldset, data, success, error;
+		var fieldset, data, success, error, shouldTriggerEvent;
 
 		if ( typeof action === 'undefined' ) {
 			jQuery( object ).find( 'input[name="frm_action"]' ).val();
@@ -566,12 +566,20 @@ function frmFrontFormJS() {
 		fieldset = jQuery( object ).find( '.frm_form_field' );
 		fieldset.addClass( 'frm_doing_ajax' );
 
-		data = jQuery( object ).serialize() + '&action=frm_entries_' + action + '&nonce=' + frm_js.nonce;
+		data               = jQuery( object ).serialize() + '&action=frm_entries_' + action + '&nonce=' + frm_js.nonce;
+		shouldTriggerEvent = ! ! object.querySelector( 'input[name="frm_trigger_event"]' );
 
 		success = function( response ) {
-			var formID, replaceContent, pageOrder, formReturned, contSubmit, delay,
-				$fieldCont, key, inCollapsedSection, frmTrigger,
-				defaultResponse = { 'content': '', 'errors': {}, 'pass': false };
+			var defaultResponse, formID, replaceContent, pageOrder, formReturned, contSubmit, delay,
+				$fieldCont, key, inCollapsedSection, frmTrigger;
+
+			defaultResponse = {
+				content: '',
+				errors: {},
+				pass: false,
+				doNothing: false
+			};
+
 			if ( response === null ) {
 				response = defaultResponse;
 			}
@@ -584,6 +592,11 @@ function frmFrontFormJS() {
 			}
 
 			if ( typeof response.redirect !== 'undefined' ) {
+				if ( shouldTriggerEvent ) {
+					triggerEvent( object, 'frmFormEvent' );
+					return;
+				}
+
 				jQuery( document ).trigger( 'frmBeforeFormRedirect', [ object, response ]);
 				window.location = response.redirect;
 			} else if ( response.content !== '' ) {
@@ -593,6 +606,12 @@ function frmFrontFormJS() {
 				if ( frm_js.offset != -1 ) {
 					frmFrontForm.scrollMsg( jQuery( object ), false );
 				}
+
+				if ( shouldTriggerEvent ) {
+					triggerEvent( object, 'frmFormEvent' );
+					return;
+				}
+
 				formID = jQuery( object ).find( 'input[name="form_id"]' ).val();
 				response.content = response.content.replace( / frm_pro_form /g, ' frm_pro_form frm_no_hide ' );
 				replaceContent = jQuery( object ).closest( '.frm_forms' );
@@ -702,6 +721,21 @@ function frmFrontFormJS() {
 		};
 
 		postToAjaxUrl( object, data, success, error );
+	}
+
+	function triggerEvent( element, eventType ) {
+		var event;
+	
+		if ( typeof window.CustomEvent === 'function' ) {
+			event = new CustomEvent( eventType );
+		} else if ( document.createEvent ) {
+			event = document.createEvent( 'HTMLEvents' );
+			event.initEvent( eventType, false, true );
+		} else {
+			return;
+		}
+	
+		element.dispatchEvent( event );
 	}
 
 	function postToAjaxUrl( form, data, success, error ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -567,7 +567,7 @@ function frmFrontFormJS() {
 		fieldset.addClass( 'frm_doing_ajax' );
 
 		data               = jQuery( object ).serialize() + '&action=frm_entries_' + action + '&nonce=' + frm_js.nonce;
-		shouldTriggerEvent = ! ! object.querySelector( 'input[name="frm_trigger_event"]' );
+		shouldTriggerEvent = null !== object.querySelector( 'input[name="frm_trigger_event"]' );
 
 		success = function( response ) {
 			var defaultResponse, formID, replaceContent, pageOrder, formReturned, contSubmit, delay,


### PR DESCRIPTION
This is required for Stripe link to work. I need to hook into before the form clears so my Stripe elements don't get destroyed when the form submits.

This hooks in only on success so the error handling is still handled normally in lite. If an entry is created successfully and the `frm_trigger_event_on_submit` class name is set on the form, it will just call that and exit early.