### PR TITLE
Fix common XML import issues

### DIFF
--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -36,10 +36,14 @@ class FrmXMLHelper {
 			return new WP_Error( 'SimpleXML_parse_error', __( 'Your server does not have XML enabled', 'formidable' ), libxml_get_errors() );
 		}
 
+		$xml_string = file_get_contents( $file );
+		self::maybe_fix_xml( $xml_string );
+
 		$dom = new DOMDocument();
+
 		// LIBXML_COMPACT activates small nodes allocation optimization.
 		// Use LIBXML_PARSEHUGE to avoid "parser error : internal error: Huge input lookup" for large (300MB) files.
-		$success = $dom->loadXML( file_get_contents( $file ), LIBXML_COMPACT | LIBXML_PARSEHUGE );
+		$success = $dom->loadXML( $xml_string, LIBXML_COMPACT | LIBXML_PARSEHUGE );
 		if ( ! $success ) {
 			return new WP_Error( 'SimpleXML_parse_error', __( 'There was an error when reading this XML file', 'formidable' ), libxml_get_errors() );
 		}
@@ -57,6 +61,33 @@ class FrmXMLHelper {
 		}
 
 		return self::import_xml_now( $xml );
+	}
+
+	/**
+	 * @since 6.3
+	 *
+	 * @param string $xml_string
+	 * @return void
+	 */
+	private static function maybe_fix_xml( &$xml_string ) {
+		if ( '<?xml' !== substr( $xml_string, 0, 5 ) ) {
+			// Some XML files have may have unexpected characters at the start.
+			$xml_string = substr( $xml_string, strpos( $xml_string, '<?xml' ) );
+		}
+
+		// The Equity theme adds a <meta name="generator" content="Equity 1.7.13" /> tag using the "the_generator" filter.
+		// Strip that out as it breaks the XML import.
+		$channel_start_position     = strpos( $xml_string, '<channel>' );
+		$content_before_channel_tag = substr( $xml_string, 0, $channel_start_position );
+		if ( 0 !== strpos( $content_before_channel_tag, '<meta name="generator" ' ) ) {
+			$content_before_channel_tag = preg_replace(
+				'/<meta\s+[^>]*name="generator"[^>]*\/>/i',
+				'',
+				$content_before_channel_tag,
+				1
+			);
+			$xml_string = $content_before_channel_tag . substr( $xml_string, $channel_start_position );
+		}
 	}
 
 	/**

--- a/tests/xml/test_FrmXMLHelper.php
+++ b/tests/xml/test_FrmXMLHelper.php
@@ -119,4 +119,27 @@ class test_FrmXMLHelper extends FrmUnitTest {
 	private function populate_postmeta( &$post, $meta, $imported ) {
 		$this->run_private_method( array( 'FrmXMLHelper', 'populate_postmeta' ), array( &$post, $meta, $imported ) );
 	}
+
+	/**
+	 * @covers FrmXMLHelper::maybe_fix_xml
+	 */
+	public function test_maybe_fix_xml() {
+		$wp_comment        = '<!-- generator="WordPress/5.2.4" created="2019-10-23 19:33" -->';
+		$simple_xml_string = '<?xml version="1.0" encoding="UTF-8" ?>' . PHP_EOL . $wp_comment . PHP_EOL . '<channel></channel>';
+
+		$xml_string = chr( 13 ) . $simple_xml_string;
+		$this->maybe_fix_xml( $xml_string );
+
+		$this->assertEquals( $simple_xml_string, $xml_string );
+
+		$conflicting_meta_tag = '<meta name="generator" content="Equity 1.7.13" />';
+		$xml_string = '<?xml version="1.0" encoding="UTF-8" ?>' . PHP_EOL . $wp_comment . PHP_EOL . $conflicting_meta_tag . '<channel></channel>';
+		$this->maybe_fix_xml( $xml_string );
+
+		$this->assertEquals( $simple_xml_string, $xml_string );
+	}
+
+	private function maybe_fix_xml( &$xml_string ) {
+		$this->run_private_method( array( 'FrmXMLHelper', 'maybe_fix_xml' ), array( &$xml_string ) );
+	}
 }


### PR DESCRIPTION
I was looking in HelpScout for errors and noticed a pretty common pattern with import errors.

It's common enough that there's information on how to avoid it in the documentation https://formidableforms.com/knowledgebase/import-forms-entries-and-views/#kb-simplexml_parse_error

In a few cases the customers included XML import examples

In https://secure.helpscout.net/conversation/2061631158/116223 it's because of an extra `<meta name="generator" content="Equity 1.7.13" />` tag added by the Equity WP theme. I was able to find the problematic code here in GitHub https://github.com/idxbroker/Equity-Framework

```
add_filter( 'the_generator', 'equity_generator' );
function equity_generator( $generator ) {
    $generator .= "\r\n" . '<meta name="generator" content="' . PARENT_THEME_NAME . ' ' . PARENT_THEME_VERSION . '" />';
    return $generator;
}
```

In https://secure.helpscout.net/conversation/1663593319/83217 the issue is a carriage return at the start of the file instead which is easy to strip out.

This helps eliminate two common XML parser errors:
"XML declaration allowed only at the start of the document"
"Extra content at the end of the document"