### PR TITLE
try to get style id from database even if name is numeric

### DIFF
--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -746,10 +746,10 @@ class FrmXMLHelper {
 			);
 			$select   = 'ID';
 
-			$style = $wpdb->get_row( $wpdb->prepare( "SELECT ID FROM $table WHERE post_type=%s AND post_name=%s", 'frm_styles', $form['options']['custom_style'] ) );
+			$style_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $table WHERE post_type=%s AND post_name=%s", 'frm_styles', $form['options']['custom_style'] ) );
 
-			if ( $style ) {
-				$form['options']['custom_style'] = $style->ID;
+			if ( $style_id ) {
+				$form['options']['custom_style'] = $style_id;
 			} else {
 				// save the old style to maybe update after styles import
 				$form['options']['old_style'] = $form['options']['custom_style'];

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -882,8 +882,10 @@ class FrmXMLHelper {
 		}
 		unset( $posts_with_shortcodes, $view_ids );
 
-		// clear imported forms style cache to make sure the new styles are applied to the forms
-		self::clear_forms_style_caches( $imported['forms'] );
+		if ( ! empty( $imported['forms'] ) ) {
+			// clear imported forms style cache to make sure the new styles are applied to the forms
+			self::clear_forms_style_caches( $imported['forms'] );
+		}
 
 		self::maybe_update_stylesheet( $imported );
 

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -81,8 +81,14 @@ class FrmXMLHelper {
 			if ( isset( $xml->{$item_type} ) ) {
 				$function_name = 'import_xml_' . $item_type . 's';
 				$imported      = self::$function_name( $xml->{$item_type}, $imported );
-				unset( $function_name, $xml->{$item_type} );
+				if ( $item_type === 'form' ) {
+					$imported_forms = $imported;
+				}
 			}
+		}
+
+		foreach ( $imported_forms['forms'] as $form_id ) {
+			self::update_custom_style_setting_after_import( $form_id );
 		}
 
 		$imported = apply_filters( 'frm_importing_xml', $imported, $xml );
@@ -740,6 +746,13 @@ class FrmXMLHelper {
 			);
 			$select   = 'ID';
 			$style_id = FrmDb::get_var( $table, $where, $select );
+
+			if ( ! $style_id ) {
+				$style = $wpdb->get_row( $wpdb->prepare( "SELECT ID FROM $table WHERE post_type=%s AND post_name=%s", 'frm_styles', $form['options']['custom_style'] ) );
+				if ( $style ) {
+					$style_id = $style->ID;
+				}
+			}
 
 			if ( $style_id ) {
 				$form['options']['custom_style'] = $style_id;

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -745,17 +745,11 @@ class FrmXMLHelper {
 				'post_type' => 'frm_styles',
 			);
 			$select   = 'ID';
-			$style_id = FrmDb::get_var( $table, $where, $select );
 
-			if ( ! $style_id ) {
-				$style = $wpdb->get_row( $wpdb->prepare( "SELECT ID FROM $table WHERE post_type=%s AND post_name=%s", 'frm_styles', $form['options']['custom_style'] ) );
-				if ( $style ) {
-					$style_id = $style->ID;
-				}
-			}
+			$style = $wpdb->get_row( $wpdb->prepare( "SELECT ID FROM $table WHERE post_type=%s AND post_name=%s", 'frm_styles', $form['options']['custom_style'] ) );
 
-			if ( $style_id ) {
-				$form['options']['custom_style'] = $style_id;
+			if ( $style ) {
+				$form['options']['custom_style'] = $style->ID;
 			} else {
 				// save the old style to maybe update after styles import
 				$form['options']['old_style'] = $form['options']['custom_style'];

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -744,9 +744,10 @@ class FrmXMLHelper {
 				'post_name' => $form['options']['custom_style'],
 				'post_type' => 'frm_styles',
 			);
-			$select   = 'ID';
-
-			$style_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $table WHERE post_type=%s AND post_name=%s", 'frm_styles', $form['options']['custom_style'] ) );
+			$select    = 'ID';
+			$cache_key = FrmDb::generate_cache_key( $where, array( 'limit' => 1 ), $select, 'var' );
+			FrmDb::delete_cache_and_transient( $cache_key, 'post' );
+			$style_id = FrmDb::get_var( $table, $where, $select );
 
 			if ( $style_id ) {
 				$form['options']['custom_style'] = $style_id;

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -882,8 +882,24 @@ class FrmXMLHelper {
 		}
 		unset( $posts_with_shortcodes, $view_ids );
 
+		// clear imported forms style cache to make sure the new styles are applied to the forms
+		self::clear_forms_style_caches( $imported['forms'] );
+
+		self::maybe_update_stylesheet( $imported );
+
+		flush_rewrite_rules();
+
+		return $imported;
+	}
+
+	/**
+	 * Clears styles from cache for imported forms
+	 *
+	 * @param array $imported_forms
+	 */
+	private static function clear_forms_style_caches( $imported_forms ) {
 		$where = array(
-			'id' => $imported['forms'],
+			'id' => $imported_forms,
 			'options LIKE' => '"old_style"',
 		);
 		$forms = FrmDb::get_results( 'frm_forms', $where );
@@ -903,12 +919,6 @@ class FrmXMLHelper {
 			$cache_key = FrmDb::generate_cache_key( $where, array( 'limit' => 1 ), $select, 'var' );
 			FrmDb::delete_cache_and_transient( $cache_key, 'post' );
 		}
-
-		self::maybe_update_stylesheet( $imported );
-
-		flush_rewrite_rules();
-
-		return $imported;
 	}
 
 	/**

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -895,7 +895,7 @@ class FrmXMLHelper {
 				'post_type' => 'frm_styles',
 			);
 			$select    = 'ID';
-			$cache_key = FrmDb::generate_cache_key( $where, array( 'limit' => 1 ), $select, 'var' );;
+			$cache_key = FrmDb::generate_cache_key( $where, array( 'limit' => 1 ), $select, 'var' );
 			FrmDb::delete_cache_and_transient( $cache_key, 'post' );
 			self::update_custom_style_setting_after_import( $form_id );
 		}

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -81,6 +81,7 @@ class FrmXMLHelper {
 			if ( isset( $xml->{$item_type} ) ) {
 				$function_name = 'import_xml_' . $item_type . 's';
 				$imported      = self::$function_name( $xml->{$item_type}, $imported );
+				unset( $function_name, $xml->{$item_type} );
 			}
 		}
 
@@ -737,7 +738,7 @@ class FrmXMLHelper {
 				'post_name' => $form['options']['custom_style'],
 				'post_type' => 'frm_styles',
 			);
-			$select    = 'ID';
+			$select   = 'ID';
 			$style_id = FrmDb::get_var( $table, $where, $select );
 
 			if ( $style_id ) {

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -889,11 +889,13 @@ class FrmXMLHelper {
 		$forms = FrmDb::get_results( 'frm_forms', $where );
 
 		foreach ( $forms as $form ) {
-			$form_options = unserialize( $form->options );
-
+			FrmAppHelper::unserialize_or_decode( $form->options );
+			if ( ! $form->options ) {
+				continue;
+			}
 			$where = array(
-				'post_name' => $form_options['old_style'],
-				'post_type' => 'frm_styles',
+				'post_name' => $form->options['old_style'],
+				'post_type' => FrmStylesController::$post_type,
 			);
 
 			$select = 'ID';

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -887,6 +887,9 @@ class FrmXMLHelper {
 
 		foreach ( $imported['forms'] as $form_id ) {
 			$form  = FrmForm::getOne( $form_id );
+			if ( ! isset( $form->options['old_style'] ) ) {
+				continue;
+			}
 			$where = array(
 				'post_name' => $form->options['old_style'],
 				'post_type' => 'frm_styles',

--- a/classes/models/FrmDb.php
+++ b/classes/models/FrmDb.php
@@ -232,7 +232,7 @@ class FrmDb {
 	 *
 	 * @return string
 	 */
-	private static function generate_cache_key( $where, $args, $field, $type ) {
+	public static function generate_cache_key( $where, $args, $field, $type ) {
 		$cache_key = '';
 		$where     = FrmAppHelper::array_flatten( $where );
 		foreach ( $where as $key => $value ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/2242
This update fixes the issue of style not getting applied to the form it should on by trying the same action after the forms are imported plus getting around the cache issue in `FrmXMLHelper::update_custom_style_setting_on_import` when `FrmDb::get_var` is called clearing the cache saved with the key generated from the database query.