### PR TITLE
remove crons when lite is deactivated

### DIFF
--- a/classes/controllers/FrmCronController.php
+++ b/classes/controllers/FrmCronController.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Cron controller
+ *
+ * @since x.x
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'You are not allowed to call this page directly.' );
+}
+
+/**
+ * Class FrmCronController
+ */
+class FrmCronController {
+
+	/**
+	 * Gets all cron events.
+	 *
+	 * @since x.x
+	 *
+	 * @return string[]
+	 */
+	private static function get_events() {
+		return array(
+			'formidable_send_usage' => 'weekly',
+		);
+	}
+
+
+	/**
+	 * Removes all cron events.
+	 *
+	 * @since x.x
+	 */
+	public static function remove_crons() {
+		$events = self::get_events();
+
+		foreach ( $events as $event => $recurrence ) {
+			$timestamp = wp_next_scheduled( $event );
+			if ( false !== $timestamp ) {
+				wp_unschedule_event( $timestamp, $event );
+			}
+		}
+	}
+}

--- a/formidable.php
+++ b/formidable.php
@@ -113,3 +113,14 @@ function frm_maybe_install() {
 		set_transient( FrmWelcomeController::$option_name, FrmWelcomeController::$menu_slug, 60 );
 	}
 }
+
+register_deactivation_hook(
+	__FILE__,
+	function() {
+		if ( ! class_exists( 'FrmCronController', false ) ) {
+			require_once __DIR__ . '/classes/controllers/FrmCronController.php';
+		}
+
+		FrmCronController::remove_crons();
+	}
+);


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4292

This small update just makes sure the events scheduled in lite are unscheduled when it is deactivated!

This could be tested with any cron management plugin. I'm using Advanced Cron Manager.