### PR TITLE
add extra class specific to entry page

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3345,13 +3345,13 @@ input[type="checkbox"] {
 	margin-right: 5px;
 }
 
-.with_frm_style .frm_radio input[type=radio] {
+.frm_single_entry_page .with_frm_style .frm_radio input[type=radio] {
 	margin: 5px 0;
 	width: 18px;
 	position: relative; /* override Bootstrap */
 }
 
-.with_frm_style .frm_radio input[type=radio]:before {
+.frm_single_entry_page .with_frm_style .frm_radio input[type=radio]:before {
 	position: relative !important;
 	left: calc(50% - 6px);
 	top: calc(50% - 6px);

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8237,7 +8237,7 @@ Responsive Design
 		width: 100%;
 	}
 
-	.with_frm_style .frm_radio input[type=radio] {
+	.frm_single_entry_page .with_frm_style .frm_radio input[type=radio] {
 		width: 18px !important;
 	}
 	.with_frm_style .frm_checkbox input[type=checkbox] {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8237,7 +8237,13 @@ Responsive Design
 		width: 100%;
 	}
 
-	.frm_single_entry_page .with_frm_style .frm_radio input[type=radio], .frm_single_entry_page .with_frm_style .frm_checkbox input[type=checkbox] {
+	.with_frm_style .frm_radio input[type=radio],
+	.with_frm_style .frm_checkbox input[type=checkbox] {
+		width: 25px !important;
+	}
+
+	.frm_single_entry_page .with_frm_style .frm_radio input[type=radio],
+	.frm_single_entry_page .with_frm_style .frm_checkbox input[type=checkbox] {
 		width: 18px !important;
 	}
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8237,11 +8237,8 @@ Responsive Design
 		width: 100%;
 	}
 
-	.frm_single_entry_page .with_frm_style .frm_radio input[type=radio] {
+	.frm_single_entry_page .with_frm_style .frm_radio input[type=radio], .frm_single_entry_page .with_frm_style .frm_checkbox input[type=checkbox] {
 		width: 18px !important;
-	}
-	.with_frm_style .frm_checkbox input[type=checkbox] {
-		width: 25px !important;
 	}
 
 	.wp-list-table.toplevel_page_formidable .column-entries,


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/3896
I think adding extra class that doesn't load on form builder page makes sense to avoid styles that affects form builder page.