### PR TITLE
Improve Readability of Import XML Error Messages

### DIFF
--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -1280,7 +1280,7 @@ class FrmXMLHelper {
 		if ( is_wp_error( $result ) ) {
 			$errors[] = $result->get_error_message();
 
-			// Remove the SimpleXML_parse_error from a WP_Error object to avoid
+			// Remove the SimpleXML_parse_error from the WP_Error object to avoid
 			// displaying duplicate error messages from $result->get_error_message()
 			$error_codes = $result->get_error_codes();
 			$error_details = array();

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -1279,6 +1279,9 @@ class FrmXMLHelper {
 	public static function parse_message( $result, &$message, &$errors ) {
 		if ( is_wp_error( $result ) ) {
 			$errors[] = $result->get_error_message();
+			$errors[] = '<br />' . _x( 'Error details:', 'import xml message', 'formidable' ) . '<br />' . htmlentities( print_r( $result, 1 ) );
+
+			return;
 		} elseif ( ! $result ) {
 			return;
 		}

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -1279,7 +1279,7 @@ class FrmXMLHelper {
 	public static function parse_message( $result, &$message, &$errors ) {
 		if ( is_wp_error( $result ) ) {
 			$errors[] = $result->get_error_message();
-			$errors[] = '<br />' . _x( 'Error details:', 'import xml message', 'formidable' ) . '<br />' . htmlentities( print_r( $result, 1 ) );
+			$errors[] = '<br />' . esc_html_x( 'Error details:', 'import xml message', 'formidable' ) . '<br />' . esc_html( print_r( $result, 1 ) );
 
 			return;
 		} elseif ( ! $result ) {

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -1279,7 +1279,23 @@ class FrmXMLHelper {
 	public static function parse_message( $result, &$message, &$errors ) {
 		if ( is_wp_error( $result ) ) {
 			$errors[] = $result->get_error_message();
-			$errors[] = '<br />' . esc_html_x( 'Error details:', 'import xml message', 'formidable' ) . '<br />' . esc_html( print_r( $result, 1 ) );
+
+			// Remove the SimpleXML_parse_error from a WP_Error object to avoid
+			// displaying duplicate error messages from $result->get_error_message()
+			$error_codes = $result->get_error_codes();
+			$error_details = array();
+			foreach ( $error_codes as $error_code ) {
+				// Clone WP_Error data because WP_Error removes all error messages and data
+				// associated with the specified error code when an item is removed.
+				// Source: https://developer.wordpress.org/reference/classes/wp_error/remove/#source
+				$error_details = $result->get_error_data( $error_code );
+				if ( $error_code === 'SimpleXML_parse_error' ) {
+					$result->remove( $error_code );
+					break;
+				}
+			}
+
+			$errors[] = '<br />' . esc_html_x( 'Error details:', 'import xml message', 'formidable' ) . '<br />' . esc_html( print_r( $error_details, 1 ) );
 
 			return;
 		} elseif ( ! $result ) {


### PR DESCRIPTION
In this pull request, we are improving the readability of import XML error messages by combining WP_Error details with the message.

### Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4189

---

## Before:
![image](https://user-images.githubusercontent.com/69119241/233380708-d964d44e-9ca5-43ef-b39c-a1bf690e3f5b.png)

### After:
![image](https://user-images.githubusercontent.com/69119241/233380771-9542dd5a-aaa1-4234-9ef3-84ba448f26b5.png)
