### PR TITLE
Remove Back Button from 'Leave your email address' Modal

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2652,7 +2652,7 @@ li .frm-hover-icons .frm-preview-form,
 	display: none;
 }
 
-#frm_new_form_modal:not([frm-page="create"]):not([frm-page="email"]) .frm-modal-back,
+#frm_new_form_modal:not([frm-page="create"]) .frm-modal-back,
 #frm_new_form_modal[frm-page="create"] #frm-create-title,
 #frm-create-title[frm-type="template"] span[frm-type="template"],
 #frm_new_form_modal[frm-page="preview"] #frm-preview-title,

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2652,7 +2652,7 @@ li .frm-hover-icons .frm-preview-form,
 	display: none;
 }
 
-#frm_new_form_modal:not([frm-page="create"]) .frm-modal-back,
+#frm_new_form_modal:not([frm-page="create"]):not([frm-page="email"]) .frm-modal-back,
 #frm_new_form_modal[frm-page="create"] #frm-create-title,
 #frm-create-title[frm-type="template"] span[frm-type="template"],
 #frm_new_form_modal[frm-page="preview"] #frm-preview-title,

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8896,6 +8896,13 @@ function frmAdminBuildJS() {
 				if ( firstLockedTemplate.length ) {
 					showFreeTemplatesForm( firstLockedTemplate );
 				}
+
+				// Hides the back button in the Free Template Modal and shows it when the cancel button is clicked
+				$modalBackButton = $modal.find( '.frm-modal-back' );
+				$modalBackButton.hide();
+				$modal.find( '.frm-modal-cancel' ).on( 'click', ( event ) => {
+					$modalBackButton.show();
+				});
 			}
 		}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8902,6 +8902,7 @@ function frmAdminBuildJS() {
 				$modalBackButton.hide();
 				$modal.find( '.frm-modal-cancel' ).on( 'click', ( event ) => {
 					$modalBackButton.show();
+					$modal.dialog( 'close' );
 				});
 			}
 		}


### PR DESCRIPTION
This PR involves the removal of the back button from the 'Leave your email address' modal. The proposed changes are part of the Interface Reviews conducted by Razvan.

## QA URL:
https://qa.formidableforms.com/sherv3/wp-admin/admin.php?page=formidable&triggerNewFormModal=1&free-templates=1

## Testing Instructions:
1. Navigate to `WP Admin > Formidable > Inbox`.
2. Click on the `Get Now` button in the `Get 10+ Free Form Templates` message.
3. Verify that the back button has been removed.

## Screenshots
### Before
<img width="606" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/be001df7-043d-42b2-bc7f-e53adf515b18">

### After
<img width="606" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/4b4347b3-439e-44cc-a212-cc0b3d30dac6">