### PR TITLE
Fix embed icons not triggering modal when the use tag is triggered

### DIFF
--- a/js/admin/embed.js
+++ b/js/admin/embed.js
@@ -45,7 +45,8 @@
 				break;
 
 			case 'svg':
-				clicked = element.parentNode.classList.contains( 'frm-embed-form' );
+			case 'use':
+				clicked = null !== element.closest( '.frm-embed-form' );
 				if ( clicked ) {
 					state.type = 'form';
 				}


### PR DESCRIPTION
It turns out that the inner `use` tag inside of the `svg` could trigger the click event instead, so sometimes my embed modal wouldn't pop up and the url would end up with a `#` appended because `event.preventDefault` never gets called.

This update just adds a `use` check with the `svg` case, using `closest` now instead.