### PR TITLE
Fix https://github.com/Strategy11/formidable-pro/issues/4100

### DIFF
--- a/classes/views/styles/_styles-edit.php
+++ b/classes/views/styles/_styles-edit.php
@@ -33,10 +33,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 */
 	?>
 	<input type="hidden" name="style_name" value="frm_style_<?php echo esc_attr( $style->post_name ); ?>" />
-</div>
 
-<?php
-// This holds the custom CSS for a single theme that is being worked on on the edit page.
-// It gets populated with the frm_change_styling action.
-?>
-<div id="this_css"></div>
+	<?php
+	// This holds the custom CSS for a single theme that is being worked on on the edit page.
+	// It gets populated with the frm_change_styling action.
+	?>
+	<div id="this_css"></div>
+</div>


### PR DESCRIPTION
This moves the hidden div so the flex css will apply to the preview section

Before:
<img width="1396" alt="Screen Shot 2023-02-24 at 10 55 43 AM" src="https://user-images.githubusercontent.com/1116876/221254077-0e0f36bf-9304-4665-9d1d-3ffa91f3032c.png">

After:
<img width="1400" alt="Screen Shot 2023-02-24 at 10 55 55 AM" src="https://user-images.githubusercontent.com/1116876/221254097-67867b16-661f-4c00-a015-770d53e5746c.png">
