### PR TITLE
Stop setting body to overflow-y: initial

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1930,6 +1930,10 @@ h2.frm-h2 + .howto {
 	border-top: 1px solid var(--sidebar-hover);
 }
 
+body.frm-body-with-open-modal {
+	overflow-y: hidden;
+}
+
 #frm_new_form_modal .postbox > div.inside {
 	max-height: 490px;
 	overflow-y: auto;

--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -525,6 +525,8 @@
 	}
 
 	function makeModalIntoADialogAndOpen( modal, { width } = {}) {
+		const bodyWithModalClassName = 'frm-body-with-open-modal';
+
 		const $modal = jQuery( modal );
 		if ( ! $modal.hasClass( 'frm-dialog' ) ) {
 			$modal.dialog({
@@ -559,14 +561,15 @@
 					}
 				},
 				close: function() {
-					document.body.style.overflowY = 'initial';
+					document.body.classList.remove( bodyWithModalClassName );
 					jQuery( '#wpwrap' ).removeClass( 'frm_overlay' );
 					jQuery( '.spinner' ).css( 'visibility', 'hidden' );
 				}
 			});
 		}
 
-		document.body.style.overflowY = 'hidden';
+		document.body.classList.add( bodyWithModalClassName );
+
 		$modal.dialog( 'open' );
 		return $modal;
 	}


### PR DESCRIPTION
I think this may be the cause of https://github.com/Strategy11/formidable-pro/issues/3918 but I'm not 100% positive it's totally resolved. I think it may at least be related. When I noticed this behaviour in the styler, I linked to this issue as it seems similar.

With the visual styler I noticed that every time I closed a modal that the body became scrollable and I'd end up with a double scroll bar.

I had added this `overflowY: initial` rule when a modal closes previously to fix an issue with all modals scrolling to the top of the page which gets weird when you want to use the embed pop up anywhere where you've scrolled (like in the list of actions or in the list of forms).

I'm going with a less conflicting method now. Instead of changing the `overflowY` on the element directly, I added a new `frm-body-with-open-modal` class that I toggle on and off, which sets a `overflowY` rule only when it's open.