### PR TITLE
Required for Date calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ pro
 .phpintel
 frm.min.js
 formidableforms.css
+formidableforms1.css
 formidable.zip
 languages/formidable-js.pot
 languages/formidable-js-strings.php

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -16,7 +16,7 @@ class FrmAppHelper {
 	/**
 	 * @since 2.0
 	 */
-	public static $plug_version = '6.4-date-calculation';
+	public static $plug_version = '6.4.1';
 
 	/**
 	 * @since 1.07.02

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -16,7 +16,7 @@ class FrmAppHelper {
 	/**
 	 * @since 2.0
 	 */
-	public static $plug_version = '6.4';
+	public static $plug_version = '6.4-date-calculation';
 
 	/**
 	 * @since 1.07.02

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1024,7 +1024,6 @@ class FrmAppHelper {
 	public static function add_allowed_icon_tags( $allowed_html ) {
 		$allowed_html['svg']['data-open'] = true;
 		$allowed_html['svg']['title']     = true;
-		$allowed_html['svg']['data-fid']  = true;
 		return $allowed_html;
 	}
 

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1024,6 +1024,7 @@ class FrmAppHelper {
 	public static function add_allowed_icon_tags( $allowed_html ) {
 		$allowed_html['svg']['data-open'] = true;
 		$allowed_html['svg']['title']     = true;
+		$allowed_html['svg']['data-fid']  = true;
 		return $allowed_html;
 	}
 

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -492,7 +492,12 @@ class FrmFieldsHelper {
 	}
 
 	/**
+	 * Shows the inline modal.
+	 *
 	 * @since 4.0
+	 * @since x.x Added `inside_class` in the arguments.
+	 *
+	 * @param array $args The arguments.
 	 */
 	public static function inline_modal( $args ) {
 		$defaults = array(
@@ -502,6 +507,7 @@ class FrmFieldsHelper {
 			'callback' => array(),
 			'args'     => array(),
 			'title'    => '',
+			'inside_class' => 'inside',
 		);
 		$args = array_merge( $defaults, $args );
 

--- a/classes/views/frm-fields/back-end/inline-modal.php
+++ b/classes/views/frm-fields/back-end/inline-modal.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</a>
 		</li>
 	</ul>
-	<div class="inside">
+	<div class="<?php echo esc_attr( $args['inside_class'] ); ?>">
 		<?php call_user_func( $args['callback'], $args['args'] ); ?>
 	</div>
 </div>

--- a/formidable.php
+++ b/formidable.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Formidable Forms
 Description: Quickly and easily create drag-and-drop forms
-Version: 6.4-date-calculation
+Version: 6.4.1
 Plugin URI: https://formidableforms.com/
 Author URI: https://formidableforms.com/
 Author: Strategy11 Form Builder Team

--- a/formidable.php
+++ b/formidable.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Formidable Forms
 Description: Quickly and easily create drag-and-drop forms
-Version: 6.4
+Version: 6.4-date-calculation
 Plugin URI: https://formidableforms.com/
 Author URI: https://formidableforms.com/
 Author: Strategy11 Form Builder Team

--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -692,6 +692,15 @@
 		return div({ children: [ label, input ] });
 	}
 
+	/**
+	 * Build an element.
+	 *
+	 * @since x.x Accept a string as one of `children` to append a text node inside the element.
+	 *
+	 * @param {String} type Element tag name.
+	 * @param {Object} args The args.
+	 * @return {Object}
+	 */
 	function tag( type, args = {}) {
 		const output = document.createElement( type );
 
@@ -710,7 +719,13 @@
 			output.className = className;
 		}
 		if ( children ) {
-			children.forEach( child => output.appendChild( child ) );
+			children.forEach( child => {
+				if ( 'string' === typeof child ) {
+					output.appendChild( document.createTextNode( child ) );
+				} else {
+					output.appendChild( child )
+				}
+			} );
 		} else if ( child ) {
 			output.appendChild( child );
 		} else if ( text ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5987,6 +5987,11 @@ function frmAdminBuildJS() {
 
 			container.addClass( 'frm-open' );
 			box.classList.remove( 'frm_hidden' );
+
+			/**
+			 * @since x.x
+			 */
+			wp.hooks.doAction( 'frm_show_inline_modal', box, icon );
 		}
 	}
 


### PR DESCRIPTION
This PR includes:
- Ignore `formidableforms1.css` file.
- Improve `dom.tag()` to accept a string as one of children.
- Add JS action when show inline modal (in the backend).
- Add `inside_class` to the inline modal args (to fix the ugly styling of nested modals inside the `<div class="inside">` tag).
- Bump version for testing.