### PR TITLE
Use active form type when searching forms

### DIFF
--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -163,7 +163,7 @@ class FrmFormsListHelper extends FrmListHelper {
 		$form_type = FrmAppHelper::simple_get( 'form_type', 'sanitize_title', 'published' );
 
 		if ( isset( $statuses[ $form_type ] ) ) {
-			$counts->$form_type = count( $this->items );
+			$counts->$form_type = $this->total_items;
 		}
 
 		$form_type = self::get_param(

--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -160,6 +160,10 @@ class FrmFormsListHelper extends FrmListHelper {
 
 		$links     = array();
 		$counts    = FrmForm::get_count();
+		$form_type = FrmAppHelper::simple_get( 'form_type', 'sanitize_title', 'published' );
+
+		$counts->$form_type = count( $this->items );
+
 		$form_type = self::get_param(
 			array(
 				'param'   => 'form_type',

--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -162,7 +162,9 @@ class FrmFormsListHelper extends FrmListHelper {
 		$counts    = FrmForm::get_count();
 		$form_type = FrmAppHelper::simple_get( 'form_type', 'sanitize_title', 'published' );
 
-		$counts->$form_type = count( $this->items );
+		if ( isset( $statuses[ $form_type ] ) ) {
+			$counts->$form_type = count( $this->items );
+		}
 
 		$form_type = self::get_param(
 			array(

--- a/classes/views/frm-forms/list.php
+++ b/classes/views/frm-forms/list.php
@@ -23,13 +23,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php
 require FrmAppHelper::plugin_path() . '/classes/views/shared/errors.php';
 $wp_list_table->views();
-$form_type = FrmAppHelper::simple_get( 'form_type' );
+$form_type = FrmAppHelper::simple_get( 'form_type', 'sanitize_title', 'published' );
 ?>
 
 <form id="posts-filter" method="get">
 	<input type="hidden" name="page" value="<?php echo esc_attr( FrmAppHelper::simple_get( 'page', 'sanitize_title' ) ); ?>" />
 	<input type="hidden" name="frm_action" value="list" />
-	<input type="hidden" name="form_type"  value="<?php echo $form_type ? esc_attr( $form_type ) : 'published'; ?>" />
+	<input type="hidden" name="form_type"  value="<?php echo esc_attr( $form_type ); ?>" />
 <?php
 
 $wp_list_table->search_box( __( 'Search', 'formidable' ), 'entry' );

--- a/classes/views/frm-forms/list.php
+++ b/classes/views/frm-forms/list.php
@@ -23,11 +23,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php
 require FrmAppHelper::plugin_path() . '/classes/views/shared/errors.php';
 $wp_list_table->views();
+$form_type = FrmAppHelper::simple_get( 'form_type' );
 ?>
 
 <form id="posts-filter" method="get">
 	<input type="hidden" name="page" value="<?php echo esc_attr( FrmAppHelper::simple_get( 'page', 'sanitize_title' ) ); ?>" />
 	<input type="hidden" name="frm_action" value="list" />
+	<input type="hidden" name="form_type"  value="<?php echo $form_type ? esc_attr( $form_type ) : 'published'; ?>" />
 <?php
 
 $wp_list_table->search_box( __( 'Search', 'formidable' ), 'entry' );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3824
This update allows searching forms in the selected category. In addition it would update the count of forms based on the search result.

_Searching in Published:_

Before search:
![image](https://user-images.githubusercontent.com/41271840/222703591-104783bd-bd83-406f-86b4-9c7735e4d035.png)
After search:
**BEFORE**
![image](https://user-images.githubusercontent.com/41271840/222704008-14f3ca4b-e7c7-4e5d-8fbc-3fafee6ffb4f.png)

**NOW**:
![image](https://user-images.githubusercontent.com/41271840/222703695-2be5d63b-6365-4065-9f42-468123ceab0a.png)

_Searching in Trash:_

Before search:
![image](https://user-images.githubusercontent.com/41271840/222704398-34e37465-e2c6-4270-98c3-77340ca9eb6a.png)

**BEFORE**
After search (switches back to Published forms):
![image](https://user-images.githubusercontent.com/41271840/222704491-4410afcd-537b-465d-a91d-525db8003588.png)

**NOW**
![image](https://user-images.githubusercontent.com/41271840/222704834-a545415e-69d4-4392-8608-85a85cd79fed.png)
