### PR TITLE
Fix Collapsed Section Styling Issues

### DIFF
--- a/classes/views/frm-forms/add_field.php
+++ b/classes/views/frm-forms/add_field.php
@@ -17,16 +17,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 			(ID <?php echo esc_html( $field['id'] ); ?>)
 		</div>
 
-		<?php if ( $field['type'] === 'divider' ) { ?>
+		<?php if ( $field['type'] === 'divider' ) : ?>
 			<a href="#" class="frm-collapse-section" title="<?php esc_attr_e( 'Expand/Collapse Section', 'formidable' ); ?>">
 				<?php
 				FrmAppHelper::icon_by_class(
 					'frmfont frm_arrowdown6_icon',
-					array( 'aria-label' => __( 'Expand/Collapse Section Icon', 'formidable' ) )
+					array( 'aria-label' => esc_attr__( 'Expand/Collapse Section Icon', 'formidable' ) )
 				);
 				?>
 			</a>
-		<?php } ?>
+		<?php endif; ?>
 
 		<a href="#" class="frm_bstooltip frm-move frm-hover-icon" title="<?php esc_attr_e( 'Move Field', 'formidable' ); ?>" data-container="body" aria-label="<?php esc_attr_e( 'Move Field', 'formidable' ); ?>">
 			<?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_thick_move_icon' ); ?>

--- a/classes/views/frm-forms/add_field.php
+++ b/classes/views/frm-forms/add_field.php
@@ -18,7 +18,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 
 		<?php if ( $field['type'] === 'divider' ) { ?>
-			<a href="#" class="frm-collapse-section frm-hover-icon frm_icon_font frm_arrowdown6_icon" title="<?php esc_attr_e( 'Expand/Collapse Section', 'formidable' ); ?>"></a>
+			<a href="#" class="frm-collapse-section" title="<?php esc_attr_e( 'Expand/Collapse Section', 'formidable' ); ?>">
+				<?php
+				FrmAppHelper::icon_by_class(
+					'frmfont frm_arrowdown6_icon',
+					array( 'aria-label' => __( 'Expand/Collapse Section Icon', 'formidable' ) )
+				);
+				?>
+			</a>
 		<?php } ?>
 
 		<a href="#" class="frm_bstooltip frm-move frm-hover-icon" title="<?php esc_attr_e( 'Move Field', 'formidable' ); ?>" data-container="body" aria-label="<?php esc_attr_e( 'Move Field', 'formidable' ); ?>">

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1735,7 +1735,14 @@ form .frm_primary_label input {
 }
 
 #frm_form_editor_container .divider_section_only .frm_primary_label {
+	display: flex;
+	align-items: center;
+	gap: var(--gap-xs);
 	font-size: 20px;
+}
+
+#frm_form_editor_container .divider_section_only .frm_primary_label .frm-sub-label {
+	padding: 0;
 }
 
 form .form-field.frm_field_loading {
@@ -6330,6 +6337,7 @@ ul.start_divider {
 
 .frm-section-collapsed .divider_section_only:hover:after,
 li.selected.frm-section-collapsed .divider_section_only:before,
+li.selected.frm-section-collapsed .divider_section_only:after,
 .divider_section_only:hover:before,
 li.selected .divider_section_only:before {
 	border-color: transparent;
@@ -6502,9 +6510,21 @@ li.selected .divider_section_only:before {
 }
 
 .frm-collapsed i:before,
-.frm-section-collapsed .frm_arrowdown6_icon:before,
 .frm-page-collapsed .frm_arrowdown6_icon:before {
 	content: '\e913';
+}
+
+.frm-collapse-section svg {
+	fill: var(--primary-color);
+	transition: transform 0.2s ease-out, fill 0.2s ease-out;
+}
+
+.frm-collapse-section:hover svg {
+	fill: var(--primary-700);
+}
+
+.frm-section-collapsed .frm-collapse-section svg {
+	transform: rotate(-90deg);
 }
 
 .open .widget-top .frm_arrow_right_icon:before {


### PR DESCRIPTION
This PR resolves the styling issues present in the collapsed section. The specific areas of improvement include:

1. The misplaced collapse/expand toggle is now switched to an SVG and CSS is used to manage its rotation.
2. An extra border that was overlapping with `:after` has been removed to clean up the UI.
3. Excessive space between "Section" and "Collapsed" has been addressed.

## Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4099

## QA URL:
https://qa.formidableforms.com/sherv3/wp-admin/admin.php?page=formidable&frm_action=edit&id=1

## Testing Instructions:
1. Go to `WP Admin > Formidable`.
2. Open an existing form or create a new one.
3. Add a `section` field.
4. Verify that all styling issues have been properly addressed.

## Screenshots:
### Before
<img width="1146" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/550d1714-7497-4d19-840a-3a10d72d3bd7">

### After
<img width="1146" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/371a4179-7f98-476c-9737-205e0a74cc98">
