### PR TITLE
Only use action option limit if greater than 99

### DIFF
--- a/classes/models/FrmFormAction.php
+++ b/classes/models/FrmFormAction.php
@@ -550,7 +550,7 @@ class FrmFormAction {
 	}
 
 	public function get_all( $form_id = false, $atts = array() ) {
-		if ( is_array( $atts ) && ! isset( $atts['limit'] ) ) {
+		if ( is_array( $atts ) && ! isset( $atts['limit'] ) && $this->action_options['limit'] > 99 ) {
 			$atts['limit'] = $this->action_options['limit'];
 		}
 


### PR DESCRIPTION
The unit tests were breaking in Pro. Posts have a limit of 1. To be on the safe side, I added a check to only change the limit if the option limit is greater than 99.

> There was 1 failure:
> 
> 1) test_FrmProEntriesHelper::test_search_form_posts
> Failed asserting that false is true.
> 
> /tmp/wordpress/src/wp-content/plugins/formidable-pro/tests/entries/test_FrmProEntriesHelper.php:712
> /tmp/wordpress/src/wp-content/plugins/formidable-pro/tests/entries/test_FrmProEntriesHelper.php:675