### PR TITLE
Set the date fields the same height in the reports filtering

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7960,6 +7960,10 @@ button.frm_choose_image_box,
 	line-height: var(--leading);
 }
 
+.frm_wrap ::-webkit-datetime-edit {
+    line-height: var(--leading);
+}
+
 .frm-white-body textarea:focus,
 .frm-white-body input:focus,
 .frm-white-body select:focus,
@@ -8034,6 +8038,10 @@ button.frm_choose_image_box,
 	padding-top: 0;
 	padding-bottom: 0;
 	line-height: 1;
+}
+
+.frm_wrap .tablenav ::-webkit-datetime-edit {
+    line-height: 1;
 }
 
 .frm-fields button.btn,


### PR DESCRIPTION
Before:
https://github.com/Strategy11/formidable-forms/pull/1135#issuecomment-1497670828

After:
<img width="508" alt="Screenshot 2023-04-05 at 1 08 02 PM" src="https://user-images.githubusercontent.com/1116876/230180596-eac8b66f-4088-47b5-b92e-2c07ae83b598.png">

This css overrides this in the wp forms.css:
```
::-webkit-datetime-edit {
    line-height: 1.85714286;
}
```

@Crabcyborg is this too late to be merged?
