### PR TITLE
Block edit.css from loading on styler page, remove frm_wrap from list…

### DIFF
--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -156,6 +156,7 @@ class FrmHooksController {
 		add_action( 'admin_menu', 'FrmStylesController::menu', 14 );
 		add_action( 'plugins_loaded', 'FrmStylesController::plugins_loaded' );
 		add_action( 'admin_init', 'FrmStylesController::admin_init' );
+		add_action( 'wp_default_styles', 'FrmStylesController::remove_edit_css', 11 ); // Use 11 so it happens after add_action( 'wp_default_styles', 'wp_default_styles' ); where edit.css is added.
 
 		// XML Controller.
 		add_action( 'admin_menu', 'FrmXMLController::menu', 41 );

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -1152,6 +1152,40 @@ class FrmStylesController {
 	}
 
 	/**
+	 * Prevent the WordPress edit.css file from loading on the visual styler page.
+	 * This way .form-field elements do not have border styles applied to them.
+	 *
+	 * @since x.x
+	 *
+	 * @param WP_Styles $styles
+	 * @return void
+	 */
+	public static function remove_edit_css( $styles ) {
+		if ( ! FrmAppHelper::is_style_editor_page() ) {
+			return;
+		}
+
+		if ( ! is_callable( array( $styles, 'remove' ) ) || ! array_key_exists( 'wp-admin', $styles->registered ) ) {
+			return;
+		}
+
+		$styles->remove( 'edit' );
+
+		$wp_admin_dependencies = $styles->registered['wp-admin']->deps;
+		$edit_key              = array_search( 'edit', $wp_admin_dependencies );
+		if ( false === $edit_key ) {
+			return;
+		}
+
+		// Remove the edit dependency from wp-admin so it still loads, just without edit.css.
+		unset( $wp_admin_dependencies[ $edit_key ] );
+		$wp_admin_dependencies = array_values( $wp_admin_dependencies );
+
+		$styles->remove( 'wp-admin' );
+		$styles->add( 'wp-admin', false, $wp_admin_dependencies );
+	}
+
+	/**
 	 * @deprecated x.x Saving custom CSS has been moved into Global Settings.
 	 *
 	 * @return void

--- a/classes/helpers/FrmStylesCardHelper.php
+++ b/classes/helpers/FrmStylesCardHelper.php
@@ -41,7 +41,6 @@ class FrmStylesCardHelper {
 		$this->form_id       = (int) $form_id;
 	}
 
-
 	/**
 	 * Echo a style card for a specific target Style Post object.
 	 *
@@ -98,7 +97,7 @@ class FrmStylesCardHelper {
 	private function get_params_for_style_card( $style ) {
 		$class_name = 'frm_style_' . $style->post_name;
 		$params     = array(
-			'class'               => 'with_frm_style frm-style-card ' . $class_name,
+			'class'               => 'with_frm_style frm-style-card',// . $class_name,
 			'style'               => self::get_style_param_for_card( $style ),
 			'data-classname'      => $class_name,
 			'data-style-id'       => $style->ID,
@@ -151,6 +150,9 @@ class FrmStylesCardHelper {
 	public static function get_style_param_for_card( $style ) {
 		$styles = array();
 
+		$frm_style = new FrmStyle();
+		$defaults  = $frm_style->get_defaults();
+
 		// Add the background color setting for fieldsets to the card.
 		if ( ! $style->post_content['fieldset_bg_color'] ) {
 			$background_color = '#fff';
@@ -163,10 +165,44 @@ class FrmStylesCardHelper {
 		$defaults  = $frm_style->get_defaults();
 
 		// Overwrite some styles. We want to make sure the sizes are normalized for the cards.
-		$styles[] = '--font-size: ' . $defaults['field_font_size'];
-		$styles[] = '--field-font-size: ' . $defaults['field_font_size'];
-		$styles[] = '--label-padding: ' . $defaults['label_padding'];
-		$styles[] = '--field-height: ' . $defaults['field_height'];
+		$styles[]  = '--field-font-size: ' . $defaults['field_font_size'];
+		$styles[]  = '--field-height: ' . $defaults['field_height'];
+		$styles[]  = '--field-pad: ' . $defaults['field_pad'];
+		$styles[]  = '--font-size: ' . $defaults['font_size'];
+
+		// Apply additional styles from the style.
+		$rules_to_apply = array(
+			'fieldset_bg_color',
+			'field_border_width',
+			'field_border_style',
+			'border_color',
+			'submit_bg_color',
+			'submit_border_color',
+			'submit_border_width',
+			'submit_border_radius',
+			'submit_text_color',
+			'submit_weight',
+			'submit_width',
+			'label_color',
+			'text_color',
+			'bg_color',
+		);
+
+		$color_settings = $frm_style->get_color_settings();
+
+		foreach ( $rules_to_apply as $key ) {
+			if ( ! array_key_exists( $key, $style->post_content ) ) {
+				continue;
+			}
+
+			$value = $style->post_content[ $key ];
+
+			if ( in_array( $key, $color_settings, true ) && $value && '#' !== $value[0] && false === strpos( $value, 'rgb' ) ) {
+				$value = '#' . $value;
+			}
+
+			$styles[] = '--' . str_replace( '_', '-', $key ) . ':' . $value;
+		}
 
 		return implode( ';', $styles );
 	}

--- a/classes/views/styles/_custom-style-card.php
+++ b/classes/views/styles/_custom-style-card.php
@@ -2,8 +2,8 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
-// This view is used on the style page to render a single custom theme card.
-// This includes a basic preview (text field and submit button only)
+// This view is used on the style page to render a single custom style card.
+// This includes a basic preview (text field and submit button only).
 // It also includes the title of the style and some basic meta (# of forms assigned, and tags for "selected" and "default").
 
 ?>

--- a/classes/views/styles/_styles-list.php
+++ b/classes/views/styles/_styles-list.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $enabled = '0' !== $form->options['custom_style'];
 ?>
-<div id="frm_style_sidebar" class="frm-right-panel frm_wrap frm_p_4">
+<div id="frm_style_sidebar" class="frm-right-panel frm_p_4"><?php // Make sure not to put .frm_wrap on the whole container because it will cause admin styles to apply to style cards. ?>
 	<?php
 	/**
 	 * Pro needs to hook in here to add the "New Style" trigger.

--- a/css/admin/style.css
+++ b/css/admin/style.css
@@ -153,6 +153,15 @@ This file is added to the visual styler admin page, accessed from the style tab.
 	white-space: nowrap;
 }
 
+.frm-style-card .frm_submit input {
+	border-width: var(--submit-border-width);
+	border-color: var(--submit-border-color);
+	border-radius: var(--submit-border-radius);
+	font-weight: var(--submit-weight);
+	width: var(--submit-width);
+	margin: 0;
+}
+
 .frm_button_submit {
 	transition: none !important; /* Avoid the preview updates from transitioning between one another. */
 }

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -443,7 +443,7 @@
 		dropdownMenu.setAttribute( 'role', 'menu' );
 
 		return div({
-			className: 'dropdown',
+			className: 'dropdown frm_wrap', // The .frm_wrap class prevents a blue outline on the active dropdown trigger.
 			children: [ hamburgerMenu, dropdownMenu ]
 		});
 	}


### PR DESCRIPTION
… page sidebar to avoid admin page styling in style cards, remove class names from style cards and apply style rules directly instead

I'm experimenting with a solution that works better for templates. Instead of using the style class name on the style cards, I'm now only applying specific target rules.

This update also includes the fix that removes edit.css as the borders get applied here in the style card as well.

<img width="429" alt="Screen Shot 2023-01-16 at 11 07 13 AM" src="https://user-images.githubusercontent.com/9134515/212709725-c4e9b1a1-5398-498a-9aa9-c46901a31ea3.png">
