### PR TITLE
Exit early in handleFieldGroupLayoutOptionClick if there is no select…

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3857,11 +3857,20 @@ function frmAdminBuildJS() {
 		return wrapper;
 	}
 
+	/**
+	 * Handle when a field group layout option (that sets grid classes/column sizing) is selected in the "Row Layout" popup.
+	 *
+	 * @returns {void}
+	 */
 	function handleFieldGroupLayoutOptionClick() {
-		var type, row;
-		type = this.getAttribute( 'layout-type' );
-		row = document.querySelector( '.frm-field-group-hover-target' );
-		size = getFieldsInRow( jQuery( row ) ).length;
+		const row  = document.querySelector( '.frm-field-group-hover-target' );
+		if ( ! row ) {
+			// The field group layout options also get clicked when merging multiple rows.
+			// The following code isn't required for multiple rows though so just exit early.
+			return;
+		}
+
+		const type = this.getAttribute( 'layout-type' );
 		syncLayoutClasses( getFieldsInRow( jQuery( row ) ).first(), type );
 		destroyFieldGroupPopup();
 	}


### PR DESCRIPTION
…ed hover target

I noticed this error when trying to merge multiple rows. This function is for the other row layout click event (inside of a single target field group). It works fine if I just exit early here to avoid the error because there is no hover target.

<img width="384" alt="Screen Shot 2022-11-25 at 10 56 30 AM" src="https://user-images.githubusercontent.com/9134515/204010802-113e4c0e-c382-4e04-878b-72fafac54ca0.png">

> Uncaught TypeError: row is undefined

<img width="1002" alt="Screen Shot 2022-11-25 at 10 56 34 AM" src="https://user-images.githubusercontent.com/9134515/204010753-08f78fdf-0fdd-4342-b626-35b2d576d6f1.png">
