### PR TITLE
Check if result is null when getting form name

### DIFF
--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -688,7 +688,9 @@ class FrmForm {
 
 		$query_key = is_numeric( $id ) ? 'id' : 'form_key';
 		$r         = FrmDb::get_var( 'frm_forms', array( $query_key => $id ), 'name' );
-		$r         = stripslashes( $r );
+
+		// An empty form name can result in a null value.
+		$r = is_null( $r ) ? '' : stripslashes( $r );
 
 		return $r;
 	}

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -198,4 +198,14 @@ class test_FrmForm extends FrmUnitTest {
 	private function normalize_calc_spaces( $calc ) {
 		return $this->run_private_method( array( 'FrmForm', 'normalize_calc_spaces' ), array( $calc ) );
 	}
+
+	/**
+	 * @covers FrmForm::getName
+	 */
+	public function test_getName() {
+		$form_name = 'Test form';
+		$form_id   = $this->factory->form->create( array( 'name' => $form_name ) );
+		$name      = FrmForm::getName( (string) $form_id );
+		$this->assertEquals( $form_name, $name );
+	}
 }


### PR DESCRIPTION
This is triggered by my "(no title)" form in PHP 8.2.

<img width="1024" alt="Screen Shot 2023-05-25 at 10 21 35 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/4b3a3562-ba4b-4bac-a1a2-4a44ca6ab856">
