### PR TITLE
Exclude admin js file from hubspot zip

### DIFF
--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -73,6 +73,7 @@ zip -r $zipname $destination \
 	-x "formidable-chat/js/chat.js" \
 	-x "formidable-api/js/embed.js" \
 	-x "formidable-api/js/iframe-embed.js" \
+	-x "formidable-hubspot/js/admin.js" \
 	-x "*/webpack.config.js" \
 	-x "*.zip"
 


### PR DESCRIPTION
This shouldn't be used directly. The zip still includes the minified version.