### PR TITLE
Avoid a fatal error if hidden columns are a string

### DIFF
--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -306,7 +306,18 @@ class FrmEntriesController {
 		return apply_filters( 'frm_field_column_is_sortable', $is_sortable, $field );
 	}
 
+	/**
+	 * @param mixed $result Option value from database for hidden columns in entries table.
+	 * @return array
+	 */
 	public static function hidden_columns( $result ) {
+		if ( ! is_array( $result ) ) {
+			// Force an unexpected value to be an array.
+			// Since $result is a filtered option and gets saved to the database, it's possible it could be a string.
+			// Since this code expects an array it would break with a "Uncaught Error: [] operator not supported for strings" error.
+			$result = array();
+		}
+
 		$form_id = FrmForm::get_current_form_id();
 
 		$hidden = self::user_hidden_columns_for_form( $form_id, $result );

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -888,7 +888,15 @@ class FrmFormsController {
 		);
 	}
 
+	/**
+	 * @param mixed $hidden_columns
+	 * @return array
+	 */
 	public static function hidden_columns( $hidden_columns ) {
+		if ( ! is_array( $hidden_columns ) ) {
+			$hidden_columns = array();
+		}
+
 		$type = FrmAppHelper::get_simple_request(
 			array(
 				'param' => 'form_type',

--- a/tests/entries/test_FrmEntriesController.php
+++ b/tests/entries/test_FrmEntriesController.php
@@ -67,7 +67,6 @@ class test_FrmEntriesController extends FrmUnitTest {
 
 	/**
 	 * @covers FrmEntriesController::hidden_columns
-	 * @group mike
 	 */
 	public function test_hidden_columns() {
 		// Confirm that a string option value doesn't trigger a fatal error.

--- a/tests/entries/test_FrmEntriesController.php
+++ b/tests/entries/test_FrmEntriesController.php
@@ -64,4 +64,14 @@ class test_FrmEntriesController extends FrmUnitTest {
 
 		return $new_post->ID;
 	}
+
+	/**
+	 * @covers FrmEntriesController::hidden_columns
+	 * @group mike
+	 */
+	public function test_hidden_columns() {
+		// Confirm that a string option value doesn't trigger a fatal error.
+		$columns = FrmEntriesController::hidden_columns( '' );
+		$this->assertIsArray( $columns );
+	}
 }


### PR DESCRIPTION
I was looking at the Support for a second in WordPress and noticed this issue https://wordpress.org/support/topic/frmentriescontroller-php/.

I haven't seen it come up in support but every time I see a fatal error with the stack trace I try to look at the code for a better idea.

This is simple to replicate with a basic snippet but I'm not sure how it comes up naturally. Possibly the option is a string, or another plugin is filtering the value and returning a string when it shouldn't.

```
add_filter(
	'get_user_option_manageformidable_page_formidable-entriescolumnshidden',
	function() {
		return '';
	},
	9
);
```

I added a unit test that also covers this case. And I repeated the fix for the forms list which can have the same issue.