### PR TITLE
remove repeaters from exportable forms only for xml export

### DIFF
--- a/classes/controllers/FrmXMLController.php
+++ b/classes/controllers/FrmXMLController.php
@@ -283,7 +283,6 @@ class FrmXMLController {
 	public static function form( $errors = array(), $message = '' ) {
 		$where = array(
 			'status'         => array( null, '', 'published' ),
-			'parent_form_id' => array( null, 0 ),
 		);
 		$forms = FrmForm::getAll( $where, 'name' );
 

--- a/classes/views/xml/import_form.php
+++ b/classes/views/xml/import_form.php
@@ -124,7 +124,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</thead>
 					<tbody>
 						<?php foreach ( $forms as $form ) { ?>
-							<tr class="frm-row <?php echo ! empty( $form->parent_form_id ) ? esc_attr( 'is-repeater' ) : ''; ?>">
+							<tr class="frm-row <?php echo ! empty( $form->parent_form_id ) ? esc_attr( 'frm-is-repeater' ) : ''; ?>">
 								<td>
 									<input type="checkbox" name="frm_export_forms[]" value="<?php echo esc_attr( $form->id ); ?>" id="export_form_<?php echo esc_attr( $form->id ); ?>" />
 								</td>

--- a/classes/views/xml/import_form.php
+++ b/classes/views/xml/import_form.php
@@ -124,7 +124,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</thead>
 					<tbody>
 						<?php foreach ( $forms as $form ) { ?>
-							<tr class="frm-row">
+							<tr class="frm-row <?php echo ! empty( $form->parent_form_id ) ? esc_attr( 'is-repeater' ) : ''; ?>">
 								<td>
 									<input type="checkbox" name="frm_export_forms[]" value="<?php echo esc_attr( $form->id ); ?>" id="export_form_<?php echo esc_attr( $form->id ); ?>" />
 								</td>

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8804,7 +8804,6 @@ function frmAdminBuildJS() {
 				jQuery( category ).toggleClass( 'frm_hidden', this.value !== '' && ! count );
 				setTemplateCount( category, searchableTemplates );
 			}
-
 		});
 
 		jQuery( document ).on( 'click', '#frm_new_form_modal .frm-modal-back, #frm_new_form_modal .frm_modal_footer .frm-modal-cancel, #frm_new_form_modal .frm-back-to-all-templates', function( event ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8199,14 +8199,14 @@ function frmAdminBuildJS() {
 		if ( exportOption === 'csv' ) {
 			repeaters.forEach( form => {
 				form.classList.remove( 'frm_hidden' );
-			} );
+			});
 		} else {
 			repeaters.forEach( form => {
 				form.classList.add( 'frm_hidden' );
-			} );
+			});
 		}
 
-		searchContent.call(document.querySelector( '.frm-auto-search' ));
+		searchContent.call( document.querySelector( '.frm-auto-search' ) );
 	}
 
 	function preventMultipleExport() {
@@ -9721,7 +9721,7 @@ function frmAdminBuildJS() {
 					maybeAddSaveAndDragIcons( fieldId );
 				});
 			});
-			
+
 			const exportFormatSelect = document.querySelector( 'select[name="format"]' );
 			if ( exportFormatSelect ) {
 				showOrHideRepeaters( exportFormatSelect.value );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8150,6 +8150,15 @@ function frmAdminBuildJS() {
 		}
 	}
 
+	function getExportOption() {
+		const exportFormatSelect = document.querySelector( 'select[name="format"]' );
+		if ( exportFormatSelect ) {
+			return exportFormatSelect.value;
+		} else {
+			return '';
+		}
+	}
+
 	function checkExportTypes() {
 		/*jshint validthis:true */
 		var $dropdown = jQuery( this );
@@ -8189,7 +8198,11 @@ function frmAdminBuildJS() {
 	}
 
 	function showOrHideRepeaters( exportOption ) {
-		const repeaters = document.querySelectorAll( '.is-repeater' );
+		if ( exportOption === '' ) {
+			return;
+		}
+
+		const repeaters = document.querySelectorAll( '.frm-is-repeater' );
 		if ( ! repeaters.length ) {
 			return;
 		}
@@ -9072,11 +9085,9 @@ function frmAdminBuildJS() {
 			addons.add( 'frm-limited-actions' );
 		}
 
-		const exportOption = document.querySelector( 'select[name="format"]' ).value;
-
 		for ( i = 0; i < items.length; i++ ) {
 			var innerText = items[i].innerText.toLowerCase();
-			const itemCanBeShown = ! ( exportOption === 'xml' && items[i].classList.contains( 'is-repeater' ) );
+			const itemCanBeShown = ! ( getExportOption() === 'xml' && items[i].classList.contains( 'frm-is-repeater' ) );
 			if ( searchText === '' ) {
 				if ( itemCanBeShown ) {
 					items[i].classList.remove( 'frm_hidden' );
@@ -10410,10 +10421,7 @@ function frmAdminBuildJS() {
 				this.parentElement.remove();
 			});
 
-			const exportFormatSelect = document.querySelector( 'select[name="format"]' );
-			if ( exportFormatSelect ) {
-				showOrHideRepeaters( exportFormatSelect.value );
-			}
+			showOrHideRepeaters( getExportOption() );
 		},
 
 		inboxBannerInit: function() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8172,9 +8172,11 @@ function frmAdminBuildJS() {
 		if ( $dropdown.val() === 'csv' ) {
 			jQuery( '.csv_opts' ).show();
 			jQuery( '.xml_opts' ).hide();
+			showOrHideRepeaters( 'csv' );
 		} else {
 			jQuery( '.csv_opts' ).hide();
 			jQuery( '.xml_opts' ).show();
+			showOrHideRepeaters( 'xml' );
 		}
 
 		var c = $selected.data( 'count' );
@@ -8185,6 +8187,23 @@ function frmAdminBuildJS() {
 		} else {
 			exportField.prop( 'multiple', true );
 			exportField.prop( 'disabled', false );
+		}
+	}
+
+	function showOrHideRepeaters( exportOption ) {
+		const repeaters = document.querySelectorAll( '.is-repeater' );
+		if ( ! repeaters.length ) {
+			return;
+		}
+
+		if ( exportOption === 'csv' ) {
+			repeaters.forEach( form => {
+				form.classList.remove( 'frm_hidden' );
+			} );
+		} else {
+			repeaters.forEach( form => {
+				form.classList.add( 'frm_hidden' );
+			} );
 		}
 	}
 
@@ -8785,6 +8804,7 @@ function frmAdminBuildJS() {
 				jQuery( category ).toggleClass( 'frm_hidden', this.value !== '' && ! count );
 				setTemplateCount( category, searchableTemplates );
 			}
+
 		});
 
 		jQuery( document ).on( 'click', '#frm_new_form_modal .frm-modal-back, #frm_new_form_modal .frm_modal_footer .frm-modal-cancel, #frm_new_form_modal .frm-back-to-all-templates', function( event ) {
@@ -9053,13 +9073,20 @@ function frmAdminBuildJS() {
 			addons.add( 'frm-limited-actions' );
 		}
 
+		const exportOption = document.querySelector( 'select[name="format"]' ).value;
+		
 		for ( i = 0; i < items.length; i++ ) {
 			var innerText = items[i].innerText.toLowerCase();
+			const itemCanBeHidden = ! ( exportOption === 'xml' && items[i].classList.contains( 'is-repeater' ) );
 			if ( searchText === '' ) {
-				items[i].classList.remove( 'frm_hidden' );
+				if ( itemCanBeHidden ) {
+					items[i].classList.remove( 'frm_hidden' );
+				}
 				items[i].classList.remove( 'frm-search-result' );
 			} else if ( ( regEx && new RegExp( searchText ).test( innerText ) ) || innerText.indexOf( searchText ) >= 0 ) {
-				items[i].classList.remove( 'frm_hidden' );
+				if ( itemCanBeHidden ) {
+					items[i].classList.remove( 'frm_hidden' );
+				}
 				items[i].classList.add( 'frm-search-result' );
 			} else {
 				items[i].classList.add( 'frm_hidden' );
@@ -9693,6 +9720,11 @@ function frmAdminBuildJS() {
 					maybeAddSaveAndDragIcons( fieldId );
 				});
 			});
+			
+			const exportFormatSelect = document.querySelector( 'select[name="format"]' );
+			if ( exportFormatSelect ) {
+				showOrHideRepeaters( exportFormatSelect.value );
+			}
 		},
 
 		buildInit: function() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10393,7 +10393,7 @@ function frmAdminBuildJS() {
 			jQuery( '#frm_export_xml input, #frm_export_xml select' ).on( 'change', removeExportError );
 			jQuery( 'input[name="frm_import_file"]' ).on( 'change', checkCSVExtension );
 			jQuery( 'select[name="format"]' ).on( 'change', checkExportTypes ).trigger( 'change' );
-			jQuery( 'select[name="format"]' ).on( 'change', event => {
+			document.querySelector( 'select[name="format"]' ).addEventListener( 'change', event => {
 				showOrHideRepeaters( event.target.value );
 			});
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8172,11 +8172,9 @@ function frmAdminBuildJS() {
 		if ( $dropdown.val() === 'csv' ) {
 			jQuery( '.csv_opts' ).show();
 			jQuery( '.xml_opts' ).hide();
-			showOrHideRepeaters( 'csv' );
 		} else {
 			jQuery( '.csv_opts' ).hide();
 			jQuery( '.xml_opts' ).show();
-			showOrHideRepeaters( 'xml' );
 		}
 
 		var c = $selected.data( 'count' );
@@ -10395,6 +10393,10 @@ function frmAdminBuildJS() {
 			jQuery( '#frm_export_xml input, #frm_export_xml select' ).on( 'change', removeExportError );
 			jQuery( 'input[name="frm_import_file"]' ).on( 'change', checkCSVExtension );
 			jQuery( 'select[name="format"]' ).on( 'change', checkExportTypes ).trigger( 'change' );
+			jQuery( 'select[name="format"]' ).on( 'change', event => {
+				showOrHideRepeaters( event.target.value );
+			});
+
 			jQuery( 'input[name="frm_export_forms[]"]' ).on( 'click', preventMultipleExport );
 			initiateMultiselect();
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8159,6 +8159,11 @@ function frmAdminBuildJS() {
 		}
 	}
 
+	function exportTypeChanged( event ) {
+		showOrHideRepeaters( event.target.value );
+		checkExportTypes.call( event.target );
+	}
+
 	function checkExportTypes() {
 		/*jshint validthis:true */
 		var $dropdown = jQuery( this );
@@ -8195,6 +8200,7 @@ function frmAdminBuildJS() {
 			exportField.prop( 'multiple', true );
 			exportField.prop( 'disabled', false );
 		}
+		$dropdown.trigger( 'change' );
 	}
 
 	function showOrHideRepeaters( exportOption ) {
@@ -10403,10 +10409,7 @@ function frmAdminBuildJS() {
 			jQuery( document.getElementById( 'frm_export_xml' ) ).on( 'submit', validateExport );
 			jQuery( '#frm_export_xml input, #frm_export_xml select' ).on( 'change', removeExportError );
 			jQuery( 'input[name="frm_import_file"]' ).on( 'change', checkCSVExtension );
-			jQuery( 'select[name="format"]' ).on( 'change', checkExportTypes ).trigger( 'change' );
-			document.querySelector( 'select[name="format"]' ).addEventListener( 'change', event => {
-				showOrHideRepeaters( event.target.value );
-			});
+			document.querySelector( 'select[name="format"]' ).addEventListener( 'change', exportTypeChanged );
 
 			jQuery( 'input[name="frm_export_forms[]"]' ).on( 'click', preventMultipleExport );
 			initiateMultiselect();

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9721,11 +9721,6 @@ function frmAdminBuildJS() {
 					maybeAddSaveAndDragIcons( fieldId );
 				});
 			});
-
-			const exportFormatSelect = document.querySelector( 'select[name="format"]' );
-			if ( exportFormatSelect ) {
-				showOrHideRepeaters( exportFormatSelect.value );
-			}
 		},
 
 		buildInit: function() {
@@ -10412,6 +10407,11 @@ function frmAdminBuildJS() {
 				});
 				this.parentElement.remove();
 			});
+
+			const exportFormatSelect = document.querySelector( 'select[name="format"]' );
+			if ( exportFormatSelect ) {
+				showOrHideRepeaters( exportFormatSelect.value );
+			}
 		},
 
 		inboxBannerInit: function() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8205,6 +8205,8 @@ function frmAdminBuildJS() {
 				form.classList.add( 'frm_hidden' );
 			} );
 		}
+
+		searchContent.call(document.querySelector( '.frm-auto-search' ));
 	}
 
 	function preventMultipleExport() {
@@ -9073,17 +9075,17 @@ function frmAdminBuildJS() {
 		}
 
 		const exportOption = document.querySelector( 'select[name="format"]' ).value;
-		
+
 		for ( i = 0; i < items.length; i++ ) {
 			var innerText = items[i].innerText.toLowerCase();
-			const itemCanBeHidden = ! ( exportOption === 'xml' && items[i].classList.contains( 'is-repeater' ) );
+			const itemCanBeShown = ! ( exportOption === 'xml' && items[i].classList.contains( 'is-repeater' ) );
 			if ( searchText === '' ) {
-				if ( itemCanBeHidden ) {
+				if ( itemCanBeShown ) {
 					items[i].classList.remove( 'frm_hidden' );
 				}
 				items[i].classList.remove( 'frm-search-result' );
 			} else if ( ( regEx && new RegExp( searchText ).test( innerText ) ) || innerText.indexOf( searchText ) >= 0 ) {
-				if ( itemCanBeHidden ) {
+				if ( itemCanBeShown ) {
 					items[i].classList.remove( 'frm_hidden' );
 				}
 				items[i].classList.add( 'frm-search-result' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -5775,8 +5775,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
 			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"bluebird": {
 			"version": "3.5.3",


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4024

This update uses js to show or hide repeaters in the form export page based on the type of export selected. When CSV is selected, both forms and repeaters would be shown and the repeaters are hidden when XML is selected.

![image](https://user-images.githubusercontent.com/41271840/214233098-308002a0-9174-4078-a2a1-ee1272331534.png)

![image](https://user-images.githubusercontent.com/41271840/214233046-623d6de1-fa4a-4815-8cfd-6a174f4102c4.png)
