### PR TITLE
Add Missing `for` Attributes to Labels on Admin Pages

### DIFF
--- a/classes/views/frm-settings/messages.php
+++ b/classes/views/frm-settings/messages.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 </p>
 
 <p>
-	<label class="frm_left_label"><?php esc_html_e( 'Failed/Duplicate Entry', 'formidable' ); ?>
+	<label for="frm_failed_msg" class="frm_left_label"><?php esc_html_e( 'Failed/Duplicate Entry', 'formidable' ); ?>
 		<span class="frm_help frm_icon_font frm_tooltip_icon"
 			title="<?php esc_attr_e( 'The message seen when a form is submitted and passes validation, but something goes wrong.', 'formidable' ); ?>"></span>
 	</label>
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 </p>
 
 <p>
-	<label class="frm_left_label"><?php esc_html_e( 'Blank Field', 'formidable' ); ?>
+	<label for="frm_blank_msg" class="frm_left_label"><?php esc_html_e( 'Blank Field', 'formidable' ); ?>
 		<span class="frm_help frm_icon_font frm_tooltip_icon"
 			title="<?php esc_attr_e( 'The message seen when a required field is left blank.', 'formidable' ); ?>"></span>
 	</label>
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 </p>
 
 <p>
-	<label class="frm_left_label"><?php esc_html_e( 'Incorrect Field', 'formidable' ); ?>
+	<label for="frm_invalid_msg" class="frm_left_label"><?php esc_html_e( 'Incorrect Field', 'formidable' ); ?>
 		<span class="frm_help frm_icon_font frm_tooltip_icon"
 			title="<?php esc_attr_e( 'The message seen when a field response is either incorrect or missing.', 'formidable' ); ?>"></span>
 	</label>
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 </p>
 
 <p>
-	<label class="frm_left_label"><?php esc_html_e( 'Requires Privileged Access', 'formidable' ); ?>
+	<label for="frm_admin_permission" class="frm_left_label"><?php esc_html_e( 'Requires Privileged Access', 'formidable' ); ?>
 		<span class="frm_help frm_icon_font frm_tooltip_icon"
 			title="<?php esc_attr_e( 'The message shown to users who do not have access to a resource.', 'formidable' ); ?>"></span>
 	</label>
@@ -49,7 +49,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <?php if ( FrmAppHelper::pro_is_installed() ) { ?>
 	<p>
-		<label class="frm_left_label"><?php esc_html_e( 'Unique Value', 'formidable' ); ?>
+		<label for="frm_unique_msg" class="frm_left_label"><?php esc_html_e( 'Unique Value', 'formidable' ); ?>
 			<span class="frm_help frm_icon_font frm_tooltip_icon"
 				title="<?php esc_attr_e( 'The message seen when a user selects a value in a unique field that has already been used.', 'formidable' ); ?>"></span>
 		</label>
@@ -66,7 +66,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php } ?>
 
 <p>
-	<label class="frm_left_label"><?php esc_html_e( 'Success Message', 'formidable' ); ?>
+	<label for="frm_success_msg" class="frm_left_label"><?php esc_html_e( 'Success Message', 'formidable' ); ?>
 		<span class="frm_help frm_icon_font frm_tooltip_icon"
 			title="<?php esc_attr_e( 'The default message seen after a form is submitted.', 'formidable' ); ?>"></span>
 	</label>
@@ -76,7 +76,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 </p>
 
 <p>
-	<label class="frm_left_label"><?php esc_html_e( 'Submit Button Text', 'formidable' ); ?>
+	<label for="frm_submit_value" class="frm_left_label"><?php esc_html_e( 'Submit Button Text', 'formidable' ); ?>
 		<span class="frm_help frm_icon_font frm_tooltip_icon"
 			title="<?php esc_attr_e( 'The default label for the submit button.', 'formidable' ); ?>"></span>
 	</label>

--- a/classes/views/styles/_sample_form.php
+++ b/classes/views/styles/_sample_form.php
@@ -15,8 +15,8 @@ $pos_class = 'frm_' . ( $style->post_content['position'] == 'none' ? 'top' : ( $
 
 				<div class="frm_fields_container">
 					<div class="frm_form_field frm_half frm_first form-field <?php echo esc_attr( $pos_class ); ?>">
-						<label class="frm_primary_label"><?php esc_html_e( 'Text field', 'formidable' ); ?> <span class="frm_required">*</span></label>
-						<input type="text" value="<?php esc_attr_e( 'This is sample text', 'formidable' ); ?>" />
+						<label for="field_aq7w5e" class="frm_primary_label"><?php esc_html_e( 'Text field', 'formidable' ); ?> <span class="frm_required">*</span></label>
+						<input id="field_aq7w5e" type="text" value="<?php esc_attr_e( 'This is sample text', 'formidable' ); ?>" />
 						<div class="frm_description"><?php esc_html_e( 'A field with a description', 'formidable' ); ?></div>
 					</div>
 
@@ -30,24 +30,24 @@ $pos_class = 'frm_' . ( $style->post_content['position'] == 'none' ? 'top' : ( $
 					</div>
 
 					<div class="frm_form_field form-field frm_third frm_first frm_blank_field <?php echo esc_attr( $pos_class ); ?>">
-						<label class="frm_primary_label"><?php esc_html_e( 'Text field with error', 'formidable' ); ?> <span class="frm_required">*</span></label>
-						<input type="text" value="<?php esc_attr_e( 'This is sample text', 'formidable' ); ?>" />
+						<label for="field_bq7w5e" class="frm_primary_label"><?php esc_html_e( 'Text field with error', 'formidable' ); ?> <span class="frm_required">*</span></label>
+						<input id="field_bq7w5e" type="text" value="<?php esc_attr_e( 'This is sample text', 'formidable' ); ?>" />
 						<div class="frm_error"><?php echo esc_html( $frm_settings->blank_msg ); ?></div>
 					</div>
 
 					<div class="frm_form_field frm_third form-field frm_focus_field <?php echo esc_attr( $pos_class ); ?>">
-						<label class="frm_primary_label"><?php esc_html_e( 'Text field in active state', 'formidable' ); ?> <span class="frm_required">*</span></label>
-						<input type="text" value="<?php esc_attr_e( 'Active state will be seen when the field is clicked', 'formidable' ); ?>" />
+						<label for="field_cq7w5e" class="frm_primary_label"><?php esc_html_e( 'Text field in active state', 'formidable' ); ?> <span class="frm_required">*</span></label>
+						<input id="field_cq7w5e" type="text" value="<?php esc_attr_e( 'Active state will be seen when the field is clicked', 'formidable' ); ?>" />
 					</div>
 
 					<div class="frm_form_field frm_third form-field <?php echo esc_attr( $pos_class ); ?>">
-						<label class="frm_primary_label"><?php esc_html_e( 'Read-only field', 'formidable' ); ?></label>
-						<input type="text" value="<?php esc_attr_e( 'This field is not editable', 'formidable' ); ?>" disabled="disabled" />
+						<label for="field_dq7w5e" class="frm_primary_label"><?php esc_html_e( 'Read-only field', 'formidable' ); ?></label>
+						<input id="field_dq7w5e" type="text" value="<?php esc_attr_e( 'This field is not editable', 'formidable' ); ?>" disabled="disabled" />
 					</div>
 
 					<div class="frm_form_field form-field frm_half frm_first <?php echo esc_attr( $pos_class ); ?> frm_lite_style">
-						<label class="frm_primary_label"><?php esc_html_e( 'Text Area', 'formidable' ); ?></label>
-						<textarea></textarea>
+						<label for="field_eq7w5e" class="frm_primary_label"><?php esc_html_e( 'Text Area', 'formidable' ); ?></label>
+						<textarea id="field_eq7w5e"></textarea>
 						<div class="frm_description"><?php esc_html_e( 'Another field with a description', 'formidable' ); ?></div>
 					</div>
 


### PR DESCRIPTION
I have added `for` attributes to the `label` tags for several options in the Visual Styler's sample form and the Message Defaults settings within Global Settings.

### Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4008

### Testing Instructions - Sample Form:
1. Navigate to `WP Admin > Formidable > Forms`
2. Open an existing form or create a new one
3. Access the `Style` page via the top navigation
4. Click the `View sample form` button to display the form
5. Verify that clicking on a label field focuses the corresponding form field

### Testing Instructions - Message Defaults in Global Settings:
1. Go to `WP Admin > Formidable > Global Settings > Message Defaults`
2. Confirm that for the options shown in the following image, clicking on the label field focuses the respective form field

<img width="1517" alt="image" src="https://user-images.githubusercontent.com/69119241/235772499-f391213f-02a6-4528-95c2-118dce29ffb5.png">
