### PR TITLE
Remove confusing useless comment floating in FrmFormAction.php

### DIFF
--- a/classes/models/FrmFormAction.php
+++ b/classes/models/FrmFormAction.php
@@ -202,8 +202,6 @@ class FrmFormAction {
 		return $field_name . '_' . $this->number;
 	}
 
-	// Private Function. Don't worry about this.
-
 	/**
 	 * @param int|string $number
 	 * @return void


### PR DESCRIPTION
Noticed this. I don't think it benefits anyone having this here.

Confirmed in check-in that there isn't any reason for it.