### PR TITLE
Issue 3889

### DIFF
--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -398,12 +398,14 @@ class FrmEmail {
 			$this->message = wp_specialchars_decode( strip_tags( $this->message ), ENT_QUOTES );
 		} else {
 			$message = $this->message;
-			if ( strpos( $message, '<body>' ) !== false ) {
+			$result  = preg_match( '/<body[^>]*>([\s\S]*?)<\/body>/', $message, $match );
+
+			if ( ! empty( $match[1] ) ) {
 				$result        = preg_match( '/<body[^>]*>([\s\S]*?)<\/body>/', $message, $match );
 				$message       = preg_replace( '/(<body[^>]*>)([\s\S]+?)(<\/body>)/', '${1}' . wpautop( $match[1] ) . '${3}', $message );
 				$this->message = $message; // HTML emails should use autop.
 			} else {
-				$this->message = wpautop( $this->message );
+				$this->message = wpautop( $message );
 			}
 		}
 

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -398,20 +398,15 @@ class FrmEmail {
 			$this->message = wp_specialchars_decode( strip_tags( $this->message ), ENT_QUOTES );
 		} else {
 			$message = $this->message;
-			if ( strpos( $message, '<html' ) !== false ) {
-				$message = preg_replace( '|\s*(<html[^>]*>)\s*|', '$1', $message );
-				$message = preg_replace( '|\s*</html>\s*|', '</html>', $message );
-			}
-			if ( strpos( $message, '<head' ) !== false ) {
-				$message = preg_replace( '|\s*(<head[^>]*>)\s*|', '$1', $message );
-				$message = preg_replace( '|\s*</head>\s*|', '</head>', $message );
-			}
-			if ( strpos( $message, '<body' ) !== false ) {
-				$message = preg_replace( '|\s*(<body[^>]*>)\s*|', '$1', $message );
-				$message = preg_replace( '|</body>\s*|', '</body>', $message );
-			}
 
-			$this->message = wpautop( $message ); // HTML emails should use autop.
+			if ( strpos( $message, '<body>' ) !== false ) {
+				$result        = preg_match( '/<body[^>]*>([\s\S]*?)<\/body>/', $message, $match );
+				$body_inside   = wpautop( $match[1] );
+				$message       = preg_replace( '/(<body[^>]*>)([\s\S]+?)(<\/body>)/', '${1}' . $body_inside . '${3}', $message );
+				$this->message = $message; // HTML emails should use autop.
+			} else {
+				$this->message = wpautop( $this->message ); // HTML emails should use autop.
+			}
 		}
 
 		$this->message = apply_filters( 'frm_email_message', $this->message, $this->package_atts() );

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -394,29 +394,26 @@ class FrmEmail {
 
 		$this->message = do_shortcode( $this->message );
 
-		$this->message = $this->decode_or_autop( $this->message );
+		if ( $this->is_plain_text ) {
+			$this->message = wp_specialchars_decode( strip_tags( $message ), ENT_QUOTES );
+		} else {
+			$this->add_autop();
+		}
 
 		$this->message = apply_filters( 'frm_email_message', $this->message, $this->package_atts() );
 	}
 
 	/**
-	 * Decode the message if it is plain text or runs it through autop for html messages.
-	 *
-	 * @param string $message
+	 * Runs message through autop if it contains body tag.
 	 */
-	private function decode_or_autop( $message ) {
-		if ( $this->is_plain_text ) {
-			$message = wp_specialchars_decode( strip_tags( $message ), ENT_QUOTES );
+	private function add_autop() {
+		$message = $this->message;
+		$result  = preg_match( '/<body[^>]*>([\s\S]*?)<\/body>/', $message, $match );
+		if ( ! empty( $match[1] ) ) {
+			$this->message = str_replace( $match[1], wpautop( $match[1] ), $message );
 		} else {
-			$result = preg_match( '/<body[^>]*>([\s\S]*?)<\/body>/', $message, $match );
-			if ( ! empty( $match[1] ) ) {
-				$message = str_replace( $match[1], wpautop( $match[1] ), $message );
-			} else {
-				$message = wpautop( $message );
-			}
+			$this->message = wpautop( $message );
 		}
-
-		return $message;
 	}
 
 	private function maybe_add_ip( &$mail_body ) {

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -410,9 +410,9 @@ class FrmEmail {
 		$message = $this->message;
 		$result  = preg_match( '/<body[^>]*>([\s\S]*?)<\/body>/', $message, $match );
 		if ( ! empty( $match[1] ) ) {
-			$this->message = str_replace( $match[1], wpautop( $match[1] ), $message );
+			$this->message = str_replace( $match[1], trim( wpautop( $match[1] ) ), $message );
 		} else {
-			$this->message = wpautop( $message );
+			$this->message = trim( wpautop( $message ) );
 		}
 	}
 

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -395,7 +395,7 @@ class FrmEmail {
 		$this->message = do_shortcode( $this->message );
 
 		if ( $this->is_plain_text ) {
-			$this->message = wp_specialchars_decode( strip_tags( $message ), ENT_QUOTES );
+			$this->message = wp_specialchars_decode( strip_tags( $this->message ), ENT_QUOTES );
 		} else {
 			$this->add_autop();
 		}

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -404,7 +404,7 @@ class FrmEmail {
 	}
 
 	/**
-	 * Runs message through autop if it contains body tag.
+	 * Runs message through autop, extracting the content inside body tag if it has <body>.
 	 */
 	private function add_autop() {
 		$message = $this->message;

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -397,7 +397,21 @@ class FrmEmail {
 		if ( $this->is_plain_text ) {
 			$this->message = wp_specialchars_decode( strip_tags( $this->message ), ENT_QUOTES );
 		} else {
-			$this->message = wpautop( $this->message ); // HTML emails should use autop.
+			$message = $this->message;
+			if ( strpos( $message, '<html' ) !== false ) {
+				$message = preg_replace( '|\s*(<html[^>]*>)\s*|', '$1', $message );
+				$message = preg_replace( '|\s*</html>\s*|', '</html>', $message );
+			}
+			if ( strpos( $message, '<head' ) !== false ) {
+				$message = preg_replace( '|\s*(<head[^>]*>)\s*|', '$1', $message );
+				$message = preg_replace( '|\s*</head>\s*|', '</head>', $message );
+			}
+			if ( strpos( $message, '<body' ) !== false ) {
+				$message = preg_replace( '|\s*(<body[^>]*>)\s*|', '$1', $message );
+				$message = preg_replace( '|</body>\s*|', '</body>', $message );
+			}
+
+			$this->message = wpautop( $message ); // HTML emails should use autop.
 		}
 
 		$this->message = apply_filters( 'frm_email_message', $this->message, $this->package_atts() );

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -398,14 +398,12 @@ class FrmEmail {
 			$this->message = wp_specialchars_decode( strip_tags( $this->message ), ENT_QUOTES );
 		} else {
 			$message = $this->message;
-
 			if ( strpos( $message, '<body>' ) !== false ) {
 				$result        = preg_match( '/<body[^>]*>([\s\S]*?)<\/body>/', $message, $match );
-				$body_inside   = wpautop( $match[1] );
-				$message       = preg_replace( '/(<body[^>]*>)([\s\S]+?)(<\/body>)/', '${1}' . $body_inside . '${3}', $message );
+				$message       = preg_replace( '/(<body[^>]*>)([\s\S]+?)(<\/body>)/', '${1}' . wpautop( $match[1] ) . '${3}', $message );
 				$this->message = $message; // HTML emails should use autop.
 			} else {
-				$this->message = wpautop( $this->message ); // HTML emails should use autop.
+				$this->message = wpautop( $this->message );
 			}
 		}
 

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -697,7 +697,7 @@ LINE 1<br>LINE 2<br></body></html>'
 		$action->post_content['email_message'] = 'Value <br/>with HTML';
 
 		$settings = array(
-			0 => "<p>Value <br />with HTML</p>\n", // This is testing HTML, not plain text because it's indexed by 0 which is used for the plain_text setting.
+			0 => "<p>Value <br />with HTML</p>", // This is testing HTML, not plain text because it's indexed by 0 which is used for the plain_text setting.
 			1 => 'Value with HTML',
 		);
 

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -628,7 +628,7 @@ class test_FrmEmail extends FrmUnitTest {
 		);
 
 		foreach ( $settings as $key => $expected ) {
-			$settings[ $key ] = wpautop( $expected, false );
+			$settings[ $key ] = trim( wpautop( $expected, false ) );
 		}
 
 		$this->check_private_properties( $settings, 'email_message', 'message' );

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -635,6 +635,26 @@ class test_FrmEmail extends FrmUnitTest {
 	}
 
 	/**
+	 * @covers FrmEmail::add_autop
+	 */
+	public function test_add_autop() {
+		$action                                = $this->email_action;
+		$action->post_content['plain_text'] = '0';
+		$messages = array(
+			'<html><head><style>label{font-size:14px;font-weight:bold;padding-bottom:5px;}</style></head><body>
+LINE 1<br>LINE 2<br></body></html>'
+			=>
+			'<html><head><style>label{font-size:14px;font-weight:bold;padding-bottom:5px;}</style></head><body><p>LINE 1<br />LINE 2</p></body></html>',
+		);
+		foreach ( $messages as $message => $expected ) {
+			$action->post_content['email_message'] = $message;
+			$email                                 = new FrmEmail( $action, $this->entry, $this->contact_form );
+			$actual                                = $this->get_private_property( $email, 'message' );
+			$this->assertEquals( $expected, $actual );
+		}
+	}
+
+	/**
 	 * @covers FrmEmail::set_message
 	 */
 	public function test_message_user_info() {


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/3889
This update avoids passing the whole html content through autop for html emails and just extracts the body content (if exists), wpply `wpautop` to it and then put it back into the original content.

Before:
```
<p><html><head></p>
<style>h3{text-decoration:underline;}.label{font-size:14px;font-weight:bold;padding-bottom:5px;}.value{font-size:17px;padding:0 0 0 5px;}.question{font-size:17px;padding:0 0 10px 0;}table{margin-bottom:60px;}tr,td{border:none;padding:6px;}.blue{background:#f0f8ff;}.grey{background:#f8f8f8;}</style>
<p></head><body><br />
LINE 1<br />
LINE 2<br />
</body></html></p>
```

After:
```
<html><head><style>h3{text-decoration:underline;}.label{font-size:14px;font-weight:bold;padding-bottom:5px;}.value{font-size:17px;padding:0 0 0 5px;}.question{font-size:17px;padding:0 0 10px 0;}table{margin-bottom:60px;}tr,td{border:none;padding:6px;}.blue{background:#f0f8ff;}.grey{background:#f8f8f8;}</style></head><body><p>LINE 1<br />
			LINE 2</p>
</body></html>

```