### PR TITLE
Avoid changing the label position container classes if a field does not use the default

### DIFF
--- a/classes/helpers/FrmStylesPreviewHelper.php
+++ b/classes/helpers/FrmStylesPreviewHelper.php
@@ -21,11 +21,23 @@ class FrmStylesPreviewHelper {
 	private $form_includes_captcha = false;
 
 	/**
+	 * Track the field ids with the default label position.
+	 * A field with a default label position will have a frm-default-label-position class in the styler preview.
+	 * Only fields with this class will change when you update the position setting in the styler.
+	 *
+	 * @since 6.0.1
+	 *
+	 * @var array
+	 */
+	private $default_label_position_field_ids;
+
+	/**
 	 * @param string|int $form_id
 	 * @return void
 	 */
 	public function __construct( $form_id ) {
 		$this->form_id = (int) $form_id;
+		$this->default_label_position_field_ids = array();
 	}
 
 	/**
@@ -44,6 +56,24 @@ class FrmStylesPreviewHelper {
 	}
 
 	private function add_a_div_class_for_default_label_positions() {
+		// Only fields with no label position set hit this filter, so track those for the frm_field_div_classes filter.
+		add_filter(
+			'frm_html_label_position',
+			/**
+			 * @param string $position
+			 * @param object|array $field
+			 * @return string
+			 */
+			function( $position, $field ) {
+				if ( is_array( $field ) ) {
+					$this->default_label_position_field_ids[] = (int) $field['id'];
+				}
+				return $position;
+			},
+			10,
+			2
+		);
+
 		add_filter(
 			'frm_field_div_classes',
 			/**
@@ -52,17 +82,9 @@ class FrmStylesPreviewHelper {
 			 * @return string
 			 */
 			function( $classes, $field ) {
-				if ( ! is_array( $field ) ) {
-					return $classes;
-				}
-
-				// TODO how do we get access to this in a more efficient way?
-				// $field['label'] it's very useful as it uses 'top' already for an unset value.
-				$field_object = FrmField::getOne( $field['id'] );
-				if ( empty( $field_object->field_options['label'] ) ) {
+				if ( is_array( $field ) && in_array( (int) $field['id'], $this->default_label_position_field_ids, true ) ) {
 					$classes .= ' frm-default-label-position';
 				}
-
 				return $classes;
 			},
 			10,

--- a/classes/helpers/FrmStylesPreviewHelper.php
+++ b/classes/helpers/FrmStylesPreviewHelper.php
@@ -40,6 +40,34 @@ class FrmStylesPreviewHelper {
 		add_filter( 'frm_run_honeypot', '__return_false' ); // We don't need the honeypot in the preview so leave it out.
 		$this->hide_captcha_fields();
 		$this->disable_javascript_validation();
+		$this->add_a_div_class_for_default_label_positions();
+	}
+
+	private function add_a_div_class_for_default_label_positions() {
+		add_filter(
+			'frm_field_div_classes',
+			/**
+			 * @param string       $classes
+			 * @param object|array $field
+			 * @return string
+			 */
+			function( $classes, $field ) {
+				if ( ! is_array( $field ) ) {
+					return $classes;
+				}
+
+				// TODO how do we get access to this in a more efficient way?
+				// $field['label'] it's very useful as it uses 'top' already for an unset value.
+				$field_object = FrmField::getOne( $field['id'] );
+				if ( empty( $field_object->field_options['label'] ) ) {
+					$classes .= ' frm-default-label-position';
+				}
+
+				return $classes;
+			},
+			10,
+			2
+		);
 	}
 
 	/**

--- a/classes/helpers/FrmStylesPreviewHelper.php
+++ b/classes/helpers/FrmStylesPreviewHelper.php
@@ -55,6 +55,12 @@ class FrmStylesPreviewHelper {
 		$this->add_a_div_class_for_default_label_positions();
 	}
 
+	/**
+	 * Add a frm-default-label-position class to any field with a default label position.
+	 * A field with a custom label position shouldn't ever change in the styler preview.
+	 *
+	 * @since 6.0.1
+	 */
 	private function add_a_div_class_for_default_label_positions() {
 		// Only fields with no label position set hit this filter, so track those for the frm_field_div_classes filter.
 		add_filter(

--- a/classes/helpers/FrmStylesPreviewHelper.php
+++ b/classes/helpers/FrmStylesPreviewHelper.php
@@ -60,6 +60,7 @@ class FrmStylesPreviewHelper {
 	 * A field with a custom label position shouldn't ever change in the styler preview.
 	 *
 	 * @since 6.0.1
+	 * @return void
 	 */
 	private function add_a_div_class_for_default_label_positions() {
 		// Only fields with no label position set hit this filter, so track those for the frm_field_div_classes filter.

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1289,8 +1289,6 @@
 	/**
 	 * Update label container classes when the label "Position" setting is changed.
 	 *
-	 * @todo This doesn't work yet with the "My form" preview.
-	 *
 	 * @returns {void}
 	 */
 	function setPosClass() {
@@ -1302,12 +1300,13 @@
 			value = 'none';
 		}
 
-		document.getElementById( 'frm_style_preview' ).querySelectorAll( '.frm_form_field' ).forEach( container => {
+		const posClasses = [ 'frm_top_container', 'frm_left_container', 'frm_right_container', 'frm_none_container', 'frm_inside_container', 'frm_inline_container' ];
+		document.getElementById( 'frm_style_preview' ).querySelectorAll( '.frm_form_field.frm-default-label-position, #frm_sample_form .frm_form_field' ).forEach( container => {
 			const input                 = container.querySelector( ':scope > input, :scope > select, :scope > textarea' ); // Fields that support floating label should have a directly child input/textarea/select.
 			const shouldForceTopStyling = 'inside' === value && ( ! input || 'hidden' === input.type ); // We do not want file upload to use floating labels, or inline datepickers, which both use hidden inputs.
 			const currentValue          = shouldForceTopStyling ? 'top' : value;
 
-			container.classList.remove( 'frm_top_container', 'frm_left_container', 'frm_right_container', 'frm_none_container', 'frm_inside_container' );
+			container.classList.remove( ...posClasses );
 			container.classList.add( 'frm_' + currentValue + '_container' );
 
 			if ( 'inside' === currentValue ) {

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1300,13 +1300,12 @@
 			value = 'none';
 		}
 
-		const posClasses = [ 'frm_top_container', 'frm_left_container', 'frm_right_container', 'frm_none_container', 'frm_inside_container', 'frm_inline_container' ];
 		document.getElementById( 'frm_style_preview' ).querySelectorAll( '.frm_form_field.frm-default-label-position, #frm_sample_form .frm_form_field' ).forEach( container => {
 			const input                 = container.querySelector( ':scope > input, :scope > select, :scope > textarea' ); // Fields that support floating label should have a directly child input/textarea/select.
 			const shouldForceTopStyling = 'inside' === value && ( ! input || 'hidden' === input.type ); // We do not want file upload to use floating labels, or inline datepickers, which both use hidden inputs.
 			const currentValue          = shouldForceTopStyling ? 'top' : value;
 
-			container.classList.remove( ...posClasses );
+			container.classList.remove( 'frm_top_container', 'frm_left_container', 'frm_right_container', 'frm_none_container', 'frm_inside_container' );
 			container.classList.add( 'frm_' + currentValue + '_container' );
 
 			if ( 'inside' === currentValue ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4072

The old code for this was fine because it was for the sample form where this setting doesn't exist. I hadn't considered this field setting.

This update adds a class to any field with the default set, and only those get changed now.