### PR TITLE
remove default limit on the number of actions triggered

### DIFF
--- a/classes/models/FrmFormAction.php
+++ b/classes/models/FrmFormAction.php
@@ -519,6 +519,7 @@ class FrmFormAction {
 			);
 		}
 		$defaults = array(
+			'limit'       => 99,
 			'post_status' => $default_status,
 		);
 		$args     = wp_parse_args( $args, $defaults );
@@ -548,8 +549,13 @@ class FrmFormAction {
 	}
 
 	public function get_all( $form_id = false, $atts = array() ) {
+		if ( is_array( $atts ) && ! isset( $atts['limit'] ) ) {
+			$atts['limit'] = $this->action_options['limit'];
+		}
+
 		self::prepare_get_action( $atts, 'any' );
-		$limit = $this->action_options['limit'];
+
+		$limit = $atts['limit'];
 
 		if ( $form_id ) {
 			$this->form_id = $form_id;

--- a/classes/models/FrmFormAction.php
+++ b/classes/models/FrmFormAction.php
@@ -519,7 +519,6 @@ class FrmFormAction {
 			);
 		}
 		$defaults = array(
-			'limit'       => 99,
 			'post_status' => $default_status,
 		);
 		$args     = wp_parse_args( $args, $defaults );
@@ -550,7 +549,7 @@ class FrmFormAction {
 
 	public function get_all( $form_id = false, $atts = array() ) {
 		self::prepare_get_action( $atts, 'any' );
-		$limit = $atts['limit'];
+		$limit = $this->action_options['limit'];
 
 		if ( $form_id ) {
 			$this->form_id = $form_id;


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3991

It looks that there is a default limit (99) defined for the number of actions triggered in `FrmFormAction::prepare_get_action` which prevents those extra actions to be triggered even if `frm_${action}_action_options` filter is used to extend the number of actions added in a given form.

I imagine two alternative solutions.

First, it looks we actually can use the action's `action_options['limit']` value instead to account for the new limit of actions as in this PR.

If we don't want to do that, I think we need to provide `$args['limit']` value everywhere `FrmFormAction::get_action_for_form` is called so that we override the default limit mentioned above.