### PR TITLE
Adding a new filter that allows updating new entry values

### DIFF
--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -357,8 +357,17 @@ class FrmEntriesHelper {
 
 		$value = self::get_posted_meta( $field_id, $args );
 
-		// TODO: add comment.
-		$value = apply_filters( 'frm_new_entry_value', $value, array( 'allow_array' => false, 'field' => $field_obj ) );
+		$args = array( 'allow_array' => false, 'field' => $field_obj );
+
+		/**
+		 * Allows updating posted entry value for a field.
+		 *
+		 * @since x.x
+		 *
+		 * @param string|int $value
+		 * @param array $args
+		 */
+		$value = apply_filters( 'frm_new_entry_value', $value, $args );
 
 		$field_obj->sanitize_value( $value );
 	}

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -380,7 +380,6 @@ class FrmEntriesHelper {
 		$field_id_and_object = self::get_field_id_and_object( $field );
 
 		$field_id  = $field_id_and_object[0];
-		$field_obj = $field_id_and_object[1];
 
 		$value = self::get_posted_meta( $field_id, $args );
 

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -94,7 +94,6 @@ class FrmEntriesHelper {
 	 */
 	private static function get_field_value_for_new_entry( $field, $reset, $args ) {
 		$new_value = $field->default_value;
-
 		if ( ! $reset && self::value_is_posted( $field, $args ) ) {
 			self::get_posted_value( $field, $new_value, $args );
 		}
@@ -118,7 +117,7 @@ class FrmEntriesHelper {
 		 * @param string|int $new_value
 		 * @param array $args
 		 */
-		$new_value = apply_filters( 'frm_new_entry_value', $new_value, $args );
+		$new_value = apply_filters( 'frm_new_entry_value', $new_value, $field, $args );
 
 		return $new_value;
 	}

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -380,6 +380,7 @@ class FrmEntriesHelper {
 		$field_id_and_object = self::get_field_id_and_object( $field );
 
 		$field_id  = $field_id_and_object[0];
+		$field_obj = $field_id_and_object[1];
 
 		$value = self::get_posted_meta( $field_id, $args );
 

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -359,7 +359,7 @@ class FrmEntriesHelper {
 
 		$args = array(
 			'allow_array' => false,
-			'field' => $field_obj,
+			'field'       => $field_obj,
 		);
 
 		/**

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -357,6 +357,9 @@ class FrmEntriesHelper {
 
 		$value = self::get_posted_meta( $field_id, $args );
 
+		// TODO: add a hook here and use it instead.
+		FrmProFieldsHelper::replace_field_id_shortcodes( $value, array( 'allow_array' => false, 'field' => $field_obj ) );
+
 		$field_obj->sanitize_value( $value );
 	}
 
@@ -370,6 +373,7 @@ class FrmEntriesHelper {
 		} else {
 			$value = isset( $_POST['item_meta'][ $args['parent_field_id'] ][ $args['key_pointer'] ][ $field_id ] ) ? wp_unslash( $_POST['item_meta'][ $args['parent_field_id'] ][ $args['key_pointer'] ][ $field_id ] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing
 		}
+
 		return $value;
 	}
 

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -356,6 +356,13 @@ class FrmEntriesHelper {
 		$_POST['item_meta'][ $args['parent_field_id'] ][ $args['key_pointer'] ][ $field->id ] = $value; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 	}
 
+	/**
+	 * Returns an array with field id and object for any field data type.
+	 *
+	 * @param mixed $field
+	 *
+	 * @return array
+	 */
 	private static function get_field_id_and_object( $field ) {
 		if ( is_array( $field ) ) {
 			$field_id  = $field['id'];

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -357,8 +357,8 @@ class FrmEntriesHelper {
 
 		$value = self::get_posted_meta( $field_id, $args );
 
-		// TODO: add a hook here and use it instead.
-		FrmProFieldsHelper::replace_field_id_shortcodes( $value, array( 'allow_array' => false, 'field' => $field_obj ) );
+		// TODO: add comment.
+		$value = apply_filters( 'frm_new_entry_value', $value, array( 'allow_array' => false, 'field' => $field_obj ) );
 
 		$field_obj->sanitize_value( $value );
 	}

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -357,7 +357,10 @@ class FrmEntriesHelper {
 
 		$value = self::get_posted_meta( $field_id, $args );
 
-		$args = array( 'allow_array' => false, 'field' => $field_obj );
+		$args = array(
+			'allow_array' => false,
+			'field' => $field_obj,
+		);
 
 		/**
 		 * Allows updating posted entry value for a field.

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,6 +13,7 @@
 		<ignoreFiles>
 			<directory name="vendor" />
 			<directory name="classes/views/" />
+			<file name="classes/widgets/FrmShowForm.php" />
 		</ignoreFiles>
 	</projectFiles>
 	<stubs>

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,7 +13,6 @@
 		<ignoreFiles>
 			<directory name="vendor" />
 			<directory name="classes/views/" />
-			<file name="classes/widgets/FrmShowForm.php" />
 		</ignoreFiles>
 	</projectFiles>
 	<stubs>
@@ -54,5 +53,10 @@
 				<directory name="deprecated" />
 			</errorLevel>
 		</InvalidParamDefault>
+		<MethodSignatureMustProvideReturnType>
+			<errorLevel type="suppress">
+				<file name="classes/widgets/FrmShowForm.php" />
+			</errorLevel>
+		</MethodSignatureMustProvideReturnType>
 	</issueHandlers>
 </psalm>


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3975

Just adding a new filter that allows updating new entry value for a given field and extract reusable code into a new function and call it twice.