### PR TITLE
Fix failing pro unit test when calling fill_missing_repeater_metas

### DIFF
--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -479,9 +479,11 @@ class FrmCSVExportHelper {
 			if ( ! isset( $metas[ $repeater_child->id ] ) ) {
 				$metas[ $repeater_child->id ] = '';
 
-				if ( isset( $entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ] ) && is_array( $entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ] ) ) {
-					$entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ][] = '';
+				if ( ! isset( $entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ] ) || ! is_array( $entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ] ) ) {
+					$entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ] = array();
 				}
+
+				$entries[ self::$entry->parent_item_id ]->metas[ $repeater_child->id ][] = '';
 			}
 		}
 


### PR DESCRIPTION
Related to https://github.com/Strategy11/formidable-forms/pull/945

With that update this unit test breaks in Pro. Instead I'm setting it to an array as it works with the test better this way.

```
1) test_FrmCSVExportHelper::test_prepare_csv_row_empty_fields_in_repeaters
empty fields in repeaters are not exporting in the proper order
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'"Text Field #1","Text Field #2","","Text Field #4","","Text Field #6","Text Field #7","Text Field #8","Text Field #9"'
+'"Text Field #1","Text Field #2","","Text Field #4","Text Field #7","Text Field #6","Text Field #9","Text Field #8",""'
```