### PR TITLE
Prevent box shadow in RTE with rounded corners

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -328,6 +328,7 @@ legend.frm_hidden{
 
 .with_frm_style .wp-editor-container textarea{
 	border:none<?php echo esc_html( $important ); ?>;
+	box-shadow:none !important;
 }
 
 .with_frm_style .mceIframeContainer{


### PR DESCRIPTION
I'm seeing this with the "Sleek and Smooth" style.

Before:
<img width="695" alt="Screen Shot 2023-02-08 at 1 36 56 PM" src="https://user-images.githubusercontent.com/1116876/217645478-813aaaa0-b49d-4a35-a3b8-ebfb281c0a79.png">

After:
<img width="705" alt="Screen Shot 2023-02-08 at 1 37 17 PM" src="https://user-images.githubusercontent.com/1116876/217645504-e2524994-ffda-4763-8034-39e77fb1a1b3.png">
