### PR TITLE
Enhance Field Button Width and Standardize Icon Sizes in Builder

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7537,7 +7537,8 @@ input[disabled],
 }
 
 .field_type_list li.frmbutton .frmsvg {
-	width: var(--h-xs);
+	width: var(--text-xl);
+	font-size: var(--text-xl);
 }
 
 .frm_code_list i:before {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7536,6 +7536,7 @@ input[disabled],
 	font-size: var(--text-md);
 }
 
+/* Standardize icon size for field buttons in the builder */
 .field_type_list li.frmbutton .frmsvg {
 	width: var(--text-xl);
 	font-size: var(--text-xl);

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7566,6 +7566,11 @@ input[disabled],
 	color: var(--grey-900) !important;
 }
 
+/* Adjust field button size to full width in builder */
+#frm-insert-fields li a {
+	display: flex !important;
+}
+
 .frmbutton.ui-draggable-dragging a {
 	border: 1px solid var(--grey-300);
 	box-shadow: var(--box-shadow-md);

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7536,6 +7536,10 @@ input[disabled],
 	font-size: var(--text-md);
 }
 
+.field_type_list li.frmbutton .frmsvg {
+	width: var(--h-xs);
+}
+
 .frm_code_list i:before {
 	font-size: inherit;
 }


### PR DESCRIPTION
This PR enhances the field buttons' appearance and usability in the form builder by extending their width to full size and standardizing the icon sizes for a more consistent look.

### Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4206

### QA URL:
https://qa.formidableforms.com/sherv/wp-admin/admin.php?page=formidable&frm_action=edit&id=1

### Testing Instruction:
1. Navigate to WP Admin > Formidable > Forms
2. Open an existing form or create a new one
3. Locate the "Add Fields" section in the sidebar to view the implemented changes

### Before - Icon Sizes:
<img width="435" alt="image" src="https://user-images.githubusercontent.com/69119241/235472055-ae06d075-9fab-4731-b263-2053722d9610.png">

### After - Icon Sizes:
<img width="435" alt="image" src="https://user-images.githubusercontent.com/69119241/235488942-0bdc1e96-20a3-4ed7-8239-2dc2e2c8575b.png">


### Before - Field Button Width:
<img width="435" alt="image" src="https://user-images.githubusercontent.com/69119241/235488785-264f6d1d-05d8-4347-8ce8-0922bac9bc8c.png">


### After - Field Button Width:
<img width="430" alt="image" src="https://user-images.githubusercontent.com/69119241/235488453-9953e26a-f719-4a5a-a501-808ca6a212ae.png">

