### PR TITLE
Fix captcha settings property typo

### DIFF
--- a/classes/models/FrmFieldCaptchaSettings.php
+++ b/classes/models/FrmFieldCaptchaSettings.php
@@ -8,11 +8,20 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class FrmFieldCaptchaSettings {
 
+	/**
+	 * @var string
+	 */
 	public $secret;
 
+	/**
+	 * @var string
+	 */
 	public $token_field;
 
-	public $end_point;
+	/**
+	 * @var string
+	 */
+	public $endpoint;
 
 	public function __construct( $frm_settings ) {
 		if ( $frm_settings->active_captcha === 'recaptcha' ) {


### PR DESCRIPTION
I noticed this deprecation message when testing Captcha

> PHP Deprecated:  Creation of dynamic property FrmFieldCaptchaSettings::$endpoint is deprecated in /var/www/src/wp-content/plugins/formidable/classes/models/FrmFieldCaptchaSettings.php on line 21

It was defined, but with an extra underscore.