### PR TITLE
Update pencil icon

### DIFF
--- a/images/icons.svg
+++ b/images/icons.svg
@@ -250,9 +250,9 @@
 <title>pencil_solid</title>
 <path d="M1.7 13.4a1 1 0 0 0-.3.4l-1.3 5a.9.9 0 0 0 0 .5 1 1 0 0 0 1 .6l5-1.3c.2 0 .4-.2.5-.3l.2-.2-5-4.9zm.5 4.4zM19.7 2.2l-.8-1.1c-.6-.6-1.5-1-2.5-1S14.6.5 14 1l-1.3 1.3 4.9 5L18.9 6a3.5 3.5 0 0 0 .7-3.8zM3 12.1l8.6-8.6 5 5L7.8 17l-5-5z"/>
 </symbol>
-<symbol id="frm_pencil_icon" viewBox="0 0 20 20">
+<symbol id="frm_pencil_icon" viewBox="0 0 18 18" fill="none">
 <title>pencil</title>
-<path d="M19.7 2.2l-.8-1.1c-.6-.6-1.5-1-2.5-1S14.6.5 14 1L1.7 13.4a1 1 0 0 0-.3.4l-1.4 5a.9.9 0 0 0 0 .5 1 1 0 0 0 1.2.6l5-1.3.4-.3L18.9 6a3.5 3.5 0 0 0 .7-3.8zm-6.8 2.6L15.2 7l-8.6 8.7-2.4-2.4zm-10.7 13l1-3.3L5.4 17zM18 4.2l-.4.5L16.3 6 14 3.7l1.3-1.3A1.7 1.7 0 0 1 18 3.6l-.1.6z"/>
+<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M13.167 1.5A2.358 2.358 0 0 1 16.5 4.833L5.25 16.083l-4.583 1.25 1.25-4.583L13.167 1.5Z"/>
 </symbol>
 <symbol id="frm_signature_icon" viewBox="0 0 20 20">
 <title>signature</title>


### PR DESCRIPTION
I'm trying to work toward some better icon consistency as I work on the visual styler. The thicket pencil doesn't look great in the dropdown, but I think it may be worth avoiding adding another icon for the same thing when we can just replace our current one. It's a bit smaller and has less detail. I looked at the code and identified it's used in a few places. I think it looks okay.

I'm not sure if we want to just change all icons at once but I figure it's easier to do this one at a time since each one could be used in multiple places. Do we have updated icons for all of these in one of the designs?

It's also used when you edit a summary, but the SVG is separate code so it doesn't get updated with this update. If we want to change it there as well, it isn't difficult to update In Pro too.

Or maybe we want to leave the old icon alone for now?

**Before**

<img width="279" alt="Screen Shot 2022-11-25 at 12 00 05 PM" src="https://user-images.githubusercontent.com/9134515/204021209-4b19eb1b-9657-4942-a277-e8bad5ade7c6.png">

**In the Edit Entry sidebar link.**

<img width="225" alt="Screen Shot 2022-11-25 at 11 49 13 AM" src="https://user-images.githubusercontent.com/9134515/204021094-787236b0-a809-48e8-b414-6e28c064aba2.png">

**In the Other option setting in the form builder.**

<img width="346" alt="Screen Shot 2022-11-25 at 11 44 30 AM" src="https://user-images.githubusercontent.com/9134515/204021102-2285f976-cc40-4e82-92a1-f5bd05bb9d89.png">
