### PR TITLE
Use #frm_builder_page id before repeater button styles

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6322,15 +6322,14 @@ li.selected .divider_section_only:before {
 	display: none;
 }
 
-.frm_wrap .frm_remove_form_row.frm_button,
-.frm_wrap .frm_add_form_row.frm_button {
+#frm_builder_page .frm_remove_form_row.frm_button,
+#frm_builder_page .frm_add_form_row.frm_button {
 	border-radius: var(--small-radius);
 	border: 1px solid var(--blue-border);
-	color: var(--primary-500);
 }
 
-.frm_wrap .frm_remove_form_row .frmsvg,
-.frm_remove_form_row i:before,
+#frm_builder_page .frm_remove_form_row .frmsvg,
+#frm_builder_page .frm_remove_form_row i:before,
 .frm_wrap .frm_add_form_row .frmsvg,
 .frm_add_form_row i:before {
 	color: var(--primary-700);


### PR DESCRIPTION
I'm seeing this locally, not on QA.

If I try to load the "Edit entry" admin page with a repeater in versions v6.0, the button has a blue text so you can't see it on the blue background.

<img width="251" alt="Screen Shot 2023-03-10 at 12 53 51 PM" src="https://user-images.githubusercontent.com/9134515/224375658-6d313488-1299-4345-a25a-4bd00029eeef.png">

It's because of this style rule,
```
.frm_wrap .frm_remove_form_row.frm_button {
    color: var(--primary-500);
}
```

That rule is to make the text blue on the builder page since it looks different from a real repeater button.
<img width="180" alt="Screen Shot 2023-03-10 at 12 55 50 PM" src="https://user-images.githubusercontent.com/9134515/224376128-193f15fb-ed17-404d-8935-0f85efe2bc2d.png">

The `color: var(--primary-500);` rule is redunant as `.frm_wrap a` is `--color-primary` which is `--primary-500`, so nothing changes when I moreve the rule.

I also made it more strict with `#frm_builder_page` so it only applies in the builder. There's no reason to apply these rules on the Edit Entry page.