### PR TITLE
Fix: Dark text on Repeater buttons in Gutenberg block preview

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -632,10 +632,6 @@ legend.frm_hidden{
 	color:var(--submit-bg-color)<?php echo esc_html( $important ); ?>;
 	background:var(--submit-text-color)<?php echo esc_html( $important ); ?>;
 }
-
-.editor-styles-wrapper .wp-block-post-content .with_frm_style .frm_button{
-	color:var(--submit-text-color)<?php echo esc_html( $important ); ?>;
-}
 <?php } ?>
 
 .with_frm_style .frm_submit{

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -632,6 +632,10 @@ legend.frm_hidden{
 	color:var(--submit-bg-color)<?php echo esc_html( $important ); ?>;
 	background:var(--submit-text-color)<?php echo esc_html( $important ); ?>;
 }
+
+.editor-styles-wrapper .wp-block-post-content .with_frm_style .frm_button{
+	color:var(--submit-text-color)<?php echo esc_html( $important ); ?>;
+}
 <?php } ?>
 
 .with_frm_style .frm_submit{

--- a/css/frm_blocks.css
+++ b/css/frm_blocks.css
@@ -72,6 +72,6 @@
 }
 
 .editor-styles-wrapper .wp-block-post-content .with_frm_style .frm_repeat_buttons .frm_button {
-	/* Prevent blue anrchor text in Add/Remove buttons */
+	/* Prevent blue anchor text in Add/Remove buttons */
 	color:var(--submit-text-color) !important;
 }

--- a/css/frm_blocks.css
+++ b/css/frm_blocks.css
@@ -74,5 +74,6 @@
 .editor-styles-wrapper .wp-block-post-content .with_frm_style .frm_repeat_buttons .frm_button {
 	/* Prevent blue anchor text in Add/Remove buttons */
 	color: var(--submit-text-color) !important;
+	/* Ensure consistent background color on focus for Add/Remove buttons */
 	background: var(--submit-bg-color) !important;
 }

--- a/css/frm_blocks.css
+++ b/css/frm_blocks.css
@@ -73,5 +73,6 @@
 
 .editor-styles-wrapper .wp-block-post-content .with_frm_style .frm_repeat_buttons .frm_button {
 	/* Prevent blue anchor text in Add/Remove buttons */
-	color:var(--submit-text-color) !important;
+	color: var(--submit-text-color) !important;
+	background: var(--submit-bg-color) !important;
 }

--- a/css/frm_blocks.css
+++ b/css/frm_blocks.css
@@ -65,3 +65,13 @@
 .frm-admin-loading {
 	width: 200px;
 }
+
+.editor-styles-wrapper .frm_repeat_buttons i {
+	/* Avoid font-style: italic conflicts. The +/- icon should not be italic */
+	font-style: unset;
+}
+
+.editor-styles-wrapper .wp-block-post-content .with_frm_style .frm_repeat_buttons .frm_button {
+	/* Prevent blue anrchor text in Add/Remove buttons */
+	color:var(--submit-text-color) !important;
+}


### PR DESCRIPTION
With this PR, we strengthen the CSS selector for the repeater button color in Gutenberg to ensure the correct text color is displayed.

### Issue Link:
https://github.com/Strategy11/formidable-pro/issues/4131

### before
<kbd>
<img width="677" alt="image" src="https://user-images.githubusercontent.com/69119241/233634098-8e041b83-8dd2-4d4b-a2c1-21680847fb06.png">
</kbd>

### After:
<kbd>
<img width="680" alt="image" src="https://user-images.githubusercontent.com/69119241/233634055-d950e4db-fa16-4d8a-a72c-0ce8f8831de1.png">
</kbd>