### PR TITLE
Fix broken auto scroll in form builder with scroll bars

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -971,12 +971,11 @@ function frmAdminBuildJS() {
 
 	function handleDrag( event, ui ) {
 		var container = jQuery( '#post-body-content' );
-		var startSort = 0;
 
 		container.scrollTop( function( i, v ) {
 			var moved, h, relativePos, y;
 
-			moved = event.clientY - startSort;
+			moved = event.clientY;
 			h = this.offsetHeight;
 			relativePos = event.clientY - this.offsetTop;
 			y = relativePos - h / 2;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9771,7 +9771,7 @@ function frmAdminBuildJS() {
 			debouncedSyncAfterDragAndDrop = debounce( syncAfterDragAndDrop, 10 );
 			postBodyContent = document.getElementById( 'post-body-content' );
 			$postBodyContent = jQuery( postBodyContent );
-	
+
 			if ( jQuery( '.frm_field_loading' ).length ) {
 				loadFieldId = jQuery( '.frm_field_loading' ).first().attr( 'id' );
 				loadFields( loadFieldId );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -332,7 +332,8 @@ function frmAdminBuildJS() {
 		thisFormId = 0,
 		autoId = 0,
 		optionMap = {},
-		lastNewActionIdReturned = 0;
+		lastNewActionIdReturned = 0,
+		$postBodyContent;
 
 	const { __ } = wp.i18n;
 	let debouncedSyncAfterDragAndDrop, postBodyContent;
@@ -1006,8 +1007,8 @@ function frmAdminBuildJS() {
 	}
 
 	function maybeScrollBuilder( event ) {
-		jQuery( '#post-body-content' ).scrollTop( function( i, v ) {
-			var moved, h, relativePos, y;
+		$postBodyContent.scrollTop( function( i, v ) {
+			let moved, h, relativePos, y;
 
 			moved = event.clientY;
 			h = this.offsetHeight;
@@ -9767,7 +9768,8 @@ function frmAdminBuildJS() {
 
 			debouncedSyncAfterDragAndDrop = debounce( syncAfterDragAndDrop, 10 );
 			postBodyContent = document.getElementById( 'post-body-content' );
-
+			$postBodyContent = jQuery( postBodyContent );
+	
 			if ( jQuery( '.frm_field_loading' ).length ) {
 				loadFieldId = jQuery( '.frm_field_loading' ).first().attr( 'id' );
 				loadFields( loadFieldId );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1006,23 +1006,24 @@ function frmAdminBuildJS() {
 	}
 
 	function maybeScrollBuilder( event ) {
-		$postBodyContent.scrollTop( function( i, v ) {
-			let moved, h, relativePos, y;
+		$postBodyContent.scrollTop(
+			( _, v ) => {
+				const moved       = event.clientY;
+				const h           = postBodyContent.offsetHeight;
+				const relativePos = event.clientY - postBodyContent.offsetTop;
+				const y           = relativePos - h / 2;
 
-			moved = event.clientY;
-			h = this.offsetHeight;
-			relativePos = event.clientY - this.offsetTop;
-			y = relativePos - h / 2;
-			if ( relativePos > ( h - 50 ) && moved > 5 ) {
+				if ( relativePos > ( h - 50 ) && moved > 5 ) {
+					// Scrolling down.
+					return v + y * 0.1;
+				}
 
-				// scrolling down
-				return v + y * 0.1;
-			} else if ( relativePos < 50 && moved < -5 ) {
-
-				//scrolling up
-				return v - Math.abs( y * 0.1 );
+				if ( relativePos < 50 && moved < -5 ) {
+					// Scrolling up.
+					return v - Math.abs( y * 0.1 );
+				}
 			}
-		});
+		);
 	}
 
 	function getDragOffset( $helper ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -332,11 +332,10 @@ function frmAdminBuildJS() {
 		thisFormId = 0,
 		autoId = 0,
 		optionMap = {},
-		lastNewActionIdReturned = 0,
-		$postBodyContent;
+		lastNewActionIdReturned = 0;
 
 	const { __ } = wp.i18n;
-	let debouncedSyncAfterDragAndDrop, postBodyContent;
+	let debouncedSyncAfterDragAndDrop, postBodyContent, $postBodyContent;
 
 	if ( thisForm !== null ) {
 		thisFormId = thisForm.value;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -970,25 +970,7 @@ function frmAdminBuildJS() {
 	}
 
 	function handleDrag( event, ui ) {
-		var container = jQuery( '#post-body-content' );
-
-		container.scrollTop( function( i, v ) {
-			var moved, h, relativePos, y;
-
-			moved = event.clientY;
-			h = this.offsetHeight;
-			relativePos = event.clientY - this.offsetTop;
-			y = relativePos - h / 2;
-			if ( relativePos > ( h - 50 ) && moved > 5 ) {
-
-				// scrolling down
-				return v + y * 0.1;
-			} else if ( relativePos < 50 && moved < -5 ) {
-
-				//scrolling up
-				return v - Math.abs( y * 0.1 );
-			}
-		});
+		maybeScrollBuilder( event );
 		const draggable = event.target;
 		const droppable = getDroppableTarget();
 
@@ -1021,6 +1003,26 @@ function frmAdminBuildJS() {
 
 		placeholder.style.top = '';
 		handleDragOverFieldGroup({ droppable, x: event.clientX, placeholder });
+	}
+
+	function maybeScrollBuilder( event ) {
+		jQuery( '#post-body-content' ).scrollTop( function( i, v ) {
+			var moved, h, relativePos, y;
+
+			moved = event.clientY;
+			h = this.offsetHeight;
+			relativePos = event.clientY - this.offsetTop;
+			y = relativePos - h / 2;
+			if ( relativePos > ( h - 50 ) && moved > 5 ) {
+
+				// scrolling down
+				return v + y * 0.1;
+			} else if ( relativePos < 50 && moved < -5 ) {
+
+				//scrolling up
+				return v - Math.abs( y * 0.1 );
+			}
+		});
 	}
 
 	function getDragOffset( $helper ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -989,11 +989,9 @@ function frmAdminBuildJS() {
 				className: 'sortable-placeholder'
 			});
 		}
-		const frmSortableHelper = ui.helper.get( 0 );
-		if ( frmSortableHelper.classList.contains( 'form-field' ) ) {
-			// Sync the y position of the draggable so it still follows the cursor after scrolling up and down the field list.
-			frmSortableHelper.style.transform = 'translateY(' + getDragOffset( ui.helper ) + 'px)';
-		}
+
+		// Sync the y position of the draggable so it still follows the cursor after scrolling up and down the field list.
+		ui.helper.get( 0 ).style.transform = 'translateY(' + getDragOffset( ui.helper ) + 'px)';
 
 		if ( 'frm-show-fields' === droppable.id || droppable.classList.contains( 'start_divider' ) ) {
 			placeholder.style.left = 0;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1022,6 +1022,8 @@ function frmAdminBuildJS() {
 					// Scrolling up.
 					return v - Math.abs( y * 0.1 );
 				}
+
+				return v;
 			}
 		);
 	}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -971,6 +971,7 @@ function frmAdminBuildJS() {
 	function handleDrag( event, ui ) {
 		var container = jQuery( '#post-body-content' );
 		var startSort = 0;
+
 		container.scrollTop( function( i, v ) {
 			var moved, h, relativePos, y;
 
@@ -979,14 +980,15 @@ function frmAdminBuildJS() {
 			relativePos = event.clientY - this.offsetTop;
 			y = relativePos - h / 2;
 			if ( relativePos > ( h - 50 ) && moved > 5 ) {
+
 				// scrolling down
-				return v + y * 0.1;
+				return v + y * 0.03;
 			} else if ( relativePos < 50 && moved < -5 ) {
+
 				//scrolling up
-				return v - Math.abs( y * 0.1 );
+				return v - Math.abs( y * 0.03 );
 			}
 		});
-
 		const draggable = event.target;
 		const droppable = getDroppableTarget();
 
@@ -1004,6 +1006,10 @@ function frmAdminBuildJS() {
 				id: 'frm_drag_placeholder',
 				className: 'sortable-placeholder'
 			});
+		}
+
+		if ( ui.helper.get( 0 ).classList.contains( 'form-field' ) ) {
+			ui.helper.get( 0 ).style.transform = 'translateY(' + getDragOffset( ui.helper ) + 'px)';
 		}
 
 		if ( 'frm-show-fields' === droppable.id || droppable.classList.contains( 'start_divider' ) ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -892,6 +892,7 @@ function frmAdminBuildJS() {
 			stop: handleDragStop,
 			drag: handleDrag,
 			cursor: 'grabbing',
+			refreshPositions: true,
 			cursorAt: {
 				top: 0,
 				left: 90 // The width of draggable button is 180. 90 should center the draggable on the cursor.
@@ -982,11 +983,11 @@ function frmAdminBuildJS() {
 			if ( relativePos > ( h - 50 ) && moved > 5 ) {
 
 				// scrolling down
-				return v + y * 0.05;
+				return v + y * 0.1;
 			} else if ( relativePos < 50 && moved < -5 ) {
 
 				//scrolling up
-				return v - Math.abs( y * 0.05 );
+				return v - Math.abs( y * 0.1 );
 			}
 		});
 		const draggable = event.target;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -969,6 +969,24 @@ function frmAdminBuildJS() {
 	}
 
 	function handleDrag( event, ui ) {
+		var container = jQuery( '#post-body-content' );
+		var startSort = 0;
+		container.scrollTop( function( i, v ) {
+			var moved, h, relativePos, y;
+
+			moved = event.clientY - startSort;
+			h = this.offsetHeight;
+			relativePos = event.clientY - this.offsetTop;
+			y = relativePos - h / 2;
+			if ( relativePos > ( h - 50 ) && moved > 5 ) {
+				// scrolling down
+				return v + y * 0.1;
+			} else if ( relativePos < 50 && moved < -5 ) {
+				//scrolling up
+				return v - Math.abs( y * 0.1 );
+			}
+		});
+
 		const draggable = event.target;
 		const droppable = getDroppableTarget();
 
@@ -987,9 +1005,6 @@ function frmAdminBuildJS() {
 				className: 'sortable-placeholder'
 			});
 		}
-
-		// Sync the y position of the draggable so it still follows the cursor after scrolling up and down the field list.
-		ui.helper.get( 0 ).style.transform = 'translateY(' + getDragOffset( ui.helper ) + 'px)';
 
 		if ( 'frm-show-fields' === droppable.id || droppable.classList.contains( 'start_divider' ) ) {
 			placeholder.style.left = 0;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1007,9 +1007,10 @@ function frmAdminBuildJS() {
 				className: 'sortable-placeholder'
 			});
 		}
-
-		if ( ui.helper.get( 0 ).classList.contains( 'form-field' ) ) {
-			ui.helper.get( 0 ).style.transform = 'translateY(' + getDragOffset( ui.helper ) + 'px)';
+		const frmSortableHelper = ui.helper.get( 0 );
+		if ( frmSortableHelper.classList.contains( 'form-field' ) ) {
+			// Sync the y position of the draggable so it still follows the cursor after scrolling up and down the field list.
+			frmSortableHelper.style.transform = 'translateY(' + getDragOffset( ui.helper ) + 'px)';
 		}
 
 		if ( 'frm-show-fields' === droppable.id || droppable.classList.contains( 'start_divider' ) ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -989,9 +989,11 @@ function frmAdminBuildJS() {
 				className: 'sortable-placeholder'
 			});
 		}
-
-		// Sync the y position of the draggable so it still follows the cursor after scrolling up and down the field list.
-		ui.helper.get( 0 ).style.transform = 'translateY(' + getDragOffset( ui.helper ) + 'px)';
+		const frmSortableHelper = ui.helper.get( 0 );
+		if ( frmSortableHelper.classList.contains( 'form-field' ) || frmSortableHelper.classList.contains( 'frm_field_box' ) ) {
+			// Sync the y position of the draggable so it still follows the cursor after scrolling up and down the field list.
+			frmSortableHelper.style.transform = 'translateY(' + getDragOffset( ui.helper ) + 'px)';
+		}
 
 		if ( 'frm-show-fields' === droppable.id || droppable.classList.contains( 'start_divider' ) ) {
 			placeholder.style.left = 0;
@@ -1016,7 +1018,7 @@ function frmAdminBuildJS() {
 					return v + y * 0.1;
 				}
 
-				if ( relativePos < 50 && moved < -5 ) {
+				if ( relativePos < 70 && moved < 130 ) {
 					// Scrolling up.
 					return v - Math.abs( y * 0.1 );
 				}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -982,11 +982,11 @@ function frmAdminBuildJS() {
 			if ( relativePos > ( h - 50 ) && moved > 5 ) {
 
 				// scrolling down
-				return v + y * 0.03;
+				return v + y * 0.05;
 			} else if ( relativePos < 50 && moved < -5 ) {
 
 				//scrolling up
-				return v - Math.abs( y * 0.03 );
+				return v - Math.abs( y * 0.05 );
 			}
 		});
 		const draggable = event.target;


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3917

This update fixes the broken autoscroll when dragging fields around a form with many fields that is scrollable. The form now auto scrolls up and down as you grab a field and move the cursor around the top/bottom inside the builder.

BEFORE:
https://user-images.githubusercontent.com/41271840/216592817-68b9ef47-69f4-440e-a8ef-49514b8530ee.mp4


AFTER:
https://user-images.githubusercontent.com/41271840/216592213-471b72b7-adfb-4cbf-9b88-63a9db862d1c.mp4

