### PR TITLE
Add frm_conf_input_backend filter and show password live update JS

### DIFF
--- a/classes/views/frm-forms/add_field.php
+++ b/classes/views/frm-forms/add_field.php
@@ -61,19 +61,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 	<?php } ?>
 </div>
-<?php if ( $display['conf_field'] ) { ?>
-<div id="frm_conf_field_<?php echo esc_attr( $field['id'] ); ?>_container" class="frm_conf_field_container frm_form_fields frm_conf_details<?php echo esc_attr( $field['id'] . ( $field['conf_field'] ? '' : ' frm_hidden' ) ); ?>">
-	<div id="frm_conf_field_<?php echo esc_attr( $field['id'] ); ?>_inner_container" class="frm_inner_conf_container">
-		<label class="frm_primary_label">&nbsp;</label>
-		<div class="frm_form_fields">
-			<input type="text" id="conf_field_<?php echo esc_attr( $field['field_key'] ); ?>" name="field_options[conf_input_<?php echo esc_attr( $field['id'] ); ?>]" placeholder="<?php echo esc_attr( $field['conf_input'] ); ?>" class="dyn_default_value" />
-		</div>
-		<div id="conf_field_description_<?php echo esc_attr( $field['id'] ); ?>" class="frm_description"><?php
-			echo FrmAppHelper::kses( force_balance_tags( $field['conf_desc'] ), 'all' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		?></div>
-</div>
-</div>
-<div class="clear"></div>
+<?php if ( $display['conf_field'] ) {
+	$input_html = sprintf(
+		'<input type="text" id="conf_field_%1$s" name="field_options[conf_input_%2$s]" placeholder="%3$s" class="dyn_default_value" />',
+		esc_attr( $field['field_key'] ),
+		esc_attr( $field['id'] ),
+		esc_attr( $field['conf_input'] )
+	);
+	?>
+	<div id="frm_conf_field_<?php echo esc_attr( $field['id'] ); ?>_container" class="frm_conf_field_container frm_form_fields frm_conf_details<?php echo esc_attr( $field['id'] . ( $field['conf_field'] ? '' : ' frm_hidden' ) ); ?>">
+		<div id="frm_conf_field_<?php echo esc_attr( $field['id'] ); ?>_inner_container" class="frm_inner_conf_container">
+			<label class="frm_primary_label">&nbsp;</label>
+			<div class="frm_form_fields">
+				<?php
+				/**
+				 * Filters the HTML of confirmation input in the backend.
+				 *
+				 * @since x.x
+				 *
+				 * @param string $input_html Input HTML.
+				 * @param array  $args       Contains `field` array.
+				 */
+				echo apply_filters( 'frm_conf_input_backend', $input_html, compact( 'field' ) );
+				?>
+			</div>
+			<div id="conf_field_description_<?php echo esc_attr( $field['id'] ); ?>" class="frm_description"><?php
+				echo FrmAppHelper::kses( force_balance_tags( $field['conf_desc'] ), 'all' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			?></div>
+	</div>
+	</div>
+	<div class="clear"></div>
 	<?php
 }
 

--- a/classes/views/frm-forms/add_field.php
+++ b/classes/views/frm-forms/add_field.php
@@ -61,7 +61,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 	<?php } ?>
 </div>
-<?php if ( $display['conf_field'] ) {
+<?php
+if ( $display['conf_field'] ) {
 	$input_html = sprintf(
 		'<input type="text" id="conf_field_%1$s" name="field_options[conf_input_%2$s]" placeholder="%3$s" class="dyn_default_value" />',
 		esc_attr( $field['field_key'] ),
@@ -82,7 +83,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				 * @param string $input_html Input HTML.
 				 * @param array  $args       Contains `field` array.
 				 */
-				echo apply_filters( 'frm_conf_input_backend', $input_html, compact( 'field' ) );
+				echo apply_filters( 'frm_conf_input_backend', $input_html, compact( 'field' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				?>
 			</div>
 			<div id="conf_field_description_<?php echo esc_attr( $field['id'] ); ?>" class="frm_description"><?php

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5842,6 +5842,18 @@ function frmAdminBuildJS() {
 		noSectionFields.classList.toggle( 'frm_block', ! sectionHasFields );
 	}
 
+	function handleShowPasswordLiveUpdate() {
+		frmDom.util.documentOn( 'change', '.frm_show_password_setting_input', event => {
+			const fieldId = event.target.getAttribute( 'data-fid' );
+			const fieldEl = document.getElementById( 'frm_field_id_' + fieldId );
+			if ( ! fieldEl ) {
+				return;
+			}
+
+			fieldEl.classList.toggle( 'frm_disabled_show_password', ! event.target.checked );
+		});
+	}
+
 	function slideDown() {
 		/*jshint validthis:true */
 		var id = jQuery( this ).data( 'slidedown' );
@@ -9949,6 +9961,7 @@ function frmAdminBuildJS() {
 			maybeHideQuantityProductFieldOption();
 			handleNameFieldOnFormBuilder();
 			toggleSectionHolder();
+			handleShowPasswordLiveUpdate();
 		},
 
 		settingsInit: function() {


### PR DESCRIPTION
This is required to make the Show password option live update. Without this update, users must update the form to see the change in the form builder, and the confirm password field won't have that button.