### PR TITLE
Prevent Dragging of Disabled Field Types

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9740,7 +9740,7 @@ function frmAdminBuildJS() {
 
 			setupSortable( 'ul.frm_sorting' );
 
-			document.querySelectorAll( '.field_type_list > li' ).forEach( makeDraggable );
+			document.querySelectorAll( '.field_type_list > li:not(.frm_show_upgrade)' ).forEach( makeDraggable );
 
 			jQuery( 'ul.field_type_list, .field_type_list li, ul.frm_code_list, .frm_code_list li, .frm_code_list li a, #frm_adv_info #category-tabs li, #frm_adv_info #category-tabs li a' ).disableSelection();
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -913,7 +913,8 @@ function frmAdminBuildJS() {
 			cursorAt: {
 				top: 0,
 				left: 90 // The width of draggable button is 180. 90 should center the draggable on the cursor.
-			}
+			},
+			cancel: '.frm_show_upgrade' // Prevent .frm_show_upgrade elements from being draggable.
 		};
 		if ( 'string' === typeof handle ) {
 			settings.handle = handle;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -913,8 +913,7 @@ function frmAdminBuildJS() {
 			cursorAt: {
 				top: 0,
 				left: 90 // The width of draggable button is 180. 90 should center the draggable on the cursor.
-			},
-			cancel: '.frm_show_upgrade' // Prevent .frm_show_upgrade elements from being draggable.
+			}
 		};
 		if ( 'string' === typeof handle ) {
 			settings.handle = handle;


### PR DESCRIPTION
In this pull request, we've updated the makeDraggable function to prevent elements with the .frm_show_upgrade class from being draggable.

### Related PR:
https://github.com/Strategy11/formidable-pro/issues/4201