### PR TITLE
Disallow editing form in trash

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1977,12 +1977,12 @@ class FrmFormsController {
 	public static function show_form( $id = '', $key = '', $title = false, $description = false, $atts = array() ) {
 		$form = self::maybe_get_form_by_id_or_key( $id, $key );
 
-		if ( is_object( $form ) && $form->status === 'trash' ) {
-			wp_die( esc_html__( 'You cannot preview this item because it is in the Trash. Please restore it and try again.', 'formidable' ) );
-		}
-
 		if ( ! $form ) {
 			return __( 'Please select a valid form', 'formidable' );
+		}
+
+		if ( is_object( $form ) && $form->status === 'trash' ) {
+			wp_die( esc_html__( 'You cannot preview this item because it is in the Trash. Please restore it and try again.', 'formidable' ) );
 		}
 
 		if ( 'auto' === $title ) {

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1090,6 +1090,10 @@ class FrmFormsController {
 			wp_die( esc_html__( 'You are trying to edit a form that does not exist.', 'formidable' ) );
 		}
 
+		if ( $form->status === 'trash' ) {
+			wp_die( esc_html__( 'You cannot edit this item because it is in the Trash. Please restore it and try again.', 'formidable' ) );
+		}
+
 		if ( $form->parent_form_id ) {
 			/* translators: %1$s: Start link HTML, %2$s: End link HTML */
 			wp_die( sprintf( esc_html__( 'You are trying to edit a child form. Please edit from %1$shere%2$s', 'formidable' ), '<a href="' . esc_url( FrmForm::get_edit_link( $form->parent_form_id ) ) . '">', '</a>' ) );

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1977,6 +1977,10 @@ class FrmFormsController {
 	public static function show_form( $id = '', $key = '', $title = false, $description = false, $atts = array() ) {
 		$form = self::maybe_get_form_by_id_or_key( $id, $key );
 
+		if ( is_object( $form ) && $form->status === 'trash' ) {
+			wp_die( esc_html__( 'You cannot preview this item because it is in the Trash. Please restore it and try again.', 'formidable' ) );
+		}
+
 		if ( ! $form ) {
 			return __( 'Please select a valid form', 'formidable' );
 		}
@@ -2028,7 +2032,7 @@ class FrmFormsController {
 
 		if ( ! empty( $id ) ) { // form id or key is set
 			$form = FrmForm::getOne( $id );
-			if ( ! $form || $form->parent_form_id || $form->status === 'trash' ) {
+			if ( ! $form || $form->parent_form_id ) {
 				$form = false;
 			}
 		}

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2040,6 +2040,13 @@ class FrmFormsController {
 		return $form;
 	}
 
+	public static function get_form_status() {
+		// check_ajax_referer( 'frm_ajax', 'nonce' );
+		$form_id = FrmAppHelper::get_param( 'form_id', '', 'post', 'absint' );
+		$form    = FrmForm::getOne( $form_id );
+		wp_send_json_success( $form->status );
+	}
+
 	private static function is_viewable_draft_form( $form ) {
 		return $form->status === 'draft' && current_user_can( 'frm_edit_forms' ) && ! FrmAppHelper::is_preview_page();
 	}

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2040,11 +2040,18 @@ class FrmFormsController {
 		return $form;
 	}
 
+	/**
+	 * Gets a form status and send it over to an ajax request.
+	 *
+	 * @since x.x
+	 *
+	 * @return void
+	 */
 	public static function get_form_status() {
 		check_ajax_referer( 'frm_ajax', 'nonce' );
-		$form_id = FrmAppHelper::get_param( 'form_id', '', 'post', 'absint' );
-		$form    = FrmForm::getOne( $form_id );
-		wp_send_json_success( $form->status );
+		$form_id     = FrmAppHelper::get_param( 'form_id', '', 'post', 'absint' );
+		$form_status = FrmDb::get_var( 'frm_forms', array( 'id' => $form_id ), 'status' );
+		wp_send_json_success( $form_status );
 	}
 
 	private static function is_viewable_draft_form( $form ) {

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1981,7 +1981,7 @@ class FrmFormsController {
 			return __( 'Please select a valid form', 'formidable' );
 		}
 
-		if ( is_object( $form ) && $form->status === 'trash' ) {
+		if ( $form->status === 'trash' ) {
 			wp_die( esc_html__( 'You cannot preview this item because it is in the Trash. Please restore it and try again.', 'formidable' ) );
 		}
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2041,7 +2041,7 @@ class FrmFormsController {
 	}
 
 	public static function get_form_status() {
-		// check_ajax_referer( 'frm_ajax', 'nonce' );
+		check_ajax_referer( 'frm_ajax', 'nonce' );
 		$form_id = FrmAppHelper::get_param( 'form_id', '', 'post', 'absint' );
 		$form    = FrmForm::getOne( $form_id );
 		wp_send_json_success( $form->status );

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -258,6 +258,8 @@ class FrmHooksController {
 
 		// Submit with AJAX.
 		add_action( 'wp_loaded', 'FrmEntriesAJAXSubmitController::ajax_create', 5 ); // Trigger before process_entry.
+
+		add_action( 'wp_ajax_frm_get_form_status', 'FrmFormsController::get_form_status' );
 	}
 
 	/**

--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -374,7 +374,7 @@ class FrmFormsListHelper extends FrmListHelper {
 		}
 
 		if ( current_user_can( 'frm_edit_forms' ) ) {
-			$actions['frm_edit']     = '<a href="' . esc_url( $edit_link ) . '">' . __( 'Edit', 'formidable' ) . '</a>';
+			$actions['frm_edit']     = '<a data-untrash_nonce="' . wp_create_nonce( 'untrash_form_' . $item->id ) . '" href="' . esc_url( $edit_link ) . '">' . __( 'Edit', 'formidable' ) . '</a>';
 			$actions['frm_settings'] = '<a href="' . esc_url( '?page=formidable&frm_action=settings&id=' . $item->id ) . '">' . __( 'Settings', 'formidable' ) . '</a>';
 		}
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2161,7 +2161,7 @@ h2.frm-h2 + .howto {
 	margin-top: 0;
 }
 
-.frm-admin-page-formidableedit #wpbody-content > *:not(.frm-review-notice):not(.frm_previous_install):not(.frm-banner-alert),
+.frm-admin-page-formidableedit #wpbody-content > *:not(.frm-review-notice):not(.frm_previous_install):not(.frm-banner-alert):not(.wp-die-message),
 #wpbody-content > .updated,
 #wpbody-content > #update-nag,
 #wpbody-content > .update-nag,

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9737,33 +9737,38 @@ function frmAdminBuildJS() {
 
 				const checkFormStatus = ( e ) => {
 					e.preventDefault();
-					let formID = e.target.closest( 'tr' ).querySelector( '.check-column input[type=checkbox]' ).value;
-					const formData  = new FormData();
+
+					const targetElement = e.currentTarget;
+					let formID     = targetElement.closest( 'tr' ).querySelector( '.check-column input[type=checkbox]' ).value;
+					const formData = new FormData();
 					formData.append( 'form_id', formID );
-					const confirmButton = document.getElementById( 'frm-confirmed-click' );
+
+					const confirmButton       = document.getElementById( 'frm-confirmed-click' );
 					confirmButton.textContent = __( 'Restore form', 'formidable' );
 
 					// Revert 'Confirm' button text when modal is closed or 'Delete' form button is clicked
-					const unbindHandleConfirmedClick = ( e ) => {
+					const resetModalConfirmText = ( e ) => {
 						if ( e.target.matches( '.ui-widget-overlay, .dismiss, .frm-trash-link' ) ) {
 							confirmButton.innerText = __( 'Confirm', 'formidable' );
-							document.removeEventListener( 'click', unbindHandleConfirmedClick );
+							document.removeEventListener( 'click', resetModalConfirmText );
 						}
 					};
 
-					document.addEventListener( 'click', unbindHandleConfirmedClick );
+					document.addEventListener( 'click', resetModalConfirmText );
 
 					doJsonPost( 'get_form_status', formData ).then( ( formStatus ) => {
 						if ( formStatus === 'trash' ) {
-							e.target.setAttribute( 'data-frmverify', 'You can\'t edit a deleted form.' );
+							targetElement.setAttribute( 'data-frmverify', 'You can\'t edit a deleted form.' );
 
-							confirmModal( e.target );
+							confirmModal( targetElement );
+
 							let url = new URL( confirmButton.getAttribute( 'href' ) );
 							url.searchParams.set( 'frm_action', 'untrash' );
-							url.searchParams.set( '_wpnonce', e.target.dataset.untrash_nonce );
+							url.searchParams.set( '_wpnonce', targetElement.dataset.untrash_nonce );
+
 							confirmButton.setAttribute( 'href', url.href );
 						} else {
-							window.location = e.target.href;
+							window.location = targetElement.href;
 						}
 					});
 				};

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9745,6 +9745,7 @@ function frmAdminBuildJS() {
 
 					const confirmButton       = document.getElementById( 'frm-confirmed-click' );
 					confirmButton.textContent = __( 'Restore form', 'formidable' );
+					confirmButton.classList.remove( 'frm-button-red' );
 
 					// Revert 'Confirm' button text when modal is closed or 'Delete' form button is clicked
 					const resetModalConfirmText = ( e ) => {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9753,7 +9753,7 @@ function frmAdminBuildJS() {
 
 					doJsonPost( 'get_form_status', formData ).then( ( formStatus ) => {
 						if ( formStatus === 'trash' ) {
-							targetElement.setAttribute( 'data-frmverify', __( 'You can\'t edit a deleted form.', 'formidable' ) );
+							targetElement.setAttribute( 'data-frmverify', __( 'The form you\'re trying to edit is trash. Consider restoring it.', 'formidable' ) );
 
 							confirmModal( targetElement );
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9737,21 +9737,31 @@ function frmAdminBuildJS() {
 
 				const checkFormStatus = ( e ) => {
 					e.preventDefault();
-					let formID = e.target.closest( 'tr' ).querySelector( '.check-column input[type=checkbox]').value;
+					let formID = e.target.closest( 'tr' ).querySelector( '.check-column input[type=checkbox]' ).value;
 					const formData  = new FormData();
 					formData.append( 'form_id', formID );
+					const confirmButton = document.getElementById( 'frm-confirmed-click' );
+					confirmButton.textContent = __( 'Restore form', 'formidable' );
+
+					// Revert 'Confirm' button text when modal is closed
+					const unbindHandleConfirmedClick = ( e ) => {
+						if ( e.target.matches( '.ui-widget-overlay, .dismiss, .frm-trash-link' ) ) {
+							confirmButton.innerText = __( 'Confirm', 'formidable' );
+							document.removeEventListener( 'click', unbindHandleConfirmedClick );
+						}
+					};
+
+					document.addEventListener( 'click', unbindHandleConfirmedClick );
+
 					doJsonPost( 'get_form_status', formData ).then( ( formStatus ) => {
 						if ( formStatus === 'trash' ) {
 							e.target.setAttribute( 'data-frmverify', 'You can\'t edit a deleted form.' );
+
 							confirmModal( e.target );
-							const confirmButton = document.getElementById( 'frm-confirmed-click' );
-							confirmButton.innerText = 'Restore form';
-							console.log(confirmButton.getAttribute( 'href' ));
 							let url = new URL( confirmButton.getAttribute( 'href' ) );
 							url.searchParams.set( 'frm_action', 'untrash' );
-							url.searchParams.set( '_wpnonce', frmGlobal.nonce );
+							url.searchParams.set( '_wpnonce', e.target.dataset.untrash_nonce );
 							confirmButton.setAttribute( 'href', url.href );
-							// Revert 'Confirm' button text when modal is closed
 						} else {
 							window.location = e.target.href;
 						}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9743,7 +9743,7 @@ function frmAdminBuildJS() {
 					const confirmButton = document.getElementById( 'frm-confirmed-click' );
 					confirmButton.textContent = __( 'Restore form', 'formidable' );
 
-					// Revert 'Confirm' button text when modal is closed
+					// Revert 'Confirm' button text when modal is closed or 'Delete' form button is clicked
 					const unbindHandleConfirmedClick = ( e ) => {
 						if ( e.target.matches( '.ui-widget-overlay, .dismiss, .frm-trash-link' ) ) {
 							confirmButton.innerText = __( 'Confirm', 'formidable' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9739,7 +9739,11 @@ function frmAdminBuildJS() {
 					e.preventDefault();
 
 					const targetElement = e.currentTarget;
-					let formID     = targetElement.closest( 'tr' ).querySelector( '.check-column input[type=checkbox]' ).value;
+					let formID = targetElement.closest( 'tr' ).querySelector( '.check-column input[type=checkbox]' ).value;
+					if ( ! formID ) {
+						return;
+					}
+
 					const formData = new FormData();
 					formData.append( 'form_id', formID );
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9734,6 +9734,33 @@ function frmAdminBuildJS() {
 					window.print();
 					return false;
 				});
+
+				const checkFormStatus = ( e ) => {
+					e.preventDefault();
+					let formID = e.target.closest( 'tr' ).querySelector( '.check-column input[type=checkbox]').value;
+					const formData  = new FormData();
+					formData.append( 'form_id', formID );
+					doJsonPost( 'get_form_status', formData ).then( ( formStatus ) => {
+						if ( formStatus === 'trash' ) {
+							e.target.setAttribute( 'data-frmverify', 'You can\'t edit a deleted form.' );
+							confirmModal( e.target );
+							const confirmButton = document.getElementById( 'frm-confirmed-click' );
+							confirmButton.innerText = 'Restore form';
+							console.log(confirmButton.getAttribute( 'href' ));
+							let url = new URL( confirmButton.getAttribute( 'href' ) );
+							url.searchParams.set( 'frm_action', 'untrash' );
+							url.searchParams.set( '_wpnonce', frmGlobal.nonce );
+							confirmButton.setAttribute( 'href', url.href );
+							// Revert 'Confirm' button text when modal is closed
+						} else {
+							window.location = e.target.href;
+						}
+					});
+				};
+
+				document.querySelectorAll( '.frm_edit a' ).forEach( ( el ) => {
+					el.addEventListener( 'click', checkFormStatus );
+				});
 			}
 
 			var $advInfo = jQuery( document.getElementById( 'frm_adv_info' ) );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9747,19 +9747,9 @@ function frmAdminBuildJS() {
 					confirmButton.textContent = __( 'Restore form', 'formidable' );
 					confirmButton.classList.remove( 'frm-button-red' );
 
-					// Revert 'Confirm' button text when modal is closed or 'Delete' form button is clicked
-					const resetModalConfirmText = ( e ) => {
-						if ( e.target.matches( '.ui-widget-overlay, .dismiss, .frm-trash-link' ) ) {
-							confirmButton.innerText = __( 'Confirm', 'formidable' );
-							document.removeEventListener( 'click', resetModalConfirmText );
-						}
-					};
-
-					document.addEventListener( 'click', resetModalConfirmText );
-
 					doJsonPost( 'get_form_status', formData ).then( ( formStatus ) => {
 						if ( formStatus === 'trash' ) {
-							targetElement.setAttribute( 'data-frmverify', 'You can\'t edit a deleted form.' );
+							targetElement.setAttribute( 'data-frmverify', __( 'You can\'t edit a deleted form.', 'formidable' ) );
 
 							confirmModal( targetElement );
 
@@ -9773,6 +9763,16 @@ function frmAdminBuildJS() {
 							window.location = targetElement.href;
 						}
 					});
+
+					// Revert 'Confirm' button text when modal is closed or 'Delete' form button is clicked
+					const resetModalConfirmText = ( e ) => {
+						if ( e.target.matches( '.ui-widget-overlay, .dismiss, .frm-trash-link' ) ) {
+							confirmButton.innerText = __( 'Confirm', 'formidable' );
+							document.removeEventListener( 'click', resetModalConfirmText );
+						}
+					};
+
+					document.addEventListener( 'click', resetModalConfirmText );
 				};
 
 				document.querySelectorAll( '.frm_edit a' ).forEach( ( el ) => {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9765,6 +9765,7 @@ function frmAdminBuildJS() {
 							let url = new URL( confirmButton.getAttribute( 'href' ) );
 							url.searchParams.set( 'frm_action', 'untrash' );
 							url.searchParams.set( '_wpnonce', targetElement.dataset.untrash_nonce );
+							url.searchParams.set( 'form_type', 'trash' );
 
 							confirmButton.setAttribute( 'href', url.href );
 						} else {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4296

This update prevents a deleted form from being edited. It could use some styling if required for some alignment and color stuff.

I also added more text to the form preview message as to why the form cannot be previewed for deleted form case.

In addition to that there is a minor style fix as the message from is hidden when using `wp_die` for cases like attempting to edit non-existent form or deleted one.

Sreenshots:
Attempting to edit a deleted form,
![image](https://github.com/Strategy11/formidable-forms/assets/41271840/02c1cc7e-6c09-4880-9102-526e7aa31ac2)

Attempting to preview a deleted form,
![image](https://github.com/Strategy11/formidable-forms/assets/41271840/fef276ae-1fca-4c63-9bb8-150b36bd8c11)

Steps to test:
1. On the form list page, open the 'Trash' link in new tab so that the list page doesn't reload with the deleted form gone.
![image](https://github.com/Strategy11/formidable-forms/assets/41271840/0c24dd69-c5be-4334-ae0b-818cfb68e007)

2. Try to click on the edit and preview buttons and test.

