### PR TITLE
Resolved JavaScript Errors Triggered by Rapid Preview Dropdown Interactions

### DIFF
--- a/classes/views/frm-forms/_publish_box.php
+++ b/classes/views/frm-forms/_publish_box.php
@@ -16,7 +16,7 @@ if ( 'settings' === FrmAppHelper::simple_get( 'frm_action', 'sanitize_title' ) )
 			<div id="frm-preview-action">
 				<?php if ( ( ! isset( $hide_preview ) || ! $hide_preview ) && isset( $values['form_key'] ) ) { ?>
 					<div class="preview dropdown">
-						<a href="#" id="frm-previewDrop" class="frm-dropdown-toggle button frm-button-secondary" data-toggle="dropdown" role="button">
+						<a href="#" id="frm-previewDrop" class="frm-dropdown-toggle button frm-button-secondary" role="button">
 							<?php esc_html_e( 'Preview', 'formidable' ); ?>
 							<?php FrmAppHelper::icon_by_class( 'frmfont frm_arrowdown6_icon frm_svg13', array( 'aria-hidden' => 'true' ) ); ?>
 						</a>

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10482,7 +10482,7 @@ jQuery( document ).ready(
 		frmAdminBuild.init();
 
 		frmDom.bootstrap.setupBootstrapDropdowns( convertOldBootstrapDropdownsToBootstrap4 );
-		document.querySelector( '.preview.dropdown .frm-dropdown-toggle' ).setAttribute( 'data-toggle', 'dropdown' );
+		document.querySelector( '.preview.dropdown .frm-dropdown-toggle' )?.setAttribute( 'data-toggle', 'dropdown' );
 
 		function convertOldBootstrapDropdownsToBootstrap4( frmDropdownMenu ) {
 			const toggle = frmDropdownMenu.querySelector( '.frm-dropdown-toggle' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10482,6 +10482,8 @@ jQuery( document ).ready(
 		frmAdminBuild.init();
 
 		frmDom.bootstrap.setupBootstrapDropdowns( convertOldBootstrapDropdownsToBootstrap4 );
+		document.querySelector( '.preview.dropdown .frm-dropdown-toggle' ).setAttribute( 'data-toggle', 'dropdown' );
+
 		function convertOldBootstrapDropdownsToBootstrap4( frmDropdownMenu ) {
 			const toggle = frmDropdownMenu.querySelector( '.frm-dropdown-toggle' );
 			if ( toggle ) {


### PR DESCRIPTION
This Pull Request delivers a solution for the JavaScript errors that emerged when the preview dropdown was engaged too swiftly.

## Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4109

## Steps to Reproduce:
For a detailed guide on how to reproduce this issue, please refer to the video below:
https://www.loom.com/share/c70cc31f5daa49b6b4f97ca74f328d22

Kindly follow these steps to verify that the issue has been adequately addressed.