### PR TITLE
Support 0 for to value for human time diff function

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2393,7 +2393,7 @@ class FrmAppHelper {
 	 * @return string $time_ago
 	 */
 	public static function human_time_diff( $from, $to = '', $levels = 1 ) {
-		if ( empty( $to ) ) {
+		if ( empty( $to ) && 0 !== $to ) {
 			$now = new DateTime();
 		} else {
 			$now = new DateTime( '@' . $to );

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -617,4 +617,24 @@ class test_FrmAppHelper extends FrmUnitTest {
 		add_filter( 'frm_use_custom_header_ip', '__return_true' );
 		$this->assertEquals( '1.2.3.4', FrmAppHelper::get_ip_address(), 'When custom header IPs are enabled, we should check for headers like HTTP_X_FORWARDED_FOR' );
 	}
+
+	/**
+	 * @covers FrmAppHelper::human_time_diff
+	 */
+	public function test_human_time_diff() {
+		$difference = FrmAppHelper::human_time_diff( 0, 0 );
+		$this->assertEquals( '0 seconds', $difference );
+
+		$difference = FrmAppHelper::human_time_diff( 0, 1 );
+		$this->assertEquals( '1 second', $difference );
+
+		$difference = FrmAppHelper::human_time_diff( 0, HOUR_IN_SECONDS );
+		$this->assertEquals( '1 hour', $difference );
+
+		$difference = FrmAppHelper::human_time_diff( 0, DAY_IN_SECONDS );
+		$this->assertEquals( '1 day', $difference );
+
+		$difference = FrmAppHelper::human_time_diff( 0, DAY_IN_SECONDS * 2 );
+		$this->assertEquals( '2 days', $difference );
+	}
 }


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2189119190/155804/
Related update https://github.com/Strategy11/formidable-user-tracking/pull/24

Prior to this update `FrmAppHelper::human_time_diff( 0, 0 )` would return `53 years` as `$to` was "empty". I'm adding an exception for 0.