### PR TITLE
Fix redirect setTimeout runs too fast

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2194,7 +2194,7 @@ class FrmFormsController {
 		} else {
 			add_filter( 'frm_use_wpautop', '__return_true' );
 			echo FrmAppHelper::maybe_kses( $redirect_msg ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo "<script type='text/javascript'>window.onload = function(){setTimeout(window.location='" . esc_url_raw( $success_url ) . "', 8000);}</script>";
+			echo "<script type='text/javascript'>window.onload = function(){setTimeout(function(){window.location='" . esc_url_raw( $success_url ) . "';}, 8000);}</script>";
 		}
 	}
 


### PR DESCRIPTION
I found this issue when working on the On Submit action. I'm not sure how to replicate this with the current version.

`setTimeout(window.location='xxx', 8000);` will execute window.location assignment immediately.