### PR TITLE
Avoid fatal woocommerce error

### DIFF
--- a/classes/controllers/FrmEntriesAJAXSubmitController.php
+++ b/classes/controllers/FrmEntriesAJAXSubmitController.php
@@ -120,6 +120,12 @@ class FrmEntriesAJAXSubmitController {
 		$registered_scripts = (array) $wp_scripts->registered;
 		$registered_scripts = array_diff( array_keys( $registered_scripts ), $keep_scripts );
 		$wp_scripts->done   = array_merge( $wp_scripts->done, $registered_scripts );
+
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			// Prevent WooCommerce 7.6.0 from triggering a fatal error when wp_print_footer_scripts is called.
+			require_once ABSPATH . 'wp-admin/includes/screen.php';
+		}
+
 		wp_print_footer_scripts();
 	}
 


### PR DESCRIPTION
Requires https://github.com/Strategy11/formidable-pro/pull/4192 when Pro is active.

@garretlaxton This fix may not be final. I think I could avoid the duplicate code better. But the fix will be the same, and this is an important bug so testing it as soon as possible would be great.