### PR TITLE
Avoid PHP Notice that get_current_screen is called incorrectly when u…

### DIFF
--- a/classes/controllers/FrmEntriesAJAXSubmitController.php
+++ b/classes/controllers/FrmEntriesAJAXSubmitController.php
@@ -122,6 +122,12 @@ class FrmEntriesAJAXSubmitController {
 				if ( ! function_exists( 'get_current_screen' ) ) {
 					require_once ABSPATH . 'wp-admin/includes/screen.php';
 				}
+
+				if ( ! class_exists( 'WP_Screen', false ) ) {
+					require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
+				}
+
+				FrmAppHelper::set_current_screen_and_hook_suffix();
 			},
 			1
 		);


### PR DESCRIPTION
…sing WooCommerce

Fixes https://secure.helpscout.net/conversation/2261261948/163616/

> Function get_current_page was called incorrectly. Current page retrieval should be called on or after the `current_screen` hook. Please see [Debugging in WordPress](https://wordpress.org/documentation/article/debugging-in-wordpress/) for more information. (This message was added in version 0.16.0.)