### PR TITLE
Prevent both radio buttons from being selected in sample form

### DIFF
--- a/classes/views/styles/_sample_form.php
+++ b/classes/views/styles/_sample_form.php
@@ -60,8 +60,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div class="frm_form_field form-field frm_fourth <?php echo esc_attr( $pos_class ); ?> frm_lite_style">
 	<label class="frm_primary_label"><?php esc_html_e( 'Radio Buttons', 'formidable' ); ?></label>
 	<div class="frm_opt_container">
-		<div class="frm_radio"><label><input type="radio" /><?php esc_html_e( 'Option 1', 'formidable' ); ?></label></div>
-		<div class="frm_radio"><label><input type="radio" /><?php esc_html_e( 'Option 2', 'formidable' ); ?></label></div>
+		<div class="frm_radio"><label><input type="radio" name="item_meta[1029]" /><?php esc_html_e( 'Option 1', 'formidable' ); ?></label></div>
+		<div class="frm_radio"><label><input type="radio" name="item_meta[1029]" /><?php esc_html_e( 'Option 2', 'formidable' ); ?></label></div>
 	</div>
 </div>
 


### PR DESCRIPTION
As I'm working on the styler I've noticed some things in the sample form seem off, especially when compared side-by-side with the target form that doesn't have the same issues.

This update works to avoid both radio buttons being selected at the same time as the radio buttons have no `name` attribute, so they aren't connected.

<img width="269" alt="Screen Shot 2023-01-05 at 10 55 11 AM" src="https://user-images.githubusercontent.com/9134515/210809274-fbf67e43-65ee-416b-b765-a2bc2a330737.png">

This update only applies to the radio button in the styler's sample form **when Pro is not active**. For the same update in Pro, you also need https://github.com/Strategy11/formidable-pro/pull/3997 as Pro renders a different set of radio buttons inside of a repeater instead.

I pulled my solution from the dropdown HTML which handles this better.

```
<div class="frm_form_field form-field frm_half <?php echo esc_attr( $pos_class ); ?>">
	<label for="field_wq7w5e" class="frm_primary_label"><?php esc_html_e( 'Drop-down Select', 'formidable' ); ?></label>

	<select name="item_meta[1028]" id="field_wq7w5e" >
		<option value=""> </option>
		<option value="option-1"><?php esc_html_e( 'Option 1', 'formidable' ); ?></option>
	</select>
</div>
```

**Question** - Should we add the missing `id`/`for` attributes for inputs and labels in the sample form as well? They're only set here for the dropdown select, none of the other fields in the sample.