### PR TITLE
fallback to textarea for rte default value field if pro is <= 5.5.6

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -446,14 +446,16 @@ DEFAULT_HTML;
 	 * @return void
 	 */
 	public function show_default_value_field( $field, $default_name, $default_value ) {
-		$pro_version              = class_exists( 'FrmProDb' ) ? FrmProDb::$plug_version : '0';
-		$min_pro_version_not_met  = version_compare( $pro_version, '5.5.6', '<=' );
-
-		if ( $field['type'] === 'rte' && $min_pro_version_not_met ) {
-			include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/textarea-default-value-field.php';
-		} else {
-			include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/default-value-field.php';
+		if ( $field['type'] === 'rte' ) {
+			$pro_version              = class_exists( 'FrmProDb' ) ? FrmProDb::$plug_version : '0';
+			$min_pro_version_not_met  = version_compare( $pro_version, '5.5.6', '<=' );
+			if ( $min_pro_version_not_met ) {
+				include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/textarea-default-value-field.php';
+				return;
+			}
 		}
+
+		include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/default-value-field.php';
 	}
 
 	/**

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -447,10 +447,9 @@ DEFAULT_HTML;
 	 */
 	public function show_default_value_field( $field, $default_name, $default_value ) {
 		if ( $field['type'] === 'rte' ) {
-			if ( ! FrmAppHelper::meets_min_pro_version( '5.5.7' ) ) {
-				include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/textarea-default-value-field.php';
-				return;
-			}
+			// This function is overwritten in Pro. This check is for backwards compatibility.
+			include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/textarea-default-value-field.php';
+			return;
 		}
 
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/default-value-field.php';

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -446,7 +446,14 @@ DEFAULT_HTML;
 	 * @return void
 	 */
 	public function show_default_value_field( $field, $default_name, $default_value ) {
-		include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/default-value-field.php';
+		$pro_version              = class_exists( 'FrmProDb' ) ? FrmProDb::$plug_version : '0';
+		$min_pro_version_not_met  = version_compare( $pro_version, '5.5.6', '<=' );
+
+		if ( $field['type'] === 'rte' && $min_pro_version_not_met ) {
+			include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/textarea-default-value-field.php';
+		} else {
+			include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/default-value-field.php';
+		}
 	}
 
 	/**

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -447,9 +447,7 @@ DEFAULT_HTML;
 	 */
 	public function show_default_value_field( $field, $default_name, $default_value ) {
 		if ( $field['type'] === 'rte' ) {
-			$pro_version              = class_exists( 'FrmProDb' ) ? FrmProDb::$plug_version : '0';
-			$min_pro_version_not_met  = version_compare( $pro_version, '5.5.6', '<=' );
-			if ( $min_pro_version_not_met ) {
+			if ( ! FrmAppHelper::meets_min_pro_version( '5.5.7' ) ) {
 				include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/textarea-default-value-field.php';
 				return;
 			}

--- a/classes/views/frm-fields/back-end/textarea-default-value-field.php
+++ b/classes/views/frm-fields/back-end/textarea-default-value-field.php
@@ -6,6 +6,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <textarea name="<?php echo esc_attr( $default_name ); ?>" class="default-value-field" id="frm_default_value_<?php echo esc_attr( $field['id'] ); ?>" rows="3" data-changeme="field_<?php echo esc_attr( $field['field_key'] ); ?>">
 <?php
-    echo FrmAppHelper::esc_textarea( $default_value ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo FrmAppHelper::esc_textarea( $default_value ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 ?>
 </textarea>


### PR DESCRIPTION
This is an extension from the previous update added to make sure paragraph is used instead of text field for RTE field default value setting when lite is updated but pro is not.

Before this update:
![image](https://user-images.githubusercontent.com/41271840/215582647-83ffb14b-83d4-49dd-85b6-91c3f0a8aca9.png)

After:
![image](https://user-images.githubusercontent.com/41271840/215583254-f65c71cf-fa07-4988-a4e0-2362657ed081.png)
