### PR TITLE
Stripe more characters from style settings

### DIFF
--- a/classes/models/FrmStyle.php
+++ b/classes/models/FrmStyle.php
@@ -241,8 +241,21 @@ class FrmStyle {
 			} else {
 				$sanitized_settings[ $key ] = $defaults[ $key ];
 			}
+			$sanitized_settings[ $key ] = $this->strip_invalid_characters( $sanitized_settings[ $key ] );
 		}
 		return $sanitized_settings;
+	}
+
+	/**
+	 * Remove any characters that should not be used in CSS.
+	 *
+	 * @since 6.2.1
+	 *
+	 * @param string $setting
+	 * @return string
+	 */
+	private static function strip_invalid_characters( $setting ) {
+		return str_replace( array( '{', '}', ';' ), '', $setting );
 	}
 
 	/**

--- a/tests/styles/test_FrmStyle.php
+++ b/tests/styles/test_FrmStyle.php
@@ -36,4 +36,26 @@ class test_FrmStyle extends FrmUnitTest {
 			$this->assertEquals( $expected_color_val, $color_val );
 		}
 	}
+
+	/**
+	 * @covers FrmStyle::sanitize_post_content
+	 */
+	public function test_sanitize_post_content() {
+		$post_content = array(
+			'bg_color'            => '000',
+			'font_size'           => '14px',
+			'title_margin_bottom' => '60px}',
+			'field_height'        => ';12px',
+			'field_width'         => '{10px',
+		);
+		$frm_style              = new FrmStyle();
+		$sanitized_post_content = $frm_style->sanitize_post_content( $post_content );
+
+		$this->assertIsArray( $sanitized_post_content );
+		$this->assertEquals( '000', $sanitized_post_content['bg_color'] );
+		$this->assertEquals( '14px', $sanitized_post_content['font_size'] );
+		$this->assertEquals( '60px', $sanitized_post_content['title_margin_bottom'] );
+		$this->assertEquals( '12px', $sanitized_post_content['field_height'] );
+		$this->assertEquals( '10px', $sanitized_post_content['field_width'] );
+	}
 }


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/3830

I'm not really sure how Nat's CSS is the way it is, but I think it could just be a weird setting somewhere.

It's been an ongoing project to try cleaning up our CSS, like our rgba color normalizing.

It looks like `{`, `}`, ';' are never stripped so if you accidentally put one in the CSS it will break the file.

@stephywells Do you see any of these characters being required for anything? Do you think there are other characters or phrases we'd want to remove as well?