### PR TITLE
Fix Confirmation actions don't enforce sanitize_url option in shortcodes

### DIFF
--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -285,11 +285,6 @@ class FrmForm {
 		$options['after_html']   = isset( $values['options']['after_html'] ) ? $values['options']['after_html'] : FrmFormsHelper::get_default_html( 'after' );
 		$options['submit_html']  = ( isset( $values['options']['submit_html'] ) && '' !== $values['options']['submit_html'] ) ? $values['options']['submit_html'] : FrmFormsHelper::get_default_html( 'submit' );
 
-		if ( ! empty( $options['success_url'] ) && ! empty( $args['form_id'] ) ) {
-			$options['success_url']           = FrmFormsHelper::maybe_add_sanitize_url_attr( $options['success_url'], (int) $args['form_id'] );
-			$values['options']['success_url'] = $options['success_url'];
-		}
-
 		/**
 		 * Allows modifying form options before updating or creating.
 		 *

--- a/classes/models/FrmOnSubmitAction.php
+++ b/classes/models/FrmOnSubmitAction.php
@@ -56,6 +56,26 @@ class FrmOnSubmitAction extends FrmFormAction {
 	}
 
 	/**
+	 * This function should check that $new_instance is set correctly.
+	 * The newly calculated value of $instance should be returned.
+	 * If "false" is returned, the instance won't be saved/updated.
+	 *
+	 * @param array $new_instance New settings for this instance as input by the user via form()
+	 * @param array $old_instance Old settings for this instance
+	 *
+	 * @return array Settings to save or bool false to cancel saving
+	 */
+	public function update( $new_instance, $old_instance ) {
+		if ( 'redirect' === $new_instance['post_content']['success_action'] && ! empty( $new_instance['post_content']['success_url'] ) ) {
+			$new_instance['post_content']['success_url'] = FrmFormsHelper::maybe_add_sanitize_url_attr(
+				$new_instance['post_content']['success_url'],
+				(int) $new_instance['menu_order']
+			);
+		}
+		return $new_instance;
+	}
+
+	/**
 	 * Add a workaround in case Pro hasn't been updated. We don't want to
 	 * lose the trigger and have edit messages start showing on create.
 	 *

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7406,7 +7406,7 @@ function frmAdminBuildJS() {
 	}
 
 	function maybeAddSanitizeUrlToShortcodeVariable( variable, element, contentBox ) {
-		if ( 'object' !== typeof element || ! ( element instanceof jQuery ) || 'success_url' !== contentBox[0].id ) {
+		if ( 'object' !== typeof element || ! ( element instanceof jQuery ) || 0 !== contentBox[0].id.indexOf( 'success_url_' ) ) {
 			return variable;
 		}
 

--- a/tests/forms/test_FrmOnSubmitAction.php
+++ b/tests/forms/test_FrmOnSubmitAction.php
@@ -23,6 +23,7 @@ class test_FrmOnSubmitAction extends FrmUnitTest {
 			$number => array(
 				'ID'          => $action_id,
 				'post_status' => 'publish',
+				'post_title'  => 'Confirmation',
 				'post_content' => array(
 					'success_action' => 'redirect',
 					'success_url'    => 'https://example.com/?param=[1]',
@@ -30,13 +31,13 @@ class test_FrmOnSubmitAction extends FrmUnitTest {
 			),
 		);
 
-		$action = new FrmFormAction( $id_base, 'Confirmation' );
+		$action = new FrmOnSubmitAction();
 		$action->update_callback( $form_id );
 
 		$updated_action = get_post( $action_id );
 		$post_content = (array) FrmAppHelper::maybe_json_decode( $updated_action->post_content );
 
 		$this->assertFalse( empty( $post_content['success_url'] ) );
-		$this->assertEquals( 'https://example.com/?param[1 sanitize_url=1]', $post_content['success_url'] );
+		$this->assertEquals( 'https://example.com/?param=[1 sanitize_url=1]', $post_content['success_url'] );
 	}
 }

--- a/tests/forms/test_FrmOnSubmitAction.php
+++ b/tests/forms/test_FrmOnSubmitAction.php
@@ -6,10 +6,16 @@
 class test_FrmOnSubmitAction extends FrmUnitTest {
 
 	public function test_adding_sanitize_url_after_updating() {
-		$form_id               = $this->factory->form->create();
-		$id_base               = 'on_submit';
-		$option_name           = 'frm_' . $id_base . '_action';
-		$number                = -1;
+		$form_id     = $this->factory->form->create();
+		$field_id    = $this->factory->field->create(
+			array(
+				'form_id' => $form_id,
+				'type'    => 'text',
+			)
+		);
+		$id_base     = 'on_submit';
+		$option_name = 'frm_' . $id_base . '_action';
+		$number      = -1;
 
 		$action_id           = $this->factory->post->create(
 			array(
@@ -21,12 +27,12 @@ class test_FrmOnSubmitAction extends FrmUnitTest {
 
 		$_POST[ $option_name ] = array(
 			$number => array(
-				'ID'          => $action_id,
-				'post_status' => 'publish',
-				'post_title'  => 'Confirmation',
+				'ID'           => $action_id,
+				'post_status'  => 'publish',
+				'post_title'   => 'Confirmation',
 				'post_content' => array(
 					'success_action' => 'redirect',
-					'success_url'    => 'https://example.com/?param=[1]',
+					'success_url'    => 'https://example.com/?param=[' . $field_id . ']',
 				),
 			),
 		);
@@ -38,6 +44,6 @@ class test_FrmOnSubmitAction extends FrmUnitTest {
 		$post_content = (array) FrmAppHelper::maybe_json_decode( $updated_action->post_content );
 
 		$this->assertFalse( empty( $post_content['success_url'] ) );
-		$this->assertEquals( 'https://example.com/?param=[1 sanitize_url=1]', $post_content['success_url'] );
+		$this->assertEquals( 'https://example.com/?param=[' . $field_id . ' sanitize_url=1]', $post_content['success_url'] );
 	}
 }

--- a/tests/forms/test_FrmOnSubmitAction.php
+++ b/tests/forms/test_FrmOnSubmitAction.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @group forms
+ */
+class test_FrmOnSubmitAction extends FrmUnitTest {
+
+	public function test_adding_sanitize_url_after_updating() {
+		$form_id               = $this->factory->form->create();
+		$id_base               = 'on_submit';
+		$option_name           = 'frm_' . $id_base . '_action';
+		$number                = -1;
+
+		$action_id           = $this->factory->post->create(
+			array(
+				'post_type'    => FrmFormActionsController::$action_post_type,
+				'menu_order'   => $form_id,
+				'post_excerpt' => $id_base,
+			)
+		);
+
+		$_POST[ $option_name ] = array(
+			$number => array(
+				'ID'          => $action_id,
+				'post_status' => 'publish',
+				'post_content' => array(
+					'success_action' => 'redirect',
+					'success_url'    => 'https://example.com/?param=[1]',
+				),
+			),
+		);
+
+		$action = new FrmFormAction( $id_base, 'Confirmation' );
+		$action->update_callback( $form_id );
+
+		$updated_action = get_post( $action_id );
+		$post_content = (array) FrmAppHelper::maybe_json_decode( $updated_action->post_content );
+
+		$this->assertFalse( empty( $post_content['success_url'] ) );
+		$this->assertEquals( 'https://example.com/?param[1 sanitize_url=1]', $post_content['success_url'] );
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4148