### PR TITLE
Pass previous form id to frm update field after move and fix how previous section id is retreived

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1020,7 +1020,7 @@ function frmAdminBuildJS() {
 		maybeOpenCollapsedPage( placeholder );
 
 		const $previousFieldContainer = ui.helper.parent();
-		const previousSection         = ui.helper.get( 0 ).closest( 'ul.frm_sorting' );
+		const previousSection         = ui.helper.get( 0 ).closest( 'ul.start_divider' );
 		const newSection              = placeholder.closest( 'ul.frm_sorting' );
 
 		if ( draggable.classList.contains( 'frm-new-field' ) ) {
@@ -1029,7 +1029,7 @@ function frmAdminBuildJS() {
 			moveFieldThatAlreadyExists( draggable, placeholder );
 		}
 
-		const previousSectionId = previousSection && previousSection.classList.contains( 'start_divider' ) ? parseInt( previousSection.closest( '.edit_field_type_divider' ).getAttribute( 'data-fid' ) ) : 0;
+		const previousSectionId = previousSection ? parseInt( previousSection.closest( '.edit_field_type_divider' ).getAttribute( 'data-fid' ) ) : 0;
 		const newSectionId      = newSection.classList.contains( 'start_divider' ) ? parseInt( newSection.closest( '.edit_field_type_divider' ).getAttribute( 'data-fid' ) ) : 0;
 
 		placeholder.remove();
@@ -1039,8 +1039,8 @@ function frmAdminBuildJS() {
 		maybeUpdatePreviousFieldContainerAfterDrop( $previousFieldContainer, $previousContainerFields );
 		maybeUpdateDraggableClassAfterDrop( draggable, $previousContainerFields );
 
-		if ( ! newSectionId || previousSectionId !== newSectionId ) {
-			updateFieldAfterMovingBetweenSections( jQuery( draggable ) );
+		if ( previousSectionId !== newSectionId ) {
+			updateFieldAfterMovingBetweenSections( jQuery( draggable ), previousSection );
 		}
 
 		debouncedSyncAfterDragAndDrop();
@@ -1538,23 +1538,26 @@ function frmAdminBuildJS() {
 	/**
 	 * Update a field after it is dragged and dropped into, out of, or between sections
 	 *
-	 * @param {object} currentItem
+	 * @param {Object} currentItem
+	 * @param {Object} previousSection
+	 * @returns {void}
 	 */
-	function updateFieldAfterMovingBetweenSections( currentItem ) {
+	function updateFieldAfterMovingBetweenSections( currentItem, previousSection ) {
 		if ( ! currentItem.hasClass( 'form-field' ) ) {
 			// currentItem is a field group. Call for children recursively.
 			getFieldsInRow( jQuery( currentItem.get( 0 ).firstChild ) ).each(
 				function() {
-					updateFieldAfterMovingBetweenSections( jQuery( this ) );
+					updateFieldAfterMovingBetweenSections( jQuery( this ), previousSection );
 				}
 			);
 			return;
 		}
 
-		const fieldId   = currentItem.attr( 'id' ).replace( 'frm_field_id_', '' );
-		const section   = getSectionForFieldPlacement( currentItem );
-		const formId    = getFormIdForFieldPlacement( section );
-		const sectionId = getSectionIdForFieldPlacement( section );
+		const fieldId        = currentItem.attr( 'id' ).replace( 'frm_field_id_', '' );
+		const section        = getSectionForFieldPlacement( currentItem );
+		const formId         = getFormIdForFieldPlacement( section );
+		const sectionId      = getSectionIdForFieldPlacement( section );
+		const previousFormId = previousSection ? getFormIdForFieldPlacement( jQuery( previousSection.parentNode ) ) : 0;
 
 		jQuery.ajax({
 			type: 'POST',
@@ -1564,6 +1567,7 @@ function frmAdminBuildJS() {
 				form_id: formId,
 				field: fieldId,
 				section_id: sectionId,
+				previous_form_id: previousFormId,
 				nonce: frmGlobal.nonce
 			},
 			success: function() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1039,7 +1039,7 @@ function frmAdminBuildJS() {
 		maybeUpdatePreviousFieldContainerAfterDrop( $previousFieldContainer, $previousContainerFields );
 		maybeUpdateDraggableClassAfterDrop( draggable, $previousContainerFields );
 
-		if ( previousSectionId !== newSectionId ) {
+		if ( ! newSectionId || previousSectionId !== newSectionId ) {
 			updateFieldAfterMovingBetweenSections( jQuery( draggable ) );
 		}
 


### PR DESCRIPTION
Following up from https://github.com/Strategy11/formidable-forms/pull/987 to fix https://github.com/Strategy11/formidable-pro/issues/3024 and https://github.com/Strategy11/formidable-acf/issues/28

Complimentary pull request for clearing the field cache https://github.com/Strategy11/formidable-pro/pull/3948