### PR TITLE
Add a submit element html reset button

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -3089,7 +3089,7 @@ class FrmFormsController {
 		FrmAppHelper::permission_check( 'frm_edit_forms' );
 		check_ajax_referer( 'frm_ajax', 'nonce' );
 
-		$submit_html = self::get_default_html( 'submit' );
+		$submit_html = FrmFormsHelper::get_default_html( 'submit' );
 		wp_send_json_success( $submit_html );
 		die();
 	}

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -3078,6 +3078,23 @@ class FrmFormsController {
 	}
 
 	/**
+	 * Get the default HTML for a submit button.
+	 * This is called when the reset action is triggered in the Customize HTML section.
+	 *
+	 * @since x.x
+	 *
+	 * @return void
+	 */
+	public static function get_default_submit_html() {
+		FrmAppHelper::permission_check( 'frm_edit_forms' );
+		check_ajax_referer( 'frm_ajax', 'nonce' );
+
+		$submit_html = self::get_default_html( 'submit' );
+		wp_send_json_success( $submit_html );
+		die();
+	}
+
+	/**
 	 * @deprecated 4.0
 	 */
 	public static function new_form( $values = array() ) {

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -143,6 +143,9 @@ class FrmHooksController {
 		add_action( 'admin_head-toplevel_page_formidable', 'FrmFormsController::head' );
 		add_action( 'frm_after_field_options', 'FrmFormsController::logic_tip' );
 
+		// Forms Helper.
+		add_action( 'wp_ajax_frm_get_default_submit_html', 'FrmFormsHelper::get_default_submit_html' );
+
 		add_filter( 'set-screen-option', 'FrmFormsController::save_per_page', 10, 3 );
 		add_action( 'admin_footer', 'FrmFormsController::insert_form_popup' );
 

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -143,9 +143,6 @@ class FrmHooksController {
 		add_action( 'admin_head-toplevel_page_formidable', 'FrmFormsController::head' );
 		add_action( 'frm_after_field_options', 'FrmFormsController::logic_tip' );
 
-		// Forms Helper.
-		add_action( 'wp_ajax_frm_get_default_submit_html', 'FrmFormsHelper::get_default_submit_html' );
-
 		add_filter( 'set-screen-option', 'FrmFormsController::save_per_page', 10, 3 );
 		add_action( 'admin_footer', 'FrmFormsController::insert_form_popup' );
 
@@ -261,6 +258,9 @@ class FrmHooksController {
 
 		// Submit with AJAX.
 		add_action( 'wp_loaded', 'FrmEntriesAJAXSubmitController::ajax_create', 5 ); // Trigger before process_entry.
+
+		// Forms Helper.
+		add_action( 'wp_ajax_frm_get_default_submit_html', 'FrmFormsHelper::get_default_submit_html' );
 	}
 
 	/**

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -229,6 +229,7 @@ class FrmHooksController {
 		add_action( 'wp_ajax_frm_build_template', 'FrmFormsController::build_template' );
 		add_action( 'wp_ajax_frm_create_page_with_shortcode', 'FrmFormsController::create_page_with_shortcode' );
 		add_action( 'wp_ajax_get_page_dropdown', 'FrmFormsController::get_page_dropdown' );
+		add_action( 'wp_ajax_frm_get_default_submit_html', 'FrmFormsController::get_default_submit_html' );
 
 		add_action( 'wp_ajax_frm_dismiss_migrator', 'FrmFormMigratorsHelper::dismiss_migrator' );
 
@@ -258,9 +259,6 @@ class FrmHooksController {
 
 		// Submit with AJAX.
 		add_action( 'wp_loaded', 'FrmEntriesAJAXSubmitController::ajax_create', 5 ); // Trigger before process_entry.
-
-		// Forms Helper.
-		add_action( 'wp_ajax_frm_get_default_submit_html', 'FrmFormsHelper::get_default_submit_html' );
 	}
 
 	/**

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -449,11 +449,12 @@ BEFORE_HTML;
 	 * @return void
 	 */
 	public static function get_default_submit_html() {
+		FrmAppHelper::permission_check( 'frm_edit_forms' );
 		check_ajax_referer( 'frm_ajax', 'nonce' );
 
 		$submit_html = self::get_default_html( 'submit' );
-		echo $submit_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		wp_die();
+		wp_send_json_success( $submit_html );
+		die();
 	}
 
 	public static function get_draft_link() {

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -443,20 +443,6 @@ BEFORE_HTML;
 		return $default_html;
 	}
 
-	/**
-	 * @since x.x
-	 *
-	 * @return void
-	 */
-	public static function get_default_submit_html() {
-		FrmAppHelper::permission_check( 'frm_edit_forms' );
-		check_ajax_referer( 'frm_ajax', 'nonce' );
-
-		$submit_html = self::get_default_html( 'submit' );
-		wp_send_json_success( $submit_html );
-		die();
-	}
-
 	public static function get_draft_link() {
 		$link = '[if save_draft]<a href="#" tabindex="0" class="frm_save_draft" [draft_hook]>[draft_label]</a>[/if save_draft]';
 

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -443,6 +443,19 @@ BEFORE_HTML;
 		return $default_html;
 	}
 
+	/**
+	 * @since x.x
+	 *
+	 * @return void
+	 */
+	public static function get_default_submit_html() {
+		check_ajax_referer( 'frm_ajax', 'nonce' );
+
+		$submit_html = self::get_default_html( 'submit' );
+		echo $submit_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		wp_die();
+	}
+
 	public static function get_draft_link() {
 		$link = '[if save_draft]<a href="#" tabindex="0" class="frm_save_draft" [draft_hook]>[draft_label]</a>[/if save_draft]';
 

--- a/classes/views/frm-forms/settings-html.php
+++ b/classes/views/frm-forms/settings-html.php
@@ -39,7 +39,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</p>
 
 	<p class="frm_has_shortcodes">
-		<label><?php esc_html_e( 'Submit Button', 'formidable' ); ?></label>
+		<span><?php esc_html_e( 'Submit Button', 'formidable' ); ?></span>
+		<a href="#" id="frm_reset_submit_html"><?php esc_html_e( 'Reset to default', 'formidable' ); ?></a>
 		<textarea name="options[submit_html]" rows="3" id="submit_html" class="frm_long_input"><?php echo FrmAppHelper::esc_textarea( $values['submit_html'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></textarea>
 	</p>
 </div>

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6724,6 +6724,10 @@ td.frm_left_label + td {
 	width: 100%;
 }
 
+#frm_reset_submit_html {
+	float: right;
+}
+
 ul.frm-category-tabs {
 	margin-top: 2px;
 }

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10188,6 +10188,14 @@ function frmAdminBuildJS() {
 			jQuery( document ).on( 'frm-action-loaded', onActionLoaded );
 
 			initOnSubmitAction();
+			document.getElementById( 'frm_reset_submit_html' ).addEventListener( 'click', ( e ) => {
+				const htmlContainer = e.target.parentElement.querySelector( 'textarea' );
+				htmlContainer.innerHTML = `<div class="frm_submit">
+	[if back_button]<button type="submit" name="frm_prev_page" formnovalidate="formnovalidate" class="frm_prev_page" [back_hook]>[back_label]</button>[/if back_button]
+	<button class="frm_button_submit" type="submit"  [button_action]>[button_label]</button>
+	[if save_draft]<a href="#" tabindex="0" class="frm_save_draft" [draft_hook]>[draft_label]</a>[/if save_draft]
+</div>`;
+			});
 		},
 
 		panelInit: function() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10198,8 +10198,7 @@ function frmAdminBuildJS() {
 						nonce: frmGlobal.nonce
 					},
 					success: function( html ) {
-						const htmlContainer = e.target.parentElement.querySelector( 'textarea' );
-						htmlContainer.value = html;
+						htmlContainer.value = e.target.parentElement.querySelector( 'textarea' );
 					}
 				});
 			});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10188,13 +10188,20 @@ function frmAdminBuildJS() {
 			jQuery( document ).on( 'frm-action-loaded', onActionLoaded );
 
 			initOnSubmitAction();
+
 			document.getElementById( 'frm_reset_submit_html' ).addEventListener( 'click', ( e ) => {
-				const htmlContainer = e.target.parentElement.querySelector( 'textarea' );
-				htmlContainer.innerHTML = `<div class="frm_submit">
-	[if back_button]<button type="submit" name="frm_prev_page" formnovalidate="formnovalidate" class="frm_prev_page" [back_hook]>[back_label]</button>[/if back_button]
-	<button class="frm_button_submit" type="submit"  [button_action]>[button_label]</button>
-	[if save_draft]<a href="#" tabindex="0" class="frm_save_draft" [draft_hook]>[draft_label]</a>[/if save_draft]
-</div>`;
+				jQuery.ajax({
+					type: 'POST',
+					url: ajaxurl,
+					data: {
+						action: 'frm_get_default_submit_html',
+						nonce: frmGlobal.nonce
+					},
+					success: function( html ) {
+						const htmlContainer = e.target.parentElement.querySelector( 'textarea' );
+						htmlContainer.value = html;
+					}
+				});
 			});
 		},
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10200,7 +10200,7 @@ function frmAdminBuildJS() {
 					success: function( html ) {
 						const htmlContainer = e.target.parentElement.querySelector( 'textarea' );
 						if ( htmlContainer ) {
-							htmlContainer.value = e.target.parentElement.querySelector( 'textarea' );
+							htmlContainer.value = html;
 						}
 					}
 				});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10190,20 +10190,14 @@ function frmAdminBuildJS() {
 			initOnSubmitAction();
 
 			document.getElementById( 'frm_reset_submit_html' ).addEventListener( 'click', ( e ) => {
-				jQuery.ajax({
-					type: 'POST',
-					url: ajaxurl,
-					data: {
-						action: 'frm_get_default_submit_html',
-						nonce: frmGlobal.nonce
-					},
-					success: function( html ) {
+				doJsonPost( 'get_default_submit_html', new FormData() ).then(
+					( html ) => {
 						const htmlContainer = e.target.parentElement.querySelector( 'textarea' );
 						if ( htmlContainer ) {
 							htmlContainer.value = html;
 						}
 					}
-				});
+				);
 			});
 		},
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10198,7 +10198,10 @@ function frmAdminBuildJS() {
 						nonce: frmGlobal.nonce
 					},
 					success: function( html ) {
-						htmlContainer.value = e.target.parentElement.querySelector( 'textarea' );
+						const htmlContainer = e.target.parentElement.querySelector( 'textarea' );
+						if ( htmlContainer ) {
+							htmlContainer.value = e.target.parentElement.querySelector( 'textarea' );
+						}
 					}
 				});
 			});


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4335

This update just adds a reset button to Submit element html box to allow resetting the value.

Screenshot:
![image](https://github.com/Strategy11/formidable-forms/assets/41271840/1375d869-8bae-4e93-8bdb-183ebbd7e8ca)
