### PR TITLE
Add a warning to the styler to a detect a broken style

### DIFF
--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -1035,7 +1035,7 @@ class FrmStylesController {
 	public static function maybe_hide_sample_form_error_message() {
 		$referer = FrmAppHelper::get_server_value( 'HTTP_REFERER' );
 		if ( false !== strpos( $referer, 'admin.php?page=formidable-styles' ) ) {
-			echo '#frm_css_error { display: none; }';
+			echo '#frm_broken_styles_warning { display: none; }';
 		}
 	}
 

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -1018,7 +1018,25 @@ class FrmStylesController {
 		$output = apply_filters( 'frm_saved_css', $output );
 
 		echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+		self::maybe_hide_sample_form_error_message();
+
 		wp_die();
+	}
+
+	/**
+	 * Add an extra style rule to hide a broken style warning.
+	 * To avoid cluttering the front end with any unecessary styles this is only added when the referer URL matches the styler.
+	 *
+	 * @since 6.3
+	 *
+	 * @return void
+	 */
+	public static function maybe_hide_sample_form_error_message() {
+		$referer = FrmAppHelper::get_server_value( 'HTTP_REFERER' );
+		if ( false !== strpos( $referer, 'admin.php?page=formidable-styles' ) ) {
+			echo '#frm_css_error { display: none; }';
+		}
 	}
 
 	/**

--- a/classes/views/styles/_style-preview-container.php
+++ b/classes/views/styles/_style-preview-container.php
@@ -22,6 +22,9 @@ if ( $sample_form_is_on ) {
 		include FrmAppHelper::plugin_path() . '/classes/views/shared/errors.php';
 		?>
 		<?php FrmTipsHelper::pro_tip( 'get_styling_tip', 'p' ); // If Pro is not active, this will show an upsell. ?>
+		<div id="frm_css_error" class="frm_warning_style">
+			<?php esc_html_e( 'If you can see this warning it means that one or more of your style settings are incorrectly formatted!', 'formidable' ); ?>
+		</div>
 		<div <?php FrmAppHelper::array_to_html_params( $active_form_wrapper_params, true ); ?>>
 			<?php
 			// The right side body shows a preview (of the target form) so you can see the form you're actually styling.

--- a/classes/views/styles/_style-preview-container.php
+++ b/classes/views/styles/_style-preview-container.php
@@ -22,8 +22,8 @@ if ( $sample_form_is_on ) {
 		include FrmAppHelper::plugin_path() . '/classes/views/shared/errors.php';
 		?>
 		<?php FrmTipsHelper::pro_tip( 'get_styling_tip', 'p' ); // If Pro is not active, this will show an upsell. ?>
-		<div id="frm_css_error" class="frm_warning_style">
-			<?php esc_html_e( 'If you can see this warning it means that one or more of your style settings are incorrectly formatted!', 'formidable' ); ?>
+		<div id="frm_broken_styles_warning" class="frm_warning_style">
+			<?php esc_html_e( 'One or more of your style settings may contain invalid characters that break form styling.', 'formidable' ); ?>
 		</div>
 		<div <?php FrmAppHelper::array_to_html_params( $active_form_wrapper_params, true ); ?>>
 			<?php

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -8,6 +8,7 @@ if ( ! isset( $saving ) ) {
 
 	if ( ! empty( $css ) ) {
 		echo strip_tags( $css, 'all' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		FrmStylesController::maybe_hide_sample_form_error_message();
 		die();
 	}
 }


### PR DESCRIPTION
Following up from Steph's comment here https://github.com/Strategy11/formidable-forms/pull/1141#pullrequestreview-1380009049

This update doesn't include https://github.com/Strategy11/formidable-forms/pull/1141. It's easier to test this when you can still break it with `(` or `)` like in my example here,

I added a referer check so it wouldn't interfere with the front end. It also only happens through the `frmpro_css` action but that is the fallback for when the CSS file doesn't work.

![gpvqvEdH0o](https://user-images.githubusercontent.com/9134515/231862065-d1388c29-ee67-41be-b5d0-d62baab10940.gif)

@stephywells What do you think we should use for the warning's message body? I put something but it could probably use more information.