### PR TITLE
add read only setting to name field

### DIFF
--- a/classes/models/fields/FrmFieldName.php
+++ b/classes/models/fields/FrmFieldName.php
@@ -40,6 +40,13 @@ class FrmFieldName extends FrmFieldCombo {
 		);
 	}
 
+	protected function field_settings_for_type() {
+		$settings = parent::field_settings_for_type();
+		$settings['read_only'] = true;
+
+		return $settings;
+	}
+
 	/**
 	 * Gets processed sub fields.
 	 * This should return the list of sub fields after sorting or show/hide based of some options.


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4306
Just adding a "read only" field setting to Name field.

![image](https://github.com/Strategy11/formidable-forms/assets/41271840/53173741-555a-4b47-89a5-697ffab7cc51)
