### PR TITLE
permanently delete trashed form before xml import

### DIFF
--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -304,7 +304,13 @@ class FrmXMLHelper {
 
 		$edit_query = apply_filters( 'frm_match_xml_form', $edit_query, $form );
 
-		return FrmForm::getAll( $edit_query, '', 1 );
+		$form = FrmForm::getAll( $edit_query, '', 1 );
+		if ( is_object( $form ) && $form->status === 'trash' ) {
+			FrmForm::destroy( $form->id );
+			return false;
+		}
+
+		return $form;
 	}
 
 	private static function update_form( $this_form, $form, &$imported ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4321

This update makes sure a trashed form is permanently deleted before import.

Before:
![image](https://github.com/Strategy11/formidable-forms/assets/41271840/6997e3b5-f1e0-4336-a784-714fa4cf1d07)

After:
![image](https://github.com/Strategy11/formidable-forms/assets/41271840/cdb9fcef-521e-4d19-bf17-50d1184ed594)
