### PR TITLE
Remove extra comma in mb adv info view

### DIFF
--- a/classes/views/shared/mb_adv_info.php
+++ b/classes/views/shared/mb_adv_info.php
@@ -101,7 +101,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					'value'       => 'id',
 					'show_labels' => true,
 					'echo'        => true,
-				),
+				)
 			);
 			?>
 		</div>

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,9 +10,9 @@
 		<file name="formidable.php" />
 		<directory name="classes" />
 		<directory name="deprecated" />
+		<directory name="classes/views/" />
 		<ignoreFiles>
 			<directory name="vendor" />
-			<directory name="classes/views/" />
 		</ignoreFiles>
 	</projectFiles>
 	<stubs>
@@ -58,5 +58,46 @@
 				<file name="classes/widgets/FrmShowForm.php" />
 			</errorLevel>
 		</MethodSignatureMustProvideReturnType>
+		<!-- Add exceptions for classes/views files. -->
+		<UndefinedGlobalVariable>
+			<errorLevel type="suppress">
+				<directory name="classes/views" />
+			</errorLevel>
+		</UndefinedGlobalVariable>
+		<UndefinedVariable>
+			<errorLevel type="suppress">
+				<directory name="classes/views" />
+			</errorLevel>
+		</UndefinedVariable>
+		<NonStaticSelfCall>
+			<errorLevel type="suppress">
+				<directory name="classes/views" />
+			</errorLevel>
+		</NonStaticSelfCall>
+		<NullReference>
+			<errorLevel type="suppress">
+				<directory name="classes/views" />
+			</errorLevel>
+		</NullReference>
+		<InvalidScope>
+			<errorLevel type="suppress">
+				<directory name="classes/views" />
+			</errorLevel>
+		</InvalidScope>
+		<InaccessibleMethod>
+			<errorLevel type="suppress">
+				<directory name="classes/views" />
+			</errorLevel>
+		</InaccessibleMethod>
+		<ParadoxicalCondition>
+			<errorLevel type="suppress">
+				<file name="classes/views/frm-form-actions/_action_inside.php" />
+			</errorLevel>
+		</ParadoxicalCondition>
+		<ParamNameMismatch>
+			<errorLevel type="suppress">
+				<file name="classes/views/frm-form-actions/email_action.php" />
+			</errorLevel>
+		</ParamNameMismatch>
 	</issueHandlers>
 </psalm>


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2157723026/151310/

There was an extra comma here. This only breaks in versions of PHP 7.2 and lower.

I spent some time trying to add a rule for this with phpcs, psalm, or phpstan, but it doesn't really appear to be easy to check for with any of these. Maybe with the PHPCompatibilityWP in phpcs but I don't think it's worth pulling that in just for a comma check.

But in that process, I removed some Psalm exceptions from view files. It was previously ignoring the files entirely. Now it's just ignoring specific rules.