### PR TITLE
Fix confirmation action is forced to message

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2159,6 +2159,20 @@ class FrmFormsController {
 			)
 		);
 
+		self::maybe_trigger_redirect_with_action( $conf_method, $form, $params, $args );
+	}
+
+	/**
+	 * Maybe trigger redirect with the new Confirmation action.
+	 *
+	 * @since 6.1.1
+	 *
+	 * @param array|string $conf_method Array of confirmation actions or the action type string.
+	 * @param object       $form        Form object.
+	 * @param array        $params      See {@see FrmFormsController::maybe_trigger_redirect()}.
+	 * @param array        $args        See {@see FrmFormsController::maybe_trigger_redirect()}.
+	 */
+	public static function maybe_trigger_redirect_with_action( $conf_method, $form, $params, $args ) {
 		if ( is_array( $conf_method ) && 1 === count( $conf_method ) ) {
 			if ( 'redirect' === FrmOnSubmitHelper::get_action_type( $conf_method[0] ) ) {
 				FrmOnSubmitHelper::populate_on_submit_data( $form->options, $conf_method[0] );

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2127,13 +2127,10 @@ class FrmFormsController {
 		$opt    = 'success_action';
 		$method = ( isset( $atts['form']->options[ $opt ] ) && ! empty( $atts['form']->options[ $opt ] ) ) ? $atts['form']->options[ $opt ] : 'message';
 
-		if ( ! empty( $atts['entry_id'] ) && FrmOnSubmitHelper::form_has_migrated( $atts['form'] ) ) { // Check against entry has already submitted error.
+		if ( ! empty( $atts['entry_id'] ) && FrmOnSubmitHelper::form_has_migrated( $atts['form'] ) ) {
 			$met_actions = self::get_met_on_submit_actions( $atts );
 			if ( $met_actions ) {
 				$method = $met_actions;
-			} else {
-				// If no actions match, use the default message.
-				$method = array( FrmOnSubmitHelper::get_fallback_action() );
 			}
 		}
 
@@ -2284,7 +2281,13 @@ class FrmFormsController {
 		 * @param array $met_actions Actions that meet the conditional logics.
 		 * @param array $args        See {@see FrmFormsController::run_success_action()}. `$args['event']` is also added.
 		 */
-		return apply_filters( 'frm_get_met_on_submit_actions', $met_actions, $args );
+		$met_actions = apply_filters( 'frm_get_met_on_submit_actions', $met_actions, $args );
+
+		if ( empty( $met_actions ) ) {
+			$met_actions = array( FrmOnSubmitHelper::get_fallback_action( $event ) );
+		}
+
+		return $met_actions;
 	}
 
 	/**

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2128,11 +2128,12 @@ class FrmFormsController {
 		$opt    = 'success_action';
 		$method = ( isset( $atts['form']->options[ $opt ] ) && ! empty( $atts['form']->options[ $opt ] ) ) ? $atts['form']->options[ $opt ] : 'message';
 
-		if ( ! empty( $atts['entry_id'] ) ) { // Check against entry has already submitted error.
+		if ( ! empty( $atts['entry_id'] ) && FrmOnSubmitHelper::form_has_migrated( $atts['form'] ) ) { // Check against entry has already submitted error.
 			$met_actions = self::get_met_on_submit_actions( $atts );
 			if ( $met_actions ) {
 				$method = $met_actions;
 			} else {
+				// If no actions match, use the default message.
 				$method = 'message';
 			}
 		}

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2133,7 +2133,7 @@ class FrmFormsController {
 				$method = $met_actions;
 			} else {
 				// If no actions match, use the default message.
-				$method = 'message';
+				$method = array( FrmOnSubmitHelper::get_fallback_action() );
 			}
 		}
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2124,17 +2124,18 @@ class FrmFormsController {
 	 * @return string|array
 	 */
 	private static function get_confirmation_method( $atts ) {
-		$opt    = 'success_action';
+		$action = FrmOnSubmitHelper::current_event( $atts );
+		$opt    = 'update' === $action ? 'edit_action' : 'success_action';
 		$method = ( isset( $atts['form']->options[ $opt ] ) && ! empty( $atts['form']->options[ $opt ] ) ) ? $atts['form']->options[ $opt ] : 'message';
 
 		if ( ! empty( $atts['entry_id'] ) && FrmOnSubmitHelper::form_has_migrated( $atts['form'] ) ) {
-			$met_actions = self::get_met_on_submit_actions( $atts );
+			$met_actions = self::get_met_on_submit_actions( $atts, $action );
 			if ( $met_actions ) {
 				$method = $met_actions;
 			}
 		}
 
-		$method = apply_filters( 'frm_success_filter', $method, $atts['form'], 'create' );
+		$method = apply_filters( 'frm_success_filter', $method, $atts['form'], $action );
 
 		if ( $method != 'message' && ( ! $atts['entry_id'] || ! is_numeric( $atts['entry_id'] ) ) ) {
 			$method = 'message';
@@ -2153,6 +2154,7 @@ class FrmFormsController {
 			array(
 				'form'     => $form,
 				'entry_id' => $params['id'],
+				'action'   => FrmOnSubmitHelper::current_event( $params ),
 			)
 		);
 
@@ -2302,6 +2304,7 @@ class FrmFormsController {
 			array(
 				'form'     => $args['form'],
 				'entry_id' => $args['entry_id'],
+				'action'   => FrmOnSubmitHelper::current_event( $args ),
 			)
 		);
 		if ( ! is_array( $args['conf_method'] ) ) {

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2128,7 +2128,7 @@ class FrmFormsController {
 		$opt    = 'update' === $action ? 'edit_action' : 'success_action';
 		$method = ( isset( $atts['form']->options[ $opt ] ) && ! empty( $atts['form']->options[ $opt ] ) ) ? $atts['form']->options[ $opt ] : 'message';
 
-		if ( ! empty( $atts['entry_id'] ) && FrmOnSubmitHelper::form_has_migrated( $atts['form'] ) ) {
+		if ( ! empty( $atts['entry_id'] ) ) {
 			$met_actions = self::get_met_on_submit_actions( $atts, $action );
 			if ( $met_actions ) {
 				$method = $met_actions;
@@ -2247,6 +2247,10 @@ class FrmFormsController {
 	 * @return array Array of actions that meet the conditional logics.
 	 */
 	public static function get_met_on_submit_actions( $args, $event = 'create' ) {
+		if ( ! FrmOnSubmitHelper::form_has_migrated( $args['form'] ) ) {
+			return array();
+		}
+
 		$entry       = FrmEntry::getOne( $args['entry_id'], true );
 		$actions     = FrmOnSubmitHelper::get_actions( $args['form']->id );
 		$met_actions = array();

--- a/classes/helpers/FrmOnSubmitHelper.php
+++ b/classes/helpers/FrmOnSubmitHelper.php
@@ -274,4 +274,15 @@ class FrmOnSubmitHelper {
 
 		return $action;
 	}
+
+	/**
+	 * Check if the current event has been paased. If not, use create actions.
+	 *
+	 * @since 6.1.1
+	 *
+	 * @return string
+	 */
+	public static function current_event( $atts ) {
+		return ! empty( $atts['action'] ) ? $atts['action'] : 'create';
+	}
 }

--- a/classes/helpers/FrmOnSubmitHelper.php
+++ b/classes/helpers/FrmOnSubmitHelper.php
@@ -243,6 +243,110 @@ class FrmOnSubmitHelper {
 	}
 
 	/**
+	 * Maybe migrate submit settings from the form options to On Submit action.
+	 * This is added after On Submit action is released. This might migrate the frontend editing submit settings too.
+	 *
+	 * @since 6.1.1
+	 *
+	 * @param int $form_id Form ID.
+	 */
+	public static function maybe_migrate_submit_settings_to_action( $form_id ) {
+		$form = FrmDb::get_row( 'frm_forms', array( 'id' => $form_id ), 'options,editable' );
+		if ( ! $form ) {
+			return;
+		}
+
+		FrmAppHelper::unserialize_or_decode( $form->options );
+
+		if ( self::form_has_migrated( $form ) ) {
+			return;
+		}
+
+		$form->id = $form_id;
+		$action_type = FrmOnSubmitAction::$slug;
+
+		// Check if form already has form actions to avoid creating duplicates.
+		$has_actions = FrmFormAction::form_has_action_type( $form_id, $action_type );
+		if ( ! empty( $has_actions ) ) {
+			// Don't migrate again.
+			self::save_migrated_success_actions( $form );
+			return;
+		}
+
+		// Create On Submit action.
+		$base_action = array();
+
+		$base_action['post_type']    = FrmFormActionsController::$action_post_type;
+		$base_action['post_excerpt'] = $action_type;
+		$base_action['post_title']   = FrmOnSubmitAction::get_name();
+		$base_action['menu_order']   = $form_id;
+		$base_action['post_status']  = 'publish';
+		$base_action['post_content'] = array(
+			'event' => array( 'create' ),
+		);
+
+		$action_data = self::get_on_submit_action_data_from_form_options( $form->options );
+
+		// If frontend editing is enabled, migrate its settings too.
+		if ( method_exists( 'FrmProFormActionsController', 'change_on_submit_action_ops' ) && FrmAppHelper::pro_is_connected() && $form->editable ) {
+			$edit_data = self::get_on_submit_action_data_from_form_options( $form->options, 'update' );
+
+			if ( $action_data === $edit_data ) {
+				// Just create one action for both create and update if they are the same.
+				$base_action['post_content']['event'][] = 'update';
+			} else {
+				// Create a separate action for update.
+				$edit_action                          = $base_action;
+				$edit_action['post_content']         += $edit_data;
+				$edit_action['post_content']['event'] = array( 'update' );
+
+				$edit_action['post_content'] = FrmAppHelper::prepare_and_encode( $edit_action['post_content'] );
+				FrmDb::save_json_post( $edit_action );
+			}
+		}
+
+		$action                  = $base_action;
+		$action['post_content'] += $action_data;
+
+		$action['post_content'] = FrmAppHelper::prepare_and_encode( $action['post_content'] );
+		FrmDb::save_json_post( $action );
+
+		self::save_migrated_success_actions( $form );
+	}
+
+	/**
+	 * Gets On Submit action data from form options to be used for the migration.
+	 *
+	 * @since 6.1.1
+	 *
+	 * @param array  $form_options Form options.
+	 * @param string $event        Action event. Accepts `create` or `update`. Default is `create`.
+	 * @return array
+	 */
+	private static function get_on_submit_action_data_from_form_options( $form_options, $event = 'create' ) {
+		$opt  = 'update' === $event ? 'edit_' : 'success_';
+		$data = array(
+			'success_action' => isset( $form_options[ $opt . 'action' ] ) ? $form_options[ $opt . 'action' ] : FrmOnSubmitHelper::get_default_action_type(),
+		);
+
+		switch ( $data['success_action'] ) {
+			case 'redirect':
+				$data['success_url'] = isset( $form_options[ $opt . 'url' ] ) ? $form_options[ $opt . 'url' ] : '';
+				break;
+
+			case 'page':
+				$data['success_page_id'] = isset( $form_options[ $opt . 'page_id' ] ) ? $form_options[ $opt . 'page_id' ] : '';
+				break;
+
+			default:
+				$data['success_msg'] = isset( $form_options[ $opt . 'msg' ] ) ? $form_options[ $opt . 'msg' ] : FrmOnSubmitHelper::get_default_msg();
+				$data['show_form']   = ! empty( $form_options['show_form'] );
+		}
+
+		return $data;
+	}
+
+	/**
 	 * Checks if On Submit settings are migrated.
 	 *
 	 * @since 6.1.1
@@ -252,6 +356,16 @@ class FrmOnSubmitHelper {
 	 */
 	public static function form_has_migrated( $form ) {
 		return ! empty( $form->options['on_submit_migrated'] );
+	}
+
+	/**
+	 * @since 6.1.1
+	 *
+	 * @param object $form Limited form object.
+	 */
+	private static function save_migrated_success_actions( $form ) {
+		$form->options['on_submit_migrated'] = 1;
+		FrmForm::update( $form->id, array( 'options' => $form->options ) );
 	}
 
 	/**

--- a/classes/helpers/FrmOnSubmitHelper.php
+++ b/classes/helpers/FrmOnSubmitHelper.php
@@ -241,4 +241,16 @@ class FrmOnSubmitHelper {
 				$form_options['show_form']    = ! empty( $action->post_content['show_form'] );
 		}
 	}
+
+	/**
+	 * Checks if On Submit settings are migrated.
+	 *
+	 * @since 6.x
+	 *
+	 * @param object $form Form object.
+	 * @return bool
+	 */
+	public static function form_has_migrated( $form ) {
+		return ! empty( $form->options['on_submit_migrated'] );
+	}
 }

--- a/classes/helpers/FrmOnSubmitHelper.php
+++ b/classes/helpers/FrmOnSubmitHelper.php
@@ -259,13 +259,15 @@ class FrmOnSubmitHelper {
 	 *
 	 * @since 6.1.1
 	 *
+	 * @param string|array $event Uses 'create' or 'update'.
+	 *
 	 * @return object
 	 */
-	public static function get_fallback_action() {
+	public static function get_fallback_action( $event = 'create' ) {
 		$action = new stdClass();
 
 		$action->post_content = array(
-			'event'          => array( 'create' ),
+			'event'          => (array) $event,
 			'success_action' => 'message',
 			'success_msg'    => self::get_default_msg(),
 		);

--- a/classes/helpers/FrmOnSubmitHelper.php
+++ b/classes/helpers/FrmOnSubmitHelper.php
@@ -326,7 +326,7 @@ class FrmOnSubmitHelper {
 	private static function get_on_submit_action_data_from_form_options( $form_options, $event = 'create' ) {
 		$opt  = 'update' === $event ? 'edit_' : 'success_';
 		$data = array(
-			'success_action' => isset( $form_options[ $opt . 'action' ] ) ? $form_options[ $opt . 'action' ] : FrmOnSubmitHelper::get_default_action_type(),
+			'success_action' => isset( $form_options[ $opt . 'action' ] ) ? $form_options[ $opt . 'action' ] : self::get_default_action_type(),
 		);
 
 		switch ( $data['success_action'] ) {
@@ -339,7 +339,7 @@ class FrmOnSubmitHelper {
 				break;
 
 			default:
-				$data['success_msg'] = isset( $form_options[ $opt . 'msg' ] ) ? $form_options[ $opt . 'msg' ] : FrmOnSubmitHelper::get_default_msg();
+				$data['success_msg'] = isset( $form_options[ $opt . 'msg' ] ) ? $form_options[ $opt . 'msg' ] : self::get_default_msg();
 				$data['show_form']   = ! empty( $form_options['show_form'] );
 		}
 

--- a/classes/helpers/FrmOnSubmitHelper.php
+++ b/classes/helpers/FrmOnSubmitHelper.php
@@ -245,12 +245,31 @@ class FrmOnSubmitHelper {
 	/**
 	 * Checks if On Submit settings are migrated.
 	 *
-	 * @since 6.x
+	 * @since 6.1.1
 	 *
 	 * @param object $form Form object.
 	 * @return bool
 	 */
 	public static function form_has_migrated( $form ) {
 		return ! empty( $form->options['on_submit_migrated'] );
+	}
+
+	/**
+	 * Gets fallback action, used when no actions match.
+	 *
+	 * @since 6.1.1
+	 *
+	 * @return object
+	 */
+	public static function get_fallback_action() {
+		$action = new stdClass();
+
+		$action->post_content = array(
+			'event'          => array( 'create' ),
+			'success_action' => 'message',
+			'success_msg'    => self::get_default_msg(),
+		);
+
+		return $action;
 	}
 }

--- a/tests/forms/test_FrmFormsController.php
+++ b/tests/forms/test_FrmFormsController.php
@@ -2,6 +2,7 @@
 
 /**
  * @group forms
+ * @group forms-controller
  */
 class test_FrmFormsController extends FrmUnitTest {
 
@@ -210,6 +211,7 @@ class test_FrmFormsController extends FrmUnitTest {
 
 		// Update form object from cache.
 		wp_cache_delete( $form_id, 'frm_form' );
+		$this->trigger_migrate_actions( $form_id );
 		$form = FrmForm::getOne( $form_id );
 
 		// Create entry.
@@ -230,12 +232,15 @@ class test_FrmFormsController extends FrmUnitTest {
 
 		// Test the output.
 		$response = FrmFormsController::show_form( $form->id ); // this is where the message is returned
-		$this->assertNotFalse( strpos( $response, '<div class="frm_message" role="status"><p>Done!</p>' ) );
-		$this->assertNotFalse( strpos( $response, 'frmFrontForm.scrollMsg(' . $form->id . ')' ) );
-
-		$this->assertNotFalse( strpos( $response, 'window.location="http://example.com"' ) );
-
-		$this->assertNotFalse( strpos( $response, 'Test page content' ) );
+		$contains = array(
+			'frmFrontForm.scrollMsg(' . $form->id . ')',
+			'Done!',
+			'window.location="http://example.com"',
+			'Test page content',
+		);
+		foreach ( $contains as $c ) {
+			$this->assertStringContainsString( $c, $response );
+		}
 	}
 
 	/**
@@ -256,6 +261,7 @@ class test_FrmFormsController extends FrmUnitTest {
 		);
 
 		wp_cache_delete( $form_id, 'frm_form' );
+		$this->trigger_migrate_actions( $form_id );
 
 		$form = $this->factory->form->get_object_by_id( $form_id );
 
@@ -272,6 +278,13 @@ class test_FrmFormsController extends FrmUnitTest {
 
 		$response = FrmFormsController::show_form( $form->id ); // this is where the redirect happens
 		$this->assertNotFalse( strpos( $response, 'window.location="http://example.com"' ) );
+	}
+
+	/**
+	 * Trigger migration check and the flag.
+	 */
+	private function trigger_migrate_actions( $form_id ) {
+		FrmOnSubmitHelper::maybe_migrate_submit_settings_to_action( $form_id );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4101

My last fix added `$method = 'message'` to show the default message if no actions match. But it breaks the form that hasn't been migrated. I added a check if the form hasn't been migrated there.