### PR TITLE
Enhancement of Category Headings Visibility and Search Results

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7593,6 +7593,11 @@ input[disabled],
 	display: flex !important;
 }
 
+/* Prevents advanced fields from always appearing in search results */
+#frm-insert-fields li.frm_show_upgrade.frm_hidden {
+	display: none !important;
+}
+
 .frmbutton.ui-draggable-dragging a {
 	border: 1px solid var(--grey-300);
 	box-shadow: var(--box-shadow-md);

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9218,6 +9218,9 @@ function frmAdminBuildJS() {
 
 		headingElements.forEach( heading => {
 			const fieldsListElement = heading.nextElementSibling;
+			if ( ! fieldsListElement ) {
+				return;
+			}
 			const listItemElements = fieldsListElement.querySelectorAll( ':scope > li.frmbutton' );
 			const allHidden = Array.from( listItemElements ).every( li => li.classList.contains( 'frm_hidden' ) );
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9199,7 +9199,31 @@ function frmAdminBuildJS() {
 			}
 		}
 
+		// Updates the visibility of category headings based on search results.
+		updateCatHeadingVisibility();
+
 		jQuery( this ).trigger( 'frmAfterSearch' );
+	}
+
+	/**
+	 * Updates the visibility of category headings based on search results.
+	 * If all associated fields are hidden (indicating no search matches),
+	 * the heading is hidden.
+	 *
+	 * @since x.x
+	 */
+	function updateCatHeadingVisibility() {
+		const insertFieldsElement = document.querySelector( '#frm-insert-fields' );
+		const headingElements = insertFieldsElement.querySelectorAll( ':scope > .frm-with-line' );
+
+		headingElements.forEach( heading => {
+			const fieldsListElement = heading.nextElementSibling;
+			const listItemElements = fieldsListElement.querySelectorAll( ':scope > li.frmbutton' );
+			const allHidden = Array.from( listItemElements ).every( li => li.classList.contains( 'frm_hidden' ) );
+
+			// Add or remove class based on `allHidden` condition
+			heading.classList.toggle( 'frm_hidden', allHidden );
+		});
 	}
 
 	function stopPropagation( e ) {


### PR DESCRIPTION
This PR introduces two enhancements:

The first is synchronizing the visibility of category headings with their associated fields' search results. When all fields under a heading are hidden due to not matching the search criteria, the category heading will also be hidden.

The second enhancement addresses an issue where advanced fields were always shown in the field list, regardless of the search value. With the changes introduced in this PR, advanced fields won't show by default, they will only appear if the search string contains the field name.

## Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4283
https://github.com/Strategy11/formidable-pro/issues/4289

## QA URL:
https://qa.formidableforms.com/sherv5/wp-admin/admin.php?page=formidable&frm_action=edit&id=1

## Testing Instructions:
1. Navigate to `WP Admin > Formidable`.
2. Open an existing form or create a new one.
3. Perform a search using the search functionality.
4. Notice that category headings are hidden when all their associated fields have no search matches.
5. Ensure that advanced fields don't appear in the search results unless the search string contains the field name.

## Visual Outputs:
### Before
![2023-06-29 04 32 27](https://github.com/Strategy11/formidable-forms/assets/69119241/0d913edb-0e3a-4469-8339-6cd6d5396b65)

### After
![2023-06-29 04 31 13](https://github.com/Strategy11/formidable-forms/assets/69119241/a0acc9fa-84d6-4462-8098-ef7a496082da)