### PR TITLE
Add a string check to replace_form_name_shortcodes function

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1616,11 +1616,15 @@ class FrmFormsController {
 	 *
 	 * @since 5.5
 	 *
-	 * @param string              $string
+	 * @param string|array        $string
 	 * @param stdClass|string|int $form
-	 * @return string
+	 * @return string|array
 	 */
 	public static function replace_form_name_shortcodes( $string, $form ) {
+		if ( ! is_string( $string ) ) {
+			return $string;
+		}
+
 		if ( false === strpos( $string, '[form_name]' ) ) {
 			return $string;
 		}


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2256620330/163168/

This avoids the fatal error. I don't think we need to support form name shortcodes in an array that comes through this function.