### PR TITLE
Fix overflowing rte box on smaller spaces

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -4056,6 +4056,8 @@ label input[type="checkbox"], label input[type="radio"] {
 
 .frm_rte {
 	background: url(../images/rte.png) no-repeat;
+	background-size: clamp( 400px, 100%, 654px) auto;
+
 }
 
 .frm_rte .howto {
@@ -4111,9 +4113,10 @@ label input[type="checkbox"], label input[type="radio"] {
 
 .frm_sorting .frm_rte textarea {
 	width: 653px;
+	max-width: 100%;
 	background: #fff;
 	margin: 1px 0 0;
-	border: 1px solid #dfdfdf;
+	border: 1px solid var(--grey-300);
 	border-top: none;
 	-moz-border-radius: 0;
 	-webkit-border-radius: 0;


### PR DESCRIPTION
Before:
<img width="681" alt="Screen Shot 2023-02-17 at 4 33 25 PM" src="https://user-images.githubusercontent.com/1116876/219816631-48a6b118-cb19-467a-9fc9-92a581d980fc.png">
<img width="557" alt="Screen Shot 2023-02-17 at 4 33 13 PM" src="https://user-images.githubusercontent.com/1116876/219816640-3c4c7d30-9626-484f-8cb3-017056785bc6.png">

After:
<img width="684" alt="Screen Shot 2023-02-17 at 4 32 36 PM" src="https://user-images.githubusercontent.com/1116876/219816660-1a664606-974d-4695-b5a2-fe848dc8af5e.png">
<img width="514" alt="Screen Shot 2023-02-17 at 4 32 54 PM" src="https://user-images.githubusercontent.com/1116876/219816669-4629067d-ab9e-4dbe-b69f-f1d0063b6918.png">

The message still overlaps, but that text is in Pro.