### PR TITLE
add 'Select All' button to forms export

### DIFF
--- a/classes/views/xml/import_form.php
+++ b/classes/views/xml/import_form.php
@@ -115,8 +115,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<thead>
 						<tr>
 							<td class="column-cb check-column">
-								<label class="screen-reader-text" for="cb-import-select-all"><?php esc_html_e( 'Select All', 'formidable' ); ?></label>
-								<input id="cb-import-select-all" type="checkbox">
+								<label class="screen-reader-text" for="frm-export-select-all"><?php esc_html_e( 'Select All', 'formidable' ); ?></label>
+								<input id="frm-export-select-all" type="checkbox">
 							</td>
 							<td><?php esc_html_e( 'Form Title', 'formidable' ); ?></td>
 							<td><?php esc_html_e( 'ID / Form Key', 'formidable' ); ?></td>

--- a/classes/views/xml/import_form.php
+++ b/classes/views/xml/import_form.php
@@ -114,7 +114,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<table class="widefat striped frm-border frm-mt-0">
 					<thead>
 						<tr>
-							<td class="column-cb check-column"></td>
+							<td class="column-cb check-column">
+								<label class="screen-reader-text" for="cb-import-select-all"><?php esc_html_e( 'Select All', 'formidable' ); ?></label>
+								<input id="cb-import-select-all" type="checkbox">
+							</td>
 							<td><?php esc_html_e( 'Form Title', 'formidable' ); ?></td>
 							<td><?php esc_html_e( 'ID / Form Key', 'formidable' ); ?></td>
 							<td><?php esc_html_e( 'Type', 'formidable' ); ?></td>

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10267,6 +10267,10 @@ function frmAdminBuildJS() {
 			});
 
 			showOrHideRepeaters( getExportOption() );
+
+			document.querySelector( '#cb-import-select-all' ).addEventListener( 'change', event => {
+				document.querySelectorAll( '[name="frm_export_forms[]"]' ).forEach( cb => cb.checked = event.target.checked );
+			});
 		},
 
 		inboxBannerInit: function() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8133,10 +8133,10 @@ function frmAdminBuildJS() {
 	}
 
 	function exportTypeChanged( event ) {
-		var target = event.target;
-		showOrHideRepeaters( target.value );
-		checkExportTypes.call( target );
-		checkSelectedAllFormsCheckbox( target.value );
+		var value = event.target;
+		showOrHideRepeaters( value );
+		checkExportTypes.call( event.target );
+		checkSelectedAllFormsCheckbox( value );
 	}
 
 	function checkSelectedAllFormsCheckbox( exportType ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8133,7 +8133,7 @@ function frmAdminBuildJS() {
 	}
 
 	function exportTypeChanged( event ) {
-		var value = event.target;
+		var value = event.target.value;
 		showOrHideRepeaters( value );
 		checkExportTypes.call( event.target );
 		checkSelectedAllFormsCheckbox( value );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10268,7 +10268,7 @@ function frmAdminBuildJS() {
 
 			showOrHideRepeaters( getExportOption() );
 
-			document.querySelector( '#cb-import-select-all' ).addEventListener( 'change', event => {
+			document.querySelector( '#frm-export-select-all' ).addEventListener( 'change', event => {
 				document.querySelectorAll( '[name="frm_export_forms[]"]' ).forEach( cb => cb.checked = event.target.checked );
 			});
 		},

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8133,8 +8133,19 @@ function frmAdminBuildJS() {
 	}
 
 	function exportTypeChanged( event ) {
-		showOrHideRepeaters( event.target.value );
-		checkExportTypes.call( event.target );
+		var target = event.target;
+		showOrHideRepeaters( target.value );
+		checkExportTypes.call( target );
+		checkSelectedAllFormsCheckbox( target.value );
+	}
+
+	function checkSelectedAllFormsCheckbox( exportType ) {
+		if ( exportType === 'csv' ) {
+			document.querySelector( '#frm-export-select-all' ).checked = false;
+			document.querySelector( '#frm-export-select-all' ).disabled = true;
+		} else {
+			document.querySelector( '#frm-export-select-all' ).disabled = false;
+		}
 	}
 
 	function checkExportTypes() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8133,18 +8133,19 @@ function frmAdminBuildJS() {
 	}
 
 	function exportTypeChanged( event ) {
-		var value = event.target.value;
+		const value = event.target.value;
 		showOrHideRepeaters( value );
 		checkExportTypes.call( event.target );
 		checkSelectedAllFormsCheckbox( value );
 	}
 
 	function checkSelectedAllFormsCheckbox( exportType ) {
+		const selectAllCheckbox = document.getElementById( 'frm-export-select-all' );
 		if ( exportType === 'csv' ) {
-			document.querySelector( '#frm-export-select-all' ).checked = false;
-			document.querySelector( '#frm-export-select-all' ).disabled = true;
+			selectAllCheckbox.checked = false;
+			selectAllCheckbox.disabled = true;
 		} else {
-			document.querySelector( '#frm-export-select-all' ).disabled = false;
+			selectAllCheckbox.disabled = false;
 		}
 	}
 


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/3715

Just adding a checkbox that allows selecting/deselecting forms for in the export table.

![image](https://user-images.githubusercontent.com/41271840/230878467-197ec984-e346-4cbd-8534-ae33715b95aa.png)
