### PR TITLE
Add abandonment event to trigger_actions besides draft

### DIFF
--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -505,7 +505,7 @@ class FrmFormActionsController {
 				$entry = FrmEntry::getOne( $entry, true );
 			}
 
-			if ( empty( $entry ) || ( $entry->is_draft && $event != 'draft' ) ) {
+			if ( empty( $entry ) || ( $entry->is_draft && $event !== 'draft' && $event !== 'abandoned' ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
There is a condition to avoid triggering actions whenever the draft column is set and the event is not draft to prevent the actions to be used while is_draft is set and event is different. This PR will add the abandonment event besides the draft event since we are using is_draft column for abandonment too.
 