### PR TITLE
Add more sanitizing to styler colors

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -482,7 +482,6 @@ class FrmAppController {
 		wp_register_script( 'bootstrap_tooltip', $plugin_url . '/js/bootstrap.min.js', array( 'jquery', 'popper' ), '4.6.1', true );
 		wp_register_script( 'formidable_settings', $plugin_url . '/js/admin/settings.js', array(), $version, true );
 
-
 		$page = FrmAppHelper::simple_get( 'page', 'sanitize_title' );
 
 		if ( 'formidable-applications' === $page ) {

--- a/classes/helpers/FrmHtmlHelper.php
+++ b/classes/helpers/FrmHtmlHelper.php
@@ -25,7 +25,8 @@ class FrmHtmlHelper {
 	public static function toggle( $id, $name, $args ) {
 		wp_enqueue_script( 'formidable_settings' );
 		return FrmAppHelper::clip(
-			function() use ( $id, $name, $args ) { // @phpstan-ignore-line
+			// @phpstan-ignore-next-line
+			function() use ( $id, $name, $args ) {
 				require FrmAppHelper::plugin_path() . '/classes/views/shared/toggle.php';
 			},
 			isset( $args['echo'] ) ? $args['echo'] : false

--- a/classes/models/FrmStyle.php
+++ b/classes/models/FrmStyle.php
@@ -89,16 +89,16 @@ class FrmStyle {
 
 				if ( $this->is_color( $setting ) ) {
 					$color_val = $new_instance['post_content'][ $setting ];
-					if ( $color_val !== '' && 0 === strpos( $color_val, 'rgb' ) ) {
-						// maybe sanitize if invalid rgba value is entered
+					if ( $color_val !== '' && false !== strpos( $color_val, 'rgb' ) ) {
+						// Maybe sanitize if invalid rgba value is entered.
 						$this->maybe_sanitize_rgba_value( $color_val );
 					}
 					$new_instance['post_content'][ $setting ] = str_replace( '#', '', $color_val );
-				} elseif ( in_array( $setting, array( 'submit_style', 'important_style', 'auto_width' ) )
+				} elseif ( in_array( $setting, array( 'submit_style', 'important_style', 'auto_width' ), true )
 					&& ! isset( $new_instance['post_content'][ $setting ] )
 					) {
 					$new_instance['post_content'][ $setting ] = 0;
-				} elseif ( $setting == 'font' ) {
+				} elseif ( $setting === 'font' ) {
 					$new_instance['post_content'][ $setting ] = $this->force_balanced_quotation( $new_instance['post_content'][ $setting ] );
 				}
 			}
@@ -128,6 +128,7 @@ class FrmStyle {
 		}
 
 		$color_val = trim( $color_val );
+		$color_val = ltrim( $color_val, '(' ); // Remove leading braces so (rgba(1,1,1,1) doesn't cause inconsistent braces.
 		$patterns  = array( '/rgba\((\s*\d+\s*,){3}[[0-1]\.]+\)/', '/rgb\((\s*\d+\s*,){2}\s*[\d]+\)/' );
 		foreach ( $patterns as $pattern ) {
 			if ( preg_match( $pattern, $color_val ) === 1 ) {
@@ -135,9 +136,9 @@ class FrmStyle {
 			}
 		}
 
-		if ( substr( $color_val, -1 ) !== ')' ) {
-			$color_val .= ')';
-		}
+		// Remove all leading ')' braces, then add one back. This way there's always a single brace.
+		$color_val  = rtrim( $color_val, ')' );
+		$color_val .= ')';
 
 		$color_rgba            = substr( $color_val, strpos( $color_val, '(' ) + 1, strlen( $color_val ) - strpos( $color_val, '(' ) - 2 );
 		$length_of_color_codes = strpos( $color_val, '(' );

--- a/classes/models/FrmStyle.php
+++ b/classes/models/FrmStyle.php
@@ -167,6 +167,8 @@ class FrmStyle {
 					$new_value = 4 === $length_of_color_codes ? 1 : 0;
 				} elseif ( $value > 1 || $value < 0 ) {
 					$new_value = 1;
+				} else {
+					$new_value = floatval( $value );
 				}
 			}
 

--- a/classes/models/FrmStyle.php
+++ b/classes/models/FrmStyle.php
@@ -141,6 +141,7 @@ class FrmStyle {
 		$color_val .= ')';
 
 		$color_rgba            = substr( $color_val, strpos( $color_val, '(' ) + 1, strlen( $color_val ) - strpos( $color_val, '(' ) - 2 );
+		$color_rgba            = trim( $color_rgba, '()' ); // Remove any excessive braces from the rgba like rgba((.
 		$length_of_color_codes = strpos( $color_val, '(' );
 		$new_color_values      = array();
 
@@ -150,16 +151,18 @@ class FrmStyle {
 			$value_is_empty_string = '' === trim( $value ) || '' === $value;
 
 			if ( 3 === $length_of_color_codes || ( $index !== $length_of_color_codes - 1 ) ) {
-				// insert a value for r, g, or b
+				// Insert a value for r, g, or b.
 				if ( $value < 0 ) {
 					$new_value = 0;
 				} elseif ( $value > 255 ) {
 					$new_value = 255;
 				} elseif ( $value_is_empty_string ) {
 					$new_value = 0;
+				} else {
+					$new_value = absint( $value );
 				}
 			} else {
-				// insert a value for alpha
+				// Insert a value for alpha.
 				if ( $value_is_empty_string ) {
 					$new_value = 4 === $length_of_color_codes ? 1 : 0;
 				} elseif ( $value > 1 || $value < 0 ) {
@@ -185,6 +188,7 @@ class FrmStyle {
 
 		$new_color = implode( ',', $new_color_values );
 		$prefix    = substr( $color_val, 0, strpos( $color_val, '(' ) + 1 );
+		$prefix    = rtrim( $prefix, '(' ) . '('; // Limit the number of opening braces after rgb/rgba. There should only be one.
 		$new_color = $prefix . $new_color . ')';
 
 		$color_val = $new_color;

--- a/classes/views/shared/toggle.php
+++ b/classes/views/shared/toggle.php
@@ -28,7 +28,7 @@ $use_container = false;
 $div_params = array(
 	// This is important when the default style is !important as Pro styling may cause conflicts.
 	// It uses --toggle-on-color so just set the variable.
-	'style' => '--toggle-on-color:var(--primary-color);'
+	'style' => '--toggle-on-color:var(--primary-color);',
 );
 if ( $div_class ) {
 	$use_container       = true;

--- a/psalm.xml
+++ b/psalm.xml
@@ -53,5 +53,10 @@
 				<directory name="deprecated" />
 			</errorLevel>
 		</InvalidParamDefault>
+		<MethodSignatureMustProvideReturnType>
+			<errorLevel type="suppress">
+				<file name="classes/widgets/FrmShowForm.php" />
+			</errorLevel>
+		</MethodSignatureMustProvideReturnType>
 	</issueHandlers>
 </psalm>

--- a/tests/styles/test_FrmStyle.php
+++ b/tests/styles/test_FrmStyle.php
@@ -22,6 +22,12 @@ class test_FrmStyle extends FrmUnitTest {
 			'rgb(300,0,-1)'    => 'rgb(255,0,0)',
 			'rgb('             => 'rgb(0,0,0)',
 			'rgb(255,255,255)' => 'rgb(255,255,255)',
+			'(rgba(0,0,0,1)'   => 'rgba(0,0,0,1)',
+			'((rgba(0,0,0,1)'  => 'rgba(0,0,0,1)',
+			'(rgb(0,0,0)'      => 'rgb(0,0,0)',
+			'rgba(0,0,0,1))'   => 'rgba(0,0,0,1)',
+			' rgba(0,0,0,1)'   => 'rgba(0,0,0,1)',
+			' (rgb(0,0,0)'      => 'rgb(0,0,0)',
 		);
 
 		foreach ( $invalid_color_values as $color_val => $expected_color_val ) {

--- a/tests/styles/test_FrmStyle.php
+++ b/tests/styles/test_FrmStyle.php
@@ -11,7 +11,7 @@ class test_FrmStyle extends FrmUnitTest {
 	public function test_maybe_sanitize_rgba_value() {
 		$frm_style            = new FrmStyle();
 		$invalid_color_values = array(
-			'rgba(45, 45, 45,' => 'rgba(45, 45, 45,1)',
+			'rgba(45, 45, 45,' => 'rgba(45,45,45,1)',
 			'rgba(, , ,1)'     => 'rgba(0,0,0,1)',
 			'rgba(45,45'       => 'rgba(45,45,0,1)',
 			'rgba(355,,,0.5)'  => 'rgba(255,0,0,0.5)',
@@ -27,7 +27,8 @@ class test_FrmStyle extends FrmUnitTest {
 			'(rgb(0,0,0)'      => 'rgb(0,0,0)',
 			'rgba(0,0,0,1))'   => 'rgba(0,0,0,1)',
 			' rgba(0,0,0,1)'   => 'rgba(0,0,0,1)',
-			' (rgb(0,0,0)'      => 'rgb(0,0,0)',
+			' (rgb(0,0,0)'     => 'rgb(0,0,0)',
+			'rgba((0,0,0,1)'   => 'rgba(0,0,0,1)',
 		);
 
 		foreach ( $invalid_color_values as $color_val => $expected_color_val ) {

--- a/tests/styles/test_FrmStyle.php
+++ b/tests/styles/test_FrmStyle.php
@@ -7,7 +7,6 @@ class test_FrmStyle extends FrmUnitTest {
 
 	/**
 	 * @covers FrmStyle::maybe_sanitize_rgba_value
-	 * @group mike
 	 */
 	public function test_maybe_sanitize_rgba_value() {
 		$frm_style            = new FrmStyle();

--- a/tests/styles/test_FrmStyle.php
+++ b/tests/styles/test_FrmStyle.php
@@ -7,6 +7,7 @@ class test_FrmStyle extends FrmUnitTest {
 
 	/**
 	 * @covers FrmStyle::maybe_sanitize_rgba_value
+	 * @group mike
 	 */
 	public function test_maybe_sanitize_rgba_value() {
 		$frm_style            = new FrmStyle();


### PR DESCRIPTION
This came up in support on Monday.

Someone had a `(rgba(...` style with that extra leading `(` on it. This caused the rest of the styles to break.

We already have some sanitizing in place to make sure colours are formatted as expected. But the checks weren't removing any excess brackets so I've updated this to make sure that it is always consistent.

I tried cleaning it up a bit more in a few other ways too. I noticed the same issue happened with an extra brace after the `rgb` like `rgb((` so I added some trimming to remove that as well.

And I added some other sanitizing. The r/g/b values now get passed through `absint` and the alpha goes through `floatval` so if any non-numeric values are used here, they'll get removed.