### PR TITLE
Hide the WP admin menu and toolbar on full screen pages

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -450,6 +450,8 @@ class FrmAppController {
 		}
 
 		if ( FrmAppHelper::is_admin_page( 'formidable' ) ) {
+			self::disable_admin_menus();
+
 			$action = FrmAppHelper::get_param( 'frm_action' );
 
 			if ( in_array( $action, array( 'add_new', 'list_templates' ), true ) ) {
@@ -459,6 +461,27 @@ class FrmAppController {
 
 			FrmInbox::maybe_disable_screen_options();
 		}
+	}
+
+	/**
+	 * Remove the admin menus and hide the gaps on full screen pages.
+	 *
+	 * @since x.x
+	 */
+	private static function disable_admin_menus() {
+		if ( ! FrmAppHelper::is_full_screen() ) {
+			return;
+		}
+
+		wp_deregister_script( 'admin-bar' );
+		wp_deregister_style( 'admin-bar' );
+		remove_action( 'admin_footer', 'wp_admin_bar_render', 1000 );
+		add_action(
+			'admin_head',
+			function() {
+				echo '<style>html.wp-toolbar{padding-top:0}</style>';
+			}
+		);
 	}
 
 	/**

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -449,9 +449,9 @@ class FrmAppController {
 			self::admin_js();
 		}
 
-		if ( FrmAppHelper::is_admin_page( 'formidable' ) ) {
-			self::disable_admin_menus();
+		self::disable_admin_menus();
 
+		if ( FrmAppHelper::is_admin_page( 'formidable' ) ) {
 			$action = FrmAppHelper::get_param( 'frm_action' );
 
 			if ( in_array( $action, array( 'add_new', 'list_templates' ), true ) ) {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -84,7 +84,7 @@ a, .widget .widget-top, .stuffbox h3, .frm-collapsed {
 .frm-full-screen #wpbody-content,
 .frm-full-screen #wpbody,
 .frm-full-screen #wpcontent {
-	padding-bottom: 0;
+	padding: 0;
 	overflow: hidden;
 	margin: 0 !important;
 }
@@ -507,7 +507,7 @@ ul.frm_form_nav > li:last-of-type {
 	margin: 0;
 }
 
-.frm_page_container {
+.frm_wrap .frm_page_container { /* Use .frm_wrap to avoid messing up Views editor layout */
 	height: calc( 100vh - 32px );
 	display: flex;
 	flex-direction: column;
@@ -515,9 +515,23 @@ ul.frm_form_nav > li:last-of-type {
 	padding-top: 0;
 }
 
-.frm-full-screen .frm_page_container {
+.frm-full-screen .frm_wrap .frm_page_container {
 	height: 100vh;
 }
+
+/* Temp Views full screen override until HTML is updated */
+.frm-views-editor-body {
+	--header-height: 61px;
+}
+
+#frm_view_editor_left, #frm_view_editor_right {
+	height: calc( 100vh - var( --header-height ) ) !important;
+}
+
+#frm_view_editor_preview_area {
+	height: calc( 100vh - 100px - var( --header-height ) ) !important;
+}
+/* End temp Views override */
 
 .frm-full-screen.frm-admin-page-entries .frm_page_container,
 .frm-new-entry .frm_page_container,

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -75,6 +75,8 @@ a, .widget .widget-top, .stuffbox h3, .frm-collapsed {
 	overflow: auto;
 }
 
+.frm-full-screen #wpadminbar,
+.frm-full-screen #adminmenumain,
 .frm-full-screen .wp-header-end {
 	display: none;
 }
@@ -84,6 +86,7 @@ a, .widget .widget-top, .stuffbox h3, .frm-collapsed {
 .frm-full-screen #wpcontent {
 	padding-bottom: 0;
 	overflow: hidden;
+	margin: 0 !important;
 }
 
 .frm-white-body #wpbody-content {
@@ -504,12 +507,16 @@ ul.frm_form_nav > li:last-of-type {
 	margin: 0;
 }
 
-.frm_wrap .frm_page_container {
+.frm_page_container {
 	height: calc( 100vh - 32px );
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
 	padding-top: 0;
+}
+
+.frm-full-screen .frm_page_container {
+	height: 100vh;
 }
 
 .frm-full-screen.frm-admin-page-entries .frm_page_container,


### PR DESCRIPTION
This should make scrolling eaiser

Fixes https://github.com/Strategy11/formidable-pro/issues/3918
(I think)