### PR TITLE
Do not call triggerCustomEvent on duplicate entry error

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -620,7 +620,7 @@ function frmFrontFormJS() {
 			} else if ( response.content !== '' ) {
 				// the form or success message was returned
 
-				if ( shouldTriggerEvent ) {
+				if ( shouldTriggerEvent && -1 == response.content.indexOf( 'frm_error_style' ) ) {
 					triggerCustomEvent( object, 'frmSubmitEvent' );
 					return;
 				}


### PR DESCRIPTION
Related fix https://github.com/Strategy11/formidable-stripe/pull/181

So it turns out the reason I'm seeing the error I was getting after reloading was because I was submitting a duplicate entry. I didn't realize that instead of passing errors that duplicate entry errors just appear in the content. I'm treating that error case as a success case right now when it really isn't.

I'm not sold this is the final solution though. It may make sense to have the duplicate error come through as an AJAX error? I'm going to look into that next.