### PR TITLE
Fix return type comments and add some missing type comments

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -38,6 +38,9 @@ class FrmAddonsController {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function list_addons() {
 		FrmAppHelper::include_svg();
 		$installed_addons = apply_filters( 'frm_installed_addons', array() );
@@ -70,6 +73,9 @@ class FrmAddonsController {
 		include( FrmAppHelper::plugin_path() . '/classes/views/addons/list.php' );
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function license_settings() {
 		$plugins = apply_filters( 'frm_installed_addons', array() );
 		if ( empty( $plugins ) ) {
@@ -83,6 +89,9 @@ class FrmAddonsController {
 		include( FrmAppHelper::plugin_path() . '/classes/views/addons/settings.php' );
 	}
 
+	/**
+	 * @return array
+	 */
 	protected static function get_api_addons() {
 		$api    = new FrmFormApi();
 		$addons = $api->get_api_info();
@@ -243,6 +252,9 @@ class FrmAddonsController {
 
 	/**
 	 * @since 4.08
+	 *
+	 * @param array $addons
+	 * @return array
 	 */
 	protected static function get_pro_from_addons( $addons ) {
 		return isset( $addons['93790'] ) ? $addons['93790'] : array();
@@ -286,6 +298,8 @@ class FrmAddonsController {
 
 	/**
 	 * @since 4.08
+	 *
+	 * @return array|false
 	 */
 	protected static function get_primary_license_info() {
 		$installed_addons = apply_filters( 'frm_installed_addons', array() );
@@ -531,6 +545,9 @@ class FrmAddonsController {
 		return $plugin;
 	}
 
+	/**
+	 * @return void
+	 */
 	protected static function prepare_addons( &$addons ) {
 		$activate_url = '';
 		if ( current_user_can( 'activate_plugins' ) ) {
@@ -590,6 +607,9 @@ class FrmAddonsController {
 		}
 	}
 
+	/**
+	 * @return bool
+	 */
 	private static function is_plugin_active( $file_name, $slug ) {
 		if ( 'formidable-views/formidable-views.php' === $file_name ) {
 			return self::get_active_views_version() === $slug;
@@ -610,6 +630,8 @@ class FrmAddonsController {
 
 	/**
 	 * @since 3.04.02
+	 *
+	 * @return void
 	 */
 	protected static function prepare_addon_link( &$link ) {
 		$site_url = 'https://formidableforms.com/';
@@ -630,6 +652,8 @@ class FrmAddonsController {
 	 * installed, active, not installed
 	 *
 	 * @since 3.04.02
+	 *
+	 * @return void
 	 */
 	protected static function set_addon_status( &$addon ) {
 		if ( ! empty( $addon['activate_url'] ) ) {
@@ -650,6 +674,9 @@ class FrmAddonsController {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function upgrade_to_pro() {
 		FrmAppHelper::include_svg();
 
@@ -861,6 +888,8 @@ class FrmAddonsController {
 	 * Install Pro after connection with Formidable.
 	 *
 	 * @since 4.02.05
+	 *
+	 * @return void
 	 */
 	public static function connect_pro() {
 		FrmAppHelper::permission_check( 'install_plugins' );
@@ -934,6 +963,8 @@ class FrmAddonsController {
 
 	/**
 	 * @since 3.04.02
+	 *
+	 * @return void
 	 */
 	protected static function maybe_show_cred_form() {
 		if ( ! function_exists( 'request_filesystem_credentials' ) ) {
@@ -1008,6 +1039,8 @@ class FrmAddonsController {
 
 	/**
 	 * @since 3.06.03
+	 *
+	 * @return void
 	 */
 	public static function ajax_activate_addon() {
 
@@ -1057,6 +1090,7 @@ class FrmAddonsController {
 
 	/**
 	 * @since 3.04.02
+	 *
 	 * @param string $installed The plugin folder name with file name
 	 */
 	protected static function maybe_activate_addon( $installed ) {
@@ -1084,6 +1118,8 @@ class FrmAddonsController {
 	 * Run security checks before installing
 	 *
 	 * @since 3.04.02
+	 *
+	 * @return void
 	 */
 	protected static function install_addon_permissions() {
 		check_ajax_referer( 'frm_ajax', 'nonce' );
@@ -1096,6 +1132,8 @@ class FrmAddonsController {
 
 	/**
 	 * @since 4.08
+	 *
+	 * @return string
 	 */
 	public static function connect_link() {
 		$auth = get_option( 'frm_connect_token' );
@@ -1207,6 +1245,7 @@ class FrmAddonsController {
 	 * Render a conditional action button for an add on
 	 *
 	 * @since 4.09.01
+	 *
 	 * @param array $addon
 	 * @param string|false $license_type
 	 * @param string $plan_required
@@ -1222,6 +1261,10 @@ class FrmAddonsController {
 
 	/**
 	 * @since 4.09.01
+	 *
+	 * @param array|false $addon
+	 *
+	 * @return void
 	 */
 	protected static function addon_upgrade_link( $addon, $upgrade_link ) {
 		if ( $addon ) {
@@ -1241,6 +1284,8 @@ class FrmAddonsController {
 
 	/**
 	 * @since 3.04.02
+	 *
+	 * @return void
 	 */
 	public static function ajax_install_addon() {
 		self::install_addon_permissions();
@@ -1257,7 +1302,10 @@ class FrmAddonsController {
 
 	/**
 	 * @since 4.06.02
+	 *
 	 * @deprecated 4.09.01
+	 *
+	 * @return void
 	 */
 	public static function ajax_multiple_addons() {
 		FrmDeprecated::ajax_multiple_addons();
@@ -1306,8 +1354,12 @@ class FrmAddonsController {
 
 	/**
 	 * @since 3.04.03
+	 *
 	 * @deprecated 3.06
+	 *
 	 * @codeCoverageIgnore
+	 *
+	 * @return void
 	 */
 	public static function reset_cached_addons( $license = '' ) {
 		FrmDeprecated::reset_cached_addons( $license );
@@ -1343,7 +1395,10 @@ class FrmAddonsController {
 
 	/**
 	 * @deprecated 3.04.03
+	 *
 	 * @codeCoverageIgnore
+	 *
+	 * @return void
 	 */
 	public static function get_licenses() {
 		FrmDeprecated::get_licenses();

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -5,6 +5,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class FrmAppController {
 
+	/**
+	 * @return void
+	 */
 	public static function menu() {
 		FrmAppHelper::maybe_add_permissions();
 		if ( ! current_user_can( 'frm_view_forms' ) ) {
@@ -97,6 +100,8 @@ class FrmAppController {
 
 	/**
 	 * @since 4.0
+	 *
+	 * @return string
 	 */
 	private static function get_os() {
 		$agent = strtolower( FrmAppHelper::get_server_value( 'HTTP_USER_AGENT' ) );
@@ -151,10 +156,21 @@ class FrmAppController {
 		return $is_white_page;
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function load_wp_admin_style() {
 		FrmAppHelper::load_font_style();
 	}
 
+	/**
+	 * @param bool $show_nav
+	 * @param string $title
+	 *
+	 * @psalm-param 'hide'|'show' $title
+	 *
+	 * @return void
+	 */
 	public static function get_form_nav( $form, $show_nav = false, $title = 'show' ) {
 		$show_nav = FrmAppHelper::get_param( 'show_nav', $show_nav, 'get', 'absint' );
 		if ( empty( $show_nav ) || ! $form ) {
@@ -173,6 +189,9 @@ class FrmAppController {
 		include( FrmAppHelper::plugin_path() . '/classes/views/shared/form-nav.php' );
 	}
 
+	/**
+	 * @return string
+	 */
 	private static function get_current_page() {
 		$page         = FrmAppHelper::simple_get( 'page', 'sanitize_title' );
 		$post_type    = FrmAppHelper::simple_get( 'post_type', 'sanitize_title', 'None' );
@@ -185,6 +204,10 @@ class FrmAppController {
 		return $current_page;
 	}
 
+	/**
+	 * @param object $form
+	 * @return array
+	 */
 	private static function get_form_nav_items( $form ) {
 		$id = $form->parent_form_id ? $form->parent_form_id : $form->id;
 
@@ -253,10 +276,13 @@ class FrmAppController {
 			'form'    => $form,
 		);
 
-		return apply_filters( 'frm_form_nav_list', $nav_items, $nav_args );
+		return (array) apply_filters( 'frm_form_nav_list', $nav_items, $nav_args );
 	}
 
 	// Adds a settings link to the plugins page
+	/**
+	 * @return array
+	 */
 	public static function settings_link( $links ) {
 		$settings = array();
 
@@ -269,6 +295,9 @@ class FrmAppController {
 		return array_merge( $settings, $links );
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function pro_get_started_headline() {
 		self::review_request();
 		FrmAppHelper::min_pro_version_notice( '4.0' );
@@ -278,6 +307,8 @@ class FrmAppController {
 	 * Add admin notices as needed for reviews
 	 *
 	 * @since 3.04.03
+	 *
+	 * @return void
 	 */
 	private static function review_request() {
 		$reviews = new FrmReviews();
@@ -288,6 +319,8 @@ class FrmAppController {
 	 * Save the request to hide the review
 	 *
 	 * @since 3.04.03
+	 *
+	 * @return void
 	 */
 	public static function dismiss_review() {
 		FrmAppHelper::permission_check( 'frm_change_settings' );
@@ -299,6 +332,8 @@ class FrmAppController {
 
 	/**
 	 * @since 3.04.02
+	 *
+	 * @return void
 	 */
 	public static function include_upgrade_overlay() {
 		self::enqueue_dialog_assets();
@@ -319,6 +354,8 @@ class FrmAppController {
 
 	/**
 	 * @since 3.06.03
+	 *
+	 * @return void
 	 */
 	public static function upgrade_overlay_html() {
 		$is_pro       = FrmAppHelper::pro_is_installed();
@@ -338,6 +375,9 @@ class FrmAppController {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	private static function new_form_overlay_html() {
 		FrmFormsController::before_list_templates();
 
@@ -386,17 +426,25 @@ class FrmAppController {
 		include $path . 'new-form-overlay.php';
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function include_info_overlay() {
 		self::enqueue_dialog_assets();
 		add_action( 'admin_footer', 'FrmAppController::info_overlay_html' );
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function info_overlay_html() {
 		include FrmAppHelper::plugin_path() . '/classes/views/shared/info-overlay.php';
 	}
 
 	/**
 	 * @since 3.04.02
+	 *
+	 * @return void
 	 */
 	public static function remove_upsells() {
 		remove_action( 'frm_before_settings', 'FrmSettingsController::license_box' );
@@ -410,6 +458,8 @@ class FrmAppController {
 	 * Use a javascript fallback instead.
 	 *
 	 * @since 2.0.3
+	 *
+	 * @return void
 	 */
 	public static function install_js_fallback() {
 		FrmAppHelper::load_admin_wide_js();
@@ -445,6 +495,9 @@ class FrmAppController {
 	 * Check both version number and DB number for changes
 	 *
 	 * @since 3.0.04
+	 *
+	 * @param array $atts
+	 * @return bool
 	 */
 	public static function compare_for_update( $atts ) {
 		$db_version = get_option( $atts['option'] );
@@ -465,6 +518,8 @@ class FrmAppController {
 	 * Check for database update and trigger js loading
 	 *
 	 * @since 2.0.1
+	 *
+	 * @return void
 	 */
 	public static function admin_init() {
 		if ( FrmAppHelper::is_admin_page( 'formidable' ) && 'duplicate' === FrmAppHelper::get_param( 'frm_action' ) ) {
@@ -760,12 +815,19 @@ class FrmAppController {
 	/**
 	 * @since 5.3
 	 *
+	 * @param string       $block_name
+	 * @param string       $object_key
+	 * @param array|string $object_id
+	 *
 	 * @return void
 	 */
 	public static function add_js_to_inject_gutenberg_block( $block_name, $object_key, $object_id ) {
 		require FrmAppHelper::plugin_path() . '/classes/views/shared/edit-page-js.php';
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function load_lang() {
 		load_plugin_textdomain( 'formidable', false, FrmAppHelper::plugin_folder() . '/languages/' );
 	}
@@ -774,6 +836,8 @@ class FrmAppController {
 	 * Check if the styles are updated when a form is loaded on the front-end
 	 *
 	 * @since 3.0.1
+	 *
+	 * @return void
 	 */
 	public static function maybe_update_styles() {
 		if ( self::needs_update() ) {
@@ -783,6 +847,8 @@ class FrmAppController {
 
 	/**
 	 * @since 3.0
+	 *
+	 * @return void
 	 */
 	public static function create_rest_routes() {
 		$args = array(
@@ -819,6 +885,8 @@ class FrmAppController {
 	 * @since 2.0.1
 	 *
 	 * @param int $blog_id Blog ID.
+	 *
+	 * @return void
 	 */
 	public static function network_upgrade_site( $blog_id = 0 ) {
 		// Flag to check if install is happening as intended.
@@ -844,6 +912,8 @@ class FrmAppController {
 	/**
 	 * Make sure WP_Site_Health has been included because it is required when calling rest_do_request.
 	 * Check first that the file exists because WP_Site_Health was only introduced in WordPress 5.2.
+	 *
+	 * @return void
 	 */
 	private static function maybe_add_wp_site_health() {
 		if ( ! class_exists( 'WP_Site_Health' ) ) {
@@ -856,6 +926,8 @@ class FrmAppController {
 
 	/**
 	 * @since 3.0
+	 *
+	 * @return true
 	 */
 	public static function api_install() {
 		delete_transient( 'frm_updating_api' );
@@ -876,6 +948,8 @@ class FrmAppController {
 	 * Called via ajax request during network upgrade process.
 	 *
 	 * @since 2.0.1
+	 *
+	 * @return void
 	 */
 	public static function ajax_install() {
 		FrmAppHelper::permission_check( 'frm_change_settings' );
@@ -884,11 +958,17 @@ class FrmAppController {
 		wp_die();
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function install() {
 		$frmdb = new FrmMigrate();
 		$frmdb->upgrade();
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function uninstall() {
 		FrmAppHelper::permission_check( 'administrator' );
 		check_ajax_referer( 'frm_ajax', 'nonce' );
@@ -914,6 +994,9 @@ class FrmAppController {
 		return $tables;
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function deauthorize() {
 		FrmAppHelper::permission_check( 'frm_change_settings' );
 		check_ajax_referer( 'frm_ajax', 'nonce' );
@@ -935,7 +1018,10 @@ class FrmAppController {
 
 	/**
 	 * @deprecated 3.0.04
+	 *
 	 * @codeCoverageIgnore
+	 *
+	 * @return void
 	 */
 	public static function activation_install() {
 		FrmDeprecated::activation_install();

--- a/classes/controllers/FrmElementorController.php
+++ b/classes/controllers/FrmElementorController.php
@@ -8,6 +8,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class FrmElementorController {
 
+	/**
+	 * @return void
+	 */
 	public static function register_elementor_hooks() {
 		require_once FrmAppHelper::plugin_path() . '/classes/widgets/FrmElementorWidget.php';
 		\Elementor\Plugin::instance()->widgets_manager->register( new \FrmElementorWidget() );
@@ -22,6 +25,9 @@ class FrmElementorController {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function admin_init() {
 		FrmAppController::load_wp_admin_style();
 		FrmFormsController::insert_form_popup();

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -7,6 +7,10 @@ class FrmHooksController {
 
 	/**
 	 * Trigger plugin-wide hook loading
+	 *
+	 * @param string $hooks
+	 *
+	 * @return void
 	 */
 	public static function trigger_load_hook( $hooks = 'load_hooks' ) {
 		$controllers = apply_filters( 'frm_load_controllers', array( 'FrmHooksController' ) );
@@ -45,10 +49,16 @@ class FrmHooksController {
 
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function trigger_load_form_hooks() {
 		self::trigger_load_hook( 'load_form_hooks' );
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function load_hooks() {
 		add_action( 'rest_api_init', 'FrmAppController::create_rest_routes', 0 );
 		add_action( 'plugins_loaded', 'FrmAppController::load_lang' );
@@ -98,6 +108,9 @@ class FrmHooksController {
 		add_filter( 'frm_fields_in_form_builder', 'FrmFormsController::update_form_builder_fields', 10, 2 );
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function load_admin_hooks() {
 		add_action( 'admin_menu', 'FrmAppController::menu', 1 );
 		add_filter( 'admin_body_class', 'FrmAppController::add_admin_class', 999 );
@@ -179,6 +192,9 @@ class FrmHooksController {
 		new FrmPluginSearch();
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function load_ajax_hooks() {
 		add_action( 'wp_ajax_frm_install', 'FrmAppController::ajax_install' );
 		add_action( 'wp_ajax_frm_uninstall', 'FrmAppController::uninstall' );
@@ -241,6 +257,9 @@ class FrmHooksController {
 		add_action( 'wp_ajax_template_api_signup', 'FrmFormTemplateApi::signup' );
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function load_form_hooks() {
 		// Fields Controller.
 		add_filter( 'frm_field_type', 'FrmFieldsController::change_type' );
@@ -257,10 +276,16 @@ class FrmHooksController {
 		add_filter( 'frm_use_important_width', 'FrmStylesController::important_style', 10, 2 );
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function load_view_hooks() {
 		// Hooks go here when a view is loaded.
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function load_multisite_hooks() {
 		add_action( 'wpmu_upgrade_site', 'FrmAppController::network_upgrade_site' );
 
@@ -270,6 +295,8 @@ class FrmHooksController {
 
 	/**
 	 * @deprecated 5.0.06 use FrmElementorController::register_elementor_hooks directly.
+	 *
+	 * @return void
 	 */
 	public static function register_elementor_hooks() {
 		_deprecated_function( __FUNCTION__, '5.0.06', 'FrmElementorController::register_elementor_hooks' );

--- a/classes/controllers/FrmInboxController.php
+++ b/classes/controllers/FrmInboxController.php
@@ -10,6 +10,8 @@ class FrmInboxController {
 
 	/**
 	 * @since 4.05
+	 *
+	 * @return void
 	 */
 	public static function menu() {
 		$unread = self::get_notice_count();
@@ -28,6 +30,8 @@ class FrmInboxController {
 
 	/**
 	 * @since 4.06
+	 *
+	 * @return void
 	 */
 	public static function dismiss_all_button( $atts ) {
 		if ( empty( $atts['messages'] ) ) {
@@ -41,6 +45,8 @@ class FrmInboxController {
 
 	/**
 	 * @since 4.05
+	 *
+	 * @return void
 	 */
 	public static function inbox() {
 		FrmAppHelper::include_svg();
@@ -59,6 +65,8 @@ class FrmInboxController {
 
 	/**
 	 * @since 4.05
+	 *
+	 * @return void
 	 */
 	public static function dismiss_message() {
 		check_ajax_referer( 'frm_ajax', 'nonce' );
@@ -79,6 +87,8 @@ class FrmInboxController {
 
 	/**
 	 * @since 4.05
+	 *
+	 * @return void
 	 */
 	private static function add_tracking_request() {
 		$settings = FrmAppHelper::get_settings();
@@ -104,6 +114,8 @@ class FrmInboxController {
 	 * Adds free template design.
 	 *
 	 * @since 4.10.03
+	 *
+	 * @return void
 	 */
 	private static function add_free_template_message() {
 		if ( FrmAppHelper::pro_is_installed() ) {

--- a/classes/controllers/FrmSMTPController.php
+++ b/classes/controllers/FrmSMTPController.php
@@ -44,6 +44,8 @@ class FrmSMTPController {
 	 * Hooks.
 	 *
 	 * @since 4.04.04
+	 *
+	 * @return void
 	 */
 	public static function load_hooks() {
 
@@ -71,6 +73,8 @@ class FrmSMTPController {
 
 	/**
 	 * Customize the upgrade link.
+	 *
+	 * @return string
 	 */
 	public function link( $link ) {
 		$new_link = 'formidableforms.com/go-wp-mail-smtp/?urllink=wpmailsmtp%2Ecom%2Flite%2Dupgrade&';
@@ -97,6 +101,8 @@ class FrmSMTPController {
 
 	/**
 	 * SMTP submenu page.
+	 *
+	 * @return void
 	 */
 	public function menu() {
 		add_submenu_page( 'formidable', __( 'SMTP', 'formidable' ) . ' | Formidable', __( 'SMTP', 'formidable' ), 'activate_plugins', $this->slug, array( $this, 'output' ) );
@@ -106,6 +112,8 @@ class FrmSMTPController {
 	 * Generate and output page HTML.
 	 *
 	 * @since 4.04.04
+	 *
+	 * @return void
 	 */
 	public function output() {
 		FrmAppHelper::include_svg();
@@ -125,6 +133,8 @@ class FrmSMTPController {
 	 * Generate and output heading section HTML.
 	 *
 	 * @since 4.04.04
+	 *
+	 * @return void
 	 */
 	protected function output_section_heading() {
 		$size = array(
@@ -159,6 +169,8 @@ class FrmSMTPController {
 	 * Generate and output screenshot section HTML.
 	 *
 	 * @since 4.04.04
+	 *
+	 * @return void
 	 */
 	protected function output_section_screenshot() {
 
@@ -188,6 +200,8 @@ class FrmSMTPController {
 	 * Generate and output step 'Install' section HTML.
 	 *
 	 * @since 4.04.04
+	 *
+	 * @return void
 	 */
 	protected function output_section_step_install() {
 
@@ -235,6 +249,8 @@ class FrmSMTPController {
 	 * Generate and output step 'Setup' section HTML.
 	 *
 	 * @since 4.04.04
+	 *
+	 * @return void
 	 */
 	protected function output_section_step_setup() {
 
@@ -410,6 +426,8 @@ class FrmSMTPController {
 	 * Redirect to SMTP settings page if it is activated..
 	 *
 	 * @since 4.04.04
+	 *
+	 * @return void
 	 */
 	public function redirect_to_smtp_settings() {
 		if ( $this->is_smtp_configured() ) {
@@ -418,12 +436,18 @@ class FrmSMTPController {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	private function stmp_logo() {
 		?>
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" height="90" width="90"><defs><style>.cls-11,.cls-12{fill-rule:evenodd}.cls-4{fill:none}.cls-11{fill:#86a196}.cls-12{fill:#fff}</style></defs><path class="cls-4" d="M-6.3 0h60v60h-60z"/><path d="M16.7 8.1a15.4 15.4 0 00-8 10.2 23.5 23.5 0 1030 0 15.4 15.4 0 00-9.3-10.8 3.4 3.4 0 00-2.1-2.7A4.6 4.6 0 0018.4 3a24.4 24.4 0 00-1.7 5z" fill="#395360" fill-rule="evenodd"/><path fill="#fbaa6f" d="M18 26h12v14H18z"/><path d="M25.9 33.2l-.1-.1a1.4 1.4 0 111.6-2.3 1.9 1.9 0 00-1.2.8 1.9 1.9 0 00-.3 1.6zm-4.5 0a1.8 1.8 0 00-.4-1.6 2 2 0 00-1.2-.8 1.4 1.4 0 011.6 2.3zm7.2-3.2h.5l-1 4.8-2.2 6.5h-4.3l-3.2-5.4 1.1-3.2 2.1 2.7c.6.5 2.7.5 3.8-.6a26.2 26.2 0 003.2-4.8z" fill="#dc7f3c" fill-rule="evenodd"/><path d="M9.7 29H15v-9h-4a13 13 0 017.4-10q1.2-5 2.8-6.8l.1-.1.1-.1a2.3 2.3 0 011.1-.5 2.3 2.3 0 012.2 3.8 1.6 1.6 0 01-.4.3A15 15 0 0023 8a5 5 0 013-1.5 1.4 1.4 0 01.7.2 1.3 1.3 0 01.5 1.8 1.3 1.3 0 01-.6.6 13 13 0 0110.1 11l.1.8H33v8h4.8l1.8 13.4q-6.3 4-15.8 4T8 42.4zM25 38.4q3.8-6.4 3.8-7.6c0-2.2-3.2-4-4.8-4s-4.9 1.7-4.9 4q0 1.2 3.8 7.6a1.2 1.2 0 001 .6 1 1 0 001-.6z" fill="#bdcfc8" fill-rule="evenodd"/><path class="cls-4" d="M19 31h9.6L27 47.2h-6.4l-1.6-16z"/><path d="M39.8 48.8a20 20 0 01-32 0l.8-6a2.7 2.7 0 001 .1 2.8 2.8 0 002.8-2.4v1.2a2.8 2.8 0 005.6 0v1.6a2.9 2.9 0 005.7 0 2.8 2.8 0 005.7 0v-1.6a2.8 2.8 0 105.7 0v-1.2A2.8 2.8 0 0038 43a2.9 2.9 0 001-.2l.8 6z" fill="#809eb0" fill-rule="evenodd"/><path d="M8.3 44.6l.3-1.8a2.7 2.7 0 001 .2 2.8 2.8 0 002.8-2.5v1.2a2.8 2.8 0 005.7 0v1.7a2.9 2.9 0 005.6 0 2.8 2.8 0 005.7 0v-1.7a2.8 2.8 0 105.7 0v-1.2A2.8 2.8 0 0038 43a2.9 2.9 0 001-.2l.3 2a2.9 2.9 0 01-4.1-2.2v1.2a2.8 2.8 0 11-5.7 0v1.6a2.8 2.8 0 01-5.7 0 2.9 2.9 0 01-5.7 0v-1.7a2.8 2.8 0 01-5.7 0v-1.2A2.8 2.8 0 019.6 45a2.9 2.9 0 01-1.3-.3z" fill="#738e9e" fill-rule="evenodd"/><path class="cls-11" d="M37.8 22.4c-1-2.9-3-4.7-4.7-4.5-2.2.2-2.8 3.7-2.3 8s1.7 7.5 3.9 7.3 4-3.9 3.6-8c0 1.2-.5 2.3-1.3 2.4-1.2 0-1.5-1.2-1.6-2.9s-.2-3 1-3a1.5 1.5 0 011.4.7z"/><path class="cls-12" d="M37 21.8c-.6-1.3-1.5-2-2.4-1.9-1.5.1-1.9 2.6-1.6 5.5s1.2 5.1 2.7 5c1.1-.2 2-1.5 2.2-3.4a1.2 1.2 0 01-1 .6c-1 0-1.4-1.2-1.5-2.9s-.1-3 1-3a1.6 1.6 0 01.6 0z"/><path class="cls-11" d="M9.6 22.4c1-2.9 3-4.7 4.7-4.5 2.2.2 2.8 3.7 2.3 8s-1.7 7.5-3.9 7.3-4-3.9-3.7-8c.1 1.2.5 2.3 1.4 2.4 1.1 0 1.5-1.2 1.6-2.9s.1-3-1-3a1.5 1.5 0 00-1.4.7z"/><path class="cls-12" d="M10.4 21.8c.6-1.3 1.5-2 2.4-1.9 1.5.1 1.8 2.6 1.5 5.5s-1.1 5.1-2.6 5c-1.1-.2-2-1.5-2.2-3.4a1.2 1.2 0 00.9.6c1.1 0 1.4-1.2 1.6-2.9s.1-3-1-3a1.7 1.7 0 00-.7 0z"/><path d="M19 28.6a5.3 5.3 0 010-.7c0-2.4 1.2-5.2 4.9-5.2s4.8 2.8 4.8 5.2a4.4 4.4 0 010 1c-.9-1.3-2.4-2.1-4.9-2.1-2.4 0-3.9.7-4.8 1.8z" fill="#f4f8ff" fill-rule="evenodd"/><path class="cls-11" d="M26.5 9.2L23.3 9l4-1.2a1.4 1.4 0 01-.8 1.4zm-3.5-1l-1.3 1a16.8 16.8 0 002-3.8 6.6 6.6 0 00.3-2.7A2.4 2.4 0 0125.2 5a2.4 2.4 0 01-.7 1.5A15 15 0 0023 8.1z"/></svg>
 		<?php
 	}
 
+	/**
+	 * @return void
+	 */
 	private function css() {
 		?>
 <style>

--- a/classes/controllers/FrmSimpleBlocksController.php
+++ b/classes/controllers/FrmSimpleBlocksController.php
@@ -7,6 +7,8 @@ class FrmSimpleBlocksController {
 
 	/**
 	 * Enqueue Formidable Simple Blocks' js and CSS for editor in admin.
+	 *
+	 * @return void
 	 */
 	public static function block_editor_assets() {
 		$version = FrmAppHelper::plugin_version();
@@ -90,6 +92,8 @@ class FrmSimpleBlocksController {
 
 	/**
 	 * Registers simple form block
+	 *
+	 * @return void
 	 */
 	public static function register_simple_form_block() {
 		if ( ! is_callable( 'register_block_type' ) ) {

--- a/classes/controllers/FrmUsageController.php
+++ b/classes/controllers/FrmUsageController.php
@@ -13,6 +13,8 @@ class FrmUsageController {
 	 * Randomize the first send to prevent our servers from crashing.
 	 *
 	 * @since 3.06.04
+	 *
+	 * @return void
 	 */
 	public static function schedule_send() {
 		if ( wp_next_scheduled( 'formidable_send_usage' ) ) {
@@ -47,6 +49,8 @@ class FrmUsageController {
 
 	/**
 	 * @since 3.06.04
+	 *
+	 * @return void
 	 */
 	public static function send_snapshot() {
 		$usage = new FrmUsage();

--- a/classes/controllers/FrmWelcomeController.php
+++ b/classes/controllers/FrmWelcomeController.php
@@ -14,7 +14,9 @@ class FrmWelcomeController {
 	/**
 	 * Register all of the hooks related to the welcome screen functionality
 	 *
-	 * @access   public
+	 * @access public
+	 *
+	 * @return void
 	 */
 	public static function load_hooks() {
 		add_action( 'admin_init', __CLASS__ . '::redirect' );
@@ -65,6 +67,8 @@ class FrmWelcomeController {
 
 	/**
 	 * Don't redirect every time the plugin is activated.
+	 *
+	 * @return bool
 	 */
 	private static function already_redirected() {
 		$last_redirect = get_option( self::$last_redirect );
@@ -134,6 +138,9 @@ class FrmWelcomeController {
 		return admin_url( 'admin.php?page=' . self::$menu_slug );
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function upgrade_to_pro_button() {
 		if ( ! FrmAppHelper::pro_is_installed() ) {
 			?>
@@ -144,12 +151,21 @@ class FrmWelcomeController {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function maybe_show_license_box() {
 		if ( ! FrmAppHelper::pro_is_installed() ) {
 			FrmSettingsController::license_box();
 		}
 	}
 
+	/**
+	 * @param string $plugin
+	 * @param string $upgrade_link_args
+	 *
+	 * @return void
+	 */
 	public static function maybe_show_conditional_action_button( $plugin, $upgrade_link_args ) {
 		$is_installed = is_callable( 'FrmProAppHelper::views_is_installed' ) && FrmProAppHelper::views_is_installed();
 		if ( ! $is_installed ) {

--- a/classes/controllers/FrmXMLController.php
+++ b/classes/controllers/FrmXMLController.php
@@ -277,17 +277,20 @@ class FrmXMLController {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function route() {
 		$action = isset( $_REQUEST['frm_action'] ) ? 'frm_action' : 'action';
 		$action = FrmAppHelper::get_param( $action, '', 'get', 'sanitize_title' );
 		FrmAppHelper::include_svg();
 
 		if ( 'import_xml' === $action ) {
-			return self::import_xml();
+			self::import_xml();
 		} elseif ( 'export_xml' === $action ) {
-			return self::export_xml();
+			self::export_xml();
 		} elseif ( apply_filters( 'frm_xml_route', true, $action ) ) {
-			return self::form();
+			self::form();
 		}
 	}
 

--- a/classes/controllers/FrmXMLController.php
+++ b/classes/controllers/FrmXMLController.php
@@ -5,10 +5,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class FrmXMLController {
 
+	/**
+	 * @return void
+	 */
 	public static function menu() {
 		add_submenu_page( 'formidable', 'Formidable | ' . __( 'Import/Export', 'formidable' ), __( 'Import/Export', 'formidable' ), 'frm_edit_forms', 'formidable-import', 'FrmXMLController::route' );
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function add_default_templates() {
 		if ( FrmXMLHelper::check_if_libxml_disable_entity_loader_exists() ) {
 			// XML import is not enabled on your server
@@ -148,6 +154,8 @@ class FrmXMLController {
 	 * Get a different URL depending on the selection in the form.
 	 *
 	 * @since 4.06.02
+	 *
+	 * @return void
 	 */
 	private static function override_url( $form, &$url ) {
 		$selected_form = self::get_selected_in_form( $form, 'form' );
@@ -165,6 +173,9 @@ class FrmXMLController {
 
 	/**
 	 * @since 4.06.02
+	 *
+	 * @param string $value
+	 * @param array $form
 	 */
 	private static function get_selected_in_form( $form, $value = 'form' ) {
 		if ( ! empty( $form ) && isset( $form[ $value ] ) && ! empty( $form[ $value ] ) ) {
@@ -280,6 +291,12 @@ class FrmXMLController {
 		}
 	}
 
+	/**
+	 * @param string[] $errors
+	 * @param string $message
+	 *
+	 * @return void
+	 */
 	public static function form( $errors = array(), $message = '' ) {
 		$where = array(
 			'status'         => array( null, '', 'published' ),
@@ -306,9 +323,12 @@ class FrmXMLController {
 		);
 		$export_format = apply_filters( 'frm_export_formats', $export_format );
 
-		include( FrmAppHelper::plugin_path() . '/classes/views/xml/import_form.php' );
+		include FrmAppHelper::plugin_path() . '/classes/views/xml/import_form.php';
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function import_xml() {
 		$errors  = array();
 		$message = '';
@@ -383,6 +403,9 @@ class FrmXMLController {
 		self::form( $errors, $message );
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function export_xml() {
 		$error = FrmAppHelper::permission_nonce_error( 'frm_edit_forms', 'export-xml', 'export-xml-nonce' );
 		if ( ! empty( $error ) ) {
@@ -409,6 +432,13 @@ class FrmXMLController {
 		wp_die();
 	}
 
+	/**
+	 * @param array $args
+	 *
+	 * @psalm-param array{ids?: mixed} $args
+	 *
+	 * @return void
+	 */
 	public static function generate_xml( $type, $args = array() ) {
 		global $wpdb;
 
@@ -520,6 +550,9 @@ class FrmXMLController {
 		include FrmAppHelper::plugin_path() . '/classes/views/xml/xml.php';
 	}
 
+	/**
+	 * @return void
+	 */
 	private static function prepare_types_array( &$type ) {
 		$type = (array) $type;
 		if ( ! in_array( 'forms', $type ) && ( in_array( 'items', $type ) || in_array( 'posts', $type ) ) ) {
@@ -541,6 +574,8 @@ class FrmXMLController {
 	 *
 	 * @param array $type
 	 * @param array $records
+	 * @param array $args
+	 *
 	 * @return string
 	 */
 	private static function get_file_name( $args, $type, $records ) {
@@ -576,6 +611,11 @@ class FrmXMLController {
 		return apply_filters( 'frm_xml_filename', $filename );
 	}
 
+	/**
+	 * @param array $atts
+	 *
+	 * @return void
+	 */
 	public static function generate_csv( $atts ) {
 		$form_ids = $atts['ids'];
 		if ( empty( $form_ids ) ) {
@@ -588,6 +628,8 @@ class FrmXMLController {
 	 * Export to CSV
 	 *
 	 * @since 2.0.19
+	 *
+	 * @return void
 	 */
 	public static function csv( $form_id = false, $search = '', $fid = '' ) {
 		FrmAppHelper::permission_check( 'frm_view_entries' );

--- a/classes/factories/FrmFieldFactory.php
+++ b/classes/factories/FrmFieldFactory.php
@@ -49,6 +49,11 @@ class FrmFieldFactory {
 		return $field_info;
 	}
 
+	/**
+	 * @param int|string|object $field
+	 *
+	 * @return stdClass
+	 */
 	public static function get_field_object( $field ) {
 		if ( ! is_object( $field ) ) {
 			$field = FrmField::getOne( $field );
@@ -119,6 +124,8 @@ class FrmFieldFactory {
 
 	/**
 	 * @since 3.0
+	 *
+	 * @param string $property
 	 */
 	public static function field_has_property( $type, $property ) {
 		$field = self::get_field_type( $type );

--- a/classes/helpers/FrmEntriesListHelper.php
+++ b/classes/helpers/FrmEntriesListHelper.php
@@ -13,6 +13,9 @@ class FrmEntriesListHelper extends FrmListHelper {
 	 */
 	public $total_items = 0;
 
+	/**
+	 * @return void
+	 */
 	public function prepare_items() {
 		global $per_page;
 
@@ -88,6 +91,9 @@ class FrmEntriesListHelper extends FrmListHelper {
 		);
 	}
 
+	/**
+	 * @return void
+	 */
 	public function no_items() {
 		$s = self::get_param(
 			array(
@@ -119,10 +125,16 @@ class FrmEntriesListHelper extends FrmListHelper {
 		include( FrmAppHelper::plugin_path() . '/classes/views/frm-entries/no_entries.php' );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function search_box( $text, $input_id ) {
 		// Searching is a pro feature
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function display_tablenav( $which ) {
 		$is_footer = ( $which !== 'top' );
 		if ( $is_footer && ! empty( $this->items ) ) {
@@ -138,6 +150,9 @@ class FrmEntriesListHelper extends FrmListHelper {
 		parent::display_tablenav( $which );
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function extra_tablenav( $which ) {
 		$form_id = FrmAppHelper::simple_get( 'form', 'absint' );
 		if ( $which === 'top' && ! $form_id ) {
@@ -175,6 +190,9 @@ class FrmEntriesListHelper extends FrmListHelper {
 		return $primary_column;
 	}
 
+	/**
+	 * @return string
+	 */
 	public function single_row( $item, $style = '' ) {
 		// Set up the hover actions for this user
 		$actions   = array();
@@ -241,11 +259,16 @@ class FrmEntriesListHelper extends FrmListHelper {
 
 	/**
 	 * Get the column names that the logged in user can action on
+	 *
+	 * @return string[]
 	 */
 	private function get_action_columns() {
 		return array( 'cb', 'form_id', 'id', 'post_id' );
 	}
 
+	/**
+	 * @param object $item
+	 */
 	private function column_value( $item ) {
 		$col_name = $this->column_name;
 
@@ -308,6 +331,10 @@ class FrmEntriesListHelper extends FrmListHelper {
 
 	/**
 	 * @param string $view_link
+	 * @param array $actions
+	 * @param object $item
+	 *
+	 * @return void
 	 */
 	private function get_actions( &$actions, $item, $view_link ) {
 		$actions['view'] = '<a href="' . esc_url( $view_link ) . '">' . __( 'View', 'formidable' ) . '</a>';
@@ -320,6 +347,11 @@ class FrmEntriesListHelper extends FrmListHelper {
 		$actions = apply_filters( 'frm_row_actions', $actions, $item );
 	}
 
+	/**
+	 * @param false $val
+	 *
+	 * @return void
+	 */
 	private function get_column_value( $item, &$val ) {
 		$col_name = $this->column_name;
 

--- a/classes/helpers/FrmFieldGridHelper.php
+++ b/classes/helpers/FrmFieldGridHelper.php
@@ -63,6 +63,8 @@ class FrmFieldGridHelper {
 
 	/**
 	 * @param stdClass $field
+	 *
+	 * @return void
 	 */
 	public function set_field( $field ) {
 		$this->field = $field;
@@ -89,6 +91,9 @@ class FrmFieldGridHelper {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	private function maybe_close_section_helper() {
 		if ( empty( $this->section_helper ) ) {
 			return;
@@ -120,6 +125,9 @@ class FrmFieldGridHelper {
 		return '';
 	}
 
+	/**
+	 * @return void
+	 */
 	public function maybe_begin_field_wrapper() {
 		if ( $this->should_first_close_the_active_field_wrapper() ) {
 			$this->close_field_wrapper();
@@ -147,6 +155,9 @@ class FrmFieldGridHelper {
 		return ! $this->can_support_current_layout() || $this->is_frm_first;
 	}
 
+	/**
+	 * @return void
+	 */
 	private function begin_field_wrapper() {
 		echo '<li class="frm_field_box"><ul class="frm_grid_container frm_sorting">';
 		$this->parent_li           = true;
@@ -185,6 +196,9 @@ class FrmFieldGridHelper {
 		return 12;
 	}
 
+	/**
+	 * @return void
+	 */
 	public function sync_list_size() {
 		if ( ! isset( $this->field ) ) {
 			return;
@@ -214,6 +228,8 @@ class FrmFieldGridHelper {
 	/**
 	 * It is possible that there was still space for another field so the wrapper could still be open after looping the fields.
 	 * If it is, make sure it's closed now.
+	 *
+	 * @return void
 	 */
 	public function force_close_field_wrapper() {
 		if ( false !== $this->parent_li ) {
@@ -221,6 +237,9 @@ class FrmFieldGridHelper {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	private function close_field_wrapper() {
 		$this->maybe_close_section_helper();
 		echo '</ul></li>';
@@ -229,6 +248,9 @@ class FrmFieldGridHelper {
 		$this->current_field_count = 0;
 	}
 
+	/**
+	 * @return bool
+	 */
 	private function can_support_current_layout() {
 		if ( 'end_divider' === $this->field->type ) {
 			return true;

--- a/classes/helpers/FrmFormMigratorsHelper.php
+++ b/classes/helpers/FrmFormMigratorsHelper.php
@@ -5,6 +5,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class FrmFormMigratorsHelper {
 
+	/**
+	 * @return bool
+	 */
 	private static function is_dismissed( $form, $dismissed = null ) {
 		if ( $dismissed === null ) {
 			$dismissed = get_option( 'frm_dismissed' );
@@ -17,6 +20,9 @@ class FrmFormMigratorsHelper {
 		return false;
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function maybe_show_download_link() {
 		$forms = self::import_links();
 		foreach ( $forms as $form ) {
@@ -32,6 +38,8 @@ class FrmFormMigratorsHelper {
 
 	/**
 	 * @since 4.05
+	 *
+	 * @return void
 	 */
 	public static function maybe_add_to_inbox() {
 		$inbox = new FrmInbox();
@@ -51,6 +59,9 @@ class FrmFormMigratorsHelper {
 		}
 	}
 
+	/**
+	 * @return array
+	 */
 	private static function import_links() {
 		if ( ! current_user_can( 'activate_plugins' ) ) {
 			return array();
@@ -72,6 +83,9 @@ class FrmFormMigratorsHelper {
 		return $forms;
 	}
 
+	/**
+	 * @return string[][]
+	 */
 	private static function importable_forms() {
 		return array(
 			'gf' => array(
@@ -110,6 +124,12 @@ class FrmFormMigratorsHelper {
 		<?php
 	}
 
+	/**
+	 * @param array  $install
+	 * @param string $label
+	 *
+	 * @return void
+	 */
 	private static function install_button( $install, $label = '' ) {
 		$primary = 'button-secondary frm-button-secondary ';
 
@@ -141,6 +161,9 @@ class FrmFormMigratorsHelper {
 		<?php
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function dismiss_migrator() {
 		check_ajax_referer( 'frm_ajax', 'nonce' );
 		$dismissed = get_option( 'frm_dismissed' );
@@ -154,6 +177,8 @@ class FrmFormMigratorsHelper {
 
 	/**
 	 * @deprecated 4.05
+	 *
+	 * @return void
 	 */
 	public static function notification_count() {
 		_deprecated_function( __METHOD__, '4.05' );

--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -14,6 +14,9 @@ class FrmFormsListHelper extends FrmListHelper {
 		parent::__construct( $args );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function prepare_items() {
 		global $wpdb, $per_page, $mode;
 
@@ -100,6 +103,9 @@ class FrmFormsListHelper extends FrmListHelper {
 		);
 	}
 
+	/**
+	 * @return void
+	 */
 	public function no_items() {
 		if ( $this->status === 'trash' ) {
 			echo '<p>';
@@ -136,6 +142,9 @@ class FrmFormsListHelper extends FrmListHelper {
 		return $actions;
 	}
 
+	/**
+	 * @return void
+	 */
 	public function extra_tablenav( $which ) {
 		if ( 'top' != $which ) {
 			return;
@@ -192,6 +201,9 @@ class FrmFormsListHelper extends FrmListHelper {
 		return $links;
 	}
 
+	/**
+	 * @return void
+	 */
 	public function pagination( $which ) {
 		global $mode;
 
@@ -344,6 +356,10 @@ class FrmFormsListHelper extends FrmListHelper {
 
 	/**
 	 * @param string $edit_link
+	 * @param array $actions
+	 * @param stdClass $item
+	 *
+	 * @return void
 	 */
 	private function get_actions( &$actions, $item, $edit_link ) {
 		$new_actions = FrmFormsHelper::get_action_links( $item->id, $item );
@@ -368,6 +384,9 @@ class FrmFormsListHelper extends FrmListHelper {
 
 	/**
 	 * @param string $edit_link
+	 * @param stdClass $item
+	 *
+	 * @return string
 	 */
 	private function get_form_name( $item, $actions, $edit_link, $mode = 'list' ) {
 		$form_name = $item->name;
@@ -396,6 +415,8 @@ class FrmFormsListHelper extends FrmListHelper {
 
 	/**
 	 * @param string $val
+	 *
+	 * @return void
 	 */
 	private function add_draft_label( $item, &$val ) {
 		if ( 'draft' == $item->status && 'draft' != $this->status ) {
@@ -405,6 +426,8 @@ class FrmFormsListHelper extends FrmListHelper {
 
 	/**
 	 * @param string $val
+	 *
+	 * @return void
 	 */
 	private function add_form_description( $item, &$val ) {
 		global $mode;

--- a/classes/helpers/FrmStylesCardHelper.php
+++ b/classes/helpers/FrmStylesCardHelper.php
@@ -487,6 +487,9 @@ class FrmStylesCardHelper {
 		);
 	}
 
+	/**
+	 * @return array
+	 */
 	public function get_template_info() {
 		$style_api = new FrmStyleApi();
 		return $style_api->get_api_info();

--- a/classes/helpers/FrmTipsHelper.php
+++ b/classes/helpers/FrmTipsHelper.php
@@ -5,6 +5,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class FrmTipsHelper {
 
+	/**
+	 * @param string $callback
+	 * @param string $html
+	 *
+	 * @return void
+	 */
 	public static function pro_tip( $callback, $html = '' ) {
 		if ( FrmAppHelper::pro_is_installed() ) {
 			return;
@@ -23,13 +29,16 @@ class FrmTipsHelper {
 	 *
 	 * @param array $tip {
 	 *     Tip args
-	 *
+	 * 
 	 *     @type array  $link Tip link data. See the first parameter of {@see FrmAppHelper::admin_upgrade_link()} for more details.
 	 *     @type string $page The based link of the tip. If this is empty, `https://formidableforms.com/lite-upgrade/` will
 	 *                        be used. Otherwise, `https://formidableforms.com/{$page}` will be used.
 	 *     @type string $tip  Tip text.
 	 *     @type string $call Call to action text.
 	 * }
+	 * @param string $html
+	 *
+	 * @return void
 	 */
 	public static function show_tip( $tip, $html = '' ) {
 		if ( ! isset( $tip['page'] ) ) {
@@ -68,6 +77,9 @@ class FrmTipsHelper {
 		}
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function get_builder_tip() {
 		$tips = array(
 			array(
@@ -123,6 +135,9 @@ class FrmTipsHelper {
 		return $tips;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function get_form_settings_tip() {
 		$tips = array(
 			array(
@@ -154,6 +169,9 @@ class FrmTipsHelper {
 		return $tips;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function get_form_action_tip() {
 		$tips = array(
 			array(
@@ -283,6 +301,9 @@ class FrmTipsHelper {
 		return $tips;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function get_entries_tip() {
 		$tips = array(
 			array(
@@ -315,6 +336,9 @@ class FrmTipsHelper {
 		return $tips;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function get_import_tip() {
 		$tips = array(
 			array(
@@ -330,6 +354,9 @@ class FrmTipsHelper {
 		return $tips;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function get_banner_tip() {
 		$tips       = array(
 			array(

--- a/classes/helpers/FrmTipsHelper.php
+++ b/classes/helpers/FrmTipsHelper.php
@@ -29,7 +29,7 @@ class FrmTipsHelper {
 	 *
 	 * @param array $tip {
 	 *     Tip args
-	 * 
+	 *
 	 *     @type array  $link Tip link data. See the first parameter of {@see FrmAppHelper::admin_upgrade_link()} for more details.
 	 *     @type string $page The based link of the tip. If this is empty, `https://formidableforms.com/lite-upgrade/` will
 	 *                        be used. Otherwise, `https://formidableforms.com/{$page}` will be used.

--- a/classes/models/FrmAntiSpam.php
+++ b/classes/models/FrmAntiSpam.php
@@ -21,6 +21,8 @@ class FrmAntiSpam extends FrmValidate {
 
 	/**
 	 * @param int $form_id
+	 *
+	 * @return void
 	 */
 	public static function maybe_init( $form_id ) {
 		$antispam = new self( $form_id );
@@ -33,6 +35,8 @@ class FrmAntiSpam extends FrmValidate {
 	 * Initialise the actions for the Anti-spam.
 	 *
 	 * @since 4.11
+	 *
+	 * @return void
 	 */
 	public function init() {
 		add_filter( 'frm_form_attributes', array( $this, 'add_token_to_form' ), 10, 1 );
@@ -170,6 +174,8 @@ class FrmAntiSpam extends FrmValidate {
 
 	/**
 	 * @param int $form_id
+	 *
+	 * @return void
 	 */
 	public static function maybe_echo_token( $form_id ) {
 		$antispam = new self( $form_id );
@@ -293,6 +299,8 @@ class FrmAntiSpam extends FrmValidate {
 
 	/**
 	 * Clear third party cache plugins to avoid data-tokens missing or appearing when the antispam setting is changed.
+	 *
+	 * @return void
 	 */
 	public static function clear_caches() {
 		self::clear_w3_total_cache();
@@ -301,16 +309,25 @@ class FrmAntiSpam extends FrmValidate {
 		self::clear_wp_optimize();
 	}
 
+	/**
+	 * @return void
+	 */
 	private static function clear_w3_total_cache() {
 		if ( is_callable( 'w3tc_flush_all' ) ) {
 			w3tc_flush_all();
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	private static function clear_wp_fastest_cache() {
 		do_action( 'wpfc_clear_all_cache' );
 	}
 
+	/**
+	 * @return void
+	 */
 	private static function clear_wp_super_cache() {
 		if ( function_exists( 'wp_cache_clean_cache' ) ) {
 			global $file_prefix;
@@ -318,6 +335,9 @@ class FrmAntiSpam extends FrmValidate {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	private static function clear_wp_optimize() {
 		if ( class_exists( 'WP_Optimize' ) ) {
 			WP_Optimize()->get_page_cache()->purge();

--- a/classes/models/FrmApplicationTemplate.php
+++ b/classes/models/FrmApplicationTemplate.php
@@ -31,6 +31,8 @@ class FrmApplicationTemplate {
 	/**
 	 * @param array<string> $keys
 	 * @param array<string> $keys_with_images
+	 *
+	 * @return void
 	 */
 	public static function init() {
 		/**

--- a/classes/models/FrmCreateFile.php
+++ b/classes/models/FrmCreateFile.php
@@ -28,6 +28,8 @@ class FrmCreateFile {
 
 	/**
 	 * @since 3.0
+	 *
+	 * @return void
 	 */
 	private function set_new_file_path( $atts ) {
 		if ( isset( $atts['new_file_path'] ) ) {
@@ -37,6 +39,11 @@ class FrmCreateFile {
 		}
 	}
 
+	/**
+	 * @param string $file_content
+	 *
+	 * @return void
+	 */
 	public function create_file( $file_content ) {
 		if ( $this->has_permission ) {
 			$dirs_exist = true;
@@ -54,6 +61,8 @@ class FrmCreateFile {
 
 	/**
 	 * @since 3.0
+	 *
+	 * @return void
 	 */
 	public function append_file( $file_content ) {
 		if ( $this->has_permission ) {
@@ -74,6 +83,8 @@ class FrmCreateFile {
 	 * @since 3.0
 	 *
 	 * @param array $file_names And array of file paths
+	 *
+	 * @return void
 	 */
 	public function combine_files( $file_names ) {
 		if ( $this->has_permission ) {
@@ -112,6 +123,8 @@ class FrmCreateFile {
 
 	/**
 	 * @since 3.0
+	 *
+	 * @return void
 	 */
 	private function check_permission() {
 		$creds = $this->get_creds();
@@ -124,6 +137,11 @@ class FrmCreateFile {
 		}
 	}
 
+	/**
+	 * @param true $dirs_exist
+	 *
+	 * @return void
+	 */
 	private function create_directories( &$dirs_exist ) {
 		global $wp_filesystem;
 
@@ -139,6 +157,9 @@ class FrmCreateFile {
 		}
 	}
 
+	/**
+	 * @return string[]
+	 */
 	private function get_needed_dirs() {
 		$dir_names   = explode( '/', $this->folder_name );
 		$needed_dirs = array();
@@ -167,6 +188,9 @@ class FrmCreateFile {
 		return $creds;
 	}
 
+	/**
+	 * @param string $type
+	 */
 	private function get_ftp_creds( $type ) {
 		$credentials = get_option(
 			'ftp_credentials',
@@ -223,6 +247,9 @@ class FrmCreateFile {
 		return false;
 	}
 
+	/**
+	 * @return void
+	 */
 	private function show_error_message() {
 		if ( ! empty( $this->error_message ) ) {
 			echo '<div class="message">' . esc_html( $this->error_message ) . '</div>';

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -142,6 +142,8 @@ class FrmEmail {
 	 * @since 2.03.04
 	 *
 	 * @param object $action
+	 *
+	 * @return void
 	 */
 	private function set_email_key( $action ) {
 		$this->email_key = $action->ID;
@@ -153,6 +155,8 @@ class FrmEmail {
 	 * @since 2.03.04
 	 *
 	 * @param array $user_id_args
+	 *
+	 * @return void
 	 */
 	private function set_to( $user_id_args ) {
 		$to = $this->prepare_email_setting( $this->settings['email_to'], $user_id_args );
@@ -187,6 +191,8 @@ class FrmEmail {
 	 * @since 2.03.04
 	 *
 	 * @param array $user_id_args
+	 *
+	 * @return void
 	 */
 	private function set_cc( $user_id_args ) {
 		$this->cc = $this->prepare_additional_recipients( $this->settings['cc'], $user_id_args );
@@ -198,6 +204,8 @@ class FrmEmail {
 	 * @since 2.03.04
 	 *
 	 * @param array $user_id_args
+	 *
+	 * @return void
 	 */
 	private function set_bcc( $user_id_args ) {
 		$this->bcc = $this->prepare_additional_recipients( $this->settings['bcc'], $user_id_args );
@@ -247,6 +255,8 @@ class FrmEmail {
 	 * @since 2.03.04
 	 *
 	 * @param array $user_id_args
+	 *
+	 * @return void
 	 */
 	private function set_reply_to( $user_id_args ) {
 		$this->reply_to = trim( $this->settings['reply_to'] );
@@ -267,6 +277,8 @@ class FrmEmail {
 	 * This should be set before the message
 	 *
 	 * @since 2.03.04
+	 *
+	 * @return void
 	 */
 	private function set_is_plain_text() {
 		if ( $this->settings['plain_text'] ) {
@@ -279,6 +291,8 @@ class FrmEmail {
 	 * This should be set before the message
 	 *
 	 * @since 2.03.04
+	 *
+	 * @return void
 	 */
 	private function set_include_user_info() {
 		if ( isset( $this->settings['inc_user_info'] ) ) {
@@ -292,6 +306,9 @@ class FrmEmail {
 	 * @since 2.03.04
 	 *
 	 * @param $action
+	 * @param object $action
+	 *
+	 * @return void
 	 */
 	private function set_is_single_recipient( $action ) {
 		$args = array(
@@ -312,6 +329,8 @@ class FrmEmail {
 	 * Set the charset
 	 *
 	 * @since 2.03.04
+	 *
+	 * @return void
 	 */
 	private function set_charset() {
 		$this->charset = get_option( 'blog_charset' );
@@ -321,6 +340,8 @@ class FrmEmail {
 	 * Set the content type
 	 *
 	 * @since 2.03.04
+	 *
+	 * @return void
 	 */
 	private function set_content_type() {
 		if ( $this->is_plain_text ) {
@@ -359,6 +380,8 @@ class FrmEmail {
 	 * Set the email message
 	 *
 	 * @since 2.03.04
+	 *
+	 * @return void
 	 */
 	private function set_message() {
 		$this->message = $this->settings['email_message'];
@@ -405,6 +428,8 @@ class FrmEmail {
 
 	/**
 	 * Runs message through autop, extracting the content inside body tag if it has <body>.
+	 *
+	 * @return void
 	 */
 	private function add_autop() {
 		$message = $this->message;
@@ -416,6 +441,11 @@ class FrmEmail {
 		}
 	}
 
+	/**
+	 * @param string $mail_body
+	 *
+	 * @return void
+	 */
 	private function maybe_add_ip( &$mail_body ) {
 		if ( ! empty( $this->entry->ip ) ) {
 			$mail_body .= __( 'IP Address', 'formidable' ) . ': ' . $this->entry->ip . "\r\n";
@@ -738,6 +768,10 @@ class FrmEmail {
 	 * Get only the email if the name and email have been combined
 	 *
 	 * @since 3.0.06
+	 *
+	 * @param string $name
+	 *
+	 * @return string
 	 */
 	private function get_email_from_name( $name ) {
 		$email = trim( trim( $name, '>' ), '<' );
@@ -775,6 +809,9 @@ class FrmEmail {
 
 	/**
 	 * @since 3.0.06
+	 *
+	 * @param string $name
+	 * @param string $email
 	 */
 	private function format_from_email( $name, $email ) {
 		if ( '' !== $name ) {
@@ -789,6 +826,8 @@ class FrmEmail {
 	 * Send the phone numbers to the frm_send_to_not_email hook
 	 *
 	 * @since 2.03.04
+	 *
+	 * @return void
 	 */
 	private function handle_phone_numbers() {
 
@@ -848,6 +887,8 @@ class FrmEmail {
 	 * Remove the Buddypress email filters
 	 *
 	 * @since 2.03.04
+	 *
+	 * @return void
 	 */
 	private function remove_buddypress_filters() {
 		remove_filter( 'wp_mail_from', 'bp_core_email_from_address_filter' );
@@ -859,6 +900,8 @@ class FrmEmail {
 	 * Remove line breaks in HTML emails to prevent conflicts with Mandrill
 	 *
 	 * @since 2.03.04
+	 *
+	 * @return void
 	 */
 	private function add_mandrill_filter() {
 		if ( ! $this->is_plain_text ) {
@@ -870,6 +913,8 @@ class FrmEmail {
 	 * Remove Mandrill line break filter
 	 *
 	 * @since 2.03.04
+	 *
+	 * @return void
 	 */
 	private function remove_mandrill_filter() {
 		remove_filter( 'mandrill_nl2br', 'FrmEmailHelper::remove_mandrill_br' );

--- a/classes/models/FrmEntryShortcodeFormatter.php
+++ b/classes/models/FrmEntryShortcodeFormatter.php
@@ -88,6 +88,9 @@ class FrmEntryShortcodeFormatter {
 	 * @since 2.04
 	 *
 	 * @param $form_id
+	 * @param int|string $form_id
+	 *
+	 * @return void
 	 */
 	protected function init_form_id( $form_id ) {
 		$this->form_id = (int) $form_id;
@@ -97,6 +100,8 @@ class FrmEntryShortcodeFormatter {
 	 * Initialize the fields property
 	 *
 	 * @since 2.04
+	 *
+	 * @return void
 	 */
 	protected function init_fields() {
 		$this->fields = FrmField::get_all_for_form( $this->form_id, '', 'exclude', 'exclude' );
@@ -108,6 +113,8 @@ class FrmEntryShortcodeFormatter {
 	 * @since 2.05
 	 *
 	 * @param array $atts
+	 *
+	 * @return void
 	 */
 	protected function init_plain_text( $atts ) {
 		if ( isset( $atts['plain_text'] ) && $atts['plain_text'] ) {
@@ -121,6 +128,8 @@ class FrmEntryShortcodeFormatter {
 	 * @since 2.04
 	 *
 	 * @param array $atts
+	 *
+	 * @return void
 	 */
 	protected function init_format( $atts ) {
 		if ( isset( $atts['format'] ) && is_string( $atts['format'] ) && $atts['format'] !== '' ) {
@@ -134,6 +143,8 @@ class FrmEntryShortcodeFormatter {
 	 * Initialize the table_generator property
 	 *
 	 * @since 2.04
+	 *
+	 * @return void
 	 */
 	protected function init_table_generator() {
 		$this->table_generator = new FrmTableHTMLGenerator( 'shortcode' );
@@ -164,6 +175,8 @@ class FrmEntryShortcodeFormatter {
 	 * Return the default HTML array
 	 *
 	 * @since 2.04
+	 *
+	 * @return array
 	 */
 	protected function get_array() {
 		foreach ( $this->fields as $field ) {
@@ -177,6 +190,8 @@ class FrmEntryShortcodeFormatter {
 	 * Return the default plain text for an email message
 	 *
 	 * @since 2.04
+	 *
+	 * @return string
 	 */
 	protected function get_plain_text() {
 		return $this->generate_content_for_all_fields();
@@ -186,6 +201,8 @@ class FrmEntryShortcodeFormatter {
 	 * Return the default HTML for an email message
 	 *
 	 * @since 2.04
+	 *
+	 * @return string
 	 */
 	protected function get_table() {
 		$content = $this->table_generator->generate_table_header();
@@ -271,6 +288,8 @@ class FrmEntryShortcodeFormatter {
 	 * @since 2.04
 	 *
 	 * @param stdClass $field
+	 *
+	 * @return void
 	 */
 	protected function add_field_array( $field ) {
 		if ( in_array( $field->type, $this->skip_fields ) ) {
@@ -287,6 +306,8 @@ class FrmEntryShortcodeFormatter {
 	 *
 	 * @param stdClass $field
 	 * @param string $value
+	 *
+	 * @return void
 	 */
 	protected function add_single_field_array( $field, $value ) {
 		$array = array(

--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -305,7 +305,8 @@ class FrmEntryValidate {
 
 	/**
 	 * @param int $form_id
-	 * @return boolean
+	 *
+	 * @return bool|string
 	 */
 	private static function is_antispam_check( $form_id ) {
 		$aspm = new FrmAntiSpam( $form_id );

--- a/classes/models/FrmEntryValues.php
+++ b/classes/models/FrmEntryValues.php
@@ -76,6 +76,8 @@ class FrmEntryValues {
 	 * @since 2.04
 	 *
 	 * @param int|string $entry_id
+	 *
+	 * @return void
 	 */
 	protected function init_entry( $entry_id ) {
 		$this->entry = FrmEntry::getOne( $entry_id, true );
@@ -95,6 +97,8 @@ class FrmEntryValues {
 	 * Set the form_id property
 	 *
 	 * @since 2.04
+	 *
+	 * @return void
 	 */
 	protected function init_form_id() {
 		$this->form_id = (int) $this->entry->form_id;
@@ -106,6 +110,8 @@ class FrmEntryValues {
 	 * @since 2.04
 	 *
 	 * @param array $atts
+	 *
+	 * @return void
 	 */
 	protected function init_include_fields( $atts ) {
 
@@ -147,6 +153,8 @@ class FrmEntryValues {
 	 * @since 2.04
 	 *
 	 * @param array $atts
+	 *
+	 * @return void
 	 */
 	protected function init_exclude_fields( $atts ) {
 		$this->exclude_fields = $this->prepare_array_property( 'exclude_fields', $atts );
@@ -191,6 +199,8 @@ class FrmEntryValues {
 	 * Set the fields property
 	 *
 	 * @since 2.04
+	 *
+	 * @return void
 	 */
 	protected function init_fields() {
 		$this->fields = FrmField::get_all_for_form( $this->form_id, '', 'exclude', 'exclude' );
@@ -217,6 +227,8 @@ class FrmEntryValues {
 	 * Set the field_values property
 	 *
 	 * @since 2.04
+	 *
+	 * @return void
 	 */
 	protected function init_field_values() {
 		foreach ( $this->fields as $field ) {
@@ -241,6 +253,8 @@ class FrmEntryValues {
 	 * Set the user_info property
 	 *
 	 * @since 2.04
+	 *
+	 * @return void
 	 */
 	protected function init_user_info() {
 		if ( isset( $this->entry->description ) ) {
@@ -338,6 +352,8 @@ class FrmEntryValues {
 	 * @since 2.04
 	 *
 	 * @param stdClass $field
+	 *
+	 * @return void
 	 */
 	protected function add_field_values( $field ) {
 		$this->field_values[ $field->id ] = new FrmFieldValue( $field, $this->entry );

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -1074,7 +1074,7 @@ class FrmField {
 	/**
 	 * @param string $id
 	 *
-	 * @return string
+	 * @return null|string
 	 */
 	public static function get_key_by_id( $id ) {
 		return FrmDb::get_var( 'frm_fields', array( 'id' => $id ), 'field_key' );

--- a/classes/models/FrmFieldOption.php
+++ b/classes/models/FrmFieldOption.php
@@ -45,6 +45,8 @@ class FrmFieldOption {
 	 * Set the option label
 	 *
 	 * @since 2.03.05
+	 *
+	 * @return void
 	 */
 	private function set_option_label() {
 		if ( is_array( $this->option ) ) {
@@ -58,6 +60,8 @@ class FrmFieldOption {
 	 * Set the saved value
 	 *
 	 * @since 2.03.05
+	 *
+	 * @return void
 	 */
 	protected function set_saved_value() {
 		$this->saved_value = $this->option_label;
@@ -70,6 +74,8 @@ class FrmFieldOption {
 	 *
 	 * @param string $selected_value
 	 * @param int $truncate
+	 *
+	 * @return void
 	 */
 	public function print_single_option( $selected_value, $truncate ) {
 		if ( '' !== $this->saved_value ) {

--- a/classes/models/FrmFieldValue.php
+++ b/classes/models/FrmFieldValue.php
@@ -77,6 +77,8 @@ class FrmFieldValue {
 	 * @since 2.04
 	 *
 	 * @param stdClass $entry
+	 *
+	 * @return void
 	 */
 	protected function init_saved_value( $entry ) {
 		if ( $this->field->type === 'html' ) {
@@ -96,6 +98,8 @@ class FrmFieldValue {
 	 * @since 2.05
 	 *
 	 * @param array $atts
+	 *
+	 * @return void
 	 */
 	public function prepare_displayed_value( $atts = array() ) {
 		$this->displayed_value = $this->saved_value;
@@ -108,6 +112,8 @@ class FrmFieldValue {
 	 * Get a value from the field settings
 	 *
 	 * @since 2.05.06
+	 *
+	 * @param string $value
 	 */
 	public function get_field_option( $value ) {
 		return FrmField::get_option( $this->field, $value );
@@ -115,6 +121,8 @@ class FrmFieldValue {
 
 	/**
 	 * @since 4.03
+	 *
+	 * @param string $option
 	 */
 	public function get_field_attr( $option ) {
 		return is_object( $this->field ) ? $this->field->{$option} : '';
@@ -122,6 +130,8 @@ class FrmFieldValue {
 
 	/**
 	 * @since 4.03
+	 *
+	 * @return stdClass
 	 */
 	public function get_field() {
 		return $this->field;
@@ -208,6 +218,8 @@ class FrmFieldValue {
 	 * @since 2.04
 	 *
 	 * @param array $atts
+	 *
+	 * @return void
 	 */
 	protected function filter_displayed_value( $atts ) {
 		if ( ! is_object( $this->entry ) || empty( $this->entry->metas ) ) {
@@ -258,6 +270,8 @@ class FrmFieldValue {
 	 * Clean a field's saved value
 	 *
 	 * @since 2.04
+	 *
+	 * @return void
 	 */
 	protected function clean_saved_value() {
 		if ( $this->saved_value !== '' ) {

--- a/classes/models/FrmFieldValueSelector.php
+++ b/classes/models/FrmFieldValueSelector.php
@@ -102,6 +102,8 @@ class FrmFieldValueSelector {
 	 * Set the db_row property
 	 *
 	 * @since 2.03.05
+	 *
+	 * @return void
 	 */
 	private function set_db_row() {
 		$where = array(
@@ -119,6 +121,8 @@ class FrmFieldValueSelector {
 	 * Set the field_key property
 	 *
 	 * @since 2.03.05
+	 *
+	 * @return void
 	 */
 	private function set_field_key() {
 		$this->field_key = $this->db_row->field_key;
@@ -128,6 +132,8 @@ class FrmFieldValueSelector {
 	 * Set the field_settings property
 	 *
 	 * @since 2.03.05
+	 *
+	 * @return void
 	 */
 	protected function set_field_settings() {
 		// Leave as null for free version
@@ -137,6 +143,8 @@ class FrmFieldValueSelector {
 	 * Set the options property
 	 *
 	 * @since 2.03.05
+	 *
+	 * @return void
 	 */
 	protected function set_options() {
 		$field_obj     = FrmFieldFactory::get_field_object( $this->db_row );
@@ -149,6 +157,8 @@ class FrmFieldValueSelector {
 	 * @since 2.03.05
 	 *
 	 * @param array $args
+	 *
+	 * @return void
 	 */
 	protected function set_html_name( $args ) {
 		if ( isset( $args['html_name'] ) ) {
@@ -162,6 +172,8 @@ class FrmFieldValueSelector {
 	 * @since 2.03.05
 	 *
 	 * @param array $args
+	 *
+	 * @return void
 	 */
 	protected function set_value( $args ) {
 		if ( isset( $args['value'] ) ) {
@@ -175,6 +187,8 @@ class FrmFieldValueSelector {
 	 * @since 2.03.05
 	 *
 	 * @param array $args
+	 *
+	 * @return void
 	 */
 	protected function set_source( $args ) {
 		if ( isset( $args['source'] ) ) {
@@ -208,6 +222,8 @@ class FrmFieldValueSelector {
 	 * Display the field value selector (dropdown or text field)
 	 *
 	 * @since 2.03.05
+	 *
+	 * @return void
 	 */
 	public function display() {
 		if ( $this->has_options() ) {
@@ -221,6 +237,8 @@ class FrmFieldValueSelector {
 	 * Print the field value text box
 	 *
 	 * @since 2.03.05
+	 *
+	 * @return void
 	 */
 	public function display_text_box() {
 		echo '<input type="text" name="' . esc_attr( $this->html_name ) . '" value="' . esc_attr( trim( $this->value ) ) . '" />';
@@ -230,6 +248,8 @@ class FrmFieldValueSelector {
 	 * Display the field value selector
 	 *
 	 * @since 2.03.05
+	 *
+	 * @return void
 	 */
 	protected function display_dropdown() {
 		echo '<select name="' . esc_attr( $this->html_name ) . '">';

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -7,7 +7,7 @@ class FrmForm {
 
 	/**
 	 * @param array $values
-	 * @return int|boolean id on success or false on failure
+	 * @return int|bool id on success or false on failure.
 	 */
 	public static function create( $values ) {
 		global $wpdb;
@@ -808,7 +808,11 @@ class FrmForm {
 	 * Get all published forms
 	 *
 	 * @since 2.0
-	 * @return array of forms
+	 *
+	 * @param array  $query
+	 * @param int    $limit
+	 * @param string $inc_children
+	 * @return array|object of forms A single form object would be passed if $limit was set to 1.
 	 */
 	public static function get_published_forms( $query = array(), $limit = 999, $inc_children = 'exclude' ) {
 		$query['is_template'] = 0;

--- a/classes/models/FrmFormAction.php
+++ b/classes/models/FrmFormAction.php
@@ -50,6 +50,9 @@ class FrmFormAction {
 		return array();
 	}
 
+	/**
+	 * @return array
+	 */
 	public function get_switch_fields() {
 		return array();
 	}
@@ -201,11 +204,18 @@ class FrmFormAction {
 
 	// Private Function. Don't worry about this.
 
+	/**
+	 * @param int|string $number
+	 * @return void
+	 */
 	public function _set( $number ) {
 		$this->number = $number;
 		$this->id     = $this->id_base . '-' . $number;
 	}
 
+	/**
+	 * @return object
+	 */
 	public function prepare_new( $form_id = false ) {
 		if ( $form_id ) {
 			$this->form_id = $form_id;
@@ -244,6 +254,9 @@ class FrmFormAction {
 		return $this->save_settings( $action );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function duplicate_form_actions( $form_id, $old_id ) {
 		if ( $form_id == $old_id ) {
 			// don't duplicate the actions if this is a template getting updated
@@ -281,6 +294,9 @@ class FrmFormAction {
 		return $post_id;
 	}
 
+	/**
+	 * @param object $action
+	 */
 	public function duplicate_one( $action, $form_id ) {
 		global $frm_duplicate_ids;
 
@@ -509,8 +525,11 @@ class FrmFormAction {
 
 	/**
 	 * @since 3.04
+	 *
 	 * @param array  $args
 	 * @param string $default_status
+	 *
+	 * @return void
 	 */
 	protected static function prepare_get_action( &$args, $default_status = 'publish' ) {
 		if ( is_numeric( $args ) ) {
@@ -599,6 +618,9 @@ class FrmFormAction {
 		return $settings;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function action_args( $form_id = 0, $limit = 99 ) {
 		$args = array(
 			'post_type'   => FrmFormActionsController::$action_post_type,
@@ -615,6 +637,9 @@ class FrmFormAction {
 		return $args;
 	}
 
+	/**
+	 * @param WP_Post|array $action
+	 */
 	public function prepare_action( $action ) {
 		$action->post_content = (array) FrmAppHelper::maybe_json_decode( $action->post_content );
 		$action->post_excerpt = sanitize_title( $action->post_excerpt );
@@ -640,6 +665,9 @@ class FrmFormAction {
 		return $action;
 	}
 
+	/**
+	 * @return void
+	 */
 	public function destroy( $form_id = false, $type = 'default' ) {
 		global $wpdb;
 
@@ -665,6 +693,8 @@ class FrmFormAction {
 	 * Delete the action cache when a form action is created, deleted, or updated
 	 *
 	 * @since 2.0.5
+	 *
+	 * @return void
 	 */
 	public static function clear_cache() {
 		FrmDb::cache_delete_group( 'frm_actions' );
@@ -674,6 +704,9 @@ class FrmFormAction {
 		return self::get_action_for_form( $this->form_id, $this->id_base );
 	}
 
+	/**
+	 * @return array
+	 */
 	public function get_global_defaults() {
 		$defaults = $this->get_defaults();
 
@@ -793,9 +826,12 @@ class FrmFormAction {
 	 * Prepare the logic value for comparison against the entered value
 	 *
 	 * @since 2.01.02
+	 *
 	 * @deprecated 4.06.02
 	 *
 	 * @param array|string $logic_value
+	 *
+	 * @return void
 	 */
 	private static function prepare_logic_value( &$logic_value, $action, $entry ) {
 		if ( is_array( $logic_value ) ) {
@@ -845,6 +881,11 @@ class FrmFormAction {
 		return $observed_value;
 	}
 
+	/**
+	 * @param string $class
+	 *
+	 * @return array
+	 */
 	public static function default_action_opts( $class = '' ) {
 		return array(
 			'classes' => 'frm_icon_font ' . $class,
@@ -865,6 +906,9 @@ class FrmFormAction {
 		return apply_filters( 'frm_action_triggers', $triggers );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function render_conditional_logic_call_to_action() {
 		?>
 			<h3>
@@ -875,6 +919,9 @@ class FrmFormAction {
 		<?php
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function get_upgrade_text() {
 		return __( 'Conditional form actions', 'formidable' );
 	}

--- a/classes/models/FrmFormApi.php
+++ b/classes/models/FrmFormApi.php
@@ -26,6 +26,8 @@ class FrmFormApi {
 
 	/**
 	 * @since 3.06
+	 *
+	 * @return void
 	 */
 	private function set_license( $license ) {
 		if ( $license === null ) {
@@ -47,6 +49,8 @@ class FrmFormApi {
 
 	/**
 	 * @since 3.06
+	 *
+	 * @return void
 	 */
 	protected function set_cache_key() {
 		$this->cache_key = 'frm_addons_l' . ( empty( $this->license ) ? '' : md5( $this->license ) );
@@ -122,6 +126,8 @@ class FrmFormApi {
 
 	/**
 	 * @since 3.06
+	 *
+	 * @return string
 	 */
 	protected function api_url() {
 		return 'https://formidableforms.com/wp-json/s11edd/v1/updates/';
@@ -129,6 +135,8 @@ class FrmFormApi {
 
 	/**
 	 * @since 3.06
+	 *
+	 * @return string[]
 	 */
 	protected function skip_categories() {
 		return array( 'WordPress Form Templates', 'WordPress Form Style Templates' );
@@ -138,6 +146,7 @@ class FrmFormApi {
 	 * @since 3.06
 	 *
 	 * @param object $license_plugin The FrmAddon object
+	 * @param array $addons
 	 *
 	 * @return array
 	 */
@@ -199,6 +208,10 @@ class FrmFormApi {
 
 	/**
 	 * @since 3.06
+	 *
+	 * @param array $addons
+	 *
+	 * @return void
 	 */
 	protected function set_cached( $addons ) {
 		FrmAppHelper::filter_gmt_offset();
@@ -214,6 +227,8 @@ class FrmFormApi {
 
 	/**
 	 * @since 3.06
+	 *
+	 * @return void
 	 */
 	public function reset_cached() {
 		delete_option( $this->cache_key );

--- a/classes/models/FrmFormMigrator.php
+++ b/classes/models/FrmFormMigrator.php
@@ -370,7 +370,7 @@ abstract class FrmFormMigrator {
 	 *              the name key is a must. The keys are the column
 	 *              names of the forms table in the DB.
 	 *
-	 * @return int The ID of the newly created form.
+	 * @return bool|int The ID of the newly created form or false on failure.
 	 */
 	protected function create_form( $form ) {
 		$form['form_key'] = $form['name'];

--- a/classes/models/FrmFormTemplateApi.php
+++ b/classes/models/FrmFormTemplateApi.php
@@ -18,6 +18,8 @@ class FrmFormTemplateApi extends FrmFormApi {
 
 	/**
 	 * @since 3.06
+	 *
+	 * @return void
 	 */
 	protected function set_cache_key() {
 		$this->cache_key = 'frm_form_templates_l';
@@ -34,6 +36,8 @@ class FrmFormTemplateApi extends FrmFormApi {
 
 	/**
 	 * @since 3.06
+	 *
+	 * @return string
 	 */
 	protected function api_url() {
 		$url = self::$base_api_url . 'list';
@@ -52,6 +56,8 @@ class FrmFormTemplateApi extends FrmFormApi {
 
 	/**
 	 * @since 3.06
+	 *
+	 * @return array
 	 */
 	protected function skip_categories() {
 		return array();
@@ -72,6 +78,8 @@ class FrmFormTemplateApi extends FrmFormApi {
 	 * Check to make sure the free code is being used.
 	 *
 	 * @since 4.09.02
+	 *
+	 * @return bool
 	 */
 	public function has_free_access() {
 		$free_access = $this->get_free_license();
@@ -86,6 +94,8 @@ class FrmFormTemplateApi extends FrmFormApi {
 
 	/**
 	 * @param string $code the code from the email sent for the API
+	 *
+	 * @return void
 	 */
 	private static function verify_code( $code ) {
 		$base64_code = base64_encode( $code );
@@ -104,12 +114,17 @@ class FrmFormTemplateApi extends FrmFormApi {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	private static function clear_template_cache_before_getting_free_templates() {
 		delete_option( 'frm_form_templates_l' );
 	}
 
 	/**
 	 * @param array $response
+	 *
+	 * @return void
 	 */
 	private static function handle_verify_response_errors_if_any( $response ) {
 		if ( is_wp_error( $response ) ) {
@@ -123,6 +138,8 @@ class FrmFormTemplateApi extends FrmFormApi {
 
 	/**
 	 * @param string $code the base64 encoded code
+	 *
+	 * @return void
 	 */
 	private static function on_api_verify_code_success( $code ) {
 		self::$free_license = $code;
@@ -163,6 +180,8 @@ class FrmFormTemplateApi extends FrmFormApi {
 
 	/**
 	 * AJAX Hook for signing free users up for a template API key
+	 *
+	 * @return void
 	 */
 	public static function signup() {
 		$code = FrmAppHelper::get_param( 'code', '', 'post' );

--- a/classes/models/FrmHoneypot.php
+++ b/classes/models/FrmHoneypot.php
@@ -53,6 +53,8 @@ class FrmHoneypot extends FrmValidate {
 
 	/**
 	 * @param int $form_id
+	 *
+	 * @return void
 	 */
 	public static function maybe_render_field( $form_id ) {
 		$honeypot = new self( $form_id );
@@ -68,6 +70,9 @@ class FrmHoneypot extends FrmValidate {
 		return $this->is_option_on() && $this->check_honeypot_filter();
 	}
 
+	/**
+	 * @return void
+	 */
 	public function render_field() {
 		$honeypot = $this->check_honeypot_setting();
 		$form     = $this->get_form();

--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -29,6 +29,8 @@ class FrmInbox extends FrmFormApi {
 
 	/**
 	 * @since 4.05
+	 *
+	 * @return void
 	 */
 	protected function set_cache_key() {
 		$this->cache_key = 'frm_inbox_cache';
@@ -36,6 +38,8 @@ class FrmInbox extends FrmFormApi {
 
 	/**
 	 * @since 4.05
+	 *
+	 * @return string
 	 */
 	protected function api_url() {
 		return 'https://formidableforms.com/wp-json/inbox/v1/message/';
@@ -43,6 +47,8 @@ class FrmInbox extends FrmFormApi {
 
 	/**
 	 * @since 4.05
+	 *
+	 * @param false|string $filter
 	 */
 	public function get_messages( $filter = false ) {
 		$messages = self::$messages;
@@ -54,6 +60,8 @@ class FrmInbox extends FrmFormApi {
 
 	/**
 	 * @since 4.05
+	 *
+	 * @return void
 	 */
 	public function set_messages() {
 		self::$messages = get_option( $this->option );
@@ -71,6 +79,8 @@ class FrmInbox extends FrmFormApi {
 
 	/**
 	 * @since 4.05
+	 *
+	 * @return void
 	 */
 	private function add_api_messages() {
 		$api = $this->get_api_info();
@@ -85,6 +95,8 @@ class FrmInbox extends FrmFormApi {
 
 	/**
 	 * @param array|string $message
+	 *
+	 * @return void
 	 */
 	public function add_message( $message ) {
 		if ( ! is_array( $message ) || ! isset( $message['key'] ) ) {
@@ -115,6 +127,11 @@ class FrmInbox extends FrmFormApi {
 		$this->clean_messages();
 	}
 
+	/**
+	 * @param array $message
+	 *
+	 * @return void
+	 */
 	private function fill_message( &$message ) {
 		$defaults = array(
 			'time'    => time(),
@@ -133,6 +150,9 @@ class FrmInbox extends FrmFormApi {
 		unset( $message['time'] );
 	}
 
+	/**
+	 * @return void
+	 */
 	private function clean_messages() {
 		$removed = false;
 		foreach ( self::$messages as $t => $message ) {
@@ -150,6 +170,9 @@ class FrmInbox extends FrmFormApi {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	private function filter_messages( &$messages ) {
 		$user_id = get_current_user_id();
 		foreach ( $messages as $k => $message ) {
@@ -163,6 +186,11 @@ class FrmInbox extends FrmFormApi {
 		$messages = apply_filters( 'frm_filter_inbox', $messages );
 	}
 
+	/**
+	 * @param array $message
+	 *
+	 * @return bool
+	 */
 	private function is_expired( $message ) {
 		return isset( $message['expires'] ) && ! empty( $message['expires'] ) && $message['expires'] < time();
 	}
@@ -194,6 +222,8 @@ class FrmInbox extends FrmFormApi {
 
 	/**
 	 * @param string $key
+	 *
+	 * @return void
 	 */
 	public function mark_read( $key ) {
 		if ( ! $key || ! isset( self::$messages[ $key ] ) ) {
@@ -212,6 +242,8 @@ class FrmInbox extends FrmFormApi {
 	 * @param string $key
 	 *
 	 * @since 4.05.02
+	 *
+	 * @return void
 	 */
 	public function mark_unread( $key ) {
 		$is_read = isset( self::$messages[ $key ] ) && isset( self::$messages[ $key ]['read'] ) && isset( self::$messages[ $key ]['read'][ get_current_user_id() ] );
@@ -223,6 +255,8 @@ class FrmInbox extends FrmFormApi {
 
 	/**
 	 * @param string $key
+	 *
+	 * @return void
 	 */
 	public function dismiss( $key ) {
 		if ( $key === 'all' ) {
@@ -244,6 +278,8 @@ class FrmInbox extends FrmFormApi {
 
 	/**
 	 * @since 4.06
+	 *
+	 * @return void
 	 */
 	private function dismiss_all() {
 		$user_id = get_current_user_id();
@@ -286,6 +322,10 @@ class FrmInbox extends FrmFormApi {
 
 	/**
 	 * @since 4.05.02
+	 *
+	 * @param string $key
+	 *
+	 * @return void
 	 */
 	public function remove( $key ) {
 		if ( isset( self::$messages[ $key ] ) ) {
@@ -294,6 +334,9 @@ class FrmInbox extends FrmFormApi {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	private function update_list() {
 		update_option( $this->option, self::$messages, 'no' );
 	}
@@ -312,6 +355,9 @@ class FrmInbox extends FrmFormApi {
 		return true;
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function maybe_disable_screen_options() {
 		self::$banner_messages = self::get_banner_messages();
 		if ( self::$banner_messages ) {

--- a/classes/models/FrmInstallPlugin.php
+++ b/classes/models/FrmInstallPlugin.php
@@ -30,18 +30,30 @@ class FrmInstallPlugin {
 		return $url;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function is_installed() {
 		return is_dir( WP_PLUGIN_DIR . '/' . $this->plugin_slug );
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function is_active() {
 		return is_plugin_active( $this->plugin_file );
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function install_url() {
 		return wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=' . $this->plugin_slug ), 'install-plugin_' . $this->plugin_slug );
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function activate_url() {
 		return wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin=' . $this->plugin_file ), 'activate-plugin_' . $this->plugin_file );
 	}

--- a/classes/models/FrmNotification.php
+++ b/classes/models/FrmNotification.php
@@ -14,6 +14,8 @@ class FrmNotification {
 	 * @param object $action
 	 * @param object $entry
 	 * @param object $form
+	 *
+	 * @return void
 	 */
 	public static function trigger_email( $action, $entry, $form ) {
 		$email = new FrmEmail( $action, $entry, $form );
@@ -33,6 +35,8 @@ class FrmNotification {
 	 * Remove the trigger_email function from the frm_trigger_email_action hook
 	 *
 	 * @since 2.03.04
+	 *
+	 * @return void
 	 */
 	public static function stop_emails() {
 		remove_action( 'frm_trigger_email_action', 'FrmNotification::trigger_email', 10 );
@@ -42,6 +46,8 @@ class FrmNotification {
 	 * Hook the trigger_email function to frm_trigger_email_action action
 	 *
 	 * @since 2.03.04
+	 *
+	 * @return void
 	 */
 	public static function hook_emails_to_action() {
 		add_action( 'frm_trigger_email_action', 'FrmNotification::trigger_email', 10, 3 );
@@ -53,6 +59,8 @@ class FrmNotification {
 	 * @since 2.03.04
 	 *
 	 * @param array $atts
+	 *
+	 * @return void
 	 */
 	private static function print_recipients( $atts ) {
 		if ( apply_filters( 'frm_echo_emails', false ) ) {

--- a/classes/models/FrmOnSubmitAction.php
+++ b/classes/models/FrmOnSubmitAction.php
@@ -31,10 +31,16 @@ class FrmOnSubmitAction extends FrmFormAction {
 		parent::__construct( self::$slug, self::get_name(), $action_ops );
 	}
 
+	/**
+	 * @return string
+	 */
 	public static function get_name() {
 		return __( 'Confirmation', 'formidable' );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function form( $instance, $args = array() ) {
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-form-actions/on_submit_settings.php';
 	}

--- a/classes/models/FrmPersonalData.php
+++ b/classes/models/FrmPersonalData.php
@@ -50,6 +50,9 @@ class FrmPersonalData {
 		return $erasers;
 	}
 
+	/**
+	 * @return array
+	 */
 	public function export_data( $email, $page = 1 ) {
 		$this->page = absint( $page );
 

--- a/classes/models/FrmPluginSearch.php
+++ b/classes/models/FrmPluginSearch.php
@@ -29,6 +29,8 @@ class FrmPluginSearch {
 	 * @param object $screen WP Screen object.
 	 *
 	 * @since 4.12
+	 *
+	 * @return void
 	 */
 	public function start( $screen ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -47,6 +49,8 @@ class FrmPluginSearch {
 	 * @param object $result Plugin search results.
 	 * @param string $action unused.
 	 * @param object $args Search args.
+	 *
+	 * @return object
 	 */
 	public function inject_suggestion( $result, $action, $args ) {
 		// Looks like a search query; it's matching time.
@@ -101,7 +105,10 @@ class FrmPluginSearch {
 	 *
 	 * @since 4.12
 	 *
-	 * @return int
+	 * @param array $addon_list
+	 * @param array $normalized_term
+	 *
+	 * @return int|null
 	 */
 	private function matching_addon( $addon_list, $normalized_term ) {
 		$matching_addon = null;
@@ -189,6 +196,8 @@ class FrmPluginSearch {
 
 	/**
 	 * @since 4.12
+	 *
+	 * @return void
 	 */
 	private function maybe_dismiss() {
 		$addon = FrmAppHelper::get_param( 'frm-dismiss', '', 'get', 'absint' );
@@ -267,6 +276,7 @@ class FrmPluginSearch {
 	/**
 	 * @since 4.12
 	 *
+	 * @param string $terms
 	 * @return array
 	 */
 	private function search_to_array( $terms ) {
@@ -279,6 +289,8 @@ class FrmPluginSearch {
 	 *
 	 * @param array $links Related links.
 	 * @param array $plugin Plugin result information.
+	 *
+	 * @return (mixed|string)[]
 	 */
 	public function insert_related_links( $links, $plugin ) {
 		if ( self::$slug !== $plugin['slug'] ) {
@@ -344,6 +356,8 @@ class FrmPluginSearch {
 
 	/**
 	 * Load the search scripts and CSS for PSH.
+	 *
+	 * @return void
 	 */
 	public function load_plugins_search_script() {
 		wp_enqueue_script( self::$slug, FrmAppHelper::plugin_url() . '/js/plugin-search.js', array(), FrmAppHelper::plugin_version(), true );

--- a/classes/models/FrmReviews.php
+++ b/classes/models/FrmReviews.php
@@ -15,6 +15,8 @@ class FrmReviews {
 	 * Add admin notices as needed for reviews
 	 *
 	 * @since 3.04.03
+	 *
+	 * @return void
 	 */
 	public function review_request() {
 
@@ -43,6 +45,8 @@ class FrmReviews {
 	 * When was the review request last dismissed?
 	 *
 	 * @since 3.04.03
+	 *
+	 * @return void
 	 */
 	private function set_review_status() {
 		$user_id = get_current_user_id();
@@ -67,6 +71,8 @@ class FrmReviews {
 	 * Maybe show review request
 	 *
 	 * @since 3.04.03
+	 *
+	 * @return void
 	 */
 	private function review() {
 
@@ -116,6 +122,13 @@ class FrmReviews {
 		include( FrmAppHelper::plugin_path() . '/classes/views/shared/review.php' );
 	}
 
+	/**
+	 * @param string $title
+	 * @param string $name
+	 * @param int    $asked
+	 *
+	 * @return void
+	 */
 	private function add_to_inbox( $title, $name, $asked ) {
 		$message = new FrmInbox();
 		$requests = $message->get_messages();
@@ -156,6 +169,8 @@ class FrmReviews {
 	 * If there are already later requests, don't add it to the inbox again.
 	 *
 	 * @since 4.05.02
+	 *
+	 * @return bool
 	 */
 	private function has_later_request( $requests, $asked ) {
 		return isset( $requests[ $this->inbox_key . ( $asked + 1 ) ] ) || isset( $requests[ $this->inbox_key . ( $asked + 2 ) ] );
@@ -163,6 +178,8 @@ class FrmReviews {
 
 	/**
 	 * @since 4.05.02
+	 *
+	 * @return (mixed|string)[]
 	 */
 	private function inbox_keys() {
 		return array(
@@ -174,6 +191,8 @@ class FrmReviews {
 
 	/**
 	 * @since 4.05.01
+	 *
+	 * @return void
 	 */
 	private function set_inbox_dismissed() {
 		$message = new FrmInbox();
@@ -184,6 +203,8 @@ class FrmReviews {
 
 	/**
 	 * @since 4.05.01
+	 *
+	 * @return void
 	 */
 	private function set_inbox_read() {
 		$message = new FrmInbox();
@@ -196,6 +217,8 @@ class FrmReviews {
 	 * Save the request to hide the review
 	 *
 	 * @since 3.04.03
+	 *
+	 * @return void
 	 */
 	public function dismiss_review() {
 		FrmAppHelper::permission_check( 'frm_change_settings' );

--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -132,6 +132,9 @@ class FrmSettings {
 		);
 	}
 
+	/**
+	 * @return void
+	 */
 	private function set_default_options() {
 		$this->fill_captcha_settings();
 
@@ -220,6 +223,9 @@ class FrmSettings {
 		return $value;
 	}
 
+	/**
+	 * @return void
+	 */
 	private function fill_captcha_settings() {
 		if ( ! isset( $this->active_captcha ) ) {
 			$this->active_captcha = 'recaptcha';
@@ -265,6 +271,8 @@ class FrmSettings {
 	 * Get values that may be shown on the front-end without an override in the form settings.
 	 *
 	 * @since 3.06.01
+	 *
+	 * @return string[]
 	 */
 	public function translatable_strings() {
 		return array(
@@ -279,6 +287,8 @@ class FrmSettings {
 	 * Allow strings to be filtered when a specific form may be displaying them.
 	 *
 	 * @since 3.06.01
+	 *
+	 * @return void
 	 */
 	public function maybe_filter_for_form( $args ) {
 		if ( isset( $args['current_form'] ) && is_numeric( $args['current_form'] ) ) {
@@ -290,10 +300,19 @@ class FrmSettings {
 		}
 	}
 
+	/**
+	 * @param array $params
+	 * @param array $errors
+	 */
 	public function validate( $params, $errors ) {
 		return apply_filters( 'frm_validate_settings', $errors, $params );
 	}
 
+	/**
+	 * @param array $params
+	 *
+	 * @return void
+	 */
 	public function update( $params ) {
 		$this->fill_with_defaults( $params );
 		$this->update_settings( $params );
@@ -315,6 +334,9 @@ class FrmSettings {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	private function update_settings( $params ) {
 		$this->active_captcha   = $params['frm_active_captcha'];
 		$this->hcaptcha_pubkey  = trim( $params['frm_hcaptcha_pubkey'] );
@@ -333,6 +355,9 @@ class FrmSettings {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	private function update_roles( $params ) {
 		global $wp_roles;
 
@@ -356,6 +381,9 @@ class FrmSettings {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	public function store() {
 		// Save the posted value in the database
 

--- a/classes/models/FrmSolution.php
+++ b/classes/models/FrmSolution.php
@@ -42,6 +42,8 @@ class FrmSolution {
 	 * Register all WP hooks.
 	 *
 	 * @since 4.06.02
+	 *
+	 * @return void
 	 */
 	public function load_hooks() {
 		// If user is in admin ajax or doing cron, return.
@@ -81,6 +83,8 @@ class FrmSolution {
 	 * not actually show. Sneaky, sneaky.
 	 *
 	 * @since 4.06.02
+	 *
+	 * @return void
 	 */
 	public function register() {
 
@@ -100,19 +104,32 @@ class FrmSolution {
 	 * This means the pages are still available to us, but hidden.
 	 *
 	 * @since 4.06.02
+	 *
+	 * @return void
 	 */
 	public function hide_menu() {
 		remove_submenu_page( 'index.php', $this->page );
 	}
 
+	/**
+	 * @return string
+	 *
+	 * @psalm-return ''
+	 */
 	protected function plugin_name() {
 		return '';
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function page_title() {
 		return __( 'Welcome to Formidable Forms', 'formidable' );
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function page_description() {
 		return __( 'Follow the steps below to get started.', 'formidable' );
 	}
@@ -124,6 +141,8 @@ class FrmSolution {
 	 * then we redirect the user to the appropriate page.
 	 *
 	 * @since 4.06.02
+	 *
+	 * @return void
 	 */
 	public function redirect() {
 
@@ -150,6 +169,9 @@ class FrmSolution {
 		exit;
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function settings_link() {
 		return admin_url( 'index.php?page=' . $this->page );
 	}
@@ -171,6 +193,9 @@ class FrmSolution {
 
 	/*
 	 * Output for global settings.
+	 */
+	/**
+	 * @return void
 	 */
 	public function settings_page() {
 		$steps = $this->get_steps_data();
@@ -209,6 +234,8 @@ class FrmSolution {
 
 	/**
 	 * Getting Started screen. Shows after first install.
+	 *
+	 * @return void
 	 */
 	public function output() {
 		FrmAppHelper::include_svg();
@@ -225,6 +252,8 @@ class FrmSolution {
 
 	/**
 	 * Heading section.
+	 *
+	 * @return void
 	 */
 	protected function header() {
 		$size = array(
@@ -262,6 +291,8 @@ class FrmSolution {
 	/**
 	 * This is the welcome page content.
 	 * Override me to insert different content.
+	 *
+	 * @return void
 	 */
 	protected function main_content() {
 		$steps = $this->get_steps_data();
@@ -337,6 +368,11 @@ class FrmSolution {
 		return $steps;
 	}
 
+	/**
+	 * @param array $steps
+	 *
+	 * @return void
+	 */
 	protected function adjust_plugin_install_step( &$steps ) {
 		$plugins = $this->required_plugins();
 		if ( empty( $plugins ) ) {
@@ -379,6 +415,9 @@ class FrmSolution {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function step_top( $step ) {
 		$section_class = ( ! isset( $step['current'] ) || ! $step['current'] ) ? 'frm_grey' : '';
 
@@ -414,6 +453,9 @@ class FrmSolution {
 		<?php
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function step_bottom( $step ) {
 		?>
 			</div>
@@ -423,6 +465,8 @@ class FrmSolution {
 
 	/**
 	 * Generate and output Connect step section HTML.
+	 *
+	 * @return void
 	 */
 	protected function license_box( $step ) {
 		$this->step_top( $step );
@@ -440,6 +484,9 @@ class FrmSolution {
 		$this->step_bottom( $step );
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function show_plugin_install( $step ) {
 		$this->step_top( $step );
 
@@ -456,6 +503,9 @@ class FrmSolution {
 		$this->step_bottom( $step );
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function show_app_install( $step ) {
 		$is_complete = $step['complete'];
 		if ( ! empty( $this->form_options() ) && ! $is_complete ) {
@@ -530,14 +580,27 @@ class FrmSolution {
 		$this->step_bottom( $step );
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function show_form_options( $xml ) {
 		$this->show_import_options( $this->form_options(), 'form', $xml );
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function show_view_options() {
 		$this->show_import_options( $this->view_options(), 'view' );
 	}
 
+	/**
+	 * @param string $importing
+	 *
+	 * @psalm-param 'form'|'view' $importing
+	 *
+	 * @return void
+	 */
 	protected function show_import_options( $options, $importing, $xml = '' ) {
 		if ( empty( $options ) ) {
 			return;
@@ -559,6 +622,9 @@ class FrmSolution {
 		include( FrmAppHelper::plugin_path() . '/classes/views/solutions/_import.php' );
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function show_page_options() {
 		$pages = $this->needed_pages();
 		if ( empty( $pages ) ) {
@@ -578,6 +644,9 @@ class FrmSolution {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function show_page_links( $step ) {
 		if ( $step['current'] ) {
 			return;
@@ -596,6 +665,8 @@ class FrmSolution {
 
 	/**
 	 * Only show the content for the correct plugin.
+	 *
+	 * @return bool
 	 */
 	protected function is_current_plugin() {
 		$to_redirect = get_transient( 'frm_activation_redirect' );
@@ -604,6 +675,12 @@ class FrmSolution {
 
 	/**
 	 * Override this function to indicate when install is complete.
+	 *
+	 * @param int|string $count
+	 *
+	 * @psalm-param 'all'|1 $count
+	 *
+	 * @return bool
 	 */
 	protected function is_complete( $count = 1 ) {
 		$imported = $this->previously_imported_forms();
@@ -633,6 +710,8 @@ class FrmSolution {
 
 	/**
 	 * In the new plugin has any dependencies, include them here.
+	 *
+	 * @return array
 	 */
 	protected function required_plugins() {
 		return array();
@@ -640,6 +719,8 @@ class FrmSolution {
 
 	/**
 	 * This needs to be overridden.
+	 *
+	 * @return int
 	 */
 	protected function download_id() {
 		return 0;
@@ -647,6 +728,8 @@ class FrmSolution {
 
 	/**
 	 * Give options for which forms to import.
+	 *
+	 * @return array
 	 */
 	protected function form_options() {
 		/**
@@ -664,6 +747,8 @@ class FrmSolution {
 
 	/**
 	 * Give options for which view to use.
+	 *
+	 * @return array
 	 */
 	protected function view_options() {
 		return array();
@@ -671,6 +756,8 @@ class FrmSolution {
 
 	/**
 	 * If the pages aren't imported automatically, set the page names.
+	 *
+	 * @return array
 	 */
 	protected function needed_pages() {
 		/**
@@ -687,6 +774,9 @@ class FrmSolution {
 		return array();
 	}
 
+	/**
+	 * @return void
+	 */
 	private function css() {
 		wp_enqueue_style( 'formidable-pro-fields' );
 		?>

--- a/classes/models/FrmStyle.php
+++ b/classes/models/FrmStyle.php
@@ -45,6 +45,9 @@ class FrmStyle {
 		return FrmDb::save_settings( $settings, 'frm_styles' );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function duplicate( $id ) {
 		// Duplicating is a pro feature. This is handled in FrmProStyle::duplicate instead.
 	}
@@ -244,11 +247,13 @@ class FrmStyle {
 
 	/**
 	 * @since 3.01.01
+	 *
+	 * @param string $setting
+	 * @return bool
 	 */
 	private function is_color( $setting ) {
 		$extra_colors = array( 'error_bg', 'error_border', 'error_text' );
-
-		return strpos( $setting, 'color' ) !== false || in_array( $setting, $extra_colors );
+		return strpos( $setting, 'color' ) !== false || in_array( $setting, $extra_colors, true );
 	}
 
 	/**
@@ -443,6 +448,9 @@ class FrmStyle {
 		return $styles;
 	}
 
+	/**
+	 * @param array|null $styles
+	 */
 	public function get_default_style( $styles = null ) {
 		if ( ! isset( $styles ) ) {
 			$styles = $this->get_all( 'menu_order', 'DESC', 1 );

--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -83,6 +83,7 @@ class FrmTableHTMLGenerator {
 	 * @since 2.04
 	 *
 	 * @param array $atts
+	 * @return void
 	 */
 	private function init_style_settings( $atts ) {
 		$style_settings       = array(
@@ -114,6 +115,7 @@ class FrmTableHTMLGenerator {
 	 * @since 2.04
 	 *
 	 * @param array $atts
+	 * @return void
 	 */
 	private function init_use_inline_style( $atts ) {
 		if ( isset( $atts['inline_style'] ) && ! $atts['inline_style'] ) {
@@ -127,6 +129,7 @@ class FrmTableHTMLGenerator {
 	 * @since 2.04
 	 *
 	 * @param array $atts
+	 * @return void
 	 */
 	private function init_direction( $atts ) {
 		if ( isset( $atts['direction'] ) && $atts['direction'] === 'rtl' ) {
@@ -138,6 +141,7 @@ class FrmTableHTMLGenerator {
 	 * Set the table_style property
 	 *
 	 * @since 2.04
+	 * @return void
 	 */
 	private function init_table_style() {
 		if ( $this->use_inline_style === true ) {
@@ -156,6 +160,7 @@ class FrmTableHTMLGenerator {
 	 * Set the td_style property
 	 *
 	 * @since 2.04
+	 * @return void
 	 */
 	private function init_td_style() {
 		if ( $this->use_inline_style === true ) {
@@ -238,6 +243,8 @@ class FrmTableHTMLGenerator {
 	 *
 	 * @since 2.04
 	 * @since 5.0.16 Changed scope from `private` to `protected`.
+	 *
+	 * @return void
 	 */
 	protected function switch_odd() {
 		if ( $this->type !== 'shortcode' ) {
@@ -325,7 +332,10 @@ class FrmTableHTMLGenerator {
 	 * Add classes to the tr.
 	 *
 	 * @since 5.4.2
+	 *
 	 * @param bool $empty If the value in the row is blank.
+	 *
+	 * @return string
 	 */
 	protected function add_row_class( $empty = false ) {
 		$class = '';

--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -10,6 +10,8 @@ class FrmUsage {
 
 	/**
 	 * @since 3.06.04
+	 *
+	 * @return void
 	 */
 	public function send_snapshot() {
 		if ( ! $this->tracking_allowed() ) {
@@ -155,6 +157,10 @@ class FrmUsage {
 	 * Include the permissions settings for each capability.
 	 *
 	 * @since 3.06.04
+	 *
+	 * @return array
+	 *
+	 * @param FrmSettings $settings_list
 	 * @return array
 	 */
 	private function messages( $settings_list ) {
@@ -181,6 +187,8 @@ class FrmUsage {
 	 * Include the permissions settings for each capability.
 	 *
 	 * @since 3.06.04
+	 *
+	 * @param FrmSettings $settings_list
 	 * @return array
 	 */
 	private function permissions( $settings_list ) {

--- a/classes/models/fields/FrmFieldCaptcha.php
+++ b/classes/models/fields/FrmFieldCaptcha.php
@@ -88,6 +88,9 @@ class FrmFieldCaptcha extends FrmFieldType {
 		return $replaced_for;
 	}
 
+	/**
+	 * @return string
+	 */
 	public function front_field_input( $args, $shortcode_atts ) {
 		$frm_settings = FrmAppHelper::get_settings();
 		if ( ! self::should_show_captcha() ) {
@@ -116,6 +119,9 @@ class FrmFieldCaptcha extends FrmFieldType {
 		return $html;
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function load_field_scripts( $args ) {
 		$api_js_url = $this->api_url();
 
@@ -132,6 +138,9 @@ class FrmFieldCaptcha extends FrmFieldType {
 		return $this->hcaptcha_api_url();
 	}
 
+	/**
+	 * @param FrmSettings $frm_settings
+	 */
 	protected function recaptcha_api_url( $frm_settings ) {
 		$api_js_url = 'https://www.google.com/recaptcha/api.js?';
 
@@ -165,6 +174,13 @@ class FrmFieldCaptcha extends FrmFieldType {
 		return $api_js_url;
 	}
 
+	/**
+	 * @param FrmSettings $frm_settings
+	 *
+	 * @return string
+	 *
+	 * @psalm-return ''|'frm-'
+	 */
 	protected function class_prefix( $frm_settings ) {
 		if ( $this->allow_multiple( $frm_settings ) && $frm_settings->active_captcha === 'recaptcha' ) {
 			$class_prefix = 'frm-';
@@ -175,6 +191,13 @@ class FrmFieldCaptcha extends FrmFieldType {
 		return $class_prefix;
 	}
 
+	/**
+	 * @param FrmSettings $frm_settings
+	 *
+	 * @return string
+	 *
+	 * @psalm-return 'g-recaptcha'|'h-captcha'
+	 */
 	protected function captcha_class( $frm_settings ) {
 		return $frm_settings->active_captcha === 'recaptcha' ? 'g-recaptcha' : 'h-captcha';
 	}
@@ -185,6 +208,8 @@ class FrmFieldCaptcha extends FrmFieldType {
 
 	/**
 	 * @return string
+	 *
+	 * @param FrmSettings $frm_settings
 	 */
 	protected function captcha_size( $frm_settings ) {
 		if ( in_array( $frm_settings->re_type, array( 'invisible', 'v3' ), true ) ) {
@@ -287,6 +312,9 @@ class FrmFieldCaptcha extends FrmFieldType {
 		return ! empty( $frm_settings->hcaptcha_pubkey );
 	}
 
+	/**
+	 * @return bool
+	 */
 	protected function should_validate() {
 		$is_hidden_field = apply_filters( 'frm_is_field_hidden', false, $this->field, wp_unslash( $_POST ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( FrmAppHelper::is_admin() || $is_hidden_field ) {
@@ -297,6 +325,9 @@ class FrmFieldCaptcha extends FrmFieldType {
 		return self::should_show_captcha();
 	}
 
+	/**
+	 * @param FrmSettings $frm_settings
+	 */
 	protected function send_api_check( $frm_settings ) {
 		$captcha_settings = new FrmFieldCaptchaSettings( $frm_settings );
 

--- a/classes/models/fields/FrmFieldCheckbox.php
+++ b/classes/models/fields/FrmFieldCheckbox.php
@@ -36,6 +36,9 @@ class FrmFieldCheckbox extends FrmFieldType {
 		return $this->include_front_form_file();
 	}
 
+	/**
+	 * @return string[]
+	 */
 	protected function new_field_settings() {
 		return array(
 			'options' => serialize(
@@ -59,6 +62,9 @@ class FrmFieldCheckbox extends FrmFieldType {
 		);
 	}
 
+	/**
+	 * @return array
+	 */
 	protected function extra_field_opts() {
 		$form_id = $this->get_field_column( 'form_id' );
 
@@ -69,15 +75,23 @@ class FrmFieldCheckbox extends FrmFieldType {
 
 	/**
 	 * @since 4.06
+	 *
+	 * @return void
 	 */
 	protected function show_priority_field_choices( $args = array() ) {
-		include( FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/radio-images.php' );
+		include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/radio-images.php';
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function include_front_form_file() {
 		return FrmAppHelper::plugin_path() . '/classes/views/frm-fields/front-end/checkbox-field.php';
 	}
 
+	/**
+	 * @return bool
+	 */
 	protected function show_readonly_hidden() {
 		return true;
 	}

--- a/classes/models/fields/FrmFieldCombo.php
+++ b/classes/models/fields/FrmFieldCombo.php
@@ -47,6 +47,8 @@ class FrmFieldCombo extends FrmFieldType {
 	 * Registers sub fields.
 	 *
 	 * @param array $sub_fields Sub fields. Accepts array or array or array of string.
+	 *
+	 * @return void
 	 */
 	protected function register_sub_fields( array $sub_fields ) {
 		$defaults = $this->get_default_sub_field();
@@ -131,7 +133,10 @@ class FrmFieldCombo extends FrmFieldType {
 	 * of the individual field labels.
 	 *
 	 * @since 4.0
+	 *
 	 * @param array $args Includes 'field', 'display'.
+	 *
+	 * @return void
 	 */
 	public function show_after_default( $args ) {
 		$field                = (array) $args['field'];
@@ -214,6 +219,8 @@ class FrmFieldCombo extends FrmFieldType {
 	 * Shows field on the form builder.
 	 *
 	 * @param string $name Field name.
+	 *
+	 * @return void
 	 */
 	public function show_on_form_builder( $name = '' ) {
 		$field = FrmFieldsHelper::setup_edit_vars( $this->field );
@@ -274,6 +281,8 @@ class FrmFieldCombo extends FrmFieldType {
 	 *     @type array  $errors         Field errors.
 	 *     @type bool   $remove_names   Remove name attribute or not.
 	 * }
+	 *
+	 * @return void
 	 */
 	protected function load_field_output( $args ) {
 		if ( empty( $args['field'] ) ) {
@@ -308,6 +317,8 @@ class FrmFieldCombo extends FrmFieldType {
 	 *     @type array  $errors         Field errors.
 	 *     @type bool   $remove_names   Remove name attribute or not.
 	 * }
+	 *
+	 * @return void
 	 */
 	protected function process_args_for_field_output( &$args ) {
 		$args['field'] = (array) $args['field'];
@@ -335,6 +346,8 @@ class FrmFieldCombo extends FrmFieldType {
 	 * Prints sub field input atts.
 	 *
 	 * @param array $args Arguments. Includes `field`, `sub_field`.
+	 *
+	 * @return void
 	 */
 	protected function print_input_atts( $args ) {
 		$field     = $args['field'];

--- a/classes/models/fields/FrmFieldDefault.php
+++ b/classes/models/fields/FrmFieldDefault.php
@@ -16,6 +16,8 @@ class FrmFieldDefault extends FrmFieldType {
 
 	/**
 	 * @param $type string
+	 *
+	 * @return void
 	 */
 	protected function set_type( $type ) {
 		if ( empty( $type ) ) {
@@ -24,6 +26,9 @@ class FrmFieldDefault extends FrmFieldType {
 		parent::set_type( $type );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function show_on_form_builder( $name = '' ) {
 		$field = FrmFieldsHelper::setup_edit_vars( $this->field );
 
@@ -40,6 +45,9 @@ class FrmFieldDefault extends FrmFieldType {
 		}
 	}
 
+	/**
+	 * @return false|string
+	 */
 	public function front_field_input( $args, $shortcode_atts ) {
 		$pass_args = array(
 			'errors'  => $args['errors'],

--- a/classes/models/fields/FrmFieldEmail.php
+++ b/classes/models/fields/FrmFieldEmail.php
@@ -21,6 +21,9 @@ class FrmFieldEmail extends FrmFieldType {
 	 */
 	protected $holds_email_values = true;
 
+	/**
+	 * @return bool[]
+	 */
 	protected function field_settings_for_type() {
 		return array(
 			'size'           => true,
@@ -47,6 +50,8 @@ class FrmFieldEmail extends FrmFieldType {
 
 	/**
 	 * @since 4.0.04
+	 *
+	 * @return void
 	 */
 	public function sanitize_value( &$value ) {
 		FrmAppHelper::sanitize_value( 'sanitize_email', $value );

--- a/classes/models/fields/FrmFieldHTML.php
+++ b/classes/models/fields/FrmFieldHTML.php
@@ -22,15 +22,21 @@ class FrmFieldHTML extends FrmFieldType {
 
 	/**
 	 * @since 4.0
+	 *
 	 * @param array $args - Includes 'field', 'display', and 'values'
+	 *
+	 * @return void
 	 */
 	public function show_primary_options( $args ) {
 		$field = $args['field'];
-		include( FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/html-content.php' );
+		include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/html-content.php';
 
 		parent::show_primary_options( $args );
 	}
 
+	/**
+	 * @return string
+	 */
 	public function default_html() {
 		return '<div id="frm_field_[id]_container" class="frm_form_field form-field">[description]</div>';
 	}
@@ -49,10 +55,16 @@ class FrmFieldHTML extends FrmFieldType {
 		return $html;
 	}
 
+	/**
+	 * @return string
+	 */
 	public function get_container_class() {
 		return ' frm_html_container';
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function include_form_builder_file() {
 		return FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/field-html.php';
 	}

--- a/classes/models/fields/FrmFieldHidden.php
+++ b/classes/models/fields/FrmFieldHidden.php
@@ -44,6 +44,9 @@ class FrmFieldHidden extends FrmFieldType {
 		return FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/field-hidden.php';
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function html5_input_type() {
 		return 'hidden';
 	}

--- a/classes/models/fields/FrmFieldName.php
+++ b/classes/models/fields/FrmFieldName.php
@@ -109,6 +109,8 @@ class FrmFieldName extends FrmFieldCombo {
 	 * @since 4.0
 	 *
 	 * @param array $args Includes 'field', 'display', and 'values'.
+	 *
+	 * @return void
 	 */
 	public function show_primary_options( $args ) {
 		$field = (array) $args['field'];
@@ -163,6 +165,8 @@ class FrmFieldName extends FrmFieldCombo {
 
 	/**
 	 * @since 4.0.04
+	 *
+	 * @return void
 	 */
 	public function sanitize_value( &$value ) {
 		FrmAppHelper::sanitize_value( 'sanitize_text_field', $value );
@@ -196,6 +200,8 @@ class FrmFieldName extends FrmFieldCombo {
 	 *     @type array  $errors         Field errors.
 	 *     @type bool   $remove_names   Remove name attribute or not.
 	 * }
+	 *
+	 * @return void
 	 */
 	protected function process_args_for_field_output( &$args ) {
 		parent::process_args_for_field_output( $args );

--- a/classes/models/fields/FrmFieldNumber.php
+++ b/classes/models/fields/FrmFieldNumber.php
@@ -15,6 +15,9 @@ class FrmFieldNumber extends FrmFieldType {
 	protected $type = 'number';
 	protected $display_type = 'text';
 
+	/**
+	 * @return bool[]
+	 */
 	protected function field_settings_for_type() {
 		$settings = array(
 			'size'           => true,
@@ -31,6 +34,11 @@ class FrmFieldNumber extends FrmFieldType {
 		return $settings;
 	}
 
+	/**
+	 * @return (int|string)[]
+	 *
+	 * @psalm-return array{minnum: 0, maxnum: 9999999, step: 'any'}
+	 */
 	protected function extra_field_opts() {
 		return array(
 			'minnum' => 0,
@@ -41,6 +49,8 @@ class FrmFieldNumber extends FrmFieldType {
 
 	/**
 	 * @since 3.01.03
+	 *
+	 * @return void
 	 */
 	protected function add_extra_html_atts( $args, &$input_html ) {
 		$this->add_min_max( $args, $input_html );
@@ -84,6 +94,8 @@ class FrmFieldNumber extends FrmFieldType {
 	 *
 	 * @param array $errors Errors array.
 	 * @param array $args   Validation args.
+	 *
+	 * @return void
 	 */
 	private function validate_step( &$errors, $args ) {
 		if ( isset( $errors[ 'field' . $args['id'] ] ) ) {
@@ -139,6 +151,10 @@ class FrmFieldNumber extends FrmFieldType {
 	 * Remove the comma when HTML5 isn't supported
 	 *
 	 * @since 3.0
+	 *
+	 * @param array $args
+	 *
+	 * @return void
 	 */
 	private function remove_commas_from_number( &$args ) {
 		if ( strpos( $args['value'], ',' ) ) {
@@ -160,6 +176,8 @@ class FrmFieldNumber extends FrmFieldType {
 
 	/**
 	 * @since 4.0.04
+	 *
+	 * @return void
 	 */
 	public function sanitize_value( &$value ) {
 		FrmAppHelper::sanitize_value( 'sanitize_text_field', $value );

--- a/classes/models/fields/FrmFieldPhone.php
+++ b/classes/models/fields/FrmFieldPhone.php
@@ -21,6 +21,9 @@ class FrmFieldPhone extends FrmFieldType {
 	 */
 	protected $holds_email_values = true;
 
+	/**
+	 * @return bool[]
+	 */
 	protected function field_settings_for_type() {
 		return array(
 			'size'           => true,
@@ -30,6 +33,9 @@ class FrmFieldPhone extends FrmFieldType {
 		);
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function html5_input_type() {
 		$frm_settings = FrmAppHelper::get_settings();
 
@@ -38,6 +44,8 @@ class FrmFieldPhone extends FrmFieldType {
 
 	/**
 	 * @since 4.0.04
+	 *
+	 * @return void
 	 */
 	public function sanitize_value( &$value ) {
 		FrmAppHelper::sanitize_value( 'sanitize_text_field', $value );

--- a/classes/models/fields/FrmFieldRadio.php
+++ b/classes/models/fields/FrmFieldRadio.php
@@ -48,6 +48,9 @@ class FrmFieldRadio extends FrmFieldType {
 		);
 	}
 
+	/**
+	 * @return array
+	 */
 	protected function extra_field_opts() {
 		$form_id = $this->get_field_column( 'form_id' );
 
@@ -56,6 +59,9 @@ class FrmFieldRadio extends FrmFieldType {
 		);
 	}
 
+	/**
+	 * @return string[]
+	 */
 	protected function new_field_settings() {
 		return array(
 			'options' => serialize(
@@ -69,15 +75,23 @@ class FrmFieldRadio extends FrmFieldType {
 
 	/**
 	 * @since 4.06
+	 *
+	 * @return void
 	 */
 	protected function show_priority_field_choices( $args = array() ) {
-		include( FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/radio-images.php' );
+		include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/radio-images.php';
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function include_front_form_file() {
 		return FrmAppHelper::plugin_path() . '/classes/views/frm-fields/front-end/radio-field.php';
 	}
 
+	/**
+	 * @return bool
+	 */
 	protected function show_readonly_hidden() {
 		return true;
 	}

--- a/classes/models/fields/FrmFieldSelect.php
+++ b/classes/models/fields/FrmFieldSelect.php
@@ -24,13 +24,19 @@ class FrmFieldSelect extends FrmFieldType {
 		return $this->include_front_form_file();
 	}
 
+	/**
+	 * @return bool[]
+	 */
 	protected function field_settings_for_type() {
 		return array(
 			'clear_on_focus' => true,
-			'size' => true,
+			'size'           => true,
 		);
 	}
 
+	/**
+	 * @return string[]
+	 */
 	protected function new_field_settings() {
 		return array(
 			'options' => serialize(
@@ -56,16 +62,25 @@ class FrmFieldSelect extends FrmFieldType {
 
 	/**
 	 * @since 4.0
+	 *
 	 * @param array $args - Includes 'field', 'display', and 'values'
+	 *
+	 * @return void
 	 */
 	public function show_extra_field_choices( $args ) {
 		$this->auto_width_setting( $args );
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function include_front_form_file() {
 		return FrmAppHelper::plugin_path() . '/classes/views/frm-fields/front-end/dropdown-field.php';
 	}
 
+	/**
+	 * @return bool
+	 */
 	protected function show_readonly_hidden() {
 		return true;
 	}

--- a/classes/models/fields/FrmFieldText.php
+++ b/classes/models/fields/FrmFieldText.php
@@ -20,6 +20,9 @@ class FrmFieldText extends FrmFieldType {
 	 */
 	protected $holds_email_values = true;
 
+	/**
+	 * @return bool[]
+	 */
 	protected function field_settings_for_type() {
 		return array(
 			'size'           => true,

--- a/classes/models/fields/FrmFieldTextarea.php
+++ b/classes/models/fields/FrmFieldTextarea.php
@@ -14,6 +14,9 @@ class FrmFieldTextarea extends FrmFieldType {
 	 */
 	protected $type = 'textarea';
 
+	/**
+	 * @return bool[]
+	 */
 	protected function field_settings_for_type() {
 		return array(
 			'size'           => true,
@@ -21,6 +24,9 @@ class FrmFieldTextarea extends FrmFieldType {
 		);
 	}
 
+	/**
+	 * @return array
+	 */
 	protected function extra_field_opts() {
 		return array(
 			'max' => '5',
@@ -29,6 +35,8 @@ class FrmFieldTextarea extends FrmFieldType {
 
 	/**
 	 * @param string $name
+	 *
+	 * @return void
 	 */
 	public function show_on_form_builder( $name = '' ) {
 		$size = FrmField::get_option( $this->field, 'size' );

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -74,6 +74,10 @@ abstract class FrmFieldType {
 	 */
 	protected $is_tall = false;
 
+	/**
+	 * @param object|array|int $field
+	 * @param string           $type
+	 */
 	public function __construct( $field = 0, $type = '' ) {
 		$this->field = $field;
 		$this->set_type( $type );
@@ -152,8 +156,7 @@ abstract class FrmFieldType {
 	}
 
 	/**
-	 *
-	 * @return object|array
+	 * @return array|int|object
 	 */
 	public function get_field() {
 		return $this->field;

--- a/classes/models/fields/FrmFieldUrl.php
+++ b/classes/models/fields/FrmFieldUrl.php
@@ -15,6 +15,9 @@ class FrmFieldUrl extends FrmFieldType {
 	protected $type = 'url';
 	protected $display_type = 'text';
 
+	/**
+	 * @return bool[]
+	 */
 	protected function field_settings_for_type() {
 		return array(
 			'size'           => true,
@@ -33,10 +36,16 @@ class FrmFieldUrl extends FrmFieldType {
 		);
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function get_field_name() {
 		return __( 'Website', 'formidable' );
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function fill_default_atts( &$atts ) {
 		$defaults = array(
 			'sep'  => ', ',
@@ -92,6 +101,8 @@ class FrmFieldUrl extends FrmFieldType {
 
 	/**
 	 * @since 4.0.04
+	 *
+	 * @return void
 	 */
 	public function sanitize_value( &$value ) {
 		FrmAppHelper::sanitize_value( 'esc_url_raw', $value );

--- a/classes/models/fields/FrmFieldUserID.php
+++ b/classes/models/fields/FrmFieldUserID.php
@@ -124,6 +124,8 @@ class FrmFieldUserID extends FrmFieldType {
 
 	/**
 	 * @since 4.0.04
+	 *
+	 * @return void
 	 */
 	public function sanitize_value( &$value ) {
 		FrmAppHelper::sanitize_value( 'intval', $value );

--- a/classes/views/frm-form-actions/email_action.php
+++ b/classes/views/frm-form-actions/email_action.php
@@ -19,6 +19,9 @@ class FrmEmailAction extends FrmFormAction {
 		parent::__construct( 'email', __( 'Send Email', 'formidable' ), $action_ops );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function form( $form_action, $args = array() ) {
 		extract( $args ); // phpcs:ignore WordPress.PHP.DontExtract
 
@@ -40,6 +43,9 @@ class FrmEmailAction extends FrmFormAction {
 		);
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function get_upgrade_text() {
 		return __( 'Conditional emails', 'formidable' );
 	}

--- a/deprecated/FrmEDD_SL_Plugin_Updater.php
+++ b/deprecated/FrmEDD_SL_Plugin_Updater.php
@@ -81,7 +81,8 @@ class FrmEDD_SL_Plugin_Updater {
 	 * @uses api_request()
 	 *
 	 * @param array   $_transient_data Update array build by WordPress.
-	 * @return array Modified update array with custom plugin data.
+	 *
+	 * @return stdClass Modified update array with custom plugin data.
 	 */
 	public function check_update( $_transient_data ) {
 
@@ -211,7 +212,8 @@ class FrmEDD_SL_Plugin_Updater {
 	 *
 	 * @param array   $args
 	 * @param string  $url
-	 * @return object $array
+	 *
+	 * @return array $array
 	 */
 	public function http_request_args( $args, $url ) {
 

--- a/formidable.php
+++ b/formidable.php
@@ -27,6 +27,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 add_action( 'plugins_loaded', 'load_formidable_forms', 0 );
+/**
+ * @return void
+ */
 function load_formidable_forms() {
 	global $frm_vars;
 	$frm_vars = array(
@@ -53,6 +56,9 @@ if ( is_array( spl_autoload_functions() ) && in_array( '__autoload', spl_autoloa
 // Add the autoloader
 spl_autoload_register( 'frm_forms_autoloader' );
 
+/**
+ * @return void
+ */
 function frm_forms_autoloader( $class_name ) {
 	// Only load Frm classes here
 	if ( ! preg_match( '/^Frm.+$/', $class_name ) || preg_match( '/^FrmPro.+$/', $class_name ) ) {
@@ -66,6 +72,8 @@ function frm_forms_autoloader( $class_name ) {
  * Autoload the Formidable and Pro classes
  *
  * @since 3.0
+ *
+ * @return void
  */
 function frm_class_autoloader( $class_name, $filepath ) {
 	$deprecated    = array( 'FrmEntryFormat', 'FrmPointers', 'FrmEDD_SL_Plugin_Updater' );
@@ -97,6 +105,9 @@ function frm_class_autoloader( $class_name, $filepath ) {
 }
 
 add_action( 'activate_' . FrmAppHelper::plugin_folder() . '/formidable.php', 'frm_maybe_install' );
+/**
+ * @return void
+ */
 function frm_maybe_install() {
 	if ( get_transient( FrmWelcomeController::$option_name ) !== 'no' ) {
 		set_transient( FrmWelcomeController::$option_name, FrmWelcomeController::$menu_slug, 60 );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -58,3 +58,4 @@ parameters:
 		- '#always exists and is always falsy#'
 		- '#has an unused use#'
 		- '#Cannot use array destructuring on#'
+		- '#of method FrmFieldName::\_\_construct#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -99,5 +99,10 @@
 				<file name="classes/views/frm-form-actions/email_action.php" />
 			</errorLevel>
 		</ParamNameMismatch>
+		<UndefinedAttributeClass>
+			<errorLevel type="suppress">
+				<referencedClass name="AllowDynamicProperties" />
+			</errorLevel>
+		</UndefinedAttributeClass>
 	</issueHandlers>
 </psalm>


### PR DESCRIPTION
This update is simple. I just ran psalter `psalm --alter` for a couple of rules (MissingReturnType, MissingParamType, InvalidReturnType), and cleaned it up slightly.

This should all be accurate as it's only what Psalm was able to infer from analyzing the code.