### PR TITLE
Only pass objects to reflection class getValue function calls

### DIFF
--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -635,7 +635,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 
 	protected function get_private_property( $object, $property ) {
 		$p = $this->get_accessible_property( $object, $property );
-		return $p->getValue( $object );
+		return $p->getValue( is_object( $object ) ? $object : null );
 	}
 
 	protected function set_private_property( $object, $property, $value ) {


### PR DESCRIPTION
Fixes a bug that was breaking the unit tests in stripe connect. If you pass a string for `$object` it will break when it called `getValue( $object )` because it is a string. If it's not an object, I pass null now.

> TypeError: ReflectionProperty::getValue(): Argument #1 ($object) must be of type ?object, string given