### PR TITLE
Trigger change events for wysiwyg textareas

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2933,6 +2933,12 @@ function frmAdminBuildJS() {
 			}
 		} else {
 			changes.innerHTML = newValue;
+
+			if ( 'TEXTAREA' === changes.nodeName && changes.classList.contains( 'wp-editor-area' ) ) {
+				// Trigger change events on wysiwyg textareas so we can also sync default values in the visual tab.
+				jQuery( changes ).trigger( 'change' );
+			}
+
 			if ( changes.classList.contains( 'frm_primary_label' ) && 'break' === changes.nextElementSibling.getAttribute( 'data-ftype' ) ) {
 				changes.nextElementSibling.querySelector( '.frm_button_submit' ).textContent = newValue;
 			}


### PR DESCRIPTION
Part of https://github.com/Strategy11/formidable-pro/pull/4085

Without this update the visual tab in the preview won't sync when you change the default value of the field.