### PR TITLE
Only exclude $source/vendor from zip

### DIFF
--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -63,7 +63,7 @@ zip -r $zipname $destination \
 	-x "*/readme.md" \
 	-x "*/README.md" \
 	-x "*/tests/*" \
-	-x "*[^(dompdf)]/vendor/*" \
+	-x "$source/vendor/*" \
 	-x "*/temp.xml" \
 	-x "formidable-pro/views/*" \
 	-x "formidable-views/js/dom.js" \


### PR DESCRIPTION
I've been modifying `-x "*[^(dompdf)]/vendor/*" \` to exclude `[^(dompdf)]` every time I pack a zip for Pro.

I figured out an easier way to exclude the root vendor folder while keeping the PDFs vendor folder inside of the `dompdf` folder, using the `$source` variable that matches the current folder name.