### PR TITLE
Check if clip echo function is callable

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1114,7 +1114,9 @@ class FrmAppHelper {
 			ob_start();
 		}
 
-		$echo_function();
+		if ( is_callable( $echo_function ) ) {
+			$echo_function();
+		}
 
 		if ( ! $echo ) {
 			$return = ob_get_contents();

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -671,4 +671,35 @@ class test_FrmAppHelper extends FrmUnitTest {
 		$this->assertEquals( 'O:8:"DateTime":0:{}', $unserialized, 'Serialized object data should remain serialized strings.' );
 	}
 
+	/**
+	 * @covers FrmAppHelper::clip
+	 */
+	public function test_clip() {
+		// Test a function.
+		$echo_function = function() {
+			echo '<div>My html</div>';
+		};
+		$html = FrmAppHelper::clip( $echo_function );
+		$this->assertEquals( '<div>My html</div>', $html );
+
+		// Test a callable string.
+		$echo_function = __CLASS__ . '::echo_function';
+		$html = FrmAppHelper::clip( $echo_function );
+		$this->assertEquals( '<div>My echo function content</div>', $html );
+
+		// Test something uncallable.
+		// Make sure it isn't fatal just in case.
+		$echo_function = __CLASS__ . '::something_uncallable';
+		$html = FrmAppHelper::clip( $echo_function );
+		$this->assertEquals( '', $html );
+	}
+
+	/**
+	 * Echo HTML for the test_clip unit test.
+	 *
+	 * @return void
+	 */
+	public static function echo_function() {
+		echo '<div>My echo function content</div>';
+	}
 }


### PR DESCRIPTION
I noticed this came up a second time in support. It shouldn't really be possible as the same file that calls this clip function is also the file that has the function that supposedly doesn't exist. But to avoid it in the future, I'm adding a small `is_callable` check.

I also added a unit test.

First related ticket back from November last year https://secure.helpscout.net/conversation/2056768903/115574

And second related ticket that came up in March last month https://secure.helpscout.net/conversation/2183441439/155072/