### PR TITLE
add right margin to fields box

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6820,6 +6820,7 @@ i.frm-show-inline-modal,
 .frm_form_settings .wp-editor-container .frm-with-right-icon .frmsvg {
 	top: auto;
 	bottom: 0;
+	margin-right: 10px;
 }
 
 .frm_form_settings .frm_has_textarea .frm-with-right-icon .frmsvg {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6820,7 +6820,6 @@ i.frm-show-inline-modal,
 .frm_form_settings .wp-editor-container .frm-with-right-icon .frmsvg {
 	top: auto;
 	bottom: 0;
-	margin-right: 10px;
 }
 
 .frm_form_settings .frm_has_textarea .frm-with-right-icon .frmsvg {
@@ -6838,8 +6837,9 @@ i.frm-show-inline-modal {
 	z-index: 1;
 	opacity: 1;
 	top: auto;
-	padding: calc( ( 36px - 18px ) / 2 ); /* input height - svg / 2 */
-	padding-bottom: 0;
+	margin: calc( ( 36px - 18px ) / 2 ); /* input height - svg / 2 */
+	margin-bottom: 0;
+	padding: 0;
 }
 
 .frm-open .frmsvg.frm-show-inline-modal,


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4092
Just a small fix to make sure the email message text area is easily expandable.
BEFORE:
![image](https://user-images.githubusercontent.com/41271840/221023939-b73d79e2-7ee1-4c88-838d-73f5cdc20b63.png)

NOW:
![image](https://user-images.githubusercontent.com/41271840/221023710-c2b720ce-661f-415f-b134-448d88856899.png)
