### PR TITLE
make dropdown height match date inputs

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5924,6 +5924,10 @@ span.howto {
 	max-width: 100%;
 }
 
+#form_reports_page form select {
+    line-height: 2;
+}
+
 .frm_wrap .google-visualization-table .gradient,
 .frm_wrap .google-visualization-table-tr-head,
 .frm_wrap .google-visualization-table-tr-odd,


### PR DESCRIPTION
Make Date options dropdown height match date inputs.
**Before**:
![image](https://user-images.githubusercontent.com/41271840/229734493-b976cc22-a39f-47b1-a851-3a373aafd134.png)

**After**:
![image](https://user-images.githubusercontent.com/41271840/229734681-9a23b68f-1e57-428d-976e-0cf5770dbea0.png)
