### PR TITLE
Avoid setting an array an array key when parsing serialized strings

### DIFF
--- a/classes/helpers/FrmSerializedStringParserHelper.php
+++ b/classes/helpers/FrmSerializedStringParserHelper.php
@@ -66,9 +66,12 @@ class FrmSerializedStringParserHelper {
 
 				$val = array();
 				for ( $i = 0; $i < $count; $i++ ) {
-					$array_key         = $this->do_parse( $string );
-					$array_value       = $this->do_parse( $string );
-					$val[ $array_key ] = $array_value;
+					$array_key   = $this->do_parse( $string );
+					$array_value = $this->do_parse( $string );
+
+					if ( ! is_array( $array_key ) ) {
+						$val[ $array_key ] = $array_value;
+					}
 				}
 
 				// Eat "}" terminating the array.

--- a/tests/misc/test_FrmSerializedStringParserHelper.php
+++ b/tests/misc/test_FrmSerializedStringParserHelper.php
@@ -1,0 +1,21 @@
+<?php
+
+class test_FrmSerialziedStringParserHelper extends FrmUnitTest {
+
+	/**
+	 * @covers FrmSerialziedStringParserHelper::parse
+	 */
+	public function test_parse() {
+		// Test an unexpected serialized string format.
+		// Arrays should never have an array as its key like in this example.
+		$string = 'a:1:{a:1:{i:0;a:1:{i:1;s:4:"Text";}s:4:"Text";}}';
+		$parsed = FrmSerializedStringParserHelper::get()->parse( $string );
+
+		// Test a valid serialized string.
+		$string = serialize( array( 'key' => 'value' ) );
+		$parsed = FrmSerializedStringParserHelper::get()->parse( $string );
+		$this->assertIsArray( $parsed );
+		$this->assertArrayHasKey( 'key', $parsed );
+		$this->assertEquals( 'value', $parsed['key'] );
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4179

