### PR TITLE
Add Dismissible Warning Message Functionality

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -580,14 +580,14 @@ class FrmAppController {
 			return;
 		}
 
-		add_filter(
-			'frm_message_list',
-			function( $show_messages ) {
-				$global_settings_link = admin_url( 'admin.php?page=formidable-settings' ) . '#frm_custom_header_ip';
-				$show_messages['ip_msg'] = 'IP addresses in form submissions may no longer be accurate! If you are experiencing issues, we recommend going to <a href="' . esc_url( $global_settings_link ) . '">Global Settings</a> and enabling the "Use custom headers when retrieving IPs with form submissions." setting.';
-				return $show_messages;
-			}
+		$global_settings_link = admin_url( 'admin.php?page=formidable-settings' ) . '#frm_custom_header_ip';
+		$message = sprintf(
+			// Translators: 1: Global Settings Link
+			__( 'IP addresses in form submissions may no longer be accurate! If you are experiencing issues, we recommend going to %1$s and enabling the "Use custom headers when retrieving IPs with form submissions." setting.', 'formidable' ),
+			'<a href="' . esc_url( $global_settings_link ) . '">Global Settings</a>',
 		);
+		$wp_ajax_action = 'frm_dismiss_custom_header_ip_notice';
+		FrmAppHelper::print_dismissable_warning_message( $message, $wp_ajax_action );
 	}
 
 	/**

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -586,8 +586,8 @@ class FrmAppController {
 			__( 'IP addresses in form submissions may no longer be accurate! If you are experiencing issues, we recommend going to %1$s and enabling the "Use custom headers when retrieving IPs with form submissions." setting.', 'formidable' ),
 			'<a href="' . esc_url( $global_settings_link ) . '">Global Settings</a>',
 		);
-		$wp_ajax_action = 'frm_dismiss_custom_header_ip_notice';
-		FrmAppHelper::print_dismissable_warning_message( $message, $wp_ajax_action );
+		$action = FrmHooksController::DISMISS_IP_NOTICE_ACTION;
+		FrmAppHelper::print_dismissable_warning_message( $message, $action );
 	}
 
 	/**

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -584,10 +584,10 @@ class FrmAppController {
 		$message = sprintf(
 			// Translators: 1: Global Settings Link
 			__( 'IP addresses in form submissions may no longer be accurate! If you are experiencing issues, we recommend going to %1$s and enabling the "Use custom headers when retrieving IPs with form submissions." setting.', 'formidable' ),
-			'<a href="' . esc_url( $global_settings_link ) . '">Global Settings</a>',
+			'<a href="' . esc_url( $global_settings_link ) . '">Global Settings</a>'
 		);
-		$action = FrmHooksController::DISMISS_IP_NOTICE_ACTION;
-		FrmAppHelper::print_dismissable_warning_message( $message, $action );
+		$option_name = 'frm_dismiss_ip_address_notice';
+		FrmAppHelper::add_dismissable_warning_message( $message, $option_name );
 	}
 
 	/**

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -5,6 +5,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class FrmHooksController {
 
+	const DISMISS_IP_NOTICE_ACTION = 'frm_dismiss_custom_header_ip_notice';
+
 	/**
 	 * Trigger plugin-wide hook loading
 	 *
@@ -237,7 +239,7 @@ class FrmHooksController {
 
 		// Settings.
 		add_action( 'wp_ajax_frm_lite_settings_upgrade', 'FrmSettingsController::settings_cta_dismiss' );
-		add_action( 'wp_ajax_frm_dismiss_custom_header_ip_notice', 'FrmAppHelper::dismiss_warning_message' );
+		add_action( 'wp_ajax_' . self::DISMISS_IP_NOTICE_ACTION, 'FrmAppHelper::dismiss_warning_message' );
 
 		// Styles Controller.
 		add_action( 'wp_ajax_frm_settings_reset', 'FrmStylesController::reset_styling' );

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -5,8 +5,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class FrmHooksController {
 
-	const DISMISS_IP_NOTICE_ACTION = 'frm_dismiss_custom_header_ip_notice';
-
 	/**
 	 * Trigger plugin-wide hook loading
 	 *
@@ -239,7 +237,6 @@ class FrmHooksController {
 
 		// Settings.
 		add_action( 'wp_ajax_frm_lite_settings_upgrade', 'FrmSettingsController::settings_cta_dismiss' );
-		add_action( 'wp_ajax_' . self::DISMISS_IP_NOTICE_ACTION, 'FrmAppHelper::dismiss_warning_message' );
 
 		// Styles Controller.
 		add_action( 'wp_ajax_frm_settings_reset', 'FrmStylesController::reset_styling' );

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -237,6 +237,7 @@ class FrmHooksController {
 
 		// Settings.
 		add_action( 'wp_ajax_frm_lite_settings_upgrade', 'FrmSettingsController::settings_cta_dismiss' );
+		add_action( 'wp_ajax_frm_dismiss_custom_header_ip_notice', 'FrmAppHelper::dismiss_warning_message' );
 
 		// Styles Controller.
 		add_action( 'wp_ajax_frm_settings_reset', 'FrmStylesController::reset_styling' );

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3857,11 +3857,13 @@ class FrmAppHelper {
 			return;
 		}
 
+		$ajax_callback = function() use ( $option ) {
+			self::dismiss_warning_message( $option );
+		};
+
 		// We're handling JS codes with `doJsonPost` and it adds 'frm_' to the beginning of the action.
 		// To prevent any issues, we add 'frm_' from the beginning of the action.
-		add_action( 'wp_ajax_frm_' . $option, function() use ( $option ) {
-			self::dismiss_warning_message( $option );
-		});
+		add_action( 'wp_ajax_frm_' . $option, $ajax_callback);
 
 		add_filter(
 			'frm_message_list',

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3878,4 +3878,23 @@ class FrmAppHelper {
 			}
 		);
 	}
+
+	/**
+	 * Dismiss a warning message and update the dismissal state.
+	 *
+	 * @since x.x
+	 *
+	 * @return void
+	 */
+	public static function dismiss_warning_message() {
+		self::permission_check( 'frm_change_settings' );
+		check_ajax_referer( 'frm_ajax', 'nonce' );
+
+		if ( ! empty( $_POST['action'] ) ) {
+			$option = sanitize_text_field( wp_unslash( $_POST['action'] ) );
+			update_option( $option, true );
+		}
+
+		wp_die();
+	}
 }

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3897,4 +3897,25 @@ class FrmAppHelper {
 
 		wp_die();
 	}
+
+	/**
+	 * Add allowed HTML tags for the dismiss icon in a warning message.
+	 *
+	 * @since x.x
+	 *
+	 * @param array $allowed_html The array of allowed HTML tags and attributes.
+	 * @return array The updated array of allowed HTML tags and attributes.
+	 */
+	public static function add_allowed_dismiss_icon_tags( $allowed_html ) {
+		$allowed_html['span']['data-action'] = true;
+		$allowed_html['svg'] = array(
+			'class'      => true,
+			'aria-label' => true,
+		);
+		$allowed_html['use'] = array(
+			'xlink:href' => true,
+		);
+
+		return $allowed_html;
+	}
 }

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3857,17 +3857,11 @@ class FrmAppHelper {
 			return;
 		}
 
-		// Check if the option doesn't start with 'frm_'
-		if ( strpos( $option, 'frm_' ) !== 0 ) {
-			// Add the 'frm_' prefix to the option
-			$option = 'frm_' . $option;
-		}
-
-		$ajax_callback = function() use ( $option ) {
+		// We're handling JS codes with `doJsonPost` and it adds 'frm_' to the beginning of the action.
+		// To prevent any issues, we add 'frm_' from the beginning of the action.
+		add_action( 'wp_ajax_frm_' . $option, function() use ( $option ) {
 			self::dismiss_warning_message( $option );
-		};
-
-		add_action( 'wp_ajax_' . $option, $ajax_callback );
+		});
 
 		add_filter(
 			'frm_message_list',

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3880,8 +3880,8 @@ class FrmAppHelper {
 					)
 				);
 
-				$show_messages['warning_msg'] = $message;
-				$show_messages['dismiss_icon'] = '<span class="frm-warning-dismiss frmsvg" data-action="' . esc_attr( $option ) . '">' . $dismiss_icon . '</span>';
+				$show_messages[] = $message;
+				$show_messages[] = '<span class="frm-warning-dismiss frmsvg" data-action="' . esc_attr( $option ) . '">' . $dismiss_icon . '</span>';
 
 				return $show_messages;
 			}

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3842,4 +3842,40 @@ class FrmAppHelper {
 	public static function renewal_message() {
 		_deprecated_function( __METHOD__, '6.0', 'FrmProAddonsController::renewal_message' );
 	}
+
+	/**
+	 * Display a dismissable warning message and save its dismissal state.
+	 *
+	 * @since x.x
+	 *
+	 * @param string $message The warning message to display.
+	 * @param string $action The WP Ajax action.
+	 *                       The unique identifier for the dismissal state of the message.
+	 * @return void
+	 */
+	public static function print_dismissable_warning_message( $message, $action ) {
+		add_filter(
+			'frm_message_list',
+			function( $show_messages ) use ( $message, $action ) {
+				if ( get_option( $action, false ) ) {
+					return $show_messages;
+				}
+
+				add_filter( 'frm_striphtml_allowed_tags', 'FrmAppHelper::add_allowed_dismiss_icon_tags' );
+
+				$dismiss_icon = self::icon_by_class(
+					'frmfont frm_close_icon',
+					array(
+						'aria-label' => 'Dismiss',
+						'echo' => false,
+					)
+				);
+
+				$show_messages['warning_msg'] = $message;
+				$show_messages['dismiss_icon'] = '<span class="frm-warning-dismiss frmsvg" data-action="' . esc_attr( $action ) . '">' . $dismiss_icon . '</span>';
+
+				return $show_messages;
+			}
+		);
+	}
 }

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3863,7 +3863,7 @@ class FrmAppHelper {
 
 		// We're handling JS codes with `doJsonPost` and it adds 'frm_' to the beginning of the action.
 		// To prevent any issues, we add 'frm_' from the beginning of the action.
-		add_action( 'wp_ajax_frm_' . $option, $ajax_callback);
+		add_action( 'wp_ajax_frm_' . $option, $ajax_callback );
 
 		add_filter(
 			'frm_message_list',

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3901,7 +3901,7 @@ class FrmAppHelper {
 		check_ajax_referer( 'frm_ajax', 'nonce' );
 
 		if ( $option ) {
-			update_option( $option, true );
+			update_option( $option, true, 'no' );
 		}
 
 		wp_send_json_success();

--- a/classes/views/shared/errors.php
+++ b/classes/views/shared/errors.php
@@ -18,13 +18,22 @@ if ( ! isset( $show_messages ) ) {
 }
 $show_messages = apply_filters( 'frm_message_list', $show_messages );
 if ( is_array( $show_messages ) && count( $show_messages ) > 0 ) {
+	// Define a callback function to add 'data-action' attribute to allowed HTML tags
+	$add_data_action_callback = function( $allowed_html ) {
+		$allowed_html['span']['data-action'] = true;
+		return $allowed_html;
+	};
 	?>
 	<div class="frm_warning_style" role="alert">
 		<ul id="frm_messages">
 			<?php
+			// Add the callback function to the 'frm_striphtml_allowed_tags' filter
+			add_filter( 'frm_striphtml_allowed_tags', $add_data_action_callback );
 			foreach ( $show_messages as $m ) {
-				echo '<li>' . FrmAppHelper::kses( $m, array( 'a', 'br', 'span', 'p' ) ) . '</li>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo '<li>' . FrmAppHelper::kses( $m, array( 'a', 'br', 'span', 'p', 'svg', 'use' ) ) . '</li>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
+			// Remove the callback function from the 'frm_striphtml_allowed_tags' filter
+			remove_filter( 'frm_striphtml_allowed_tags', $add_data_action_callback );
 			?>
 		</ul>
 	</div>

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1891,6 +1891,43 @@ div.frm_updated_message {
 	margin-bottom:4px;
 }
 
+/* Warning message dismiss */
+.frm_warning_style:has(.frm-warning-dismiss) {
+    position: relative;
+    padding-right: calc(var(--gap-md) + 15px);
+}
+
+body.rtl .frm_warning_style:has(.frm-warning-dismiss) {
+    padding-right: var(--gap-md);
+    padding-left: calc(var(--gap-md) + 15px);
+}
+
+.frm_warning_style li:has(.frm-warning-dismiss) {
+    position: absolute;
+    top: var(--gap-sm);
+    right: var(--gap-md);
+    transform: translate(70%, -50%);
+	cursor: pointer;
+	transition: opacity 0.2s ease-out;
+}
+
+body.rtl .frm_warning_style li:has(.frm-warning-dismiss) {
+	left: var(--gap-md);
+	right: auto;
+	transform: translate(-70%, -50%);
+}
+
+.frm_warning_style li:has(.frm-warning-dismiss):hover {
+	opacity: 0.8;
+}
+
+.frm-warning-dismiss.frmsvg,
+.frm-warning-dismiss.frmsvg svg {
+	display: inline-block;
+    width: 15px;
+    height: 15px;
+}
+
 .frm_note_style {
 	background: rgba(188, 224, 253, 0.23);
 	color: var(--grey-700);

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1892,40 +1892,38 @@ div.frm_updated_message {
 }
 
 /* Warning message dismiss */
-.frm_warning_style:has(.frm-warning-dismiss) {
-    position: relative;
-    padding-right: calc(var(--gap-md) + 15px);
+.frm_warning_style {
+	position: relative;
+	padding-right: calc(var(--gap-md) + 15px);
 }
 
-body.rtl .frm_warning_style:has(.frm-warning-dismiss) {
-    padding-right: var(--gap-md);
-    padding-left: calc(var(--gap-md) + 15px);
+body.rtl .frm_warning_style {
+	padding-right: var(--gap-md);
+	padding-left: calc(var(--gap-md) + 15px);
 }
 
-.frm_warning_style li:has(.frm-warning-dismiss) {
-    position: absolute;
-    top: var(--gap-sm);
-    right: var(--gap-md);
-    transform: translate(70%, -50%);
+.frm-warning-dismiss {
+	position: absolute;
+	top: 10px;
+	right: 10px;
+	display: flex;
 	cursor: pointer;
 	transition: opacity 0.2s ease-out;
 }
 
-body.rtl .frm_warning_style li:has(.frm-warning-dismiss) {
-	left: var(--gap-md);
+body.rtl .frm-warning-dismiss {
+	left: 10px;
 	right: auto;
-	transform: translate(-70%, -50%);
 }
 
-.frm_warning_style li:has(.frm-warning-dismiss):hover {
+.frm-warning-dismiss:hover {
 	opacity: 0.8;
 }
 
 .frm-warning-dismiss.frmsvg,
 .frm-warning-dismiss.frmsvg svg {
-	display: inline-block;
-    width: 15px;
-    height: 15px;
+	width: 15px;
+	height: 15px;
 }
 
 .frm_note_style {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -318,6 +318,7 @@ function frmAdminBuildJS() {
 	/*global jQuery:false, frm_admin_js, frmGlobal, ajaxurl, fromDom */
 
 	const { tag, div, span, a, svg, img } = frmDom;
+	const { onClickPreventDefault } = frmDom.util;
 	const { doJsonFetch, doJsonPost } = frmDom.ajax;
 	const icons = {
 		save: svg({ href: '#frm_save_icon' }),
@@ -3463,12 +3464,12 @@ function frmAdminBuildJS() {
 	 * @param {Event} event The event object associated with the click on the dismiss icon.
 	 */
 	function dismissWarningMessage( event ) {
-		event.preventDefault();
+		const target = event.target;
 
-		const warningEl = this.closest( '.frm_warning_style' );
+		const warningEl = target.closest( '.frm_warning_style' );
 		jQuery( warningEl ).fadeOut( 400, () => warningEl.remove() );
 
-		const action = this.dataset.action;
+		const action = target.dataset.action;
 		const formData  = new FormData();
 		doJsonPost( action, formData );
 	}
@@ -9568,8 +9569,8 @@ function frmAdminBuildJS() {
 			}
 
 			// Add event listener for dismissible warning messages.
-			document.querySelectorAll( '.frm-warning-dismiss' )?.forEach( ( dismissIcon ) => {
-				dismissIcon.addEventListener( 'click', dismissWarningMessage );
+			document.querySelectorAll( '.frm-warning-dismiss' ).forEach( ( dismissIcon ) => {
+				onClickPreventDefault( dismissIcon, dismissWarningMessage );
 			});
 
 			frmAdminBuild.inboxBannerInit();

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9568,7 +9568,9 @@ function frmAdminBuildJS() {
 			}
 
 			// Add event listener for dismissible warning messages.
-			document.querySelector( '.frm-warning-dismiss' ).addEventListener( 'click', dismissWarningMessage );
+			document.querySelectorAll( '.frm-warning-dismiss' )?.forEach( ( dismissIcon ) => {
+				dismissIcon.addEventListener( 'click', dismissWarningMessage );
+			});
 
 			frmAdminBuild.inboxBannerInit();
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3456,6 +3456,28 @@ function frmAdminBuildJS() {
 	}
 
 	/**
+	 * Dismiss a warning message and send an AJAX request to update the dismissal state.
+	 *
+	 * @since x.x
+	 *
+	 * @param {Event} event The event object associated with the click on the dismiss icon.
+	 */
+	function dismissWarningMessage( event ) {
+		event.preventDefault();
+
+		const $this = jQuery( this );
+		const $warning = $this.closest( '.frm_warning_style' );
+		const action = $this.data( 'action' );
+
+		$warning.remove();
+
+		jQuery.post( ajaxurl, {
+			action: action,
+			nonce: frmGlobal.nonce
+		});
+	}
+
+	/**
 	 * If a field is clicked in the builder, prevent inputs from changing.
 	 */
 	function stopFieldFocus( e ) {
@@ -9548,6 +9570,9 @@ function frmAdminBuildJS() {
 			if ( typeof thisFormId === 'undefined' ) {
 				thisFormId = jQuery( document.getElementById( 'form_id' ) ).val();
 			}
+
+			// Dismiss dissmissable warning message.
+			jQuery( '.frm-warning-dismiss' ).on( 'click', dismissWarningMessage );
 
 			frmAdminBuild.inboxBannerInit();
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -318,7 +318,7 @@ function frmAdminBuildJS() {
 	/*global jQuery:false, frm_admin_js, frmGlobal, ajaxurl, fromDom */
 
 	const { tag, div, span, a, svg, img } = frmDom;
-	const { doJsonFetch } = frmDom.ajax;
+	const { doJsonFetch, doJsonPost } = frmDom.ajax;
 	const icons = {
 		save: svg({ href: '#frm_save_icon' }),
 		drag: svg({ href: '#frm_drag_icon', classList: [ 'frm_drag_icon', 'frm-drag' ] })
@@ -3465,16 +3465,14 @@ function frmAdminBuildJS() {
 	function dismissWarningMessage( event ) {
 		event.preventDefault();
 
-		const $this = jQuery( this );
-		const $warning = $this.closest( '.frm_warning_style' );
-		const action = $this.data( 'action' );
+		const warningEl = this.closest( '.frm_warning_style' );
+		jQuery( warningEl ).fadeOut( 400, () => warningEl.remove() );
 
-		$warning.remove();
-
-		jQuery.post( ajaxurl, {
-			action: action,
-			nonce: frmGlobal.nonce
-		});
+		// `doJsonPost` adds 'frm_' to the beginning of the action. To prevent
+		// any issues, we remove 'frm_' from the beginning of action if it is present.
+		const action = this.dataset.action.replace( /^frm_/, '' );
+		const formData  = new FormData();
+		doJsonPost( action, formData );
 	}
 
 	/**
@@ -9571,8 +9569,8 @@ function frmAdminBuildJS() {
 				thisFormId = jQuery( document.getElementById( 'form_id' ) ).val();
 			}
 
-			// Dismiss dissmissable warning message.
-			jQuery( '.frm-warning-dismiss' ).on( 'click', dismissWarningMessage );
+			// Add event listener for dismissible warning messages.
+			document.querySelector( '.frm-warning-dismiss' ).addEventListener( 'click', dismissWarningMessage );
 
 			frmAdminBuild.inboxBannerInit();
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3468,9 +3468,7 @@ function frmAdminBuildJS() {
 		const warningEl = this.closest( '.frm_warning_style' );
 		jQuery( warningEl ).fadeOut( 400, () => warningEl.remove() );
 
-		// `doJsonPost` adds 'frm_' to the beginning of the action. To prevent
-		// any issues, we remove 'frm_' from the beginning of action if it is present.
-		const action = this.dataset.action.replace( /^frm_/, '' );
+		const action = this.dataset.action;
 		const formData  = new FormData();
 		doJsonPost( action, formData );
 	}

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -704,28 +704,28 @@ class test_FrmAppHelper extends FrmUnitTest {
 	}
 
 	/**
-     * @covers FrmAppHelper::add_dismissable_warning_message
-     */
-    public function test_add_dismissable_warning_message() {
-        // Test with missing message and option parameters.
-        FrmAppHelper::add_dismissable_warning_message();
-        $messages = apply_filters( 'frm_message_list', array() );
-        $this->assertEmpty( $messages );
+	 * @covers FrmAppHelper::add_dismissable_warning_message
+	*/
+	public function test_add_dismissable_warning_message() {
+		// Test with missing message and option parameters.
+		FrmAppHelper::add_dismissable_warning_message();
+		$messages = apply_filters( 'frm_message_list', array() );
+		$this->assertEmpty( $messages );
 
-        // Test with valid message and option parameters.
-        $message = 'Test warning message';
-        $option = 'test_option';
-        FrmAppHelper::add_dismissable_warning_message( $message, $option );
-        $messages = apply_filters( 'frm_message_list', array() );
-        $this->assertNotEmpty( $messages );
-        $this->assertArrayHasKey( 'warning_msg', $messages );
-        $this->assertArrayHasKey( 'dismiss_icon', $messages );
-        $this->assertEquals( $message, $messages['warning_msg'] );
-
-        // Test with dismissed message.
-        update_option( $option, true );
+		// Test with valid message and option parameters.
+		$message = 'Test warning message';
+		$option = 'test_option';
 		FrmAppHelper::add_dismissable_warning_message( $message, $option );
-        $messages = apply_filters( 'frm_message_list', [] );
-        $this->assertEmpty( $messages );
-    }
+		$messages = apply_filters( 'frm_message_list', array() );
+		$this->assertNotEmpty( $messages );
+		$this->assertArrayHasKey( 'warning_msg', $messages );
+		$this->assertArrayHasKey( 'dismiss_icon', $messages );
+		$this->assertEquals( $message, $messages['warning_msg'] );
+
+		// Test with dismissed message.
+		update_option( $option, true );
+		FrmAppHelper::add_dismissable_warning_message( $message, $option );
+		$messages = apply_filters( 'frm_message_list', [] );
+		$this->assertEmpty( $messages );
+	}
 }

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -702,4 +702,30 @@ class test_FrmAppHelper extends FrmUnitTest {
 	public static function echo_function() {
 		echo '<div>My echo function content</div>';
 	}
+
+	/**
+     * @covers FrmAppHelper::add_dismissable_warning_message
+     */
+    public function test_add_dismissable_warning_message() {
+        // Test with missing message and option parameters.
+        FrmAppHelper::add_dismissable_warning_message();
+        $messages = apply_filters( 'frm_message_list', array() );
+        $this->assertEmpty( $messages );
+
+        // Test with valid message and option parameters.
+        $message = 'Test warning message';
+        $option = 'test_option';
+        FrmAppHelper::add_dismissable_warning_message( $message, $option );
+        $messages = apply_filters( 'frm_message_list', array() );
+        $this->assertNotEmpty( $messages );
+        $this->assertArrayHasKey( 'warning_msg', $messages );
+        $this->assertArrayHasKey( 'dismiss_icon', $messages );
+        $this->assertEquals( $message, $messages['warning_msg'] );
+
+        // Test with dismissed message.
+        update_option( $option, true );
+		FrmAppHelper::add_dismissable_warning_message( $message, $option );
+        $messages = apply_filters( 'frm_message_list', [] );
+        $this->assertEmpty( $messages );
+    }
 }

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -725,7 +725,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 		// Test with dismissed message.
 		update_option( $option, true );
 		FrmAppHelper::add_dismissable_warning_message( $message, $option );
-		$messages = apply_filters( 'frm_message_list', [] );
+		$messages = apply_filters( 'frm_message_list', array() );
 		$this->assertEmpty( $messages );
 	}
 }

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -718,9 +718,9 @@ class test_FrmAppHelper extends FrmUnitTest {
 		FrmAppHelper::add_dismissable_warning_message( $message, $option );
 		$messages = apply_filters( 'frm_message_list', array() );
 		$this->assertNotEmpty( $messages );
-		$this->assertArrayHasKey( 'warning_msg', $messages );
-		$this->assertArrayHasKey( 'dismiss_icon', $messages );
-		$this->assertEquals( $message, $messages['warning_msg'] );
+		$this->assertArrayHasKey( 0, $messages );
+		$this->assertArrayHasKey( 1, $messages );
+		$this->assertEquals( $message, $messages[0] );
 
 		// Test with dismissed message.
 		update_option( $option, true );

--- a/tests/misc/test_FrmAppHeperAjax.php
+++ b/tests/misc/test_FrmAppHeperAjax.php
@@ -25,7 +25,7 @@ class test_FrmAppHeperAjax extends FrmAjaxUnitTest {
 
 		$this->_handleAjax( $action );
 
-			// Check if the warning message is not dismissed
+		// Check if the warning message is not dismissed
 		$this->assertFalse( get_option( $option, false ) );
 
 		try {

--- a/tests/misc/test_FrmAppHeperAjax.php
+++ b/tests/misc/test_FrmAppHeperAjax.php
@@ -13,10 +13,10 @@ class test_FrmAppHeperAjax extends FrmAjaxUnitTest {
 	}
 
 	/**
-     * @covers FrmAppHelper::dismiss_warning_message
-     */
-    public function test_dismiss_warning_message() {
-        $option = 'test_option';
+	 * @covers FrmAppHelper::dismiss_warning_message
+	 */
+	public function test_dismiss_warning_message() {
+		$option = 'test_option';
 		$action = 'frm_' . $option;
 		$_POST = array(
 			'action' => $action,
@@ -24,25 +24,25 @@ class test_FrmAppHeperAjax extends FrmAjaxUnitTest {
 		);
 
 		try {
-            $this->_handleAjax( $action );
-        } catch ( WPAjaxDieContinueException $e ) {
-            // Ignore the die() statement in wp_send_json_success()
+			$this->_handleAjax( $action );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Ignore the die() statement in wp_send_json_success()
 			unset( $e );
-        }
+		}
 
-        try {
-            // Check if the warning message is not dismissed
-            $this->assertFalse( get_option( $option, false ) );
+		try {
+			// Check if the warning message is not dismissed
+			$this->assertFalse( get_option( $option, false ) );
 
-            // Call dismiss_warning_message method
-            FrmAppHelper::dismiss_warning_message( $option );
+			// Call dismiss_warning_message method
+			FrmAppHelper::dismiss_warning_message( $option );
 
-            // Check if the warning message is dismissed
-            $this->assertTrue( get_option( $option ) );
-        } finally {
-            // Clean up
-            delete_option( $option );
-            wp_set_current_user( 0 );
-        }
-    }
+			// Check if the warning message is dismissed
+			$this->assertTrue( get_option( $option ) );
+		} finally {
+			// Clean up
+			delete_option( $option );
+			wp_set_current_user( 0 );
+		}
+	}
 }

--- a/tests/misc/test_FrmAppHeperAjax.php
+++ b/tests/misc/test_FrmAppHeperAjax.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @group ajax
+ */
+class test_FrmAppHeperAjax extends FrmAjaxUnitTest {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->user_id );
+	}
+
+	/**
+     * @covers FrmAppHelper::dismiss_warning_message
+     */
+    public function test_dismiss_warning_message() {
+        $option = 'test_option';
+		$action = 'frm_' . $option;
+		$_POST = array(
+			'action' => $action,
+			'nonce'  => wp_create_nonce( 'frm_ajax' ),
+		);
+
+		try {
+            $this->_handleAjax( $action );
+        } catch ( WPAjaxDieContinueException $e ) {
+            // Ignore the die() statement in wp_send_json_success()
+			unset( $e );
+        }
+
+        try {
+            // Check if the warning message is not dismissed
+            $this->assertFalse( get_option( $option, false ) );
+
+            // Call dismiss_warning_message method
+            FrmAppHelper::dismiss_warning_message( $option );
+
+            // Check if the warning message is dismissed
+            $this->assertTrue( get_option( $option ) );
+        } finally {
+            // Clean up
+            delete_option( $option );
+            wp_set_current_user( 0 );
+        }
+    }
+}

--- a/tests/misc/test_FrmAppHeperAjax.php
+++ b/tests/misc/test_FrmAppHeperAjax.php
@@ -25,19 +25,19 @@ class test_FrmAppHeperAjax extends FrmAjaxUnitTest {
 
 		$this->_handleAjax( $action );
 
-		try {
 			// Check if the warning message is not dismissed
-			$this->assertFalse( get_option( $option, false ) );
+		$this->assertFalse( get_option( $option, false ) );
 
+		try {
 			// Call dismiss_warning_message method
 			FrmAppHelper::dismiss_warning_message( $option );
-
-			// Check if the warning message is dismissed
-			$this->assertTrue( get_option( $option ) );
 		} catch ( WPAjaxDieContinueException $e ) {
 			// Ignore the die() statement in wp_send_json_success()
 			unset( $e );
 		} finally {
+			// Check if the warning message is dismissed
+			$this->assertTrue( get_option( $option ) );
+
 			// Clean up
 			delete_option( $option );
 			wp_set_current_user( 0 );

--- a/tests/misc/test_FrmAppHeperAjax.php
+++ b/tests/misc/test_FrmAppHeperAjax.php
@@ -23,12 +23,7 @@ class test_FrmAppHeperAjax extends FrmAjaxUnitTest {
 			'nonce'  => wp_create_nonce( 'frm_ajax' ),
 		);
 
-		try {
-			$this->_handleAjax( $action );
-		} catch ( WPAjaxDieContinueException $e ) {
-			// Ignore the die() statement in wp_send_json_success()
-			unset( $e );
-		}
+		$this->_handleAjax( $action );
 
 		try {
 			// Check if the warning message is not dismissed
@@ -39,6 +34,9 @@ class test_FrmAppHeperAjax extends FrmAjaxUnitTest {
 
 			// Check if the warning message is dismissed
 			$this->assertTrue( get_option( $option ) );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Ignore the die() statement in wp_send_json_success()
+			unset( $e );
 		} finally {
 			// Clean up
 			delete_option( $option );


### PR DESCRIPTION
This PR introduces dismissible warning message functionality. It adds the `FrmAppHelper::add_dismissable_warning_message` method, which can be used to easily display dismissible warning messages.

### Related Issues:
https://github.com/Strategy11/formidable-pro/issues/4134

### Before:
<img width="1490" alt="image" src="https://user-images.githubusercontent.com/69119241/232885962-908117b5-90cc-40c4-9cd0-801a8bec1d56.png">

### After:
<img width="1488" alt="image" src="https://user-images.githubusercontent.com/69119241/232884296-c1a52560-9cb4-4b31-82cf-e44e628b75a6.png">

### After - RTL:
<img width="1486" alt="image" src="https://user-images.githubusercontent.com/69119241/232885790-39ec182b-3062-4b18-a611-e63ed33d4694.png">
