### PR TITLE
Handle show_title and show_description in form display args

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2602,6 +2602,14 @@ class FrmFormsController {
 	 * @since 2.05
 	 */
 	private static function fill_atts_for_form_display( &$args ) {
+		if ( ! isset( $args['title'] ) && isset( $args['show_title'] ) ) {
+			$args['title'] = $args['show_title'];
+		}
+
+		if ( ! isset( $args['description'] ) && isset( $args['show_description'] ) ) {
+			$args['description'] = $args['show_description'];
+		}
+
 		$defaults = array(
 			'errors'      => array(),
 			'message'     => '',


### PR DESCRIPTION
In v6.0, we used Confirmation code in Lite plugin to handle updating entry. Entry updating uses `show_title` and `show_description` instead of `title` and `description`. So we must handle them in Lite plugin.