### PR TITLE
Fix blank value is selected by default for radio and checkbox

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -425,6 +425,9 @@ class FrmFieldsHelper {
 			$field_name = $base_name . ( $default_type === 'checkbox' ? '[' . $opt_key . ']' : '' );
 
 			$checked = ( isset( $field['default_value'] ) && ( ( ! is_array( $field['default_value'] ) && $field['default_value'] == $field_val ) || ( is_array( $field['default_value'] ) && in_array( $field_val, $field['default_value'] ) ) ) );
+			if ( ! empty( $field['default_null'] ) ) {
+				$checked = false;
+			}
 
 			// If this is an "Other" option, get the HTML for it.
 			if ( self::is_other_opt( $opt_key ) ) {

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -373,6 +373,11 @@ class FrmForm {
 
 			self::prepare_field_update_values( $field, $values, $new_field );
 
+			// Add flag for the null default value for the radio field.
+			if ( in_array( $new_field['type'], array( 'checkbox', 'radio' ), true ) ) {
+				$new_field['field_options']['default_null'] = ! isset( $values[ 'default_value_' . $field_id ] );
+			}
+
 			FrmField::update( $field_id, $new_field );
 
 			FrmField::delete_form_transient( $field->form_id );

--- a/classes/views/frm-fields/front-end/checkbox-field.php
+++ b/classes/views/frm-fields/front-end/checkbox-field.php
@@ -38,7 +38,7 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 			// Let the checked state of 'Other' fields be determined solely by FrmFieldsHelper::prepare_other_input as below.
 			// Without this check, one 'Other' field being checked leads to making all 'Other' fields checked on submit error
 			// since they all have the same value attr of 'Other'.
-			$checked = FrmAppHelper::check_selected( $field['value'], $field_val ) ? ' checked="checked"' : '';
+			$checked = empty( $field['default_null'] ) && FrmAppHelper::check_selected( $field['value'], $field_val ) ? ' checked="checked"' : '';
 		}
 
 		// Check if other opt, and get values for other field if needed

--- a/classes/views/frm-fields/front-end/radio-field.php
+++ b/classes/views/frm-fields/front-end/radio-field.php
@@ -38,7 +38,7 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 		if ( ! isset( $shortcode_atts ) || ! isset( $shortcode_atts['label'] ) || $shortcode_atts['label'] ) {
 			?><label for="<?php echo esc_attr( $html_id ); ?>-<?php echo esc_attr( $opt_key ); ?>"><?php
 		}
-		$checked = FrmAppHelper::check_selected( $field['value'], $field_val ) ? 'checked="checked" ' : ' ';
+		$checked = empty( $field['default_null'] ) && FrmAppHelper::check_selected( $field['value'], $field_val ) ? 'checked="checked" ' : ' ';
 
 		$other_opt = false;
 		$other_args = FrmFieldsHelper::prepare_other_input( compact( 'field_name', 'opt_key', 'field' ), $other_opt, $checked );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3385

This fix applies to the radio and checkbox fields. Users need to re-save the old form to apply this fix.