### PR TITLE
Change how the placeholder ul is built when duplicating field groups …

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3521,15 +3521,13 @@ function frmAdminBuildJS() {
 		$newRow.on(
 			'frm_added_duplicated_field_to_row',
 			function( _, args ) {
-				let $duplicatedFields, index;
-
 				originalFieldIdByDuplicatedFieldId[ jQuery( args.duplicatedFieldHtml ).attr( 'data-fid' ) ] = args.originalFieldId;
 
 				if ( expectedLength > ++duplicatedCount ) {
 					return;
 				}
 
-				$duplicatedFields = getFieldsInRow( $newRowUl );
+				const $duplicatedFields = getFieldsInRow( $newRowUl );
 
 				injectedCloneOptions.forEach(
 					function( cloneOption ) {
@@ -3537,7 +3535,7 @@ function frmAdminBuildJS() {
 					}
 				);
 
-				for ( index = 0; index < expectedLength; ++index ) {
+				for ( let index = 0; index < expectedLength; ++index ) {
 					$newRowUl.append( $newRowUl.children( 'li.form-field[frm-field-order="' + index + '"]' ) );
 				}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3498,16 +3498,17 @@ function frmAdminBuildJS() {
 			return;
 		}
 
-		const newRowId = 'frm_field_group_' + getAutoId();
-		const newRowLi = document.createTextNode( '' );
-		wrapFieldLiInPlace( newRowLi );
+		const newRowId           = 'frm_field_group_' + getAutoId();
+		const placeholderUlChild = document.createTextNode( '' );
+		wrapFieldLiInPlace( placeholderUlChild );
 
-		const $newRow   = jQuery( newRowLi ).closest( 'li' );
-		const $newRowUl = $newRow.find( 'ul' );
+		const newRow = jQuery( placeholderUlChild ).closest( 'li' ).get( 0 );
+		newRow.classList.add( 'frm_hidden' );
 
-		$newRowUl.attr( 'id', newRowId );
-		$newRow.addClass( 'frm_hidden' );
-		jQuery( hoverTarget ).closest( 'li.frm_field_box' ).after( $newRow );
+		const newRowUl = newRow.querySelector( 'ul' );
+		newRowUl.id    = newRowId;
+
+		jQuery( hoverTarget.closest( 'li.frm_field_box' ) ).after( newRow );
 
 		const $fields              = getFieldsInRow( jQuery( hoverTarget ) );
 		const syncDetails          = [];
@@ -3518,7 +3519,7 @@ function frmAdminBuildJS() {
 
 		let duplicatedCount = 0;
 
-		$newRow.on(
+		jQuery( newRow ).on(
 			'frm_added_duplicated_field_to_row',
 			function( _, args ) {
 				originalFieldIdByDuplicatedFieldId[ jQuery( args.duplicatedFieldHtml ).attr( 'data-fid' ) ] = args.originalFieldId;
@@ -3527,6 +3528,7 @@ function frmAdminBuildJS() {
 					return;
 				}
 
+				const $newRowUl         = jQuery( newRowUl );
 				const $duplicatedFields = getFieldsInRow( $newRowUl );
 
 				injectedCloneOptions.forEach(
@@ -3540,7 +3542,7 @@ function frmAdminBuildJS() {
 				}
 
 				syncLayoutClasses( $duplicatedFields.first(), syncDetails );
-				$newRow.removeClass( 'frm_hidden' );
+				newRow.classList.remove( 'frm_hidden' );
 				updateFieldOrder();
 
 				getFieldsInRow( $newRowUl ).each(

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3493,33 +3493,35 @@ function frmAdminBuildJS() {
 	}
 
 	function duplicateFieldGroup() {
-		var hoverTarget, newRowId, $newRow, $fields, syncDetails, expectedLength, duplicatedCount, originalFieldIdByDuplicatedFieldId, injectedCloneOptions;
-
-		hoverTarget = document.querySelector( '.frm-field-group-hover-target' );
-
+		const hoverTarget = document.querySelector( '.frm-field-group-hover-target' );
 		if ( null === hoverTarget ) {
 			return;
 		}
 
-		newRowId = 'frm_field_group_' + getAutoId();
-		$newRow = wrapFieldLi( '' );
-		$newRowUl = $newRow.find( 'ul' );
+		const newRowId = 'frm_field_group_' + getAutoId();
+		const newRowLi = document.createTextNode( '' );
+		wrapFieldLiInPlace( newRowLi );
+
+		const $newRow   = jQuery( newRowLi ).closest( 'li' );
+		const $newRowUl = $newRow.find( 'ul' );
+
 		$newRowUl.attr( 'id', newRowId );
 		$newRow.addClass( 'frm_hidden' );
 		jQuery( hoverTarget ).closest( 'li.frm_field_box' ).after( $newRow );
 
-		$fields = getFieldsInRow( jQuery( hoverTarget ) );
-		syncDetails = [];
-		injectedCloneOptions = [];
+		const $fields              = getFieldsInRow( jQuery( hoverTarget ) );
+		const syncDetails          = [];
+		const injectedCloneOptions = [];
 
-		expectedLength = $fields.length;
-		duplicatedCount = 0;
-		originalFieldIdByDuplicatedFieldId = {};
+		const expectedLength                     = $fields.length;
+		const originalFieldIdByDuplicatedFieldId = {};
+
+		let duplicatedCount = 0;
 
 		$newRow.on(
 			'frm_added_duplicated_field_to_row',
-			function( event, args ) {
-				var $duplicatedFields, index;
+			function( _, args ) {
+				let $duplicatedFields, index;
 
 				originalFieldIdByDuplicatedFieldId[ jQuery( args.duplicatedFieldHtml ).attr( 'data-fid' ) ] = args.originalFieldId;
 


### PR DESCRIPTION
…as the old way no longer works

Fixes https://github.com/Strategy11/formidable-pro/issues/3894

With this update a duplicated field group should be in a new row.

<img width="679" alt="Screen Shot 2022-10-26 at 11 34 35 AM" src="https://user-images.githubusercontent.com/9134515/198055215-b4c5a2d8-4248-4b94-81d5-c955e4e0468b.png">

With out, since the last drag-drop enhancement update the field groups merge into one big field group instead.

<img width="683" alt="Screen Shot 2022-10-26 at 11 35 03 AM" src="https://user-images.githubusercontent.com/9134515/198055358-12514292-d52e-44fb-87a9-ccfb8cfc7f41.png">

This update also includes some refactoring. It removes some jQuery stuff, and uses more ES6 JavaScript than before.