### PR TITLE
Fix woocommerce conflict in one place

### DIFF
--- a/classes/controllers/FrmEntriesAJAXSubmitController.php
+++ b/classes/controllers/FrmEntriesAJAXSubmitController.php
@@ -15,6 +15,8 @@ class FrmEntriesAJAXSubmitController {
 	 * @return void
 	 */
 	public static function ajax_create() {
+		self::fix_woocommerce_conflict(); // This is called before we exit early to cover the conflict in Pro as well.
+
 		if ( is_callable( 'FrmProEntriesController::ajax_create' ) ) {
 			// Let Pro handle AJAX Submit if it's available.
 			// This is because Pro requires additional code to support other Pro features.
@@ -104,6 +106,25 @@ class FrmEntriesAJAXSubmitController {
 
 		echo json_encode( $response );
 		wp_die();
+	}
+
+	/**
+	 * Prevent WooCommerce 7.6.0 from triggering a fatal error when wp_print_footer_scripts is called.
+	 *
+	 * @since 6.2.3
+	 *
+	 * @return void
+	 */
+	private static function fix_woocommerce_conflict() {
+		add_action(
+			'wp_print_footer_scripts',
+			function() {
+				if ( ! function_exists( 'get_current_screen' ) ) {
+					require_once ABSPATH . 'wp-admin/includes/screen.php';
+				}
+			},
+			1
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-stripe/issues/220
Fixes https://strategy11.slack.com/archives/CJFQ599V5/p1681620515610519

Improves upon https://github.com/Strategy11/formidable-forms/pull/1161 by fixing the issue in both Lite and Pro to avoid multiple patch releases and duplicate code.

It's also a private function so it will be easy to remove if WooCommerce fixes this on their end in the future.