### PR TITLE
Use the WP full screen setting for full pages

### DIFF
--- a/classes/views/shared/admin-header.php
+++ b/classes/views/shared/admin-header.php
@@ -35,6 +35,7 @@ FrmAppHelper::print_admin_banner( ! $has_nav && empty( $atts['switcher'] ) );
 			?>
 		</h1>
 	</div>
+	<ul class="frm_form_nav"></ul>
 		<?php
 	}
 

--- a/classes/views/styles/_style-preview-container.php
+++ b/classes/views/styles/_style-preview-container.php
@@ -16,7 +16,7 @@ if ( $sample_form_is_on ) {
 }
 ?>
 <div id="frm_style_preview">
-	<div class="frm-m-12">
+	<div class="frm-m-12 frm-mt-0">
 		<?php
 		// If a $message, $warnings, or $notes variable are not empty, it will be rendered here.
 		include FrmAppHelper::plugin_path() . '/classes/views/shared/errors.php';

--- a/classes/views/styles/_styles-list.php
+++ b/classes/views/styles/_styles-list.php
@@ -38,14 +38,6 @@ if ( $globally_disabled ) {
 		$trigger_params['data-image']   = 'styles-upsell.svg';
 	}
 	?>
-	<div id="frm_new_style_trigger_wrapper">
-		<a <?php FrmAppHelper::array_to_html_params( $trigger_params, true ); ?>>
-			<?php
-			FrmAppHelper::icon_by_class( 'frmfont frm_plus_icon' );
-			esc_html_e( 'New Style', 'formidable' );
-			?>
-		</a>
-	</div>
 	<?php // This form isn't visible. It's just used for assigning the selected style id to the target form. ?>
 	<form id="frm_style_list_form" method="post" action="<?php echo esc_url( FrmStylesHelper::get_list_url( $form->id ) ); ?>">
 		<input type="hidden" name="style_id" value="<?php echo absint( $enabled ? $active_style->ID : 0 ); ?>" />
@@ -53,7 +45,7 @@ if ( $globally_disabled ) {
 		<input type="hidden" name="frm_action" value="assign_style" />
 		<?php wp_nonce_field( 'frm_save_form_style_nonce', 'frm_save_form_style' ); ?>
 	</form>
-	<div class="frm-mb-sm">
+	<div class="frm-mb-sm frm-flex-justify">
 		<?php
 		FrmHtmlHelper::toggle(
 			'frm_enable_styling',
@@ -67,6 +59,14 @@ if ( $globally_disabled ) {
 			)
 		);
 		?>
+		<div id="frm_new_style_trigger_wrapper">
+			<a <?php FrmAppHelper::array_to_html_params( $trigger_params, true ); ?>>
+				<?php
+				FrmAppHelper::icon_by_class( 'frmfont frm_plus_icon' );
+				esc_html_e( 'New Style', 'formidable' );
+				?>
+			</a>
+		</div>
 	</div>
 
 	<div class="frm_form_settings">

--- a/classes/views/styles/show.php
+++ b/classes/views/styles/show.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		);
 		?>
 	</div>
-	<div id="frm_styler_wrapper">
+	<div id="frm_styler_wrapper" class="columns-2">
 		<?php
 		$view_file = 'list' === $view ? 'list' : 'edit';
 		include $style_views_path . '_styles-' . $view_file . '.php'; // Render view based on type (either _styles-list.php or _styles-edit.php).

--- a/css/admin/style.css
+++ b/css/admin/style.css
@@ -7,19 +7,6 @@ This file is added to the visual styler admin page, accessed from the style tab.
 	flex-direction: row;
 }
 
-#frm_style_sidebar,
-#frm_style_preview {
-	height: calc( 100vh - 95px );
-	box-sizing: border-box;
-	position: relative;
-}
-
-#frm_style_sidebar {
-	vertical-align: top;
-	box-sizing: border-box;
-	overflow-y: auto;
-}
-
 #frm_style_sidebar .frm-inner-content {
 	padding-left: 0;
 	padding-right: 0;
@@ -34,13 +21,6 @@ This file is added to the visual styler admin page, accessed from the style tab.
 #frm_style_sidebar .accordion-section-title::after {
 	right: 0;
 	color: var(--grey-400);
-}
-
-#frm_style_preview {
-	overflow-y: auto;
-	overflow-x: hidden;
-	flex: 2;
-	border-left: 1px solid var(--sidebar-hover);
 }
 
 #frm_active_style_form:not(.frm_hidden) ~ #frm_sample_form,
@@ -522,14 +502,6 @@ body.rtl .frm-style-card-separator {
 .frm-styles-globally-disabled ~ #frm_style_preview #frm_edit_style {
 	pointer-events: none;
 	opacity: 0.5;
-}
-
-@media only screen and (max-width: 1200px) {
-	/* Adjust the height to account for the taller header when the tabs drop to a second line. */
-	#frm_style_sidebar,
-	#frm_style_preview {
-		height: calc( 100vh - 135px );
-	}
 }
 
 @media only screen and (max-width: 900px) {

--- a/css/admin/style.css
+++ b/css/admin/style.css
@@ -470,20 +470,16 @@ The label in the preview should use the label color setting.
 	box-shadow: none;
 }
 
-#frm_new_style_trigger_wrapper {
-	position: absolute;
-	right: 15px;
+/* Break the new style trigger into a separate line on small screens to avoid overlapping with the Enable Formidable styling toggle. */
+#frm_style_sidebar > .frm-flex-justify {
+	gap: var(--gap-sm);
+	flex-wrap: wrap;
 }
 
 /* RTL Styling */
 body.rtl #frm_toggle_sample_form {
 	right: unset;
 	left: 40px;
-}
-
-body.rtl #frm_new_style_trigger_wrapper {
-	right: unset;
-	left: 15px;
 }
 
 body.rtl .frm-input-style-example {
@@ -502,16 +498,6 @@ body.rtl .frm-style-card-separator {
 .frm-styles-globally-disabled ~ #frm_style_preview #frm_edit_style {
 	pointer-events: none;
 	opacity: 0.5;
-}
-
-@media only screen and (max-width: 900px) {
-	/* Break the new style trigger into a separate line to avoid overlapping with the Enable Formidable styling toggle. */
-	#frm_new_style_trigger_wrapper {
-		position: static;
-		display: flex;
-		justify-content: flex-end;
-		margin-bottom: 10px;
-	}
 }
 
 @media only screen and (max-width: 782px) {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -119,11 +119,6 @@ a, .widget .widget-top, .stuffbox h3, .frm-collapsed {
 	margin: 0;
 }
 
-.columns-2 .frm-right-panel + #post-body-content {
-	padding-bottom: 26px;
-	border-left: 1px solid var(--sidebar-hover);
-}
-
 .toplevel_page_formidable #post-body-content {
 	overflow-x: visible;
 }
@@ -304,6 +299,7 @@ td.column-title .frm_actions_dropdown {
 	padding: 0 var(--gap-md);
 }
 
+#frm_top_bar > .frm-full-close:last-child,
 #frm_top_bar > #frm-publishing:last-child {
 	margin-left: auto;
 }
@@ -355,20 +351,6 @@ td.column-title .frm_actions_dropdown {
 	padding-bottom: 0 !important;
 }
 
-#frm_new_view_modal .frm-category-icon .frmsvg {
-	transform: none !important;
-	position: initial;
-}
-
-#frm_new_view_modal .frm-search-input {
-	border-width: 1px;
-}
-
-#frm_new_view_modal input[type=checkbox] + label {
-	display: inline-block; /* Checkboxes need to be moved inside the labels */
-	margin-bottom: 0;
-}
-
 .frm-new-table-view-option.frm-selected-table-view-option {
 	border-radius: var(--small-radius);
 	background: var(--primary-25);
@@ -377,10 +359,6 @@ td.column-title .frm_actions_dropdown {
 .frm-views-editor-body #frm_adv_info .tabs-panel { /* Views sidebar */
 	padding-left: 4px;
 	padding-right: 4px;
-}
-
-.frm-views-editor-body .frm_grid_container {
-	grid-gap; var(--gap-md);
 }
 
 #frm_edit_box_content_modal .frm_modal_footer {
@@ -681,31 +659,36 @@ ul.frm_form_nav > li {
 	font-size: var(--text-sm);
 }
 
+.frm-admin-page-styles .frm_page_container,
 .frm_wrap .frm_page_container { /* Use .frm_wrap to avoid messing up Views editor layout */
 	height: calc( 100vh - 32px );
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
 	padding-top: 0;
+	position: fixed;
+	top: 32px;
+	bottom: 0;
+	left: 0;
+	right: 0;
 }
 
+.auto-fold.frm-admin-page-styles .frm_page_container,
+.auto-fold .frm_wrap .frm_page_container {
+	left: 160px;
+}
+
+.folded.frm-admin-page-styles .frm_page_container,
+.folded .frm_wrap .frm_page_container {
+	left: 38px;
+}
+
+.frm-full-screen.frm-admin-page-styles .frm_page_container,
 .frm-full-screen .frm_wrap .frm_page_container {
 	height: 100vh;
+	top: 0;
+	left: 0;
 }
-
-/* Temp Views full screen override until HTML is updated */
-.frm-views-editor-body {
-	--header-height: 61px;
-}
-
-#frm_view_editor_left, #frm_view_editor_right {
-	height: calc( 100vh - var( --header-height ) ) !important;
-}
-
-#frm_view_editor_preview_area {
-	height: calc( 100vh - 100px - var( --header-height ) ) !important;
-}
-/* End temp Views override */
 
 .frm-full-screen.frm-admin-page-entries .frm_page_container,
 .frm-new-entry .frm_page_container,
@@ -719,11 +702,17 @@ ul.frm_form_nav > li {
 	border: none;
 }
 
-.frm_wrap #frm_top_bar,
-.frm_wrap .columns-2 {
+.frm-white-body #frm_top_bar,
+.frm-white-body .columns-2 {
 	flex: 0 0 auto;
 }
 
+.columns-2 .frm-right-panel + div {
+	padding-bottom: var(--gap-md);
+	border-left: 1px solid var(--sidebar-hover);
+}
+
+.columns-2 .frm-right-panel + div,
 .frm_wrap #post-body-content {
 	padding-bottom: 0;
 	padding-top: var(--gap-sm);
@@ -734,14 +723,16 @@ ul.frm_form_nav > li {
 	flex: 2;
 }
 
-.frm_wrap .columns-2 {
+.frm-white-body .columns-2 {
 	flex: 1;
 	display: flex;
 	overflow: hidden;
 }
 
-.frm_wrap .columns-2 > div {
+.frm-white-body .columns-2 > div {
 	overflow-y: auto;
+	box-sizing: border-box;
+    position: relative;
 }
 
 .frm_wrap .columns-2 .frm-right-panel,
@@ -1561,6 +1552,10 @@ input.frm_insert_in_template {
 
 .frm-text-right {
 	text-align: right;
+}
+
+.frm-border-b {
+	border-bottom: 1px solid var(--grey-300);
 }
 
 .frm-no-border {
@@ -8445,9 +8440,11 @@ Responsive Design
 		grid-template-columns: 1fr;
 	}
 
-	.frm_single_entry_page.frm_wrap .frm_page_container {
-		height: auto;
-		display: block;
+	.frm-admin-page-styles .frm_page_container,
+	.frm_wrap .frm_page_container {
+		left: 0 !important;
+		top: 46px !important;
+		height: calc( 100vh - 46px ) !important;
 	}
 
 	.frm_single_entry_page.frm_wrap .columns-2 {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -732,7 +732,6 @@ ul.frm_form_nav > li {
 .frm-white-body .columns-2 > div {
 	overflow-y: auto;
 	box-sizing: border-box;
-    position: relative;
 }
 
 .frm_wrap .columns-2 .frm-right-panel,


### PR DESCRIPTION
Use the WP full screen setting for full pages
Use the css from WP for full screen pages
Use more consistent classes for two column scrolling layout
Include frm_form_nav container for layout in a view without a form selected

To test:
- Go to edit a post and click the ... and turn off fullscreen mode
- Check all the full screen pages to make sure they look and scroll correctly
- Click the collapse the admin menu and check all the pages again
- Check on different screen sizes
- Go back and turn on fullscreen mode, and check all full screen pages again