### PR TITLE
Remove margin bottom from combo inputs container fields only on builder page

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1400,7 +1400,7 @@ form .frm_primary_label input {
 	margin-bottom: 20px;
 }
 
-.with_frm_style form .frm_combo_inputs_container > .form-field {
+#frm_builder_page .with_frm_style form .frm_combo_inputs_container > .form-field {
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
I'm hitting this conflict when I try to preview the styler. In a normal preview this is useful.

@truongwp We only need this rule on the builder page, right?

<img width="726" alt="Screen Shot 2023-01-13 at 1 23 07 PM" src="https://user-images.githubusercontent.com/9134515/212380856-f2bfc460-499e-47e3-ad4f-96bda36defb2.png">
