### PR TITLE
Remove toggle accessibility code from styler

### DIFF
--- a/js/admin/settings.js
+++ b/js/admin/settings.js
@@ -25,6 +25,7 @@
 
 	function handleSpaceDownEvent( e ) {
 		if ( e.target.classList.contains( 'frm_toggle' ) ) {
+			e.preventDefault(); // Prevent automatic browser scroll when space is pressed.
 			e.target.click();
 		}
 	}

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -85,7 +85,6 @@
 		enableToggle.addEventListener( 'change', handleEnableStylingToggleChange );
 
 		syncPreviewFormLabelPositionsWithActiveStyle();
-		makeToggleAccessible();
 		initStyleCardPagination();
 	}
 
@@ -98,39 +97,6 @@
 		if ( activeCard ) {
 			changeLabelPositionsInPreview( activeCard.dataset.labelPosition );
 		}
-	}
-
-	/**
-	 * Toggle accessibility is handled for other pages in Pro.
-	 * As the only toggle in Lite is currently for Enabling styles only, simpler code can be used and loaded just for the styler for now.
-	 *
-	 * @returns {void}
-	 */
-	function makeToggleAccessible() {
-		const toggleCheckbox = document.getElementById( 'frm_enable_styling' );
-		if ( ! toggleCheckbox ) {
-			return;
-		}
-
-		const toggle = toggleCheckbox.nextElementSibling;
-
-		toggleCheckbox.addEventListener( 'change', () => toggle.setAttribute( 'aria-checked', toggleCheckbox.checked ? 'true' : 'false' ) );
-
-		toggle.addEventListener(
-			'keydown',
-			/**
-			 * Toggle the enable styling toggle when the space key is pressed.
-			 *
-			 * @param {Event} e
-			 * @returns {void}
-			 */
-			e => {
-				if ( ' ' === e.key ) {
-					e.preventDefault(); // Prevent the list from scrolling when you hit space.
-					toggle.click();
-				}
-			}
-		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4069

The styler still had the toggle accessibility code in it but it is no longer necessary as it looks like `settings.js` loads in the styler page by default. The two event listeners were both happening, causing it to toggle on/off simultaneously and remain unchanged.

Also I added a preventDefault to prevent the scroll behaviour.