### PR TITLE
Enable duplication of collapsed sections

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7301,6 +7301,7 @@ ul .frm_col_two {
 .frm_wrap .ui-autocomplete li > div,
 .multiselect-container button.multiselect-option,
 .frm-dropdown-menu > .dropdown-item > a,
+.frm-dropdown-menu > .dropdown-item > a:visited,
 .frm-dropdown-menu > .dropdown-item > a:link, /* Override jQuery UI */
 .frm-dropdown-menu .frm_dropdown_li,
 .frm_code_list.frm-full-hover a {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6310,6 +6310,10 @@ li.selected .divider_section_only:before {
 	transition: border 0.7s ease-out;
 }
 
+.frm_sorting li.ui-state-default.edit_field_type_divider.frm-section-collapsed {
+	z-index: 3;
+}
+
 .frm-section-collapsed {
 	border-left-color: transparent !important;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6309,10 +6309,6 @@ li.selected .divider_section_only:before {
 	transition: border 0.7s ease-out;
 }
 
-.frm_sorting li.ui-state-default.edit_field_type_divider.frm-section-collapsed {
-	z-index: 3;
-}
-
 .frm-section-collapsed {
 	border-left-color: transparent !important;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6241,8 +6241,7 @@ ul.start_divider {
 
 .frm-page-collapsed .frm_clone_icon,
 .frm-page-collapsed .frm_delete_field,
-.frm-section-collapsed .frm_clone_icon,
-.frm-section-collapsed .frm_delete_field {
+.frm-section-collapsed .frm_clone_icon {
 	opacity: .5;
 	cursor: not-allowed;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6241,6 +6241,7 @@ ul.start_divider {
 
 .frm-page-collapsed .frm_clone_icon,
 .frm-page-collapsed .frm_delete_field,
+.frm-page-collapsed .frm_clone_field,
 .frm-section-collapsed .frm_clone_icon {
 	opacity: .5;
 	cursor: not-allowed;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3531,7 +3531,7 @@ function frmAdminBuildJS() {
 				}
 			});
 			if ( fieldIdsToDelete ) {
-				confirmMsg = confirmFieldsDeleteMessage( fieldIdsToDelete );
+				confirmMsg = confirmFieldsDeleteMessage( ++fieldIdsToDelete );
 			}
 		}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2044,7 +2044,7 @@ function frmAdminBuildJS() {
 
 		$field = jQuery( this ).closest( 'li.form-field' );
 
-		if ( $field.hasClass( 'frm-section-collapsed' ) || $field.hasClass( 'frm-page-collapsed' ) ) {
+		if ( $field.hasClass( 'frm-page-collapsed' ) ) {
 			return false;
 		}
 
@@ -3520,7 +3520,7 @@ function frmAdminBuildJS() {
 			fieldIdsToDelete = 0;
 
 		if ( field.data( 'ftype' ) === 'divider' ) {
-			fieldBoxes = document.querySelector( '.frm-field-group-hover-target' )?.querySelector( '.start_divider')?.querySelectorAll( '.frm_field_box' );
+			fieldBoxes = document.querySelector( '.frm-field-group-hover-target' )?.querySelector( '.start_divider' )?.querySelectorAll( '.frm_field_box' );
 			if ( fieldBoxes && fieldBoxes.length ) {
 				fieldBoxes.forEach( fieldBox => {
 					fieldsInsideFieldBox = fieldBox.querySelectorAll( 'li.form-field' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3508,6 +3508,11 @@ function frmAdminBuildJS() {
 		}
 	}
 
+	function confirmFieldsDeleteMessage( numberOfFields ) {
+		/* translators: %1$s: Number of fields that are selected to be deleted. */
+		return __( 'Are you sure you want to delete these %1$s selected field(s)?', 'formidable' ).replace( '%1$s', numberOfFields );
+	}
+
 	function clickDeleteField() {
 		/*jshint validthis:true */
 		var confirmMsg = frm_admin_js.conf_delete,
@@ -3529,8 +3534,7 @@ function frmAdminBuildJS() {
 					}
 				});
 				if ( fieldIdsToDelete ) {
-					/* translators: %1$s: Number of fields that are selected to be deleted. */
-					confirmMsg = __( 'Are you sure you want to delete these %1$s selected field(s)?', 'formidable' ).replace( '%1$s', fieldIdsToDelete );
+					confirmMsg = confirmFieldsDeleteMessage( fieldIdsToDelete );
 				}
 			}
 		}
@@ -4467,8 +4471,7 @@ function frmAdminBuildJS() {
 			multiselectPopup.remove();
 		}
 
-		/* translators: %1$s: Number of fields that are selected to be deleted. */
-		this.setAttribute( 'data-frmverify', __( 'Are you sure you want to delete these %1$s selected fields?', 'formidable' ).replace( '%1$s', fieldIdsToDelete.length ) );
+		this.setAttribute( 'data-frmverify', confirmFieldsDeleteMessage( fieldIdsToDelete.length ) );
 		confirmLinkClick( this );
 
 		jQuery( '#frm-confirmed-click' ).on( 'click', deleteOnConfirm );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3522,18 +3522,16 @@ function frmAdminBuildJS() {
 			fieldId = field.data( 'fid' );
 
 		if ( field.data( 'ftype' ) === 'divider' ) {
-			const fieldBoxes = document.querySelector( '.frm-field-group-hover-target' )?.querySelector( '.start_divider' )?.querySelectorAll( '.frm_field_box' );
-			if ( fieldBoxes && fieldBoxes.length ) {
-				let fieldIdsToDelete = 0;
-				fieldBoxes.forEach( fieldBox => {
-					const fieldsInsideFieldBox = fieldBox.querySelectorAll( 'li.form-field' );
-					if ( fieldsInsideFieldBox ) {
-						fieldIdsToDelete += fieldsInsideFieldBox.length;
-					}
-				});
-				if ( fieldIdsToDelete ) {
-					confirmMsg = confirmFieldsDeleteMessage( fieldIdsToDelete );
+			const fieldBoxes = document.querySelectorAll( '.frm-field-group-hover-target .start_divider .frm_field_box' );
+			let fieldIdsToDelete = 0;
+			fieldBoxes.forEach( fieldBox => {
+				const fieldsInsideFieldBox = fieldBox.querySelectorAll( 'li.form-field' );
+				if ( fieldsInsideFieldBox ) {
+					fieldIdsToDelete += fieldsInsideFieldBox.length;
 				}
+			});
+			if ( fieldIdsToDelete ) {
+				confirmMsg = confirmFieldsDeleteMessage( fieldIdsToDelete );
 			}
 		}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2049,7 +2049,6 @@ function frmAdminBuildJS() {
 		}
 
 		closeOpenFieldDropdowns();
-
 		fieldId = $field.data( 'fid' );
 		children = fieldsInSection( fieldId );
 		newRowId = this.getAttribute( 'frm-target-row-id' );
@@ -2110,6 +2109,7 @@ function frmAdminBuildJS() {
 				afterAddField( msg, false );
 				maybeDuplicateUnsavedSettings( fieldId, msg );
 				toggleOneSectionHolder( replaceWith.find( '.start_divider' ) );
+				$field[0].querySelector( '.frm-dropdown-menu.dropdown-menu-right' )?.classList.remove( 'show' );
 			}
 		});
 		return false;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3530,7 +3530,7 @@ function frmAdminBuildJS() {
 				});
 				if ( fieldIdsToDelete ) {
 					/* translators: %1$s: Number of fields that are selected to be deleted. */
-					confirmMsg = __( 'Are you sure you want to delete these %1$s selected fields?', 'formidable' ).replace( '%1$s', fieldIdsToDelete );
+					confirmMsg = __( 'Are you sure you want to delete these %1$s selected field(s)?', 'formidable' ).replace( '%1$s', fieldIdsToDelete );
 				}
 			}
 		}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3519,16 +3519,14 @@ function frmAdminBuildJS() {
 			maybeDivider = this.parentNode.parentNode.parentNode.parentNode.parentNode,
 			li = maybeDivider.parentNode,
 			field = jQuery( this ).closest( 'li.form-field' ),
-			fieldId = field.data( 'fid' ),
-			fieldBoxes,
-			fieldsInsideFieldBox,
-			fieldIdsToDelete = 0;
+			fieldId = field.data( 'fid' );
 
 		if ( field.data( 'ftype' ) === 'divider' ) {
-			fieldBoxes = document.querySelector( '.frm-field-group-hover-target' )?.querySelector( '.start_divider' )?.querySelectorAll( '.frm_field_box' );
+			const fieldBoxes = document.querySelector( '.frm-field-group-hover-target' )?.querySelector( '.start_divider' )?.querySelectorAll( '.frm_field_box' );
 			if ( fieldBoxes && fieldBoxes.length ) {
+				let fieldIdsToDelete = 0;
 				fieldBoxes.forEach( fieldBox => {
-					fieldsInsideFieldBox = fieldBox.querySelectorAll( 'li.form-field' );
+					const fieldsInsideFieldBox = fieldBox.querySelectorAll( 'li.form-field' );
 					if ( fieldsInsideFieldBox ) {
 						fieldIdsToDelete += fieldsInsideFieldBox.length;
 					}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2310,6 +2310,19 @@ function frmAdminBuildJS() {
 		onFieldActionDropdownShow( true );
 	}
 
+	function changeSectionStyle( e ) {
+		const collapsedSection = e.target.closest( '.frm-section-collapsed' );
+		if ( ! collapsedSection ) {
+			return;
+		}
+
+		if ( e.type === 'show' ) {
+			collapsedSection.style.zIndex = 3;
+		} else {
+			collapsedSection.style.zIndex = 1;
+		}
+	}
+
 	function fillFieldActionDropdown( ul, isFieldGroup ) {
 		var classSuffix, options;
 		classSuffix = isFieldGroup ? '_field_group' : '_field';
@@ -9763,6 +9776,8 @@ function frmAdminBuildJS() {
 			jQuery( builderArea ).on( 'click', '.frm-collapse-page', maybeCollapsePage );
 			jQuery( builderArea ).on( 'click', '.frm-collapse-section', maybeCollapseSection );
 			$builderForm.on( 'click', '.frm-single-settings h3', maybeCollapseSettings );
+
+			jQuery( builderArea ).on( 'show.bs.dropdown hide.bs.dropdown', changeSectionStyle );
 
 			$builderForm.on( 'click', '.frm_toggle_sep_values', toggleSepValues );
 			$builderForm.on( 'click', '.frm_toggle_image_options', toggleImageOptions );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3516,14 +3516,16 @@ function frmAdminBuildJS() {
 			field = jQuery( this ).closest( 'li.form-field' ),
 			fieldId = field.data( 'fid' ),
 			fieldBoxes,
+			fieldsInsideFieldBox,
 			fieldIdsToDelete = 0;
 
 		if ( field.data( 'ftype' ) === 'divider' ) {
 			fieldBoxes = document.querySelector( '.frm-field-group-hover-target' )?.querySelector( '.start_divider')?.querySelectorAll( '.frm_field_box' );
 			if ( fieldBoxes && fieldBoxes.length ) {
 				fieldBoxes.forEach( fieldBox => {
-					if ( fieldBox.querySelectorAll( 'li.form-field' ) ) {
-						fieldIdsToDelete += fieldBox.querySelectorAll( 'li.form-field' ).length;
+					fieldsInsideFieldBox = fieldBox.querySelectorAll( 'li.form-field' );
+					if ( fieldsInsideFieldBox ) {
+						fieldIdsToDelete += fieldsInsideFieldBox.length;
 					}
 				});
 				if ( fieldIdsToDelete ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3514,7 +3514,24 @@ function frmAdminBuildJS() {
 			maybeDivider = this.parentNode.parentNode.parentNode.parentNode.parentNode,
 			li = maybeDivider.parentNode,
 			field = jQuery( this ).closest( 'li.form-field' ),
-			fieldId = field.data( 'fid' );
+			fieldId = field.data( 'fid' ),
+			fieldBoxes,
+			fieldIdsToDelete = 0;
+
+		if ( field.data( 'ftype' ) === 'divider' ) {
+			fieldBoxes = document.querySelector( '.frm-field-group-hover-target' )?.querySelector( '.start_divider')?.querySelectorAll( '.frm_field_box' );
+			if ( fieldBoxes && fieldBoxes.length ) {
+				fieldBoxes.forEach( fieldBox => {
+					if ( fieldBox.querySelectorAll( 'li.form-field' ) ) {
+						fieldIdsToDelete += fieldBox.querySelectorAll( 'li.form-field' ).length;
+					}
+				});
+				if ( fieldIdsToDelete ) {
+					/* translators: %1$s: Number of fields that are selected to be deleted. */
+					confirmMsg = __( 'Are you sure you want to delete these %1$s selected fields?', 'formidable' ).replace( '%1$s', fieldIdsToDelete );
+				}
+			}
+		}
 
 		if ( li.classList.contains( 'frm-section-collapsed' ) || li.classList.contains( 'frm-page-collapsed' ) ) {
 			return false;


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4087

This PR is aimed at making collapsed sections duplicatable, fix style issues in the context dropdown and also show the number of fields to be deleted in the confirmation box that is shown when trying to delete a section.
BEFORE:
![image](https://user-images.githubusercontent.com/41271840/222131130-93b74cb8-3517-4952-a4db-09522261a54a.png)

NOW:
![image](https://user-images.githubusercontent.com/41271840/222130987-98e1f700-95e9-4a35-a226-66279c85629b.png)

[issue_4087.webm](https://user-images.githubusercontent.com/41271840/222132436-603ba44f-4a68-4856-af69-dc4cdf2e77fc.webm)
