### PR TITLE
Also apply frm_redirect_url filter when paypal url is set in args

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2343,6 +2343,9 @@ class FrmFormsController {
 	 */
 	private static function run_redirect_url_filter( $url, $form, $args ) {
 		if ( empty( $args['action'] ) || ! is_string( $args['action'] ) ) {
+			if ( ! empty( $args['paypal_url'] ) ) {
+				return apply_filters( 'frm_redirect_url', $url, $form, $args );
+			}
 			return $url;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-paypal/issues/42

The issue is that it's exiting here for a PayPal action and not running `frm_redirect_url` which is required.

@truongwp Can you come up with something better than this? We probably want this behind `ran_redirect_url_filter` - this is still a bit of a rough draft.