### PR TITLE
Add horizontal margin to form preview when template is not found

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -397,6 +397,7 @@ class FrmFormsController {
 		add_filter( 'is_active_sidebar', '__return_false' );
 		FrmStylesController::enqueue_css( 'enqueue', true );
 
+		$p = get_query_template( 'page' );
 		if ( false === get_template_part( 'page' ) ) {
 			self::fallback_when_page_template_part_is_not_supported_by_theme();
 		}
@@ -413,7 +414,7 @@ class FrmFormsController {
 			// add some generic class names to the container to add some natural padding to the content.
 			// .entry-content catches the WordPress TwentyTwenty theme.
 			// .container catches Customizr content.
-			echo '<div class="container entry-content">';
+			echo '<div class="container entry-content frm-preview">';
 			the_content();
 			echo '</div>';
 			get_footer();

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -110,6 +110,10 @@ form input.frm_verify{
 <?php } ?>
 }
 
+.frm-preview {
+	margin: 0 350px;
+}
+
 legend.frm_hidden{
 	display:none !important;
 }


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4223

![image](https://github.com/Strategy11/formidable-forms/assets/41271840/b9d9b5a3-d61b-4f1b-a52a-1f5b72aa71c1)
