### PR TITLE
Allow XML files in file import in unit tests

### DIFF
--- a/classes/factories/FrmFieldFactory.php
+++ b/classes/factories/FrmFieldFactory.php
@@ -54,6 +54,10 @@ class FrmFieldFactory {
 			$field = FrmField::getOne( $field );
 		}
 
+		if ( ! is_object( $field ) ) {
+			var_dump( debug_backtrace( 2 ) );
+		}
+
 		return self::get_field_type( $field->type, $field );
 	}
 

--- a/classes/factories/FrmFieldFactory.php
+++ b/classes/factories/FrmFieldFactory.php
@@ -54,10 +54,6 @@ class FrmFieldFactory {
 			$field = FrmField::getOne( $field );
 		}
 
-		if ( ! is_object( $field ) ) {
-			var_dump( debug_backtrace( 2 ) );
-		}
-
 		return self::get_field_type( $field->type, $field );
 	}
 

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -88,6 +88,15 @@ class FrmUnitTest extends WP_UnitTestCase {
 			return;
 		}
 
+		// Allow XML files in import as we're importing several XML files below.
+		add_filter(
+			'mime_types',
+			function( $mimes ) {
+				$mimes['xml'] = 'application/xml';
+				return $mimes;
+			}
+		);
+
 		FrmHooksController::trigger_load_hook( 'load_admin_hooks' );
 		FrmAppController::install();
 		self::do_tables_exist();
@@ -136,15 +145,6 @@ class FrmUnitTest extends WP_UnitTestCase {
 		}
 
 		add_filter( 'frm_should_import_files', '__return_true' );
-
-		// Allow XML files in import as we're importing several XML files below.
-		add_filter(
-			'mime_types',
-			function( $mimes ) {
-				$mimes['xml'] = 'application/xml';
-				return $mimes;
-			}
-		);
 
 		$single_file_upload_field = FrmField::getOne( 'single-file-upload-field' );
 		$multi_file_upload_field = FrmField::getOne( 'multi-file-upload-field' );

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -97,6 +97,8 @@ class FrmUnitTest extends WP_UnitTestCase {
 			}
 		);
 
+		remove_filter( 'upload_mimes', 'check_upload_mimes' ); // Multisite appears to only allow JPG.
+
 		FrmHooksController::trigger_load_hook( 'load_admin_hooks' );
 		FrmAppController::install();
 		self::do_tables_exist();

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -88,16 +88,17 @@ class FrmUnitTest extends WP_UnitTestCase {
 			return;
 		}
 
-		$allow_mime_types_function = function( $mimes ) {
+		$allow_xml_mime_types_function = function( $mimes ) {
 			$mimes['xml'] = 'application/xml';
 			return $mimes;
 		};
 
 		// Allow XML files in import as we're importing several XML files below.
-		add_filter( 'mime_types', $allow_mime_types_function );
+		add_filter( 'mime_types', $allow_xml_mime_types_function );
 
 		if ( is_multisite() ) {
-			add_filter( 'upload_mimes', $allow_mime_types_function, 11 );
+			// Mimes get changed because of add_filter( 'upload_mimes', 'check_upload_mimes' ); in ms-default-filters.php (A WordPress file).
+			add_filter( 'upload_mimes', $allow_xml_mime_types_function, 11 );
 		}
 
 		FrmHooksController::trigger_load_hook( 'load_admin_hooks' );

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -137,6 +137,14 @@ class FrmUnitTest extends WP_UnitTestCase {
 
 		add_filter( 'frm_should_import_files', '__return_true' );
 
+		add_filter(
+			'mime_types',
+			function( $mimes ) {
+				$mimes['xml'] = 'application/xml';
+				return $mimes;
+			}
+		);
+
 		$single_file_upload_field = FrmField::getOne( 'single-file-upload-field' );
 		$multi_file_upload_field = FrmField::getOne( 'multi-file-upload-field' );
 

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -100,8 +100,6 @@ class FrmUnitTest extends WP_UnitTestCase {
 			add_filter( 'upload_mimes', $allow_mime_types_function, 11 );
 		}
 
-		remove_filter( 'upload_mimes', 'check_upload_mimes' ); // TODO if this fixes it, try a filter like above rather than removing this.
-
 		FrmHooksController::trigger_load_hook( 'load_admin_hooks' );
 		FrmAppController::install();
 		self::do_tables_exist();

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -88,16 +88,19 @@ class FrmUnitTest extends WP_UnitTestCase {
 			return;
 		}
 
-		// Allow XML files in import as we're importing several XML files below.
-		add_filter(
-			'mime_types',
-			function( $mimes ) {
-				$mimes['xml'] = 'application/xml';
-				return $mimes;
-			}
-		);
+		$allow_mime_types_function = function( $mimes ) {
+			$mimes['xml'] = 'application/xml';
+			return $mimes;
+		};
 
-		remove_filter( 'upload_mimes', 'check_upload_mimes' ); // Multisite appears to only allow JPG.
+		// Allow XML files in import as we're importing several XML files below.
+		add_filter( 'mime_types', $allow_mime_types_function );
+
+		if ( is_multisite() ) {
+			add_filter( 'upload_mimes', $allow_mime_types_function, 11 );
+		}
+
+		remove_filter( 'upload_mimes', 'check_upload_mimes' ); // TODO if this fixes it, try a filter like above rather than removing this.
 
 		FrmHooksController::trigger_load_hook( 'load_admin_hooks' );
 		FrmAppController::install();

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -137,6 +137,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 
 		add_filter( 'frm_should_import_files', '__return_true' );
 
+		// Allow XML files in import as we're importing several XML files below.
 		add_filter(
 			'mime_types',
 			function( $mimes ) {


### PR DESCRIPTION
This is required for https://github.com/Strategy11/formidable-pro/pull/3998 to pass unit tests.

XMLs are not a valid file type by default. But they're being uploaded to file fields here on import.