### PR TITLE
Remove unused function "showFormMessages"

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6815,18 +6815,6 @@ function frmAdminBuildJS() {
 		}*/
 	}
 
-	function showFormMessages() {
-		var show = false;
-		var editable = document.getElementById( 'editable' );
-		if ( editable !== null ) {
-			show = editable.checked && jQuery( document.getElementById( 'edit_action' ) ).val() === 'message';
-			if ( ! show ) {
-				show = isChecked( 'save_draft' );
-			}
-		}
-		return show;
-	}
-
 	function checkDupPost() {
 		/*jshint validthis:true */
 		var postField = jQuery( 'select.frm_single_post_field' );


### PR DESCRIPTION
We don't need this anymore. It's no longer called since v6.0