### PR TITLE
Keep view editor as "full screen"

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1447,6 +1447,10 @@ class FrmAppHelper {
 			return false;
 		}
 
+		if ( self::is_admin_page( 'formidable-views-editor' ) ) {
+			return true;
+		}
+
 		// Do not treat the view listing as full screen when no form id is being filtered.
 		global $pagenow;
 		return 'edit.php' !== $pagenow || self::simple_get( 'form' );


### PR DESCRIPTION
I forgot this was on this page. This was removed with https://github.com/Strategy11/formidable-forms/pull/948. Putting it back.