### PR TITLE
Remove max width from #frm_publishing button wrapper element

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -602,6 +602,7 @@ ul.frm_form_nav > li {
 
 #frm-publishing {
 	min-width: 225px;
+	max-width: 325px;
 	align-self: center;
 	align-items: center;
 	display: flex;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -602,7 +602,6 @@ ul.frm_form_nav > li {
 
 #frm-publishing {
 	min-width: 225px;
-	max-width: 325px;
 	align-self: center;
 	align-items: center;
 	display: flex;


### PR DESCRIPTION
German translations can be downloaded from here and dropped in the `/languages/` folder.
[formidable-de_DE.zip](https://github.com/Strategy11/formidable-forms/files/10912381/formidable-de_DE.zip)

A long German translation in buttons would cause them to break into multiple lines. I noticed this while looking at a customer's website in support the other day.

I extended this `max-width` before but this was before we added the embed button so it needs significantly more space.

I don't think we really need a `max-width`.

**Before**
<img width="567" alt="Screen Shot 2023-03-07 at 1 50 27 PM" src="https://user-images.githubusercontent.com/9134515/223507239-9cff9dba-eea5-42b6-9949-1fbd59de2837.png">

**After**
<img width="611" alt="Screen Shot 2023-03-07 at 1 50 32 PM" src="https://user-images.githubusercontent.com/9134515/223507236-c3033a95-f240-4553-a108-5d4b1b9ec84b.png">
