### PR TITLE
Do not use pro app helper for captcha icon note

### DIFF
--- a/classes/views/frm-fields/back-end/field-captcha.php
+++ b/classes/views/frm-fields/back-end/field-captcha.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! FrmFieldCaptcha::should_show_captcha() ) {
 	?>
 <span class="frm-with-icon frm-not-set frm_note_style">
-	<?php FrmProAppHelper::icon_by_class( 'frm_icon_font frm_report_problem_solid_icon' ); ?>
+	<?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_report_problem_solid_icon' ); ?>
 	<?php esc_attr_e( 'This field is not set up yet.', 'formidable' ); ?>
 </span>
 	<?php


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2172643190/153587

If you have a captcha field in your form but no captcha keys set, this error would trigger when Pro isn't active.