### PR TITLE
Fix close button on WP auth modal on styler pages

### DIFF
--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -28,6 +28,7 @@
 
 	initCommonEventListeners();
 	initPreview();
+	fixWpAuthModal();
 
 	/**
 	 * These are shared events for both the edit/list views like the sample form toggle.
@@ -54,6 +55,19 @@
 		// Then add it back where we want to use admin styles (the sidebar, otherwise inputs appear short).
 		document.body.classList.remove( 'wp-core-ui' );
 		document.getElementById( 'frm_style_sidebar' ).classList.add( 'wp-core-ui' );
+	}
+
+	/**
+	 * Add the wp-core-ui class to the #wp-auth-check-wrap element.
+	 * As this style isn't included on the body for the styler, the close button on the auth modal wasn't getting styled properly.
+	 *
+	 * @returns {void}
+	 */
+	function fixWpAuthModal() {
+		const authWrap = document.getElementById( 'wp-auth-check-wrap' );
+		if ( authWrap ) {
+			authWrap.classList.add( 'wp-core-ui' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
I noticed this was my session expired.

In the styler branch I wasn't getting these styles because I removed the `wp-core-ui` class.
<img width="378" alt="Screen Shot 2023-02-08 at 11 07 36 AM" src="https://user-images.githubusercontent.com/9134515/217570945-33d7ec98-238f-4be3-b7ae-e5753b293e52.png">

This update just inserts the wp-core-ui class on the auth wrapper so the styles get applied properly.

**Before**
<img width="306" alt="Screen Shot 2023-02-08 at 10 59 10 AM" src="https://user-images.githubusercontent.com/9134515/217571145-14d02e16-6070-4f5e-8c62-ea2a1afae698.png">

**After**
<img width="310" alt="Screen Shot 2023-02-08 at 10 56 27 AM" src="https://user-images.githubusercontent.com/9134515/217571163-699f4585-1db7-4d48-8e51-bee9a64f937d.png">
