### PR TITLE
Fallback to message if loading a page that does not exist or is in trash

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2404,12 +2404,21 @@ class FrmFormsController {
 
 	/**
 	 * @since 3.0
+	 *
+	 * @param array $args
+	 * @return void
 	 */
 	private static function load_page_after_submit( $args ) {
 		global $post;
 		$opt = $args['success_opt'];
 		if ( ! $post || $args['form']->options[ $opt . '_page_id' ] != $post->ID ) {
-			$page     = get_post( $args['form']->options[ $opt . '_page_id' ] );
+			$page = get_post( $args['form']->options[ $opt . '_page_id' ] );
+
+			if ( ! $page || 'trash' === $page->post_status ) {
+				self::show_message_after_save( $args );
+				return;
+			}
+
 			$old_post = $post;
 			$post     = $page;
 			$content  = apply_filters( 'frm_content', $page->post_content, $args['form'], $args['entry_id'] );


### PR DESCRIPTION
I tried testing an imported form action with a `success_page_id` set but it was set to a page that doesn't exist on my server (as it was a page ID from another site).

This resulted in a blank page when I submitted my form.

It also triggered this notice,
> PHP Notice:  Trying to get property 'post_content' of non-object in .../plugins/formidable/classes/controllers/FrmFormsController.php on line 2415

I figure it makes sense to just fallback to `show_message_after_save` here? It seems less jarring then hitting an empty page. I'm not sure if maybe we'd want to avoid this more often though - like check for other confirmation actions first and only use the message if the page content was the only action.

@truongwp What do you think? You've worked with the confirmation actions for a while so you might have a better idea here.