### PR TITLE
Use checkbox role for multiselect buttons and add aria checked attribute

### DIFF
--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -185,6 +185,10 @@
 					const $dropdownItem = $dropdown.find( 'input[value="' + optionValue + '"]' ).closest( 'button.dropdown-item' );
 					if ( $dropdownItem.length ) {
 						$dropdownItem.attr( 'aria-checked', checked ? 'true' : 'false' );
+
+						// Delay a focus event so the screen reader reads the option value again.
+						// Without this, and without the setTimeout, it only reads "checked" or "unchecked".
+						setTimeout( () => $dropdownItem.get( 0 ).focus(), 0 );
 					}
 				}
 			});

--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -141,12 +141,11 @@
 
 	const multiselect = {
 		init: function() {
-			let $select, id, labelledBy;
+			const $select = jQuery( this );
+			const id = $select.is( '[id]' ) ? $select.attr( 'id' ).replace( '[]', '' ) : false;
 
-			$select = jQuery( this );
-			id = $select.is( '[id]' ) ? $select.attr( 'id' ).replace( '[]', '' ) : false;
-			labelledBy = id ? jQuery( '#for_' + id ) : false;
-			labelledBy = id && labelledBy.length ? 'aria-labelledby="' + labelledBy.attr( 'id' ) + '"' : '';
+			let labelledBy = id ? jQuery( '#for_' + id ) : false;
+			labelledBy     = id && labelledBy.length ? 'aria-labelledby="' + labelledBy.attr( 'id' ) + '"' : '';
 
 			$select.multiselect({
 				templates: {
@@ -165,9 +164,28 @@
 							}
 						});
 					}
+
+					const $dropdown = $select.next( '.frm-btn-group.dropdown' );
+					$dropdown.find( '.dropdown-item' ).each(
+						function() {
+							const option         = this;
+							const dropdownInput  = option.querySelector( 'input[type="checkbox"], input[type="radio"]' );
+							if ( dropdownInput ) {
+								option.setAttribute( 'role', 'checkbox' );
+								option.setAttribute( 'aria-checked', dropdownInput.checked ? 'true' : 'false' );
+							}
+						}
+					);
 				},
-				onChange: function( element, option ) {
-					$select.trigger( 'frm-multiselect-changed', element, option );
+				onChange: function( $option, checked ) {
+					$select.trigger( 'frm-multiselect-changed', $option, checked );
+
+					const $dropdown     = $select.next( '.frm-btn-group.dropdown' );
+					const optionValue   = $option.val();
+					const $dropdownItem = $dropdown.find( 'input[value="' + optionValue + '"]' ).closest( 'button.dropdown-item' );
+					if ( $dropdownItem.length ) {
+						$dropdownItem.attr( 'aria-checked', checked ? 'true' : 'false' );
+					}
 				}
 			});
 		}


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2196994272/156886/

The multiselect dropdowns (used for field visiblity settings, and global permission settings, and registration action role settings) wouldn't state to a screen reader whether the nested input was checked or not.

I'm fixing this with a `role="checkbox"` attribute and syncing the value of `aria-checked` when the dropdown shows and when the value changes.