### PR TITLE
Remove duplicate style setting key

### DIFF
--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -399,6 +399,8 @@ class FrmStylesHelper {
 
 	/**
 	 * @since 2.3
+	 *
+	 * @return array
 	 */
 	private static function allow_color_override() {
 		$frm_style = new FrmStyle();
@@ -420,7 +422,6 @@ class FrmStylesHelper {
 			'submit_active_border_color',
 			'submit_hover_bg_color',
 			'submit_active_bg_color',
-			'success_bg_color',
 		);
 
 		return array(


### PR DESCRIPTION
I stumbled by this code and noticed that `success_bg_color` was in this array twice.

<img width="353" alt="@since 2 3" src="https://user-images.githubusercontent.com/9134515/230657662-93360605-1b56-40e4-bf2b-314fda3f7eea.png">
