### PR TITLE
Add new tag to application templates

### DIFF
--- a/classes/models/FrmApplicationTemplate.php
+++ b/classes/models/FrmApplicationTemplate.php
@@ -161,6 +161,8 @@ class FrmApplicationTemplate {
 			$application['link']       = $application['upgradeUrl'];
 		}
 
+		$application['isNew'] = $this->is_new();
+
 		return $application;
 	}
 
@@ -195,6 +197,23 @@ class FrmApplicationTemplate {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Check if an application template is new. If it is, we include a "NEW" pill beside the title.
+	 *
+	 * @since x.x
+	 *
+	 * @return bool
+	 */
+	private function is_new() {
+		if ( ! array_key_exists( 'released', $this->api_data ) ) {
+			return false;
+		}
+
+		$release_date = $this->api_data['released'];
+		$is_new       = strtotime( $release_date ) > strtotime( '-30 days' );
+		return $is_new;
 	}
 
 	/**

--- a/classes/views/frm-forms/list-template.php
+++ b/classes/views/frm-forms/list-template.php
@@ -47,7 +47,7 @@ if ( ! empty( $template['custom'] ) ) {
 				<?php } ?>
 				<?php echo esc_html( $stripped_template_name ); ?>
 				<?php
-				$template_is_new = strtotime( $template['released'] ) > strtotime( '-10 days' );
+				$template_is_new = strtotime( $template['released'] ) > strtotime( '-30 days' );
 				if ( $template_is_new && empty( $template['custom'] ) ) {
 					FrmAppHelper::show_pill_text();
 				}

--- a/js/admin/applications.js
+++ b/js/admin/applications.js
@@ -297,6 +297,11 @@
 				]
 			});
 
+			const isNew = data.isNew;
+			if ( isNew ) {
+				titleWrapper.querySelector( 'h4' ).appendChild( span({ className: 'frm-new-pill', text: __( 'NEW', 'formidable' ) }) );
+			}
+
 			const counter = getItemCounter();
 			if ( false !== counter ) {
 				header.appendChild( counter );

--- a/js/admin/applications.js
+++ b/js/admin/applications.js
@@ -284,7 +284,7 @@
 		wp.hooks.doAction( hookName, card, args );
 
 		function getCardHeader() {
-			const title = tag( 'h4', { text: data.name });
+			const title = tag( 'h4', data.name );
 
 			const titleWrapper = span({
 				children: [

--- a/js/admin/applications.js
+++ b/js/admin/applications.js
@@ -284,10 +284,12 @@
 		wp.hooks.doAction( hookName, card, args );
 
 		function getCardHeader() {
+			const title = tag( 'h4', { text: data.name });
+
 			const titleWrapper = span({
 				children: [
 					svg({ href: '#frm_lock_simple' }),
-					tag( 'h4', { text: data.name })
+					title
 				]
 			});
 			const header = div({
@@ -298,7 +300,7 @@
 			});
 
 			if ( data.isNew ) {
-				titleWrapper.querySelector( 'h4' ).appendChild( span({ className: 'frm-new-pill', text: __( 'NEW', 'formidable' ) }) );
+				title.appendChild( span({ className: 'frm-new-pill', text: __( 'NEW', 'formidable' ) }) );
 			}
 
 			const counter = getItemCounter();

--- a/js/admin/applications.js
+++ b/js/admin/applications.js
@@ -297,8 +297,7 @@
 				]
 			});
 
-			const isNew = data.isNew;
-			if ( isNew ) {
+			if ( data.isNew ) {
 				titleWrapper.querySelector( 'h4' ).appendChild( span({ className: 'frm-new-pill', text: __( 'NEW', 'formidable' ) }) );
 			}
 


### PR DESCRIPTION
We talked about this in the meeting today. It's a pretty easy add. None of our templates are new enough to show it right now, but I used a period of 300 days to get a screenshot.

I went with 30 days. We use 10 for form templates. I don't know if we want to be more consistent. 10 seems pretty short. Since we don't add as many applications, a longer duration may make sense.

<img width="1063" alt="Screen Shot 2023-02-08 at 2 42 12 PM" src="https://user-images.githubusercontent.com/9134515/217623014-db3a74fa-433c-4e79-9524-b22b8911699e.png">
