### PR TITLE
use posted recaptcha score if available

### DIFF
--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -895,8 +895,16 @@ class FrmEntry {
 	 */
 	private static function maybe_add_captcha_meta( $form_id, $entry_id ) {
 		global $frm_vars;
-		if ( array_key_exists( 'captcha_scores', $frm_vars ) && array_key_exists( $form_id, $frm_vars['captcha_scores'] ) ) {
-			$captcha_score_meta = array( 'captcha_score' => $frm_vars['captcha_scores'][ $form_id ] );
+		if ( ! empty( $frm_vars['captcha_score'][ $form_id ] ) ) {
+			$captcha_score = $frm_vars['captcha_score'][ $form_id ];
+		}
+
+		if ( empty( $captcha_score ) && FrmAppHelper::get_post_param( 'recaptcha_score', false ) ) {
+			$captcha_score = FrmAppHelper::get_post_param( 'recaptcha_score' );
+		}
+
+		if ( ! empty( $captcha_score ) ) {
+			$captcha_score_meta = array( 'captcha_score' => $captcha_score );
 			FrmEntryMeta::add_entry_meta( $entry_id, 0, '', maybe_serialize( $captcha_score_meta ) );
 		}
 	}

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -899,8 +899,11 @@ class FrmEntry {
 			$captcha_score = $frm_vars['captcha_score'][ $form_id ];
 		}
 
-		if ( empty( $captcha_score ) && FrmAppHelper::get_post_param( 'captcha_score', false ) ) {
-			$captcha_score = FrmAppHelper::get_post_param( 'captcha_score' );
+		if ( empty( $captcha_score ) ) {
+			$captcha_scores = FrmAppHelper::get_post_param( 'captcha_scores', false );
+			if ( $captcha_scores && isset( $captcha_scores[ $form_id ] ) ) {
+				$captcha_score = $captcha_scores[ $form_id ];
+			}
 		}
 
 		if ( ! empty( $captcha_score ) ) {

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -899,8 +899,8 @@ class FrmEntry {
 			$captcha_score = $frm_vars['captcha_score'][ $form_id ];
 		}
 
-		if ( empty( $captcha_score ) && FrmAppHelper::get_post_param( 'recaptcha_score', false ) ) {
-			$captcha_score = FrmAppHelper::get_post_param( 'recaptcha_score' );
+		if ( empty( $captcha_score ) && FrmAppHelper::get_post_param( 'captcha_score', false ) ) {
+			$captcha_score = FrmAppHelper::get_post_param( 'captcha_score' );
 		}
 
 		if ( ! empty( $captcha_score ) ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4161

This PR complements with https://github.com/Strategy11/formidable-pro/pull/4163/files so that the last recaptcha score is included in the next form load after failing submission and added to the post request next.