### PR TITLE
Fix buttons moving on save

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2874,7 +2874,7 @@ class FrmAppHelper {
 				'desc'              => __( '(Click to add description)', 'formidable' ),
 				'blank'             => __( '(Blank)', 'formidable' ),
 				'no_label'          => __( '(no label)', 'formidable' ),
-				'saving'            => esc_attr( __( 'Saving', 'formidable' ) ),
+				'saving'            => '', // Deprecated.
 				'saved'             => esc_attr( __( 'Saved', 'formidable' ) ),
 				'ok'                => __( 'OK', 'formidable' ),
 				'cancel'            => __( 'Cancel', 'formidable' ),

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2874,8 +2874,8 @@ class FrmAppHelper {
 				'desc'              => __( '(Click to add description)', 'formidable' ),
 				'blank'             => __( '(Blank)', 'formidable' ),
 				'no_label'          => __( '(no label)', 'formidable' ),
-				'saving'            => '', // Deprecated.
-				'saved'             => esc_attr( __( 'Saved', 'formidable' ) ),
+				'saving'            => '', // Deprecated in 6.0.
+				'saved'             => '', // Deprecated in 6.0.
 				'ok'                => __( 'OK', 'formidable' ),
 				'cancel'            => __( 'Cancel', 'formidable' ),
 				'default_label'     => __( 'Default', 'formidable' ),

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -345,7 +345,7 @@
 			form.parentNode.classList.remove( activeCard.dataset.classname );
 			form.parentNode.classList.add( card.dataset.classname );
 		}
-		
+
 		sampleForm.classList.remove( activeCard.dataset.classname );
 		sampleForm.classList.add( card.dataset.classname );
 
@@ -522,6 +522,8 @@
 			return;
 		}
 
+		document.getElementById( 'frm_submit_side_top' ).classList.add( 'frm_loading_button' );
+
 		// Submit the "list" view (assign a style to a form).
 		document.getElementById( 'frm_style_list_form' ).submit();
 	}
@@ -531,7 +533,7 @@
 	 * If the sample form toggle is active, we want to pass that as a query parameter so we know to default to the sample form on load.
 	 *
 	 * @param {HTMLElement} clickTarget
-	 * @returns 
+	 * @returns {void}
 	 */
 	function modifyStylerUrl( clickTarget ) {
 		if ( ! state.showingSampleForm ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5882,8 +5882,8 @@ function frmAdminBuildJS() {
 
 	function submitBuild() {
 		/*jshint validthis:true */
-		var $thisEle = jQuery( this );
-		var p = $thisEle.html();
+		var $thisEle = this;
+		var p = this.innerHTML;
 
 		preFormSave( this );
 
@@ -5938,30 +5938,25 @@ function frmAdminBuildJS() {
 			jQuery( '.inplace_save, .postbox' ).trigger( 'click' );
 		}
 
-		$button = jQuery( b );
-
-		if ( $button.hasClass( 'frm_button_submit' ) ) {
-			$button.addClass( 'frm_loading_form' );
-			$button.html( frm_admin_js.saving );
+		if ( b.classList.contains( 'frm_button_submit' ) ) {
+			b.classList.add( 'frm_loading_form' );
 		} else {
-			$button.addClass( 'frm_loading_button' );
-			$button.val( frm_admin_js.saving );
+			b.classList.add( 'frm_loading_button' );
 		}
+		b.setAttribute( 'aria-busy', 'true' );
 	}
 
-	function afterFormSave( $button, buttonVal ) {
-		$button.removeClass( 'frm_loading_form' ).removeClass( 'frm_loading_button' );
-		$button.html( frm_admin_js.saved );
+	function afterFormSave( button, buttonVal ) {
+		button.classList.remove( 'frm_loading_form' );
+		button.classList.remove( 'frm_loading_button' );
+		button.innterHTML = frm_admin_js.saved;
 		resetOptionTextDetails();
 		fieldsUpdated = 0;
+		button.setAttribute( 'aria-busy', 'false' );
 
 		setTimeout( function() {
 			jQuery( '.frm_updated_message' ).fadeOut( 'slow', function() {
 				this.parentNode.removeChild( this );
-			});
-			$button.fadeOut( 'slow', function() {
-				$button.html( buttonVal );
-				$button.show();
 			});
 		}, 5000 );
 	}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5883,7 +5883,6 @@ function frmAdminBuildJS() {
 	function submitBuild() {
 		/*jshint validthis:true */
 		var $thisEle = this;
-		var p = this.innerHTML;
 
 		preFormSave( this );
 
@@ -5896,7 +5895,7 @@ function frmAdminBuildJS() {
 			url: ajaxurl,
 			data: {action: 'frm_save_form', 'frm_compact_fields': v, nonce: frmGlobal.nonce},
 			success: function( msg ) {
-				afterFormSave( $thisEle, p );
+				afterFormSave( $thisEle );
 
 				var $postStuff = document.getElementById( 'post-body-content' );
 				var $html = document.createElement( 'div' );
@@ -5946,7 +5945,7 @@ function frmAdminBuildJS() {
 		b.setAttribute( 'aria-busy', 'true' );
 	}
 
-	function afterFormSave( button, buttonVal ) {
+	function afterFormSave( button ) {
 		button.classList.remove( 'frm_loading_form' );
 		button.classList.remove( 'frm_loading_button' );
 		button.innterHTML = frm_admin_js.saved;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5948,7 +5948,6 @@ function frmAdminBuildJS() {
 	function afterFormSave( button ) {
 		button.classList.remove( 'frm_loading_form' );
 		button.classList.remove( 'frm_loading_button' );
-		button.innterHTML = frm_admin_js.saved;
 		resetOptionTextDetails();
 		fieldsUpdated = 0;
 		button.setAttribute( 'aria-busy', 'false' );


### PR DESCRIPTION
Prevent movement when the form builder update button is clicked. This uses 'aria-busy' instead of changing the button label.

This also adds the loading spinner when the styler page is saved.