### PR TITLE
switch old field ids in form conditional settings

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1334,6 +1334,8 @@ class FrmFieldsHelper {
 		$replace      = array();
 		$replace_with = array();
 		foreach ( (array) $frm_duplicate_ids as $old => $new ) {
+			$replace[]      = $old;
+			$replace_with[] = $new;
 			$replace[]      = '[if ' . $old . ']';
 			$replace_with[] = '[if ' . $new . ']';
 			$replace[]      = '[if ' . $old . ' ';

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1334,8 +1334,6 @@ class FrmFieldsHelper {
 		$replace      = array();
 		$replace_with = array();
 		foreach ( (array) $frm_duplicate_ids as $old => $new ) {
-			$replace[]      = $old;
-			$replace_with[] = $new;
 			$replace[]      = '[if ' . $old . ']';
 			$replace_with[] = '[if ' . $new . ']';
 			$replace[]      = '[if ' . $old . ' ';

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -138,7 +138,7 @@ class FrmForm {
 		if ( ! empty( $new_opts['submit_conditions']['hide_field'] ) ) {
 			global $frm_duplicate_ids;
 			foreach ( $new_opts['submit_conditions']['hide_field'] as $key => $val ) {
-				if ( array_search( $val, array_keys( $frm_duplicate_ids ) ) !== false ) {
+				if ( array_search( $val, array_keys( (array) $frm_duplicate_ids ) ) !== false ) {
 					$new_opts['submit_conditions']['hide_field'][ $key ] = $frm_duplicate_ids[ $val ];
 				}
 			}

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -135,6 +135,10 @@ class FrmForm {
 			$new_opts['success_msg'] = FrmFieldsHelper::switch_field_ids( $new_opts['success_msg'] );
 		}
 
+		if ( ! empty( $new_opts['submit_conditions']['hide_field'] ) ) {
+			$new_opts['submit_conditions']['hide_field'] = FrmFieldsHelper::switch_field_ids( $new_opts['submit_conditions']['hide_field'] );
+		}
+
 		$new_opts = apply_filters( 'frm_after_duplicate_form_values', $new_opts, $form_id );
 
 		if ( $new_opts != $values['options'] ) {

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -136,7 +136,12 @@ class FrmForm {
 		}
 
 		if ( ! empty( $new_opts['submit_conditions']['hide_field'] ) ) {
-			$new_opts['submit_conditions']['hide_field'] = FrmFieldsHelper::switch_field_ids( $new_opts['submit_conditions']['hide_field'] );
+			global $frm_duplicate_ids;
+			foreach ( $new_opts['submit_conditions']['hide_field'] as $key => $val ) {
+				if ( array_search( $val, array_keys( $frm_duplicate_ids ) ) !== false ) {
+					$new_opts['submit_conditions']['hide_field'][ $key ] = $frm_duplicate_ids[ $val ];
+				}
+			}
 		}
 
 		$new_opts = apply_filters( 'frm_after_duplicate_form_values', $new_opts, $form_id );

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -138,7 +138,7 @@ class FrmForm {
 		if ( ! empty( $new_opts['submit_conditions']['hide_field'] ) ) {
 			global $frm_duplicate_ids;
 			foreach ( $new_opts['submit_conditions']['hide_field'] as $key => $val ) {
-				if ( array_search( $val, array_keys( (array) $frm_duplicate_ids ) ) !== false ) {
+				if ( isset( $frm_duplicate_ids[ $val ] ) ) {
 					$new_opts['submit_conditions']['hide_field'][ $key ] = $frm_duplicate_ids[ $val ];
 				}
 			}


### PR DESCRIPTION
This update just makes sure the submit button conditionals are copied over to the new form successfully by replacing old ids to new ids.