### PR TITLE
Move frm_show_form_after_edit filter to lite

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2499,11 +2499,17 @@ class FrmFormsController {
 	 * Prepare to show the success message and empty form after submit
 	 *
 	 * @since 2.05
+	 * @since 6.1.1 Moved `frm_show_form_after_edit` filter to this method.
 	 */
 	public static function show_message_after_save( $atts ) {
 		$atts['message'] = self::prepare_submit_message( $atts['form'], $atts['entry_id'], $atts );
+		$show_form       = ( isset( $atts['form']->options['show_form'] ) ) ? $atts['form']->options['show_form'] : true;
 
-		if ( ! isset( $atts['form']->options['show_form'] ) || $atts['form']->options['show_form'] ) {
+		if ( 'edit' === $atts['success_opt'] && version_compare( FrmProDb::$plug_version, '6.1.1', '>=' ) ) {
+			$show_form = apply_filters( 'frm_show_form_after_edit', $show_form, $atts['form'] );
+		}
+
+		if ( $show_form ) {
 			self::show_form_after_submit( $atts );
 		} else {
 			self::show_lone_success_messsage( $atts );

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2505,7 +2505,7 @@ class FrmFormsController {
 		$atts['message'] = self::prepare_submit_message( $atts['form'], $atts['entry_id'], $atts );
 		$show_form       = ! isset( $atts['form']->options['show_form'] ) || $atts['form']->options['show_form'];
 
-		if ( 'edit' === $atts['success_opt'] && version_compare( FrmProDb::$plug_version, '6.1.1', '>=' ) ) {
+		if ( 'edit' === $atts['success_opt'] && class_exists( 'FrmProDb', false ) && version_compare( FrmProDb::$plug_version, '6.1.1', '>=' ) ) {
 			$show_form = apply_filters( 'frm_show_form_after_edit', $show_form, $atts['form'] );
 		}
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2503,7 +2503,7 @@ class FrmFormsController {
 	 */
 	public static function show_message_after_save( $atts ) {
 		$atts['message'] = self::prepare_submit_message( $atts['form'], $atts['entry_id'], $atts );
-		$show_form       = ( isset( $atts['form']->options['show_form'] ) ) ? $atts['form']->options['show_form'] : true;
+		$show_form       = ! isset( $atts['form']->options['show_form'] ) || $atts['form']->options['show_form'];
 
 		if ( 'edit' === $atts['success_opt'] && version_compare( FrmProDb::$plug_version, '6.1.1', '>=' ) ) {
 			$show_form = apply_filters( 'frm_show_form_after_edit', $show_form, $atts['form'] );


### PR DESCRIPTION
I moved that filter to lite since it's get run after this change https://github.com/Strategy11/formidable-pro/pull/4102/files#diff-0b783bc2474a31b50b78b8e63872466196b161f94bd6c7a01f4cd72205e8f060R1132