### PR TITLE
make long field names wrap up to new line

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5543,6 +5543,7 @@ span.howto {
 
 .frm_wrap .google-visualization-table-tr-head,
 .frm_wrap .google-visualization-table-tr-head th {
+	white-space: pre-wrap;
 	font-size: 16px;
 	font-weight: 400 !important;
 	text-align: left;


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/3924
I think adding a single css line would fix the issue.