### PR TITLE
Enhance error message for missing DOMDocument during XML import

### DIFF
--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -33,7 +33,13 @@ class FrmXMLHelper {
 		}
 
 		if ( ! class_exists( 'DOMDocument' ) ) {
-			return new WP_Error( 'SimpleXML_parse_error', __( 'Your server does not have XML enabled', 'formidable' ), libxml_get_errors() );
+			$error_message = sprintf(
+				/* translators: 1: Documentation link */
+				__( 'In order to install XML, your server must have DOMDocument installed. Follow our documentation on %1$s to ensure DOMDocument is properly set up and XML support is enabled.', 'formidable' ),
+				'<a href="https://formidableforms.com/knowledgebase/import-forms-entries-and-views/#kb-your-server-does-not-have-xml-enabled" target="_blank">Importing Forms, Entries, and Views</a>'
+			);
+
+			return new WP_Error( 'SimpleXML_parse_error', $error_message, libxml_get_errors() );
 		}
 
 		$xml_string = file_get_contents( $file );

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -1301,7 +1301,9 @@ class FrmXMLHelper {
 				}
 			}
 
-			$errors[] = '<br />' . esc_html_x( 'Error details:', 'import xml message', 'formidable' ) . '<br />' . esc_html( print_r( $error_details, 1 ) );
+			if ( ! empty( $error_details ) ) {
+				$errors[] = '<br />' . esc_html_x( 'Error details:', 'import xml message', 'formidable' ) . '<br />' . esc_html( print_r( $error_details, 1 ) );
+			}
 
 			return;
 		} elseif ( ! $result ) {


### PR DESCRIPTION
This PR enhances the error message displayed when attempting to import XML files without the DOMDocument class installed on the server, providing a more user-friendly description and a link to the documentation for troubleshooting.

### Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4207

### Updated Error Message:
In order to install XML, your server must have DOMDocument installed. Follow our documentation on [Importing Forms, Entries, and Views](https://formidableforms.com/knowledgebase/import-forms-entries-and-views/#kb-your-server-does-not-have-xml-enabled) to ensure DOMDocument is properly set up and XML support is enabled.

### Screenshot of the Updated Output on Import/Export Admin Page:
<img width="1476" alt="image" src="https://user-images.githubusercontent.com/69119241/234382396-367e4ea0-9b27-4616-929c-2f16552062c2.png">
