### PR TITLE
Fix JS error when duplicating a form action

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6342,8 +6342,8 @@ function frmAdminBuildJS() {
 		if ( wysiwyg ) {
 			// Re-initialize the original wysiwyg which was removed before cloning.
 			frmDom.wysiwyg.init( wysiwyg );
+			frmDom.wysiwyg.init( newAction.querySelector( '.wp-editor-area' ) );
 		}
-		frmDom.wysiwyg.init( newAction.querySelector( '.wp-editor-area' ) );
 
 		initiateMultiselect();
 


### PR DESCRIPTION
This can be replicated by duplicating a form action that doesn't have a WYSIWYG editor.