### PR TITLE
Stop calling utf8_encode when wrapping cdata

### DIFF
--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -1573,8 +1573,6 @@ class FrmXMLHelper {
 		FrmAppHelper::unserialize_or_decode( $str );
 		if ( is_array( $str ) ) {
 			$str = json_encode( $str );
-		} elseif ( seems_utf8( $str ) === false ) {
-			$str = utf8_encode( $str );
 		}
 
 		if ( is_numeric( $str ) ) {

--- a/tests/xml/test_FrmXMLHelper.php
+++ b/tests/xml/test_FrmXMLHelper.php
@@ -142,4 +142,28 @@ class test_FrmXMLHelper extends FrmUnitTest {
 	private function maybe_fix_xml( &$xml_string ) {
 		$this->run_private_method( array( 'FrmXMLHelper', 'maybe_fix_xml' ), array( &$xml_string ) );
 	}
+
+	/**
+	 * @covers FrmXMLHelper::cdata
+	 */
+	public function test_cdata() {
+		$this->assertEquals( '<![CDATA[Name]]>', FrmXMLHelper::cdata( 'Name' ) );
+		$this->assertEquals( '<![CDATA[29yf4d]]>', FrmXMLHelper::cdata( '29yf4d' ) );
+		$this->assertEquals( '<![CDATA[United States]]>', FrmXMLHelper::cdata( 'United States' ) );
+		$this->assertEquals( '<![CDATA[["Red","Blue"]]]>', FrmXMLHelper::cdata( serialize( array( 'Red', 'Blue' ) ) ) );
+		$this->assertEquals( '<![CDATA[[60418,60419,60420]]]>', FrmXMLHelper::cdata( serialize( array( 60418, 60419, 60420 ) ) ) );
+		$this->assertEquals(
+			'<![CDATA[{"browser":"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10.10; rv:37.0) Gecko\/20100101 Firefox\/37.0","referrer":"http:\/\/localhost:8888\/features\/wp-admin\/admin-ajax.php?action=frm_forms_preview&form=boymfd"}]]>',
+			FrmXMLHelper::cdata(
+				serialize(
+					array(
+						'browser' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:37.0) Gecko/20100101 Firefox/37.0',
+						'referrer' => 'http://localhost:8888/features/wp-admin/admin-ajax.php?action=frm_forms_preview&form=boymfd',
+					)
+				)
+			)
+		);
+		$this->assertEquals( '5', FrmXMLHelper::cdata( '5' ), 'Numbers do not need to be wrapped' );
+		$this->assertEquals( '<![CDATA[2023-05-21]]>', FrmXMLHelper::cdata( '2023-05-21' ) );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4177

I spent some more time looking into how this is going to be handled in WordPress and found https://core.trac.wordpress.org/ticket/55603. It's still in-progress, set now for v6.3 but it's already been delayed multiple versions.

Referring to this comment https://core.trac.wordpress.org/ticket/55603#comment:11 this person at least is also suggesting that the use of `utf8_encode` may not be required at all.

> As for the two utf8_encode calls in wp_read_image_metadata and wxr_cdata functions, they are wrapped with !seems_utf8() clauses, which make believe core's utf8_encode calls are wrong too because there is no guarantee the source strings are always ISO-8859-1.