### PR TITLE
unset fields inside repeater field

### DIFF
--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -633,7 +633,7 @@ class FrmField {
 		$results = self::get_fields_from_transients( $form_id, compact( 'inc_embed', 'inc_repeat' ) );
 		if ( ! empty( $results ) ) {
 			if ( empty( $limit ) ) {
-				self::maybe_remove_fields_inside_repeater( $form_id, $results );
+				// self::maybe_remove_fields_inside_repeater( $form_id, $results );
 
 				return $results;
 			}
@@ -666,7 +666,7 @@ class FrmField {
 		if ( empty( $limit ) ) {
 			self::set_field_transient( $results, $form_id, 0, compact( 'inc_embed', 'inc_repeat' ) );
 		}
-		self::maybe_remove_fields_inside_repeater( $form_id, $results );
+		// self::maybe_remove_fields_inside_repeater( $form_id, $results );
 
 		return $results;
 	}

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -671,6 +671,12 @@ class FrmField {
 		return $results;
 	}
 
+	/**
+	 * Remove fields that should only be displayed inside a repeater field.
+	 *
+	 * @param int $form_id
+	 * @param array $fields
+	 */
 	private static function maybe_remove_fields_inside_repeater( $form_id, &$fields ) {
 		if ( ! FrmAppHelper::is_admin_page( 'formidable' ) ) {
 			foreach ( $fields as $key => $field ) {

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -633,6 +633,8 @@ class FrmField {
 		$results = self::get_fields_from_transients( $form_id, compact( 'inc_embed', 'inc_repeat' ) );
 		if ( ! empty( $results ) ) {
 			if ( empty( $limit ) ) {
+				self::maybe_remove_fields_inside_repeater( $form_id, $results );
+
 				return $results;
 			}
 
@@ -645,6 +647,8 @@ class FrmField {
 					break;
 				}
 			}
+
+			self::maybe_remove_fields_inside_repeater( $form_id, $fields );
 
 			return $fields;
 		}
@@ -662,8 +666,19 @@ class FrmField {
 		if ( empty( $limit ) ) {
 			self::set_field_transient( $results, $form_id, 0, compact( 'inc_embed', 'inc_repeat' ) );
 		}
+		self::maybe_remove_fields_inside_repeater( $form_id, $results );
 
 		return $results;
+	}
+
+	private static function maybe_remove_fields_inside_repeater( $form_id, &$fields ) {
+		if ( ! FrmAppHelper::is_admin_page( 'formidable' ) ) {
+			foreach ( $fields as $key => $field ) {
+				if ( $form_id !== $field->form_id ) {
+					unset( $fields[ $key ] );
+				}
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/3942

The fields inside a repeater field in a form embedded in another form doesn't need to be considered as an independent fields and displayed outside it as they would anyway when that repeater field generates its own fields for display.