### PR TITLE
Addition of Entry Navigation Buttons on the "View Entry" Page

### DIFF
--- a/classes/views/frm-entries/show.php
+++ b/classes/views/frm-entries/show.php
@@ -19,7 +19,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="columns-2">
 
 		<div id="post-body-content" class="frm-fields">
-			<?php do_action( 'frm_show_entry_start_content', compact( 'id', 'form' ) ); ?>
+			<?php
+			/**
+			 * Fires after the `#post-body-content` element on the entry show page.
+			 *
+			 * This action is used in Pro to display the pagination buttons. It allows developers
+			 * to add custom HTML content after the main post body content.
+			 *
+			 * @since x.x
+			 *
+			 * @param array $args Associative array with 'id' for entry ID and 'form' for form object.
+			 *
+			 * @type int    $args['id']   The ID of the entry.
+			 * @type object $args['form'] The form object.
+			 */
+			do_action( 'frm_show_entry_start_content', compact( 'id', 'form' ) );
+			?>
 
 			<div class="wrap frm-with-margin frm_form_fields">
 				<div class="postbox">

--- a/classes/views/frm-entries/show.php
+++ b/classes/views/frm-entries/show.php
@@ -19,6 +19,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="columns-2">
 
 		<div id="post-body-content" class="frm-fields">
+			<?php if ( FrmAppHelper::pro_is_installed() ) : ?>
+				<?php FrmProEntriesHelper::get_entry_navigation( $id, $form->id, 'show' ); ?>
+			<?php endif; ?>
+
 			<div class="wrap frm-with-margin frm_form_fields">
 				<div class="postbox">
 					<a href="#" class="alignright frm-pre-hndle" data-frmtoggle=".frm-empty-row" data-toggletext="<?php esc_attr_e( 'Hide empty fields', 'formidable' ); ?>">

--- a/classes/views/frm-entries/show.php
+++ b/classes/views/frm-entries/show.php
@@ -19,9 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="columns-2">
 
 		<div id="post-body-content" class="frm-fields">
-			<?php if ( FrmAppHelper::pro_is_installed() ) : ?>
-				<?php FrmProEntriesHelper::get_entry_navigation( $id, $form->id, 'show' ); ?>
-			<?php endif; ?>
+			<?php do_action( 'frm_show_entry_start_content', compact( 'id', 'form' ) ); ?>
 
 			<div class="wrap frm-with-margin frm_form_fields">
 				<div class="postbox">


### PR DESCRIPTION
### Note: This PR depends on https://github.com/Strategy11/formidable-pro/pull/4337 PR.

In this PR, we've added the 'next' and 'previous' buttons to the page where you view entries.

## Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4199

## QA URL:
https://qa.formidableforms.com/sherv/wp-admin/admin.php?page=formidable-entries&frm_action=list&form=1

## Testing Instructions:
1. Go to `WP Admin > Formidable`.
2. Choose an existing form or make a new one.
3. Go to `Entries` using the top navigation menu.
4. Open an entry (Click on the `View` button). You should see new buttons for navigating entries.

## Preview:
![2023-07-30 18 39 24](https://github.com/Strategy11/formidable-forms/assets/69119241/f65ac84e-8c22-45a0-8cb2-5ee9b19f0446)
 