### PR TITLE
Fix entry info when cached

### DIFF
--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -479,7 +479,7 @@ class FrmEntry {
 		$entries   = wp_cache_get( $cache_key, 'frm_entry' );
 
 		if ( false === $entries ) {
-			$fields = 'it.id, it.item_key, it.name, it.ip, it.form_id, it.post_id, it.user_id, it.parent_item_id, it.updated_by, it.created_at, it.updated_at, it.is_draft';
+			$fields = 'it.id, it.item_key, it.name, it.ip, it.form_id, it.post_id, it.user_id, it.parent_item_id, it.updated_by, it.created_at, it.updated_at, it.is_draft, it.description';
 			$table  = $wpdb->prefix . 'frm_items it ';
 
 			if ( $inc_form ) {


### PR DESCRIPTION
Before:
When caching is turned on, the user_info was empty in some cases, including inside a view. The problem was that the FrmEntry::getAll function added to the cache for FrmEntry::getOne, but the query wasn't exactly the same. (it.* vs it.id, it.item_key, it.name, it.ip, it.form_id, it.post_id, it.user_id, it.parent_item_id, it.updated_by, it.created_at, it.updated_at, it.is_draft')

After:
Now if an entry is cached from the FrmEntry::getAll function, it will include "description" like the FrmEntry::getOne function.