### PR TITLE
Fix plugin connection always falling

### DIFF
--- a/classes/models/FrmAddon.php
+++ b/classes/models/FrmAddon.php
@@ -251,6 +251,10 @@ class FrmAddon {
 	protected function update_pro_capabilities() {
 		global $wp_roles;
 
+		if ( ! function_exists( 'get_editable_roles' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/user.php';
+		}
+
 		$caps     = FrmAppHelper::frm_capabilities( 'pro_only' );
 		$roles    = get_editable_roles();
 		$settings = new FrmSettings();

--- a/tests/misc/test_FrmAddon.php
+++ b/tests/misc/test_FrmAddon.php
@@ -83,6 +83,17 @@ class test_FrmAddon extends FrmUnitTest {
 
 		}
 	}
+
+	public function test_update_pro_capabilities() {
+		$caps = FrmAppHelper::frm_capabilities( 'pro_only' );
+
+		$this->run_private_method( array( $this->addon, 'update_pro_capabilities' ) );
+
+		$admin_role  = get_role( 'administrator' );
+		foreach ( $caps as $cap => $label ) {
+			$this->assertTrue( $admin_role->has_cap( $cap ) );
+		}
+	}
 }
 
 class FrmTestAddon extends FrmAddon {

--- a/tests/misc/test_FrmAddon.php
+++ b/tests/misc/test_FrmAddon.php
@@ -84,13 +84,26 @@ class test_FrmAddon extends FrmUnitTest {
 		}
 	}
 
+	/**
+	 * @covers FrmAddon::update_pro_capabilities
+	 */
 	public function test_update_pro_capabilities() {
-		$caps = FrmAppHelper::frm_capabilities( 'pro_only' );
+		// Remove the roles first so we're not getting false positives for data that already exists prior to running FrmAddon::update_pro_capabilities.
+		$caps       = array_keys( FrmAppHelper::frm_capabilities( 'pro_only' ) );
+		$admin_role = get_role( 'administrator' );
+		foreach ( $caps as $cap ) {
+			$admin_role->remove_cap( $cap );
+		}
 
 		$this->run_private_method( array( $this->addon, 'update_pro_capabilities' ) );
 
-		$admin_role  = get_role( 'administrator' );
-		foreach ( $caps as $cap => $label ) {
+		// The global $wp_roles object stores an internal role_objects array.
+		// We need to reset the $wp_roles object in order to avoid stale WP_Role capabilities.
+		global $wp_roles;
+		$wp_roles = new WP_Roles();
+
+		$admin_role = get_role( 'administrator' );
+		foreach ( $caps as $cap ) {
 			$this->assertTrue( $admin_role->has_cap( $cap ) );
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3947

@Crabcyborg Somehow, the unit test fails. The code before `$wp_roles->add_cap()` runs correctly (capabilities should be added to role `administrator`). But that method seems not to run. I printed some strings inside that method, but nothing showed in the terminal.