### PR TITLE
Stop hard coding a 1 for forms restored

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -440,13 +440,22 @@ class FrmFormsController {
 		self::change_form_status( 'untrash' );
 	}
 
+	/**
+	 * @param array $ids
+	 * @return string
+	 */
 	public static function bulk_untrash( $ids ) {
 		FrmAppHelper::permission_check( 'frm_edit_forms' );
 
 		$count = FrmForm::set_status( $ids, 'published' );
 
+		if ( ! $count ) {
+			// Don't show "0 forms restored" on refresh.
+			return '';
+		}
+
 		/* translators: %1$s: Number of forms */
-		$message = sprintf( _n( '%1$s form restored from the Trash.', '%1$s forms restored from the Trash.', $count, 'formidable' ), 1 );
+		$message = sprintf( _n( '%1$s form restored from the Trash.', '%1$s forms restored from the Trash.', $count, 'formidable' ), $count );
 
 		return $message;
 	}


### PR DESCRIPTION
I just noticed if you delete some forms, and then "Undo" that it would always show a 1. I had 13 forms restore, but the count said 1.

<img width="288" alt="Screen Shot 2023-02-08 at 3 12 51 PM" src="https://user-images.githubusercontent.com/9134515/217630489-eaaac998-6f6d-426b-b82e-1197e0eafd48.png">

It's just hard coded. I'm using `$count` now and it works as expected.

<img width="449" alt="Screen Shot 2023-02-08 at 3 21 14 PM" src="https://user-images.githubusercontent.com/9134515/217630649-86bca427-de98-43e1-b758-f6331de0d834.png">

I also added a check for 0 so we don't bother showing "0 forms restored" on refresh.