### PR TITLE
Remove a few stubs we don't need in lite

### DIFF
--- a/stubs.php
+++ b/stubs.php
@@ -32,9 +32,6 @@ namespace {
 		public static function import_attachment( $val, $field ) {
 		}
 	}
-	class FrmProDisplaysController {
-
-	}
 	class FrmProAppHelper {
 		public static function get_settings() {
 		}
@@ -45,7 +42,7 @@ namespace {
 	}
 	class FrmProFormActionsController {
 	}
-	class FrmProFieldValue {
+	class FrmViewsLayout {
 	}
 	class FrmProDisplaysHelper {
 		public static function get_shortcodes( $content, $form_id ) {

--- a/stubs.php
+++ b/stubs.php
@@ -36,17 +36,7 @@ namespace {
 
 	}
 	class FrmProAppHelper {
-		public static function maybe_convert_to_db_date( $date_str, $to_format = 'Y-m-d' ) {
-		}
-		public static function format_time( $time, $format = 'H:i' ) {
-		}
-		public static function get_current_user_value( $value, $return_array = false ) {
-		}
-		public static function icon_by_class( $class, $atts = array() ) {
-		}
 		public static function get_settings() {
-		}
-		public static function get_custom_taxonomy( $post_type, $field ) {
 		}
 	}
 	class FrmProEntryMetaHelper {
@@ -54,14 +44,8 @@ namespace {
 		}
 	}
 	class FrmProFormActionsController {
-		public static function prepare_logic_value( &$logic_value, $entry ) {
-		}
-		public static function get_value_from_entry( $entry, $field_id ) {
-		}
 	}
 	class FrmProFieldValue {
-	}
-	class FrmViewsLayout {
 	}
 	class FrmProDisplaysHelper {
 		public static function get_shortcodes( $content, $form_id ) {
@@ -90,13 +74,7 @@ namespace {
 	}
 	class FrmProEntriesHelper {
 	}
-	class FrmProFormsController {
-	}
 	class FrmViewsAppHelper {
-	}
-	class FrmProHtmlHelper {
-		public static function toggle( $id, $name, $args ) {
-		}
 	}
 	class Akismet {
 	}


### PR DESCRIPTION
The Problem: This allows calls to external code to get past without a class_exists/is_callable first.

Ideally, we should use hooks instead of calling FrmPro classes directly. But this is a start to prevent more unwanted Pro functions from being called in Lite.