### PR TITLE
Extra double quote in recaptcha field fix

### DIFF
--- a/classes/models/fields/FrmFieldCaptcha.php
+++ b/classes/models/fields/FrmFieldCaptcha.php
@@ -103,7 +103,7 @@ class FrmFieldCaptcha extends FrmFieldType {
 
 		if ( $frm_settings->active_captcha === 'recaptcha' ) {
 			$site_key          = $frm_settings->pubkey;
-			$recaptcha_options = '" data-size="' . esc_attr( $captcha_size ) . '" data-theme="' . esc_attr( $this->field['captcha_theme'] ) . '"';
+			$recaptcha_options = ' data-size="' . esc_attr( $captcha_size ) . '" data-theme="' . esc_attr( $this->field['captcha_theme'] ) . '"';
 		} else {
 			$site_key = $frm_settings->hcaptcha_pubkey;
 		}


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2134228507/148173/

There was an extra double quote left from the hCaptcha update. This update removes the weird `"=""` you can see in this example.

<img width="688" alt="Screen Shot 2023-01-24 at 9 28 50 AM" src="https://user-images.githubusercontent.com/9134515/214307718-e0889736-ebc7-4631-aecf-b9ee6ff5b1ea.png">