### PR TITLE
update default rootline size

### DIFF
--- a/classes/models/FrmStyle.php
+++ b/classes/models/FrmStyle.php
@@ -573,7 +573,7 @@ class FrmStyle {
 			'progress_color'           => '3f4b5b',
 			'progress_border_color'    => 'E5E5E5',
 			'progress_border_size'     => '2px',
-			'progress_size'            => '30px',
+			'progress_size'            => '24px',
 
 			'custom_css' => '',
 		);


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3964
This update just changes the default rootline size in the style setting page from `30px` to `24px`.