### PR TITLE
Only show add new entry when pro is installed

### DIFF
--- a/classes/views/frm-entries/list.php
+++ b/classes/views/frm-entries/list.php
@@ -4,22 +4,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <div id="form_entries_page" class="frm_wrap frm_list_entry_page">
-
 		<?php
-		FrmAppHelper::get_admin_header(
-			array(
-				'label'       => __( 'Form Entries', 'formidable' ),
-				'form'        => $form,
-				'close'       => $form ? admin_url( 'admin.php?page=formidable-entries&form=' . $form->id ) : '',
-				'import_link' => true,
-				'publish'     => ! $form ? true : array(
-					'FrmAppHelper::add_new_item_link',
-					array(
-						'new_link' => admin_url( 'admin.php?page=formidable-entries&frm_action=new&form=' . $form->id ),
+		if ( FrmAppHelper::pro_is_installed() ) {
+			// Adding new entries from an admin page is a Pro feature.
+			FrmAppHelper::get_admin_header(
+				array(
+					'label'       => __( 'Form Entries', 'formidable' ),
+					'form'        => $form,
+					'close'       => $form ? admin_url( 'admin.php?page=formidable-entries&form=' . $form->id ) : '',
+					'import_link' => true,
+					'publish'     => ! $form ? true : array(
+						'FrmAppHelper::add_new_item_link',
+						array(
+							'new_link' => admin_url( 'admin.php?page=formidable-entries&frm_action=new&form=' . $form->id ),
+						),
 					),
-				),
-			)
-		);
+				)
+			);
+		}
 		?>
 
 		<div class="wrap">

--- a/classes/views/frm-entries/list.php
+++ b/classes/views/frm-entries/list.php
@@ -2,26 +2,26 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
+
+$pro_is_installed = FrmAppHelper::pro_is_installed();
 ?>
 <div id="form_entries_page" class="frm_wrap frm_list_entry_page">
 		<?php
-		if ( FrmAppHelper::pro_is_installed() ) {
-			// Adding new entries from an admin page is a Pro feature.
-			FrmAppHelper::get_admin_header(
-				array(
-					'label'       => __( 'Form Entries', 'formidable' ),
-					'form'        => $form,
-					'close'       => $form ? admin_url( 'admin.php?page=formidable-entries&form=' . $form->id ) : '',
-					'import_link' => true,
-					'publish'     => ! $form ? true : array(
-						'FrmAppHelper::add_new_item_link',
-						array(
-							'new_link' => admin_url( 'admin.php?page=formidable-entries&frm_action=new&form=' . $form->id ),
-						),
+		// Adding new entries from an admin page is a Pro feature.
+		FrmAppHelper::get_admin_header(
+			array(
+				'label'       => __( 'Form Entries', 'formidable' ),
+				'form'        => $form,
+				'close'       => $form ? admin_url( 'admin.php?page=formidable-entries&form=' . $form->id ) : '',
+				'import_link' => $pro_is_installed,
+				'publish'     => ! $form || ! $pro_is_installed ? true : array(
+					'FrmAppHelper::add_new_item_link',
+					array(
+						'new_link' => admin_url( 'admin.php?page=formidable-entries&frm_action=new&form=' . $form->id ),
 					),
-				)
-			);
-		}
+				),
+			)
+		);
 		?>
 
 		<div class="wrap">
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<h2>
 					<?php esc_html_e( 'Form Entries', 'formidable' ); ?>
 				</h2>
-				<?php if ( ! FrmAppHelper::pro_is_installed() ) { ?>
+				<?php if ( ! $pro_is_installed ) { ?>
 				<div class="clear"></div>
 				<?php } ?>
 			<?php } ?>
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php FrmTipsHelper::pro_tip( 'get_entries_tip', 'p' ); ?>
 
 				<div class="clear"></div>
-				<?php require( FrmAppHelper::plugin_path() . '/classes/views/shared/errors.php' ); ?>
+				<?php require FrmAppHelper::plugin_path() . '/classes/views/shared/errors.php'; ?>
 				<?php $wp_list_table->display(); ?>
 			</form>
 			<?php do_action( 'frm_page_footer', array( 'table' => $wp_list_table ) ); ?>


### PR DESCRIPTION
I discussed this the other day in Slack.

We're showing the import/add new buttons on the Entries page when Pro is inactive but the add new button does nothing as it links to a page that we only support in Pro.

**Before (or when Pro is installed)**
<img width="1106" alt="Screen Shot 2023-03-07 at 2 47 23 PM" src="https://user-images.githubusercontent.com/9134515/223521410-19157eaf-8d6e-4002-b11d-5f3a9808c0cc.png">

**After (when Pro is not installed)**
<img width="1111" alt="Screen Shot 2023-03-07 at 2 47 14 PM" src="https://user-images.githubusercontent.com/9134515/223521433-24d1aafd-516a-442e-88fb-800373887e6d.png">
