### PR TITLE
Fix: Resolve overflow issues on add-ons list page for smaller screens

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2072,7 +2072,7 @@ h2.frm-h2 + .howto {
 }
 
 .frm-addons .plugin-card-top {
-	height: 155px;
+	min-height: 155px;
 	padding-top: var(--gap-lg);
 	overflow: hidden;
 }


### PR DESCRIPTION
This PR addresses the overflow issues found on the add-ons list page when viewed on smaller-width screens with an excessive amount of text.

## Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4221

## QA URL:
https://qa.formidableforms.com/sherv2/wp-admin/admin.php?page=formidable-addons

## Screenshots:
### Before
<img width="239" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/479d4915-933c-4de2-8367-ca146622082c">

### After
<img width="266" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/7fddfa94-b596-4360-8daf-20266ac026b9">
