### PR TITLE
Support searching entries with fields inside repeater field

### DIFF
--- a/classes/helpers/FrmEntriesListHelper.php
+++ b/classes/helpers/FrmEntriesListHelper.php
@@ -89,7 +89,7 @@ class FrmEntriesListHelper extends FrmListHelper {
 				'default' => ( $page - 1 ) * $per_page,
 			)
 		);
-		$limit       = FrmDb::esc_limit( $start . ',' . $per_page );
+		$limit = FrmDb::esc_limit( $start . ',' . $per_page );
 		$items = FrmEntry::getAll( $s_query, $order, $limit, true, $join_form_in_query );
 
 		$items_having_parent = array_filter(
@@ -106,14 +106,12 @@ class FrmEntriesListHelper extends FrmListHelper {
 		);
 
 		$parent_items = FrmEntry::getAll( $where, $order, $limit, true );
-		foreach ( $items as $key => $item ) {
-			if ( ! empty( $item->parent_item_id ) ) {
-				if ( isset( $items[ $item->parent_item_id ] ) ) {
-					$items[ $item->parent_item_id ]->metas += $item->metas;
-					unset( $items[ $key ] );
-				} else {
-					$items[ $key ]->metas += $parent_items[ $item->parent_item_id ]->metas;
-				}
+		foreach ( $items_having_parent as $key => $item ) {
+			if ( isset( $items[ $item->parent_item_id ] ) ) {
+				$items[ $item->parent_item_id ]->metas += $item->metas;
+				unset( $items[ $key ] );
+			} else {
+				$items[ $key ]->metas += $parent_items[ $item->parent_item_id ]->metas;
 			}
 		}
 

--- a/classes/helpers/FrmEntriesListHelper.php
+++ b/classes/helpers/FrmEntriesListHelper.php
@@ -91,7 +91,23 @@ class FrmEntriesListHelper extends FrmListHelper {
 		);
 		$limit = FrmDb::esc_limit( $start . ',' . $per_page );
 		$items = FrmEntry::getAll( $s_query, $order, $limit, true, $join_form_in_query );
-		// self::merge_repeater_entries_with
+
+		self::merge_repeater_entries_with_parent( $items, $order, $limit );
+
+		$this->items = $items;
+		$total_items = FrmEntry::getRecordCount( $s_query );
+
+		$this->total_items = $total_items;
+
+		$this->set_pagination_args(
+			array(
+				'total_items' => $total_items,
+				'per_page'    => $per_page,
+			)
+		);
+	}
+
+	private static function merge_repeater_entries_with_parent( &$items, $order, $limit ) {
 		$items_having_parent = array_filter(
 			$items,
 			function( $item ) {
@@ -100,6 +116,10 @@ class FrmEntriesListHelper extends FrmListHelper {
 		);
 
 		$parent_item_ids = wp_list_pluck( $items_having_parent, 'parent_item_id' );
+
+		if ( empty( $parent_item_ids ) ) {
+			return;
+		}
 
 		$where = array(
 			'it.id' => $parent_item_ids,
@@ -113,18 +133,6 @@ class FrmEntriesListHelper extends FrmListHelper {
 			$items[ $item->parent_item_id ]->metas += $item->metas;
 			unset( $items[ $key ] );
 		}
-
-		$this->items = $items;
-		$total_items = FrmEntry::getRecordCount( $s_query );
-
-		$this->total_items = $total_items;
-
-		$this->set_pagination_args(
-			array(
-				'total_items' => $total_items,
-				'per_page'    => $per_page,
-			)
-		);
 	}
 
 	public function no_items() {

--- a/classes/helpers/FrmEntriesListHelper.php
+++ b/classes/helpers/FrmEntriesListHelper.php
@@ -250,10 +250,6 @@ class FrmEntriesListHelper extends FrmListHelper {
 			$attributes .= ' data-colname="' . $column_display_name . '"';
 
 			$form_id           = $this->params['form'] ? $this->params['form'] : 0;
-			$form   = FrmForm::maybe_get_current_form();
-			if ( $form ) {
-				$form_id = $form->id;
-			}
 			$this->column_name = preg_replace( '/^(' . $form_id . '_)/', '', $column_name );
 
 			if ( $this->column_name == 'cb' ) {

--- a/classes/helpers/FrmEntriesListHelper.php
+++ b/classes/helpers/FrmEntriesListHelper.php
@@ -91,7 +91,7 @@ class FrmEntriesListHelper extends FrmListHelper {
 		);
 		$limit = FrmDb::esc_limit( $start . ',' . $per_page );
 		$items = FrmEntry::getAll( $s_query, $order, $limit, true, $join_form_in_query );
-
+		// self::merge_repeater_entries_with
 		$items_having_parent = array_filter(
 			$items,
 			function( $item ) {
@@ -107,12 +107,11 @@ class FrmEntriesListHelper extends FrmListHelper {
 
 		$parent_items = FrmEntry::getAll( $where, $order, $limit, true );
 		foreach ( $items_having_parent as $key => $item ) {
-			if ( isset( $items[ $item->parent_item_id ] ) ) {
-				$items[ $item->parent_item_id ]->metas += $item->metas;
-				unset( $items[ $key ] );
-			} else {
-				$items[ $key ]->metas += $parent_items[ $item->parent_item_id ]->metas;
+			if ( ! isset( $items[ $item->parent_item_id ] ) ) {
+				$items[ $item->parent_item_id ] = $parent_items[ $item->parent_item_id ];
 			}
+			$items[ $item->parent_item_id ]->metas += $item->metas;
+			unset( $items[ $key ] );
 		}
 
 		$this->items = $items;


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3843
I exposed fields inside repeater to appear in the entries search box in pro (https://github.com/Strategy11/formidable-pro/pull/4061) and that didn't cover it all as searching with those new fields wasn't supported. This update adds support for searching using fields embedded in a repeater.