### PR TITLE
Remove moveTopBanner function

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6131,22 +6131,6 @@ function frmAdminBuildJS() {
 		}
 	}
 
-	// Move the top banner above the screen options to prevent overlap.
-	function moveTopBanner() {
-		const $banner = document.querySelector( '.frm-banner-alert' ) || document.querySelector( '.frm-upgrade-bar' );
-		if ( ! $banner ) {
-			return;
-		}
-
-		const $screenMeta = document.getElementById( 'screen-meta' );
-		if ( ! $screenMeta ) {
-			return;
-		}
-
-		const $parentDiv = document.getElementById( 'wpbody-content' );
-		$parentDiv.insertBefore( $banner, $screenMeta );
-	}
-
 	function getRequiredLicenseFromTrigger( element ) {
 		if ( element.dataset.requires ) {
 			return element.dataset.requires;
@@ -9610,7 +9594,6 @@ function frmAdminBuildJS() {
 
 			loadTooltips();
 			initUpgradeModal();
-			moveTopBanner();
 
 			// used on build, form settings, and view settings
 			var $shortCodeDiv = jQuery( document.getElementById( 'frm_shortcodediv' ) );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4176

The banner is being added in the proper place, then this JavaScript is breaking it.

Do we need this anymore @stephywells? It looks like it was added in v5.4.3 but the v6.0 changes appear to break it.