### PR TITLE
0 fieldset border style setting does not work fix

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -87,7 +87,7 @@ form input.frm_verify{
 }
 
 .with_frm_style .frm_form_fields > fieldset{
-<?php if ( ! empty( $defaults['fieldset'] ) ) { ?>
+<?php if ( isset( $defaults['fieldset'] ) && ( $defaults['fieldset'] || '0' === $defaults['fieldset'] ) ) { ?>
 	border-width:<?php echo esc_html( $defaults['fieldset'] . $important ); ?>;
 	border-width:var(--fieldset)<?php echo esc_html( $important ); ?>;
 <?php } ?>


### PR DESCRIPTION
A 0 would be treated the same as an empty string, when it should really have no border just like the `0px` default. The `px` should be optional, not required like it currently is.

<img width="163" alt="Font Family" src="https://user-images.githubusercontent.com/9134515/232824245-db2be139-cb77-47c2-98be-320fdd01993a.png">
