### PR TITLE
append template search results after categories list

### DIFF
--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -368,6 +368,9 @@
 					}
 					item.classList.toggle( 'frm-search-result', isSearchResult );
 				}
+
+				const event = new Event( 'frmAfterSearch', { bubbles: false } );
+				input.dispatchEvent( event );
 			}
 		}
 	};

--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -337,7 +337,6 @@
 			input.addEventListener( 'input', handleSearch );
 			input.addEventListener( 'search', handleSearch );
 			input.addEventListener( 'change', handleSearch );
-			const event = new Event( 'frmAfterSearch', { bubbles: false } );
 
 			function handleSearch() {
 				const searchText = input.value.toLowerCase();
@@ -369,8 +368,6 @@
 					}
 					item.classList.toggle( 'frm-search-result', isSearchResult );
 				}
-
-				input.dispatchEvent( event );
 			}
 		}
 	};

--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -337,6 +337,7 @@
 			input.addEventListener( 'input', handleSearch );
 			input.addEventListener( 'search', handleSearch );
 			input.addEventListener( 'change', handleSearch );
+			const event = new Event( 'frmAfterSearch', { bubbles: false } );
 
 			function handleSearch() {
 				const searchText = input.value.toLowerCase();
@@ -369,7 +370,6 @@
 					item.classList.toggle( 'frm-search-result', isSearchResult );
 				}
 
-				const event = new Event( 'frmAfterSearch', { bubbles: false } );
 				input.dispatchEvent( event );
 			}
 		}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7607,7 +7607,7 @@ function frmAdminBuildJS() {
 		}
 
 		function addTemplateToCategoryList( template ) {
-			categoryList.appendChild( getReadyMadeSolution( template ), categoryList.firstChild );
+			categoryList.insertBefore( getReadyMadeSolution( template ), categoryList.lastChild );
 		}
 
 		function getReadyMadeSolution( template ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8886,7 +8886,7 @@ function frmAdminBuildJS() {
 	function initSearch( inputID ) {
 		const searchInput = document.getElementById( inputID );
 		frmDom.search.init( searchInput, 'control-section accordion-section' );
-		frmDom.search.init( searchInput, 'frm-searchable-template' );
+		frmDom.search.init( searchInput, 'frm-searchable-template frm-ready-made-solution' );
 	}
 
 	function updateTemplateModalFreeUrls( urlByKey ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8852,7 +8852,7 @@ function frmAdminBuildJS() {
 
 			const handleTemplateSearch = () => {
 				document.querySelectorAll( '.control-section.accordion-section' ).forEach( category => {
-					const found = category.querySelector( '.frm-selectable.frm-searchable-template:not(.frm_hidden)' );
+					const found = category.querySelector( '.frm-selectable.frm-searchable-template:not(.frm_hidden)' ) || category.querySelector( '#frm-template-drop' );
 					if ( found ) {
 						setTemplateCount( category );
 					}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8880,13 +8880,14 @@ function frmAdminBuildJS() {
 			}
 		}
 
-		initSearch( 'template-search-input' );
+		initSearch( 'template-search-input', [ 'control-section accordion-section', 'frm-searchable-template frm-ready-made-solution' ]);
 	}
 
-	function initSearch( inputID ) {
+	function initSearch( inputID, itemClasses ) {
 		const searchInput = document.getElementById( inputID );
-		frmDom.search.init( searchInput, 'control-section accordion-section' );
-		frmDom.search.init( searchInput, 'frm-searchable-template frm-ready-made-solution' );
+		itemClasses.forEach( itemClass => {
+			frmDom.search.init( searchInput, itemClass );
+		});
 	}
 
 	function updateTemplateModalFreeUrls( urlByKey ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8802,30 +8802,6 @@ function frmAdminBuildJS() {
 			document.getElementById( 'frm-add-my-email-address' ).click();
 		});
 
-		jQuery( document ).on( 'frmAfterSearch', '#frm_new_form_modal #template-search-input', function() {
-			var categories = $modal.get( 0 ).querySelector( '.frm-categories-list' ).children,
-				categoryIndex,
-				category,
-				searchableTemplates,
-				count;
-
-			for ( categoryIndex in categories ) {
-				if ( isNaN( categoryIndex ) ) {
-					continue;
-				}
-
-				category = categories[ categoryIndex ];
-				if ( ! category.classList.contains( 'accordion-section' ) ) {
-					continue;
-				}
-
-				searchableTemplates = category.querySelectorAll( '.frm-searchable-template:not(.frm_hidden)' );
-				count = searchableTemplates.length;
-				jQuery( category ).toggleClass( 'frm_hidden', this.value !== '' && ! count );
-				setTemplateCount( category, searchableTemplates );
-			}
-		});
-
 		jQuery( document ).on( 'click', '#frm_new_form_modal .frm-modal-back, #frm_new_form_modal .frm_modal_footer .frm-modal-cancel, #frm_new_form_modal .frm-back-to-all-templates', function( event ) {
 			document.getElementById( 'frm-create-title' ).removeAttribute( 'frm-type' );
 			$modal.attr( 'frm-page', 'create' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9092,7 +9092,7 @@ function frmAdminBuildJS() {
 		}
 
 		for ( i = 0; i < items.length; i++ ) {
-			var innerText = items[i].innerText.toLowerCase();
+			var innerText = items[i].querySelector( 'h3' ).innerText.toLowerCase();
 			const itemCanBeShown = ! ( getExportOption() === 'xml' && items[i].classList.contains( 'frm-is-repeater' ) );
 			if ( searchText === '' ) {
 				if ( itemCanBeShown ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8852,7 +8852,7 @@ function frmAdminBuildJS() {
 
 			const handleTemplateSearch = () => {
 				document.querySelectorAll( '.control-section.accordion-section' ).forEach( category => {
-					const found = category.querySelector( '.frm-selectable.frm-searchable-template:not(.frm_hidden)' ) || category.querySelector( '#frm-template-drop' );
+					const found = category.querySelector( '.frm-selectable.frm-searchable-template:not(.frm_hidden)' ) || ( searchInput.value === '' && category.querySelector( '#frm-template-drop' ) );
 					if ( found ) {
 						setTemplateCount( category );
 					}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7607,7 +7607,7 @@ function frmAdminBuildJS() {
 		}
 
 		function addTemplateToCategoryList( template ) {
-			categoryList.insertBefore( getReadyMadeSolution( template ), categoryList.firstChild );
+			categoryList.appendChild( getReadyMadeSolution( template ), categoryList.firstChild );
 		}
 
 		function getReadyMadeSolution( template ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9094,7 +9094,12 @@ function frmAdminBuildJS() {
 		for ( i = 0; i < items.length; i++ ) {
 			var innerText;
 			if ( items[i].classList.contains( 'frm-searchable-template' ) ) {
-				innerText = items[i].querySelector( 'h3' ).innerText.toLowerCase();
+				const itemFeaturedForm = items[i].querySelector( '.frm-featured-form' );
+				if ( itemFeaturedForm ) {
+					innerText = itemFeaturedForm.innerText.toLowerCase();
+				} else {
+					innerText = items[i].querySelector( 'h3' ).innerText.toLowerCase();
+				}
 			} else {
 				innerText = items[i].innerText.toLowerCase();
 			}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8874,7 +8874,7 @@ function frmAdminBuildJS() {
 		if ( itemClass === 'control-section accordion-section' ) {
 			itemClass = 'frm-selectable frm-searchable-template';
 
-			searchInput.addEventListener( 'frmAfterSearch', () => {
+			const handleTemplateSearch = () => {
 				document.querySelectorAll( '.control-section.accordion-section' ).forEach( category => {
 					const found = category.closest( '.control-section.accordion-section' ).querySelector( '.frm-selectable.frm-searchable-template:not(.frm_hidden)' );
 					if ( found ) {
@@ -8882,7 +8882,9 @@ function frmAdminBuildJS() {
 					}
 					category.classList.toggle( 'frm_hidden', ! found );
 				});
-			});
+			};
+
+			frmDom.search.init( searchInput, itemClass, { handleSearchResult: handleTemplateSearch });
 
 		} else if ( itemClass === 'frm-searchable-template frm-ready-made-solution' ) {
 			Array.from( document.getElementsByClassName( itemClass ) ).forEach( item => {
@@ -8890,9 +8892,9 @@ function frmAdminBuildJS() {
 				innerText = item.querySelector( 'h3' ).innerText;
 				item.setAttribute( 'frm-search-text', innerText.toLowerCase() );
 			});
+			frmDom.search.init( searchInput, itemClass );
 		}
 
-		frmDom.search.init( searchInput, itemClass );
 	}
 
 	function updateTemplateModalFreeUrls( urlByKey ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7602,24 +7602,9 @@ function frmAdminBuildJS() {
 
 		const categoryList = modal.querySelector( 'ul.frm-categories-list' );
 
-		function setTemplatesSearchableText() {
-			const items = Array.from( document.querySelectorAll( '.frm-templates-list.frm-categories-list .frm-searchable-template.frm-ready-made-solution' ) );
-			items.forEach( item => {
-				let innerText;
-
-				const itemFeaturedForm = item.querySelector( '.frm-featured-form' );
-				if ( itemFeaturedForm ) {
-					innerText = itemFeaturedForm.innerText.toLowerCase();
-				} else {
-					innerText = item.querySelector( 'h3' ).innerText.toLowerCase();
-				}
-				item.setAttribute( 'frm-search-text', innerText );
-			});
-		}
-
 		function addTemplatesOnFetchSuccess( data ) {
 			data.templates.forEach( addTemplateToCategoryList );
-			setTemplatesSearchableText();
+			initSearch( 'template-search-input', 'frm-searchable-template frm-ready-made-solution' );
 		}
 
 		function addTemplateToCategoryList( template ) {
@@ -8880,14 +8865,26 @@ function frmAdminBuildJS() {
 			}
 		}
 
-		initSearch( 'template-search-input', [ 'control-section accordion-section', 'frm-searchable-template frm-ready-made-solution' ]);
+		initSearch( 'template-search-input', 'control-section accordion-section' );
 	}
 
-	function initSearch( inputID, itemClasses ) {
+	function initSearch( inputID, itemClass ) {
 		const searchInput = document.getElementById( inputID );
-		itemClasses.forEach( itemClass => {
-			frmDom.search.init( searchInput, itemClass );
+		Array.from( document.getElementsByClassName( itemClass ) ).forEach( item => {
+			let innerText;
+
+			const itemFeaturedForm = item.querySelector( '.frm-featured-form' );
+
+			if ( itemFeaturedForm ) {
+				innerText = itemFeaturedForm.innerText.toLowerCase();
+			} else {
+				innerText = item.querySelector( 'h3' ).innerText.toLowerCase();
+			}
+
+			item.setAttribute( 'frm-search-text', innerText );
 		});
+
+		frmDom.search.init( searchInput, itemClass );
 	}
 
 	function updateTemplateModalFreeUrls( urlByKey ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7602,8 +7602,24 @@ function frmAdminBuildJS() {
 
 		const categoryList = modal.querySelector( 'ul.frm-categories-list' );
 
+		function setSearchableText() {
+			const items = Array.from( document.querySelectorAll( '.frm-templates-list.frm-categories-list .frm-searchable-template.frm-ready-made-solution' ) );
+			items.forEach( item => {
+				let innerText;
+
+				const itemFeaturedForm = item.querySelector( '.frm-featured-form' );
+				if ( itemFeaturedForm ) {
+					innerText = itemFeaturedForm.innerText.toLowerCase();
+				} else {
+					innerText = item.querySelector( 'h3' ).innerText.toLowerCase();
+				}
+				item.setAttribute( 'frm-search-text', innerText );
+			});
+		}
+
 		function addTemplatesOnFetchSuccess( data ) {
 			data.templates.forEach( addTemplateToCategoryList );
+			setSearchableText();
 		}
 
 		function addTemplateToCategoryList( template ) {
@@ -9092,17 +9108,8 @@ function frmAdminBuildJS() {
 		}
 
 		for ( i = 0; i < items.length; i++ ) {
-			var innerText;
-			if ( items[i].classList.contains( 'frm-searchable-template' ) ) {
-				const itemFeaturedForm = items[i].querySelector( '.frm-featured-form' );
-				if ( itemFeaturedForm ) {
-					innerText = itemFeaturedForm.innerText.toLowerCase();
-				} else {
-					innerText = items[i].querySelector( 'h3' ).innerText.toLowerCase();
-				}
-			} else {
-				innerText = items[i].innerText.toLowerCase();
-			}
+			var innerText = items[i].innerText.toLowerCase();
+
 			const itemCanBeShown = ! ( getExportOption() === 'xml' && items[i].classList.contains( 'frm-is-repeater' ) );
 			if ( searchText === '' ) {
 				if ( itemCanBeShown ) {
@@ -9576,8 +9583,17 @@ function frmAdminBuildJS() {
 		}, options );
 	}
 
+	function initSearch( inputID ) {
+		const searchInput = document.getElementById( inputID );
+		searchInput.classList.remove( 'frm-auto-search' );
+		frmDom.search.init( searchInput, 'control-section accordion-section' );
+		frmDom.search.init( searchInput, 'frm-searchable-template' );
+	}
+
 	return {
 		init: function() {
+			initSearch( 'template-search-input' );
+
 			s = {};
 
 			// Bootstrap dropdown button

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9092,7 +9092,12 @@ function frmAdminBuildJS() {
 		}
 
 		for ( i = 0; i < items.length; i++ ) {
-			var innerText = items[i].querySelector( 'h3' ).innerText.toLowerCase();
+			var innerText;
+			if ( items[i].classList.contains( 'frm-searchable-template' ) ) {
+				innerText = items[i].querySelector( 'h3' ).innerText.toLowerCase();
+			} else {
+				innerText = items[i].innerText.toLowerCase();
+			}
 			const itemCanBeShown = ! ( getExportOption() === 'xml' && items[i].classList.contains( 'frm-is-repeater' ) );
 			if ( searchText === '' ) {
 				if ( itemCanBeShown ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9585,7 +9585,6 @@ function frmAdminBuildJS() {
 
 	function initSearch( inputID ) {
 		const searchInput = document.getElementById( inputID );
-		searchInput.classList.remove( 'frm-auto-search' );
 		frmDom.search.init( searchInput, 'control-section accordion-section' );
 		frmDom.search.init( searchInput, 'frm-searchable-template' );
 	}
@@ -9704,7 +9703,7 @@ function frmAdminBuildJS() {
 				this.select();
 			});
 
-			jQuery( document ).on( 'input search change', '.frm-auto-search', searchContent );
+			jQuery( document ).on( 'input search change', '.frm-auto-search:not(#template-search-input)', searchContent );
 			jQuery( document ).on( 'focusin click', '.frm-auto-search', stopPropagation );
 			var autoSearch = jQuery( '.frm-auto-search' );
 			if ( autoSearch.val() !== '' ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8870,36 +8870,30 @@ function frmAdminBuildJS() {
 
 	function initSearch( inputID, itemClass ) {
 		const searchInput = document.getElementById( inputID );
-		Array.from( document.getElementsByClassName( itemClass ) ).forEach( item => {
-			let innerText;
-
-			const itemFeaturedForm = item.querySelector( '.frm-featured-form' );
-
-			if ( itemFeaturedForm ) {
-				if ( item.querySelector( 'h3' ).innerText === 'My Templates' ) {
-					itemFeaturedForm.querySelectorAll( '.accordion-section-content .frm-selectable' ).forEach( li => {
-						innerText += li.innerText;
-					});
-				} else {
-					innerText = itemFeaturedForm.innerText;
-				}
-			} else {
-				innerText = item.querySelector( 'h3' ).innerText;
-			}
-
-			item.setAttribute( 'frm-search-text', innerText.toLowerCase() );
-		});
-
-		frmDom.search.init( searchInput, itemClass );
 
 		if ( itemClass === 'control-section accordion-section' ) {
 			frmDom.search.init( searchInput, 'frm-selectable frm-searchable-template' );
 
 			searchInput.addEventListener( 'frmAfterSearch', () => {
 				document.querySelectorAll( '.control-section.accordion-section' ).forEach( category => {
-					setTemplateCount( category );
+					const found = category.closest( '.control-section.accordion-section' ).querySelector( '.frm-selectable.frm-searchable-template:not(.frm_hidden)' );
+					if ( found ) {
+						setTemplateCount( category );
+					}
+					category.classList.toggle( 'frm_hidden', ! found );
 				});
 			});
+
+		} else {
+			if ( itemClass === 'frm-searchable-template frm-ready-made-solution' ) {
+				Array.from( document.getElementsByClassName( itemClass ) ).forEach( item => {
+					let innerText = '';
+					innerText = item.querySelector( 'h3' ).innerText;
+					item.setAttribute( 'frm-search-text', innerText.toLowerCase() );
+				});
+			}
+
+			frmDom.search.init( searchInput, itemClass );
 		}
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8876,7 +8876,7 @@ function frmAdminBuildJS() {
 
 			const handleTemplateSearch = () => {
 				document.querySelectorAll( '.control-section.accordion-section' ).forEach( category => {
-					const found = category.closest( '.control-section.accordion-section' ).querySelector( '.frm-selectable.frm-searchable-template:not(.frm_hidden)' );
+					const found = category.querySelector( '.frm-selectable.frm-searchable-template:not(.frm_hidden)' );
 					if ( found ) {
 						setTemplateCount( category );
 					}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7607,7 +7607,7 @@ function frmAdminBuildJS() {
 		}
 
 		function addTemplateToCategoryList( template ) {
-			categoryList.insertBefore( getReadyMadeSolution( template ), categoryList.lastChild );
+			categoryList.appendChild( getReadyMadeSolution( template ) );
 		}
 
 		function getReadyMadeSolution( template ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8886,12 +8886,14 @@ function frmAdminBuildJS() {
 
 			frmDom.search.init( searchInput, itemClass, { handleSearchResult: handleTemplateSearch });
 
-		} else if ( itemClass === 'frm-searchable-template frm-ready-made-solution' ) {
-			Array.from( document.getElementsByClassName( itemClass ) ).forEach( item => {
-				let innerText = '';
-				innerText = item.querySelector( 'h3' ).innerText;
-				item.setAttribute( 'frm-search-text', innerText.toLowerCase() );
-			});
+		} else {
+			if ( itemClass === 'frm-searchable-template frm-ready-made-solution' ) {
+				Array.from( document.getElementsByClassName( itemClass ) ).forEach( item => {
+					let innerText = '';
+					innerText = item.querySelector( 'h3' ).innerText;
+					item.setAttribute( 'frm-search-text', innerText.toLowerCase() );
+				});
+			}
 			frmDom.search.init( searchInput, itemClass );
 		}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8876,15 +8876,31 @@ function frmAdminBuildJS() {
 			const itemFeaturedForm = item.querySelector( '.frm-featured-form' );
 
 			if ( itemFeaturedForm ) {
-				innerText = itemFeaturedForm.innerText.toLowerCase();
+				if ( item.querySelector( 'h3' ).innerText === 'My Templates' ) {
+					itemFeaturedForm.querySelectorAll( '.accordion-section-content .frm-selectable' ).forEach( li => {
+						innerText += li.innerText;
+					});
+				} else {
+					innerText = itemFeaturedForm.innerText;
+				}
 			} else {
-				innerText = item.querySelector( 'h3' ).innerText.toLowerCase();
+				innerText = item.querySelector( 'h3' ).innerText;
 			}
 
-			item.setAttribute( 'frm-search-text', innerText );
+			item.setAttribute( 'frm-search-text', innerText.toLowerCase() );
 		});
 
 		frmDom.search.init( searchInput, itemClass );
+
+		if ( itemClass === 'control-section accordion-section' ) {
+			frmDom.search.init( searchInput, 'frm-selectable frm-searchable-template' );
+
+			searchInput.addEventListener( 'frmAfterSearch', () => {
+				document.querySelectorAll( '.control-section.accordion-section' ).forEach( category => {
+					setTemplateCount( category );
+				});
+			});
+		}
 	}
 
 	function updateTemplateModalFreeUrls( urlByKey ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7602,7 +7602,7 @@ function frmAdminBuildJS() {
 
 		const categoryList = modal.querySelector( 'ul.frm-categories-list' );
 
-		function setSearchableText() {
+		function setTemplatesSearchableText() {
 			const items = Array.from( document.querySelectorAll( '.frm-templates-list.frm-categories-list .frm-searchable-template.frm-ready-made-solution' ) );
 			items.forEach( item => {
 				let innerText;
@@ -7619,7 +7619,7 @@ function frmAdminBuildJS() {
 
 		function addTemplatesOnFetchSuccess( data ) {
 			data.templates.forEach( addTemplateToCategoryList );
-			setSearchableText();
+			setTemplatesSearchableText();
 		}
 
 		function addTemplateToCategoryList( template ) {
@@ -8879,6 +8879,14 @@ function frmAdminBuildJS() {
 				}
 			}
 		}
+
+		initSearch( 'template-search-input' );
+	}
+
+	function initSearch( inputID ) {
+		const searchInput = document.getElementById( inputID );
+		frmDom.search.init( searchInput, 'control-section accordion-section' );
+		frmDom.search.init( searchInput, 'frm-searchable-template' );
 	}
 
 	function updateTemplateModalFreeUrls( urlByKey ) {
@@ -9583,16 +9591,8 @@ function frmAdminBuildJS() {
 		}, options );
 	}
 
-	function initSearch( inputID ) {
-		const searchInput = document.getElementById( inputID );
-		frmDom.search.init( searchInput, 'control-section accordion-section' );
-		frmDom.search.init( searchInput, 'frm-searchable-template' );
-	}
-
 	return {
 		init: function() {
-			initSearch( 'template-search-input' );
-
 			s = {};
 
 			// Bootstrap dropdown button

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8872,7 +8872,7 @@ function frmAdminBuildJS() {
 		const searchInput = document.getElementById( inputID );
 
 		if ( itemClass === 'control-section accordion-section' ) {
-			frmDom.search.init( searchInput, 'frm-selectable frm-searchable-template' );
+			itemClass = 'frm-selectable frm-searchable-template';
 
 			searchInput.addEventListener( 'frmAfterSearch', () => {
 				document.querySelectorAll( '.control-section.accordion-section' ).forEach( category => {
@@ -8884,17 +8884,15 @@ function frmAdminBuildJS() {
 				});
 			});
 
-		} else {
-			if ( itemClass === 'frm-searchable-template frm-ready-made-solution' ) {
-				Array.from( document.getElementsByClassName( itemClass ) ).forEach( item => {
-					let innerText = '';
-					innerText = item.querySelector( 'h3' ).innerText;
-					item.setAttribute( 'frm-search-text', innerText.toLowerCase() );
-				});
-			}
-
-			frmDom.search.init( searchInput, itemClass );
+		} else if ( itemClass === 'frm-searchable-template frm-ready-made-solution' ) {
+			Array.from( document.getElementsByClassName( itemClass ) ).forEach( item => {
+				let innerText = '';
+				innerText = item.querySelector( 'h3' ).innerText;
+				item.setAttribute( 'frm-search-text', innerText.toLowerCase() );
+			});
 		}
+
+		frmDom.search.init( searchInput, itemClass );
 	}
 
 	function updateTemplateModalFreeUrls( urlByKey ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3962
The order of results is changed to Ascending from Descending but I don't believe out that is much important here or even better this way so I kept the solution as simple one liner to avoid extra DOM query but I can keep the order as before if needed.
In addition to that, I have now excluded the default `Ready Made Solution` and `Check all applications` texts from being accounted for when searching.

**BEFORE**:
![image](https://user-images.githubusercontent.com/41271840/218075230-2c5d5b0f-1408-4b11-9589-abebe803c885.png)
Searching using keyword `Rea`:
![image](https://user-images.githubusercontent.com/41271840/218406695-bb2e97bd-1d6a-46ca-881d-3bc2fbf128e2.png)

**NOW**:
![image](https://user-images.githubusercontent.com/41271840/218070130-e86d3f6f-3e89-48a1-a2a7-db46a3460f51.png)
Searching using keyword `Rea`:
![image](https://user-images.githubusercontent.com/41271840/218406898-b2ff4da9-36e8-4d3b-ba0d-0a686d503e4b.png)
