### PR TITLE
Fix: Remove Extra Whitespace on Admin Page Content for Small Screens

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8359,6 +8359,11 @@ Responsive Design
 		display: inline-block;
 	}
 
+	/* Fix: Issue where the admin page content had extra white space to the left on small screens */
+	.auto-fold.frm-admin-page-styles:not(.frm-full-screen) .frm_page_container,
+	.auto-fold:not(.frm-full-screen) .frm_wrap .frm_page_container {
+		left: 36px;
+	}
 }
 
 @media only screen and (max-width: 850px) {


### PR DESCRIPTION
This pull request addresses an issue where extra white space was present to the left of the admin page content on small screens.

### Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4217

### QA URL:
https://qa.formidableforms.com/sherv4/wp-admin/admin.php?page=formidable&frm_action=settings&id=1

### Testing Instructions:
1. You need to disable fullscreen mode. Check out https://github.com/Strategy11/formidable-pro/issues/4227
1. Open the `WP Admin > Formidable` page on a small screen device (smaller than `960px` and bigger than `850px`)
2. Confirm that the extra white space to the left of the page content has been removed.

### Before:
<img width="950" alt="image" src="https://user-images.githubusercontent.com/69119241/236248996-3f2f77b2-8f49-45b8-a93a-46ff6731974f.png">

### After:
<img width="950" alt="image" src="https://user-images.githubusercontent.com/69119241/236248730-d898183c-ba19-44b3-ab3e-b8777383eb04.png">

