### PR TITLE
Fix PHP 8.2 deprecations

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -23,6 +23,12 @@ jobs:
           - php: 8.0
             wordpress: master
             multisite: 0
+          - php: 8.1
+            wordpress: master
+            multisite: 0
+          - php: 8.2
+            wordpress: master
+            multisite: 0
 
     name: PHP ${{ matrix.php }} tests in WP ${{ matrix.wordpress }}
     steps:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -18,16 +18,13 @@ jobs:
       matrix:
         include:
           - php: 7.4
-            wordpress: master
+            wordpress: trunk
             multisite: 0
           - php: 8.0
-            wordpress: master
+            wordpress: trunk
             multisite: 0
           - php: 8.1
-            wordpress: master
-            multisite: 0
-          - php: 8.2
-            wordpress: master
+            wordpress: trunk
             multisite: 0
 
     name: PHP ${{ matrix.php }} tests in WP ${{ matrix.wordpress }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -18,13 +18,13 @@ jobs:
       matrix:
         include:
           - php: 7.4
-            wordpress: trunk
+            wordpress: master
             multisite: 0
           - php: 8.0
-            wordpress: trunk
+            wordpress: master
             multisite: 0
           - php: 8.1
-            wordpress: trunk
+            wordpress: master
             multisite: 0
 
     name: PHP ${{ matrix.php }} tests in WP ${{ matrix.wordpress }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -23,9 +23,6 @@ jobs:
           - php: 8.0
             wordpress: master
             multisite: 0
-          - php: 8.1
-            wordpress: master
-            multisite: 0
 
     name: PHP ${{ matrix.php }} tests in WP ${{ matrix.wordpress }}
     steps:

--- a/tests/base/FrmAjaxUnitTest.php
+++ b/tests/base/FrmAjaxUnitTest.php
@@ -27,7 +27,8 @@ class FrmAjaxUnitTest extends WP_Ajax_UnitTestCase {
 		FrmHooksController::trigger_load_hook( 'load_ajax_hooks' );
 		FrmHooksController::trigger_load_hook( 'load_form_hooks' );
 
-		$this->factory->form = new Form_Factory( $this );
+		$this->factory        = new FrmUnitTestFactory();
+		$this->factory->form  = new Form_Factory( $this );
 		$this->factory->field = new Field_Factory( $this );
 		$this->factory->entry = new Entry_Factory( $this );
 	}

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -54,6 +54,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 
 		FrmHooksController::trigger_load_hook( 'load_admin_hooks' );
 
+		$this->factory        = new FrmUnitTestFactory();
 		$this->factory->form  = new Form_Factory( $this );
 		$this->factory->field = new Field_Factory( $this );
 		$this->factory->entry = new Entry_Factory( $this );

--- a/tests/base/frm_factory.php
+++ b/tests/base/frm_factory.php
@@ -1,5 +1,23 @@
 <?php
 
+class FrmUnitTestFactory extends WP_UnitTest_Factory {
+
+	/**
+	 * @var Form_Factory|null
+	 */
+	public $form;
+
+	/**
+	 * @var Field_Factory|null
+	 */
+	public $field;
+
+	/**
+	 * @var Entry_Factory|null
+	 */
+	public $entry;
+}
+
 class Form_Factory extends WP_UnitTest_Factory_For_Thing {
 
 	public function __construct( $factory = null ) {


### PR DESCRIPTION
I'm just adding a new factory class that extends the WordPress one so I can define the factory properties to bypass the dynamic property deprecation messages.

Since it's working in PHP 8.2 I added a few more workflow PHP versions so we're covering PHP 8.0, 8.1, and 8.2.

> Deprecated: Creation of dynamic property WP_UnitTest_Factory::$form is deprecated in .../formidable/tests/base/FrmUnitTest.php on line 57
> Deprecated: Creation of dynamic property WP_UnitTest_Factory::$field is deprecated in .../formidable/tests/base/FrmUnitTest.php on line 58
> Deprecated: Creation of dynamic property WP_UnitTest_Factory::$entry is deprecated in .../formidable/tests/base/FrmUnitTest.php on line 59