### PR TITLE
Fix: Autocomplete Dropdown Cutoff Issue in Embed Modal When Picking Existing Pages

### DIFF
--- a/js/admin/embed.js
+++ b/js/admin/embed.js
@@ -209,6 +209,10 @@
 
 						frmDom.autocomplete.initAutocomplete( 'page', dropdownWrapper );
 
+						// Prevent cutoff issue with the autocomplete dropdown.
+						// This also adds visible overflow even if autocomplete is not activated, but that's fine for this page.
+						modal.querySelector( '.postbox' ).style.overflow = 'visible';
+
 						function redirectToExistingPageWithInjectedShortcode( event ) {
 							event.preventDefault();
 


### PR DESCRIPTION
This pull request addresses the issue of the autocomplete dropdown being cut off within the embed modal when picking existing pages.

### Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4224

### QA URL:
https://qa.formidableforms.com/sherv/wp-admin/admin.php?page=formidable&frm_action=edit&id=1

### Testing Instruction:
1. Navigate to WP Admin > Formidable > Forms
2. Open an existing form or create a new one
3. Click on the Embed button in the top navigation
4. Click on "Select Existing Page"
5. Note: Make sure you have at least 51 pages (this enables the page autocomplete feature)

### Before:
<img width="670" alt="image" src="https://user-images.githubusercontent.com/69119241/235251246-5f5062c7-38d5-45f9-b206-408c7bb8354d.png">

### After:
<img width="674" alt="image" src="https://user-images.githubusercontent.com/69119241/235251081-e74fd7e4-a5e5-457a-b1e8-eda134a522ce.png">