### PR TITLE
Add more backend validation for frm_install and doJsonFetch, remove h…

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -380,7 +380,10 @@ class FrmAppController {
 	 */
 	public static function install_js_fallback() {
 		FrmAppHelper::load_admin_wide_js();
-		echo '<div id="hidden frm_install_message"></div><script type="text/javascript">jQuery(document).ready(function(){frm_install_now();});</script>';
+		?>
+			<div id="frm_install_message"></div>
+			<script>jQuery(document).ready( frm_install_now );</script>
+		<?php
 	}
 
 	/**
@@ -741,6 +744,8 @@ class FrmAppController {
 	 * @since 2.0.1
 	 */
 	public static function ajax_install() {
+		FrmAppHelper::permission_check( 'frm_change_settings' );
+		check_ajax_referer( 'frm_ajax', 'nonce' );
 		self::api_install();
 		wp_die();
 	}

--- a/classes/controllers/FrmApplicationsController.php
+++ b/classes/controllers/FrmApplicationsController.php
@@ -72,6 +72,9 @@ class FrmApplicationsController {
 	 * @return void
 	 */
 	public static function get_applications_data() {
+		FrmAppHelper::permission_check( 'frm_view_forms' );
+		check_ajax_referer( 'frm_ajax', 'nonce' );
+
 		$view = FrmAppHelper::get_param( 'view', '', 'get', 'sanitize_text_field' );
 		$data = array();
 

--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -100,7 +100,11 @@
 
 	const ajax = {
 		doJsonFetch: async function( action ) {
-			const response = await fetch( ajaxurl + '?action=frm_' + action );
+			let targetUrl = ajaxurl + '?action=frm_' + action;
+			if ( -1 === targetUrl.indexOf( 'nonce=' ) ) {
+				targetUrl += '&nonce=' + frmGlobal.nonce;
+			}
+			const response = await fetch( targetUrl );
 			const json = await response.json();
 			if ( ! json.success ) {
 				return Promise.reject( json.data || 'JSON result is not successful' );


### PR DESCRIPTION
…idden id from frm_install_message

Related ticket https://secure.helpscout.net/conversation/2085567282/123503/

This updates adds a nonce and permission check for the `FrmAppController::ajax_install` function. The function doesn't take any user input. At most it could be abused to constantly try triggering the install process that gets used when this spinner is added to the page:

Testing this is quite easy as you can just add a custom snippet to trigger the code: `add_action( 'admin_notices', 'FrmAppController::install_js_fallback' );`.

<img width="466" alt="Screen Shot 2022-12-02 at 10 26 17 AM" src="https://user-images.githubusercontent.com/9134515/205314945-45d18d81-08be-4e8e-a1b3-232726be3003.png">

This update also fixes that spinner which wasn't previously visible because it had 2 IDs, one called "hidden" which just seems to be a bug. I looked at the git blame but this line hasn't changed in 8 years 😂.

The report also mentions the application data GET endpoint, though it later mentions that its read only and that it could be ignored. I added a nonce into `doJsonFetch` though and added the check for applications data, just to have the improved coverage. Everywhere I call this in Pro is through `doJsonFetch` so it should just work without any other changes.