### PR TITLE
Fix Global Variable Issue with Floating Links

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9225,9 +9225,9 @@ function frmAdminBuildJS() {
 	 */
 	function updateCatHeadingVisibility() {
 		const insertFieldsElement = document.querySelector( '#frm-insert-fields' );
-		const headingElements = insertFieldsElement.querySelectorAll( ':scope > .frm-with-line' );
+		const headingElements = insertFieldsElement?.querySelectorAll( ':scope > .frm-with-line' );
 
-		headingElements.forEach( heading => {
+		headingElements?.forEach( heading => {
 			const fieldsListElement = heading.nextElementSibling;
 			if ( ! fieldsListElement ) {
 				return;

--- a/js/packages/floating-links/config.js
+++ b/js/packages/floating-links/config.js
@@ -12,18 +12,21 @@
 	 */
 	const { __ } = wp.i18n;
 
+	// Define a configuration variable for Formidable's floating links.
+	const frmFloatingLinksConfig = {};
+
 	/**
 	 * SVG definitions for the icons
 	 */
 	// Icon for Upgrade link
-	const frmUpgradeIcon = `
+	frmFloatingLinksConfig.upgradeIcon = `
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
 			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m12 4.75 1.75 5.5h5.5l-4.5 3.5 1.5 5.5-4.25-3.5-4.25 3.5 1.5-5.5-4.5-3.5h5.5L12 4.75Z"/>
 		</svg>
 	`;
 
 	// Icon for Support link
-	const frmSupportIcon = `
+	frmFloatingLinksConfig.supportIcon = `
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
 			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19.25 12a7.25 7.25 0 1 1-14.5 0 7.25 7.25 0 0 1 14.5 0Z"/>
 			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.25 12a3.25 3.25 0 1 1-6.5 0 3.25 3.25 0 0 1 6.5 0ZM7 17l2.5-2.5M17 17l-2.5-2.5m-5-5L7 7m7.5 2.5L17 7"/>
@@ -31,14 +34,14 @@
 	`;
 
 	// Icon for Documentation link
-	const frmDocumentationIcon = `
+	frmFloatingLinksConfig.documentationIcon = `
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
 			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m14.924 16.002.482 2.432c.106.537.682.895 1.286.8l1.64-.256c.604-.095 1.007-.607.9-1.145l-.481-2.431m-3.827.6-1.157-5.835c-.106-.538.297-1.05.9-1.145l1.64-.257c.605-.095 1.18.264 1.287.801l1.157 5.836m-3.827.6 3.827-.6M8.75 15.75v2.5a1 1 0 0 0 1 1h1.5a1 1 0 0 0 1-1v-2.5m-3.5 0v-8a1 1 0 0 1 1-1h1.5a1 1 0 0 1 1 1v8m-3.5 0h3.5m-7.5 0v2.5a1 1 0 0 0 1 1h1.5a1 1 0 0 0 1-1v-2.5m-3.5 0v-10a1 1 0 0 1 1-1h1.5a1 1 0 0 1 1 1v10m-3.5 0h3.5"/>
 		</svg>
 	`;
 
 	// Icon for Notifications link
-	const frmNotificationsIcon = `
+	frmFloatingLinksConfig.notificationsIcon = `
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
 			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17.25 12v-2a5.25 5.25 0 1 0-10.5 0v2l-2 4.25h14.5l-2-4.25ZM9 16.75s0 2.5 3 2.5 3-2.5 3-2.5"/>
 		</svg>
@@ -47,22 +50,22 @@
 	/**
 	 * Define links for the "free" version of the plugin
 	 */
-	const frmFreeVersionLinks = [
+	frmFloatingLinksConfig.freeVersionLinks = [
 		{
 			title: __( 'Upgrade', 'formidable' ),
-			icon: frmUpgradeIcon,
+			icon: frmFloatingLinksConfig.upgradeIcon,
 			url: 'https://formidableforms.com/lite-upgrade/',
 			openInNewTab: true
 		},
 		{
 			title: __( 'Support', 'formidable' ),
-			icon: frmSupportIcon,
+			icon: frmFloatingLinksConfig.supportIcon,
 			url: 'https://wordpress.org/support/plugin/formidable/',
 			openInNewTab: true
 		},
 		{
 			title: __( 'Documentation', 'formidable' ),
-			icon: frmDocumentationIcon,
+			icon: frmFloatingLinksConfig.documentationIcon,
 			url: 'https://formidableforms.com/knowledgebase/',
 			openInNewTab: true
 		}
@@ -71,10 +74,10 @@
 	/**
 	 * Define links for the "pro" version of the plugin
 	 */
-	const frmProVersionLinks = [
+	frmFloatingLinksConfig.proVersionLinks = [
 		{
 			title: __( 'Support & Docs', 'formidable' ),
-			icon: frmSupportIcon,
+			icon: frmFloatingLinksConfig.supportIcon,
 			url: 'https://formidableforms.com/knowledgebase/',
 			openInNewTab: true
 		}
@@ -83,7 +86,7 @@
 	/**
 	 * Define options
 	 */
-	const frmOptions = {
+	frmFloatingLinksConfig.options = {
 		hoverColor: '#4199FD',
 		bgHoverColor: '#F5FAFF',
 		logoIcon: `
@@ -102,9 +105,9 @@
 	};
 
 	// Determine the appropriate links and initialize the S11FloatingLinks class
-	const frmLinks = s11FloatingLinksData.proIsInstalled ? frmProVersionLinks : frmFreeVersionLinks;
+	frmFloatingLinksConfig.links = s11FloatingLinksData.proIsInstalled ? frmFloatingLinksConfig.proVersionLinks : frmFloatingLinksConfig.freeVersionLinks;
 
-	// Trigger the 'set_floating_links_config' action, passing the links and options
-	wp.hooks.doAction( 'set_floating_links_config', { frmLinks, frmOptions });
+	// Trigger the 'set_floating_links_config' action, passing the config
+	wp.hooks.doAction( 'set_floating_links_config', frmFloatingLinksConfig );
 
 })( window.wp );

--- a/js/packages/floating-links/config.js
+++ b/js/packages/floating-links/config.js
@@ -5,102 +5,106 @@
  * @class S11FloatingLinks
  */
 
-/**
- * WordPress dependencies
- */
-const { __ } = wp.i18n;
+( ( wp ) => {
 
-/**
- * SVG definitions for the icons
- */
-// Icon for Upgrade link
-const upgradeIcon = `
-	<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
-		<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m12 4.75 1.75 5.5h5.5l-4.5 3.5 1.5 5.5-4.25-3.5-4.25 3.5 1.5-5.5-4.5-3.5h5.5L12 4.75Z"/>
-	</svg>
-`;
+	/**
+	 * WordPress dependencies
+	 */
+	const { __ } = wp.i18n;
 
-// Icon for Support link
-const supportIcon = `
-	<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
-		<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19.25 12a7.25 7.25 0 1 1-14.5 0 7.25 7.25 0 0 1 14.5 0Z"/>
-		<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.25 12a3.25 3.25 0 1 1-6.5 0 3.25 3.25 0 0 1 6.5 0ZM7 17l2.5-2.5M17 17l-2.5-2.5m-5-5L7 7m7.5 2.5L17 7"/>
-	</svg>
-`;
-
-// Icon for Documentation link
-const documentationIcon = `
-	<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
-		<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m14.924 16.002.482 2.432c.106.537.682.895 1.286.8l1.64-.256c.604-.095 1.007-.607.9-1.145l-.481-2.431m-3.827.6-1.157-5.835c-.106-.538.297-1.05.9-1.145l1.64-.257c.605-.095 1.18.264 1.287.801l1.157 5.836m-3.827.6 3.827-.6M8.75 15.75v2.5a1 1 0 0 0 1 1h1.5a1 1 0 0 0 1-1v-2.5m-3.5 0v-8a1 1 0 0 1 1-1h1.5a1 1 0 0 1 1 1v8m-3.5 0h3.5m-7.5 0v2.5a1 1 0 0 0 1 1h1.5a1 1 0 0 0 1-1v-2.5m-3.5 0v-10a1 1 0 0 1 1-1h1.5a1 1 0 0 1 1 1v10m-3.5 0h3.5"/>
-	</svg>
-`;
-
-// Icon for Notifications link
-const notificationsIcon = `
-	<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
-		<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17.25 12v-2a5.25 5.25 0 1 0-10.5 0v2l-2 4.25h14.5l-2-4.25ZM9 16.75s0 2.5 3 2.5 3-2.5 3-2.5"/>
-	</svg>
-`;
-
-/**
- * Define links for the "free" version of the plugin
- */
-const freeVersionLinks = [
-	{
-		title: __( 'Upgrade', 'formidable' ),
-		icon: upgradeIcon,
-		url: 'https://formidableforms.com/lite-upgrade/',
-		openInNewTab: true
-	},
-	{
-		title: __( 'Support', 'formidable' ),
-		icon: supportIcon,
-		url: 'https://wordpress.org/support/plugin/formidable/',
-		openInNewTab: true
-	},
-	{
-		title: __( 'Documentation', 'formidable' ),
-		icon: documentationIcon,
-		url: 'https://formidableforms.com/knowledgebase/',
-		openInNewTab: true
-	}
-];
-
-/**
- * Define links for the "pro" version of the plugin
- */
-const proVersionLinks = [
-	{
-		title: __( 'Support & Docs', 'formidable' ),
-		icon: supportIcon,
-		url: 'https://formidableforms.com/knowledgebase/',
-		openInNewTab: true
-	}
-];
-
-/**
- * Define options
- */
-const options = {
-	hoverColor: '#4199FD',
-	bgHoverColor: '#F5FAFF',
-	logoIcon: `
-		<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="none" viewBox="0 0 40 40">
-			<g clip-path="url(#a)">
-				<path fill="#F15A24" d="M19.265 25.641h9.401v4.957h-9.401v-4.957Z"/>
-				<path fill="#5E5E5F" d="M26.702 9.743H13.368a2.12 2.12 0 0 0-2.136 2.12V14.7h17.436V9.743h-1.966Zm-.171 7.864H11.249v12.991h4.957v-8.034h10.36a2.154 2.154 0 0 0 2.016-1.419 1.67 1.67 0 0 0 .103-.598v-2.94H26.53ZM20 40a20 20 0 0 1-6.748-38.827 20 20 0 0 1 14.526 37.254A19.847 19.847 0 0 1 20 40Zm0-37.35A17.35 17.35 0 0 0 7.727 32.272 17.358 17.358 0 0 0 32.275 7.726 17.232 17.232 0 0 0 20 2.666V2.65Z"/>
-			</g>
-			<defs>
-				<clipPath id="a">
-				<path fill="#fff" d="M0 0h40v40H0z"/>
-				</clipPath>
-			</defs>
+	/**
+	 * SVG definitions for the icons
+	 */
+	// Icon for Upgrade link
+	const upgradeIcon = `
+		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m12 4.75 1.75 5.5h5.5l-4.5 3.5 1.5 5.5-4.25-3.5-4.25 3.5 1.5-5.5-4.5-3.5h5.5L12 4.75Z"/>
 		</svg>
-	`
-};
+	`;
 
-// Determine the appropriate links and initialize the S11FloatingLinks class
-const links = s11FloatingLinksData.proIsInstalled ? proVersionLinks : freeVersionLinks;
+	// Icon for Support link
+	const supportIcon = `
+		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19.25 12a7.25 7.25 0 1 1-14.5 0 7.25 7.25 0 0 1 14.5 0Z"/>
+			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.25 12a3.25 3.25 0 1 1-6.5 0 3.25 3.25 0 0 1 6.5 0ZM7 17l2.5-2.5M17 17l-2.5-2.5m-5-5L7 7m7.5 2.5L17 7"/>
+		</svg>
+	`;
 
-// Trigger the 'set_floating_links_config' action, passing the links and options
-wp.hooks.doAction( 'set_floating_links_config', { links, options });
+	// Icon for Documentation link
+	const documentationIcon = `
+		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m14.924 16.002.482 2.432c.106.537.682.895 1.286.8l1.64-.256c.604-.095 1.007-.607.9-1.145l-.481-2.431m-3.827.6-1.157-5.835c-.106-.538.297-1.05.9-1.145l1.64-.257c.605-.095 1.18.264 1.287.801l1.157 5.836m-3.827.6 3.827-.6M8.75 15.75v2.5a1 1 0 0 0 1 1h1.5a1 1 0 0 0 1-1v-2.5m-3.5 0v-8a1 1 0 0 1 1-1h1.5a1 1 0 0 1 1 1v8m-3.5 0h3.5m-7.5 0v2.5a1 1 0 0 0 1 1h1.5a1 1 0 0 0 1-1v-2.5m-3.5 0v-10a1 1 0 0 1 1-1h1.5a1 1 0 0 1 1 1v10m-3.5 0h3.5"/>
+		</svg>
+	`;
+
+	// Icon for Notifications link
+	const notificationsIcon = `
+		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17.25 12v-2a5.25 5.25 0 1 0-10.5 0v2l-2 4.25h14.5l-2-4.25ZM9 16.75s0 2.5 3 2.5 3-2.5 3-2.5"/>
+		</svg>
+	`;
+
+	/**
+	 * Define links for the "free" version of the plugin
+	 */
+	const freeVersionLinks = [
+		{
+			title: __( 'Upgrade', 'formidable' ),
+			icon: upgradeIcon,
+			url: 'https://formidableforms.com/lite-upgrade/',
+			openInNewTab: true
+		},
+		{
+			title: __( 'Support', 'formidable' ),
+			icon: supportIcon,
+			url: 'https://wordpress.org/support/plugin/formidable/',
+			openInNewTab: true
+		},
+		{
+			title: __( 'Documentation', 'formidable' ),
+			icon: documentationIcon,
+			url: 'https://formidableforms.com/knowledgebase/',
+			openInNewTab: true
+		}
+	];
+
+	/**
+	 * Define links for the "pro" version of the plugin
+	 */
+	const proVersionLinks = [
+		{
+			title: __( 'Support & Docs', 'formidable' ),
+			icon: supportIcon,
+			url: 'https://formidableforms.com/knowledgebase/',
+			openInNewTab: true
+		}
+	];
+
+	/**
+	 * Define options
+	 */
+	const options = {
+		hoverColor: '#4199FD',
+		bgHoverColor: '#F5FAFF',
+		logoIcon: `
+			<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="none" viewBox="0 0 40 40">
+				<g clip-path="url(#a)">
+					<path fill="#F15A24" d="M19.265 25.641h9.401v4.957h-9.401v-4.957Z"/>
+					<path fill="#5E5E5F" d="M26.702 9.743H13.368a2.12 2.12 0 0 0-2.136 2.12V14.7h17.436V9.743h-1.966Zm-.171 7.864H11.249v12.991h4.957v-8.034h10.36a2.154 2.154 0 0 0 2.016-1.419 1.67 1.67 0 0 0 .103-.598v-2.94H26.53ZM20 40a20 20 0 0 1-6.748-38.827 20 20 0 0 1 14.526 37.254A19.847 19.847 0 0 1 20 40Zm0-37.35A17.35 17.35 0 0 0 7.727 32.272 17.358 17.358 0 0 0 32.275 7.726 17.232 17.232 0 0 0 20 2.666V2.65Z"/>
+				</g>
+				<defs>
+					<clipPath id="a">
+					<path fill="#fff" d="M0 0h40v40H0z"/>
+					</clipPath>
+				</defs>
+			</svg>
+		`
+	};
+
+	// Determine the appropriate links and initialize the S11FloatingLinks class
+	const links = s11FloatingLinksData.proIsInstalled ? proVersionLinks : freeVersionLinks;
+
+	// Trigger the 'set_floating_links_config' action, passing the links and options
+	wp.hooks.doAction( 'set_floating_links_config', { links, options });
+
+})( window.wp );

--- a/js/packages/floating-links/config.js
+++ b/js/packages/floating-links/config.js
@@ -16,14 +16,14 @@
 	 * SVG definitions for the icons
 	 */
 	// Icon for Upgrade link
-	const upgradeIcon = `
+	const frmUpgradeIcon = `
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
 			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m12 4.75 1.75 5.5h5.5l-4.5 3.5 1.5 5.5-4.25-3.5-4.25 3.5 1.5-5.5-4.5-3.5h5.5L12 4.75Z"/>
 		</svg>
 	`;
 
 	// Icon for Support link
-	const supportIcon = `
+	const frmSupportIcon = `
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
 			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19.25 12a7.25 7.25 0 1 1-14.5 0 7.25 7.25 0 0 1 14.5 0Z"/>
 			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.25 12a3.25 3.25 0 1 1-6.5 0 3.25 3.25 0 0 1 6.5 0ZM7 17l2.5-2.5M17 17l-2.5-2.5m-5-5L7 7m7.5 2.5L17 7"/>
@@ -31,14 +31,14 @@
 	`;
 
 	// Icon for Documentation link
-	const documentationIcon = `
+	const frmDocumentationIcon = `
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
 			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m14.924 16.002.482 2.432c.106.537.682.895 1.286.8l1.64-.256c.604-.095 1.007-.607.9-1.145l-.481-2.431m-3.827.6-1.157-5.835c-.106-.538.297-1.05.9-1.145l1.64-.257c.605-.095 1.18.264 1.287.801l1.157 5.836m-3.827.6 3.827-.6M8.75 15.75v2.5a1 1 0 0 0 1 1h1.5a1 1 0 0 0 1-1v-2.5m-3.5 0v-8a1 1 0 0 1 1-1h1.5a1 1 0 0 1 1 1v8m-3.5 0h3.5m-7.5 0v2.5a1 1 0 0 0 1 1h1.5a1 1 0 0 0 1-1v-2.5m-3.5 0v-10a1 1 0 0 1 1-1h1.5a1 1 0 0 1 1 1v10m-3.5 0h3.5"/>
 		</svg>
 	`;
 
 	// Icon for Notifications link
-	const notificationsIcon = `
+	const frmNotificationsIcon = `
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
 			<path stroke="#667085" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17.25 12v-2a5.25 5.25 0 1 0-10.5 0v2l-2 4.25h14.5l-2-4.25ZM9 16.75s0 2.5 3 2.5 3-2.5 3-2.5"/>
 		</svg>
@@ -47,22 +47,22 @@
 	/**
 	 * Define links for the "free" version of the plugin
 	 */
-	const freeVersionLinks = [
+	const frmFreeVersionLinks = [
 		{
 			title: __( 'Upgrade', 'formidable' ),
-			icon: upgradeIcon,
+			icon: frmUpgradeIcon,
 			url: 'https://formidableforms.com/lite-upgrade/',
 			openInNewTab: true
 		},
 		{
 			title: __( 'Support', 'formidable' ),
-			icon: supportIcon,
+			icon: frmSupportIcon,
 			url: 'https://wordpress.org/support/plugin/formidable/',
 			openInNewTab: true
 		},
 		{
 			title: __( 'Documentation', 'formidable' ),
-			icon: documentationIcon,
+			icon: frmDocumentationIcon,
 			url: 'https://formidableforms.com/knowledgebase/',
 			openInNewTab: true
 		}
@@ -71,10 +71,10 @@
 	/**
 	 * Define links for the "pro" version of the plugin
 	 */
-	const proVersionLinks = [
+	const frmProVersionLinks = [
 		{
 			title: __( 'Support & Docs', 'formidable' ),
-			icon: supportIcon,
+			icon: frmSupportIcon,
 			url: 'https://formidableforms.com/knowledgebase/',
 			openInNewTab: true
 		}
@@ -83,7 +83,7 @@
 	/**
 	 * Define options
 	 */
-	const options = {
+	const frmOptions = {
 		hoverColor: '#4199FD',
 		bgHoverColor: '#F5FAFF',
 		logoIcon: `
@@ -102,9 +102,9 @@
 	};
 
 	// Determine the appropriate links and initialize the S11FloatingLinks class
-	const links = s11FloatingLinksData.proIsInstalled ? proVersionLinks : freeVersionLinks;
+	const frmLinks = s11FloatingLinksData.proIsInstalled ? frmProVersionLinks : frmFreeVersionLinks;
 
 	// Trigger the 'set_floating_links_config' action, passing the links and options
-	wp.hooks.doAction( 'set_floating_links_config', { links, options });
+	wp.hooks.doAction( 'set_floating_links_config', { frmLinks, frmOptions });
 
 })( window.wp );

--- a/js/packages/floating-links/s11-floating-links.js
+++ b/js/packages/floating-links/s11-floating-links.js
@@ -11,11 +11,11 @@ class S11FloatingLinks {
 	 * @constructor
 	 */
 	constructor() {
-		wp.hooks.addAction( 'set_floating_links_config', 'S11FloatingLinks', ({ frmLinks, frmOptions }) => {
-			this.validateInputs( frmLinks, frmOptions );
+		wp.hooks.addAction( 'set_floating_links_config', 'S11FloatingLinks', ({ links, options }) => {
+			this.validateInputs( links, options );
 
-			this.links = frmLinks;
-			this.options = frmOptions;
+			this.links = links;
+			this.options = options;
 
 			this.initComponent();
 		});

--- a/js/packages/floating-links/s11-floating-links.js
+++ b/js/packages/floating-links/s11-floating-links.js
@@ -11,11 +11,11 @@ class S11FloatingLinks {
 	 * @constructor
 	 */
 	constructor() {
-		wp.hooks.addAction( 'set_floating_links_config', 'S11FloatingLinks', ({ links, options }) => {
-			this.validateInputs( links, options );
+		wp.hooks.addAction( 'set_floating_links_config', 'S11FloatingLinks', ({ frmLinks, frmOptions }) => {
+			this.validateInputs( frmLinks, frmOptions );
 
-			this.links = links;
-			this.options = options;
+			this.links = frmLinks;
+			this.options = frmOptions;
 
 			this.initComponent();
 		});


### PR DESCRIPTION
Addressed the issue where floating links defined `__` as a global variable, introduced in a previous merge. I've restructured the code to minimize global exposure, ensuring that any global elements now have the "frm" prefix.

## Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4346

## Testing Instructions:
- Install and activate "Formidable Google Sheets".
  - Ensure you're using the stable version.
  - [Link to the latest version](https://github.com/Strategy11/formidable-googlespreadsheet/tree/v1.0.1)
- Navigate to "WP Admin > Formidable > Global Settings".
- Open the browser's Inspect Element and ensure the `Uncaught SyntaxError: Identifier '__' has already been declared` error no longer appears.

## Visual Comparisons:
### Before
![Before Changes](https://github.com/Strategy11/formidable-forms/assets/69119241/9cdf5792-078e-4c4e-b4e2-6d96d614ce55)

### After
![After Changes](https://github.com/Strategy11/formidable-forms/assets/69119241/ad9669a5-5084-4e1b-9378-9d099e20ccc6)
