### PR TITLE
Stop sanitizing the custom CSS default

### DIFF
--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -201,6 +201,10 @@ class FrmSettings {
 	 */
 	private function maybe_sanitize_global_setting( $value, $key, $filter_keys ) {
 		if ( 'custom_css' === $key ) {
+			if ( false === $value ) {
+				// Avoid changing the false default value to an empty string.
+				return $value;
+			}
 			return sanitize_textarea_field( $value );
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4073

The defaults go through the same code that sanitizes. It led to this issue where my `false` default gets set to an empty string.

I intentionally want to support an empty custom CSS string without it forcing the old custom CSS, without needing to delete the old custom CSS (to be on the safe side in case there are issues like this that come up).

This update just makes sure that the `false` default isn't sanitized.

There may be issues though if someone had saved their global settings in v6.0 and saved an empty string for their custom CSS. Maybe we want to make a migration for that, but I fear a migration that changed global settings could have issues of its own. I noticed while testing that if I call `$frm_settings->store();` without calling `FrmProAppHelper::get_settings();` first for example, it just results in a fatal error. I think for those people they can just use the snippet workarounds.