### PR TITLE
Specify required license in applications modal

### DIFF
--- a/classes/models/FrmApplicationTemplate.php
+++ b/classes/models/FrmApplicationTemplate.php
@@ -157,6 +157,7 @@ class FrmApplicationTemplate {
 				$application['forPurchase'] = true;
 			}
 			$application['upgradeUrl'] = $this->get_admin_upgrade_link();
+			$application['requires']   = FrmFormsHelper::get_plan_required( $application );
 			$application['link']       = $application['upgradeUrl'];
 		}
 

--- a/js/admin/applications.js
+++ b/js/admin/applications.js
@@ -410,7 +410,10 @@
 				div({
 					className: 'frm_warning_style',
 					children: [
-						span( __( 'Access to this application requires a license upgrade.', 'formidable' ) ),
+						span(
+							__( 'Access to this application requires the %s plan.', 'formidable' )
+								.replace( '%s', data.requires )
+						),
 						a({
 							text: getUpgradeNowText(),
 							href: data.upgradeUrl

--- a/js/admin/applications.js
+++ b/js/admin/applications.js
@@ -411,6 +411,7 @@
 					className: 'frm_warning_style',
 					children: [
 						span(
+							/* translators: %s: The required license type (ie. Plus, Business, or Elite) */
 							__( 'Access to this application requires the %s plan.', 'formidable' )
 								.replace( '%s', data.requires )
 						),


### PR DESCRIPTION
We talked about this in check-in this morning for the style templates modal. I figured I'd do the same here with Applications too.

<img width="440" alt="Screen Shot 2023-01-26 at 4 34 47 PM" src="https://user-images.githubusercontent.com/9134515/214944768-b1607663-cdae-4137-86e6-a09c8c4d5f16.png">
<img width="439" alt="Screen Shot 2023-01-26 at 4 34 42 PM" src="https://user-images.githubusercontent.com/9134515/214944777-423b1e55-e3b2-4c22-86e2-ef00608181ae.png">
