### PR TITLE
Restore some deprecated functions used in addons

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -959,4 +959,16 @@ class FrmAppController {
 	public static function include_embed_form_icons() {
 		_deprecated_function( __METHOD__, '5.3' );
 	}
+
+	/**
+	 * @deprecated 1.07.05
+	 * @codeCoverageIgnore
+	 *
+	 * @param array $atts
+	 * @return string
+	 */
+	public static function get_form_shortcode( $atts ) {
+		_deprecated_function( __FUNCTION__, '1.07.05', 'FrmFormsController::get_form_shortcode()' );
+		return FrmFormsController::get_form_shortcode( $atts );
+	}
 }

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -961,7 +961,7 @@ class FrmAppController {
 	}
 
 	/**
-	 * @deprecated 1.07.05
+	 * @deprecated 1.07.05 This is still referenced in the API add on as of v1.13.
 	 * @codeCoverageIgnore
 	 *
 	 * @param array $atts

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -968,7 +968,7 @@ class FrmAppController {
 	 * @return string
 	 */
 	public static function get_form_shortcode( $atts ) {
-		_deprecated_function( __FUNCTION__, '1.07.05', 'FrmFormsController::get_form_shortcode()' );
+		_deprecated_function( __FUNCTION__, '1.07.05', 'FrmFormsController::get_form_shortcode' );
 		return FrmFormsController::get_form_shortcode( $atts );
 	}
 }

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -2134,4 +2134,24 @@ class FrmFieldsHelper {
 	public static function get_default_field_opts( $type, $field = null, $limit = false ) {
 		return FrmDeprecated::get_default_field_opts( $type, $field, $limit );
 	}
+
+	/**
+	 * @deprecated 2.02.07 This is still referenced in the Highrise add on as of v1.06.
+	 * @codeCoverageIgnore
+	 *
+	 * @param array $args
+	 * @return string
+	 */
+	public static function dropdown_categories( $args ) {
+		_deprecated_function( __FUNCTION__, '2.02.07', 'FrmProPost::get_category_dropdown' );
+
+		if ( FrmAppHelper::pro_is_installed() ) {
+			$args['location'] = 'front';
+			$dropdown         = FrmProPost::get_category_dropdown( $args['field'], $args );
+		} else {
+			$dropdown = '';
+		}
+
+		return $dropdown;
+	}
 }

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -2143,15 +2143,6 @@ class FrmFieldsHelper {
 	 * @return string
 	 */
 	public static function dropdown_categories( $args ) {
-		_deprecated_function( __FUNCTION__, '2.02.07', 'FrmProPost::get_category_dropdown' );
-
-		if ( FrmAppHelper::pro_is_installed() ) {
-			$args['location'] = 'front';
-			$dropdown         = FrmProPost::get_category_dropdown( $args['field'], $args );
-		} else {
-			$dropdown = '';
-		}
-
-		return $dropdown;
+		return FrmDeprecated::dropdown_categories( $args );
 	}
 }

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -1108,4 +1108,28 @@ class FrmForm {
 	public static function get_edit_link( $form_id ) {
 		return admin_url( 'admin.php?page=formidable&frm_action=edit&id=' . $form_id );
 	}
+
+	/**
+	 * @deprecated 2.03.05 This is still referenced in a few add ons (API, locations).
+	 * @codeCoverageIgnore
+	 *
+	 * @param string $key
+	 * @return int form id
+	 */
+	public static function getIdByKey( $key ) {
+		_deprecated_function( __FUNCTION__, '2.03.05', 'FrmForm::get_id_by_key' );
+		return FrmForm::get_id_by_key( $key );
+	}
+
+	/**
+	 * @deprecated 2.03.05 This is still referenced in the API add on as of v1.13.
+	 * @codeCoverageIgnore
+	 *
+	 * @param string|int $id
+	 * @return string
+	 */
+	public static function getKeyById( $id ) {
+		_deprecated_function( __FUNCTION__, '2.03.05', 'FrmForm::get_key_by_id' );
+		return FrmForm::get_key_by_id( $id );
+	}
 }

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -1118,7 +1118,7 @@ class FrmForm {
 	 */
 	public static function getIdByKey( $key ) {
 		_deprecated_function( __FUNCTION__, '2.03.05', 'FrmForm::get_id_by_key' );
-		return FrmForm::get_id_by_key( $key );
+		return self::get_id_by_key( $key );
 	}
 
 	/**
@@ -1130,6 +1130,6 @@ class FrmForm {
 	 */
 	public static function getKeyById( $id ) {
 		_deprecated_function( __FUNCTION__, '2.03.05', 'FrmForm::get_key_by_id' );
-		return FrmForm::get_key_by_id( $id );
+		return self::get_key_by_id( $id );
 	}
 }

--- a/deprecated/FrmDeprecated.php
+++ b/deprecated/FrmDeprecated.php
@@ -593,4 +593,20 @@ class FrmDeprecated {
 
 		FrmEntryValidate::validate_field_types( $errors, $field, '', $args );
 	}
+
+	/**
+	 * @deprecated 2.02.07
+	 */
+	public static function dropdown_categories( $args ) {
+		_deprecated_function( __FUNCTION__, '2.02.07', 'FrmProPost::get_category_dropdown' );
+
+		if ( FrmAppHelper::pro_is_installed() ) {
+			$args['location'] = 'front';
+			$dropdown = FrmProPost::get_category_dropdown( $args['field'], $args );
+		} else {
+			$dropdown = '';
+		}
+
+		return $dropdown;
+	}
 }


### PR DESCRIPTION
This update restores functions that are still referenced in the API add on, locations, and highrise that were removed in https://github.com/Strategy11/formidable-forms/pull/1117/files