### PR TITLE
Stop checking for php 5.x in tests

### DIFF
--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -625,7 +625,6 @@ class FrmUnitTest extends WP_UnitTestCase {
 	}
 
 	protected function run_private_method( $method, $args = array() ) {
-		$this->check_php_version( '5.3' );
 		$m = new ReflectionMethod( $method[0], $method[1] );
 		$m->setAccessible( true );
 		return $m->invokeArgs( is_string( $method[0] ) ? null : $method[0], $args );
@@ -639,7 +638,6 @@ class FrmUnitTest extends WP_UnitTestCase {
 	 * @return ReflectionProperty
 	 */
 	protected function get_accessible_property( $object, $property ) {
-		$this->check_php_version( '5.3' );
 		$rc = new ReflectionClass( $object );
 		$p = $rc->getProperty( $property );
 		$p->setAccessible( true );

--- a/tests/misc/test_FrmAddon.php
+++ b/tests/misc/test_FrmAddon.php
@@ -10,7 +10,6 @@ class test_FrmAddon extends FrmUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->check_php_version( '5.4' );
 		$this->addon = $this->getMockBuilder( 'FrmTestAddon' )
 							->setMethods( null )
 							->getMock();

--- a/tests/misc/test_FrmCSVExportHelper.php
+++ b/tests/misc/test_FrmCSVExportHelper.php
@@ -10,8 +10,6 @@ class test_FrmCSVExportHelper extends FrmUnitTest {
 	 * @covers FrmCsvExportHelper::csv_headings
 	 */
 	public function test_csv_headings() {
-		$this->check_php_version( '5.3' );
-
 		$this->set_form( FrmForm::getOne( 'all_field_types' ) );
 
 		$headings = $this->csv_headings();
@@ -75,8 +73,6 @@ class test_FrmCSVExportHelper extends FrmUnitTest {
 	 * @covers FrmCsvExportHelper::csv_headings exports the fields in a section for an embedded form
 	 */
 	public function test_csv_headings_for_embedded_sections() {
-		$this->check_php_version( '5.3' );
-
 		$embedded_form = $this->factory->form->create_and_get();
 		$section       = $this->factory->field->create_and_get(
 			array(


### PR DESCRIPTION
We don't ever run these versions anymore.