### PR TITLE
Stop trying to display entry descriptions in the entry list

### DIFF
--- a/classes/helpers/FrmEntriesListHelper.php
+++ b/classes/helpers/FrmEntriesListHelper.php
@@ -122,7 +122,7 @@ class FrmEntriesListHelper extends FrmListHelper {
 
 		$colspan = $this->get_column_count();
 
-		include( FrmAppHelper::plugin_path() . '/classes/views/frm-entries/no_entries.php' );
+		include FrmAppHelper::plugin_path() . '/classes/views/frm-entries/no_entries.php';
 	}
 
 	/**
@@ -231,7 +231,7 @@ class FrmEntriesListHelper extends FrmListHelper {
 			$form_id           = $this->params['form'] ? $this->params['form'] : 0;
 			$this->column_name = preg_replace( '/^(' . $form_id . '_)/', '', $column_name );
 
-			if ( $this->column_name == 'cb' ) {
+			if ( $this->column_name === 'cb' ) {
 				$r .= "<th scope='row' class='check-column'>$checkbox</th>";
 			} else {
 				if ( in_array( $column_name, $hidden, true ) ) {
@@ -279,7 +279,6 @@ class FrmEntriesListHelper extends FrmListHelper {
 				$val = $item->{$col_name};
 				break;
 			case 'name':
-			case 'description':
 				$val = FrmAppHelper::truncate( strip_tags( $item->{$col_name} ), 100 );
 				break;
 			case 'created_at':

--- a/tests/entries/test_FrmEntriesListHelper.php
+++ b/tests/entries/test_FrmEntriesListHelper.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @group entries
+ */
+class test_FrmEntriesListHelper extends FrmUnitTest {
+
+	/**
+	 * @covers FrmEntriesListHelper::column_value
+	 */
+	public function test_column_value() {
+		$item = new stdClass();
+
+		// This doesn't need to be accurate for this test. This ID doesn't match the database.
+		$item->id             = 1;
+		$item->name           = 'My entry name';
+		$item->description    = array(
+			'browser'  => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:107.0) Gecko/20100101 Firefox/107.0',
+			'referrer' => 'http://example.com',
+		);
+		$item->post_id        = 0;
+		$item->form_id        = $this->factory->form->create();
+		$description_field_id = $this->factory->field->create(
+			array(
+				'form_id'   => $item->form_id,
+				'field_key' => 'description',
+			)
+		);
+		$item->metas = array(
+			$description_field_id => 'Description field value',
+		);
+
+		$column_value = $this->column_value( $item, 'description' );
+		$this->assertIsString( $column_value );
+		$this->assertEquals( 'Description field value', $column_value );
+
+		$column_value = $this->column_value( $item, 'id' );
+		$this->assertEquals( 1, $column_value );
+
+		$column_value = $this->column_value( $item, 'name' );
+		$this->assertEquals( 'My entry name', $column_value );
+	}
+
+	/**
+	 * @param stdClass $item
+	 * @param string   $column_name
+	 */
+	private function column_value( $item, $column_name ) {
+		$list_helper = new FrmEntriesListHelper( array() );
+		$this->set_private_property( $list_helper, 'column_name', $column_name );
+		return $this->run_private_method( array( $list_helper, 'column_value' ), array( $item )	);
+	}
+}

--- a/tests/entries/test_FrmEntriesListHelper.php
+++ b/tests/entries/test_FrmEntriesListHelper.php
@@ -9,6 +9,8 @@ class test_FrmEntriesListHelper extends FrmUnitTest {
 	 * @covers FrmEntriesListHelper::column_value
 	 */
 	public function test_column_value() {
+		FrmAppHelper::set_current_screen_and_hook_suffix();
+
 		$item = new stdClass();
 
 		// This doesn't need to be accurate for this test. This ID doesn't match the database.


### PR DESCRIPTION
This doesn't totally fix the root of the issue in https://github.com/Strategy11/formidable-pro/issues/3986 but it helps to avoid the fatal error if you used "description" as a field key.

I don't really understand why `'description'` is here in the switch/case statement. We don't include "Entry Description" as one of our options. It doesn't work here if it's an array, which is common as we store other data in this like user journeys.
<img width="1009" alt="Screen Shot 2023-04-26 at 2 53 53 PM" src="https://user-images.githubusercontent.com/9134515/234661919-98e062f4-22c6-494c-b65a-3540ae35a789.png">

@stephywells Do you see an issue with removing `description` from the switch/case here? When I do, the description uses its meta normally and doesn't cause the fatal error,

<img width="1127" alt="Screen Shot 2023-04-26 at 2 56 44 PM" src="https://user-images.githubusercontent.com/9134515/234662526-ad3a5998-7e1b-40c6-a837-5852a7a5082d.png">
