### PR TITLE
add style that forces flex wrap

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -715,7 +715,7 @@ ul.frm_form_nav > li {
 	display: block;
 }
 
-.frm_flex_wrap {
+.frm_single_entry_page .frm_forms .columns-2 {
 	flex-wrap: wrap;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -715,6 +715,10 @@ ul.frm_form_nav > li {
 	display: block;
 }
 
+.frm_flex_wrap {
+	flex-wrap: wrap;
+}
+
 .frm-new-entry .columns-2 {
 	border: none;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -715,10 +715,6 @@ ul.frm_form_nav > li {
 	display: block;
 }
 
-.frm_single_entry_page .frm_forms .columns-2 {
-	flex-wrap: wrap;
-}
-
 .frm-new-entry .columns-2 {
 	border: none;
 }
@@ -8649,7 +8645,7 @@ Responsive Design
 		padding: 20px;
 	}
 
-	.frm_page_container .columns-2,
+	.frm_wrap .columns-2,
 	.frm_wrap .frm_page_container {
 		height: auto;
 		display: block;


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4079
A quick fix for making sure the sidebar is wrapped up into the next line.

BEFORE:
![image](https://user-images.githubusercontent.com/41271840/220615141-c844a361-7c9f-4868-9178-7415392c0e8b.png)

NOW:
![image](https://user-images.githubusercontent.com/41271840/220615022-7dd441f4-bcaf-4dbc-8d1b-d1eb639621da.png)

