### PR TITLE
Added Footer Links for Improved User Accessibility

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -1037,6 +1037,27 @@ class FrmAppController {
 	}
 
 	/**
+	 * Add admin footer links.
+	 *
+	 * @since x.x
+	 *
+	 * @return void
+	 */
+	public static function add_admin_footer_links() {
+		$is_valid_page =
+			FrmAppHelper::is_formidable_admin() &&
+			! FrmAppHelper::is_style_editor_page() &&
+			! FrmAppHelper::is_admin_page( 'formidable-views-editor' ) &&
+			! FrmAppHelper::simple_get( 'frm_action', 'sanitize_title' );
+
+		if ( ! $is_valid_page ) {
+			return;
+		}
+
+		include FrmAppHelper::plugin_path() . '/classes/views/shared/admin-footer-links.php';
+	}
+
+	/**
 	 * @deprecated 3.0.04
 	 *
 	 * @codeCoverageIgnore

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -1044,13 +1044,9 @@ class FrmAppController {
 	 * @return void
 	 */
 	public static function add_admin_footer_links() {
-		$is_valid_page =
-			FrmAppHelper::is_formidable_admin() &&
-			! FrmAppHelper::is_style_editor_page() &&
-			! FrmAppHelper::is_admin_page( 'formidable-views-editor' ) &&
-			! FrmAppHelper::simple_get( 'frm_action', 'sanitize_title' );
+		$post_type = FrmAppHelper::simple_get( 'post_type', 'sanitize_title' );
 
-		if ( ! $is_valid_page ) {
+		if ( ( ! FrmAppHelper::is_formidable_admin() && $post_type !== 'frm_logs' ) || FrmAppHelper::is_full_screen() ) {
 			return;
 		}
 

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -119,6 +119,7 @@ class FrmHooksController {
 		add_action( 'admin_enqueue_scripts', 'FrmAppController::admin_enqueue_scripts' );
 		add_filter( 'plugin_action_links_' . FrmAppHelper::plugin_folder() . '/formidable.php', 'FrmAppController::settings_link' );
 		add_filter( 'admin_footer_text', 'FrmAppController::set_footer_text' );
+		add_action( 'admin_footer', 'FrmAppController::add_admin_footer_links' );
 		add_action( 'wp_ajax_frm_dismiss_review', 'FrmAppController::dismiss_review' );
 
 		// Addons Controller.

--- a/classes/views/shared/admin-footer-links.php
+++ b/classes/views/shared/admin-footer-links.php
@@ -4,10 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Determine the support link based on lite vs pro.
-$support_link = FrmAppHelper::pro_is_installed() ? 'https://wordpress.org/support/plugin/formidable/' : 'https://formidableforms.com/new-topic/';
+$support_link = ! FrmAppHelper::pro_is_installed() ? 'https://wordpress.org/support/plugin/formidable/' : 'https://formidableforms.com/new-topic/';
 
-// Determine the upgrade link based on lite vs elite.
-$upgrade_link = FrmAppHelper::pro_is_installed() ? 'https://formidableforms.com/lite-upgrade/' : 'https://formidableforms.com/account/downloads/';
+// Determine the upgrade link based on lite vs pro.
+$upgrade_link = ! FrmAppHelper::pro_is_installed() ? 'https://formidableforms.com/lite-upgrade/' : 'https://formidableforms.com/account/downloads/';
 ?>
 
 <div class="frm-admin-footer-links">
@@ -22,19 +22,23 @@ $upgrade_link = FrmAppHelper::pro_is_installed() ? 'https://formidableforms.com/
 	</span><!-- .frm-admin-footer-links-text -->
 
 	<div class="frm-admin-footer-links-nav">
-		<a href="<?php echo esc_url( $support_link ); ?>"><?php esc_html_e( 'Support', 'formidable' ); ?></a> /
-		<a href="https://formidableforms.com/knowledgebase/"><?php esc_html_e( 'Docs', 'formidable' ); ?></a> /
-		<a href="<?php echo esc_url( $upgrade_link ); ?>"><?php esc_html_e( 'Upgrade', 'formidable' ); ?></a>
+		<a href="<?php echo esc_url( $support_link ); ?>" target="_blank"><?php esc_html_e( 'Support', 'formidable' ); ?></a>
+		<span>/</span>
+		<a href="https://formidableforms.com/knowledgebase/" target="_blank"><?php esc_html_e( 'Docs', 'formidable' ); ?></a>
+		<?php if ( 'elite' !== FrmAddonsController::license_type() ) : ?>
+			<span>/</span>
+			<a href="<?php echo esc_url( $upgrade_link ); ?>" target="_blank"><?php esc_html_e( 'Upgrade', 'formidable' ); ?></a>
+		<?php endif; ?>
 	</div><!-- .frm-admin-footer-links-nav -->
 
 	<div class="frm-admin-footer-links-socials">
 		<!-- Facebook link -->
-		<a href="https://www.facebook.com/formidableforms/"><span class="dashicons dashicons-facebook"></span></a>
+		<a href="https://www.facebook.com/formidableforms/" target="_blank"><span class="dashicons dashicons-facebook"></span></a>
 		<!-- Instagram link -->
-		<a href="https://www.instagram.com/formidableforms/"><span class="dashicons dashicons-instagram"></span></a>
+		<a href="https://www.instagram.com/formidableforms/" target="_blank"><span class="dashicons dashicons-instagram"></span></a>
 		<!-- Twitter link -->
-		<a href="https://twitter.com/formidableforms/"><span class="dashicons dashicons-twitter"></span></a>
+		<a href="https://twitter.com/formidableforms/" target="_blank"><span class="dashicons dashicons-twitter"></span></a>
 		<!-- Youtube link -->
-		<a href="https://www.youtube.com/c/FormidableFormsPlugin/"><span class="dashicons dashicons-youtube"></span></a>
+		<a href="https://www.youtube.com/c/FormidableFormsPlugin/" target="_blank"><span class="dashicons dashicons-youtube"></span></a>
 	</div><!-- .frm-admin-footer-links-socials -->
 </div><!-- .frm-admin-footer-links -->

--- a/classes/views/shared/admin-footer-links.php
+++ b/classes/views/shared/admin-footer-links.php
@@ -1,0 +1,40 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'You are not allowed to call this page directly.' );
+}
+
+// Determine the support link based on lite vs pro.
+$support_link = FrmAppHelper::pro_is_installed() ? 'https://wordpress.org/support/plugin/formidable/' : 'https://formidableforms.com/new-topic/';
+
+// Determine the upgrade link based on lite vs elite.
+$upgrade_link = FrmAppHelper::pro_is_installed() ? 'https://formidableforms.com/lite-upgrade/' : 'https://formidableforms.com/account/downloads/';
+?>
+
+<div class="frm-admin-footer-links">
+	<span class="frm-admin-footer-links-text">
+		<?php
+		printf(
+			/* translators: %1$s: Heart icon */
+			esc_html__( 'Made with %1$s by the Formidable Team', 'formidable' ),
+			'<span class="dashicons dashicons-heart"></span>'
+		);
+		?>
+	</span><!-- .frm-admin-footer-links-text -->
+
+	<div class="frm-admin-footer-links-nav">
+		<a href="<?php echo esc_url( $support_link ); ?>"><?php esc_html_e( 'Support', 'formidable' ); ?></a> /
+		<a href="https://formidableforms.com/knowledgebase/"><?php esc_html_e( 'Docs', 'formidable' ); ?></a> /
+		<a href="<?php echo esc_url( $upgrade_link ); ?>"><?php esc_html_e( 'Upgrade', 'formidable' ); ?></a>
+	</div><!-- .frm-admin-footer-links-nav -->
+
+	<div class="frm-admin-footer-links-socials">
+		<!-- Facebook link -->
+		<a href="https://www.facebook.com/formidableforms/"><span class="dashicons dashicons-facebook"></span></a>
+		<!-- Instagram link -->
+		<a href="https://www.instagram.com/formidableforms/"><span class="dashicons dashicons-instagram"></span></a>
+		<!-- Twitter link -->
+		<a href="https://twitter.com/formidableforms/"><span class="dashicons dashicons-twitter"></span></a>
+		<!-- Youtube link -->
+		<a href="https://www.youtube.com/c/FormidableFormsPlugin/"><span class="dashicons dashicons-youtube"></span></a>
+	</div><!-- .frm-admin-footer-links-socials -->
+</div><!-- .frm-admin-footer-links -->

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -154,8 +154,7 @@ a, .widget .widget-top, .stuffbox h3, .frm-collapsed {
 }
 
 .post-new-php.post-type-frm_display #screen-meta-links,
-.post-php.post-type-frm_display #screen-meta-links,
-.frm-white-body #wpfooter {
+.post-php.post-type-frm_display #screen-meta-links {
 	display: none;
 }
 
@@ -1088,9 +1087,46 @@ p.frm_has_shortcodes {
 	position: relative;
 }
 
+/* Admin footer */
 .frm-white-body #footer-upgrade {
 	display: none;
 }
+
+.frm-admin-footer-links,
+.frm-admin-footer-links-nav,
+.frm-admin-footer-links-socials {
+	display: flex;
+	justify-content: center;
+}
+
+.frm-admin-footer-links {
+	gap: var(--gap-2xs);
+	flex-direction: column;
+	text-align: center;
+	padding: var(--gap-xl) 0 var(--gap-lg) 160px;
+	font-size: var(--text-xs);
+	color: var(--grey-400);
+}
+
+body.rtl .frm-admin-footer-links {
+	padding-left: unset;
+	padding-right: 160px;
+}
+
+
+.frm-admin-footer-links-nav {
+	gap: var(--gap-2xs);
+	margin-bottom: var(--gap-xs);
+}
+
+.frm-admin-footer-links-socials {
+	gap: var(--gap-xs);
+}
+
+.frm-admin-footer-links-socials a {
+	color: var(--grey-400);
+}
+/* End Admin footer */
 
 .frm_list_entry_page h2 {
 	float: left;
@@ -8400,6 +8436,14 @@ Responsive Design
 	.auto-fold:not(.frm-full-screen) .frm_wrap .frm_page_container {
 		left: 36px;
 	}
+
+	.frm-admin-footer-links {
+		padding-left: 36px;
+	}
+
+	body.rtl .frm-admin-footer-links {
+		padding-right: 36px;
+	}
 }
 
 @media only screen and (max-width: 850px) {
@@ -8640,6 +8684,14 @@ Responsive Design
 
 	#wp-content-media-buttons a.frm_insert_form {
 		padding: 0 var(--gap-sm);
+	}
+
+	.frm-admin-footer-links {
+		padding-left: 0;
+	}
+
+	body.rtl .frm-admin-footer-links {
+		padding-right: 0;
 	}
 }
 


### PR DESCRIPTION
This PR introduces footer links. This enhancement ensures users no longer need to rely solely on the floating icon, which fades away upon scrolling.

## QA URL:
https://qa.formidableforms.com/sherv2/wp-admin/admin.php?page=formidable

## Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4350

## Testing Instructions:
1. Navigate to `WP Admin > Formidable`.
2. Check anywhere other than the builder pages and verify that the admin footer links have been added as depicted in the preview screenshot.

## Preview:
### Lite version
<img width="1680" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/d81d1060-5358-4dd5-bf8e-2847a37fe429">

### Elite version
<img width="1680" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/1f3f169c-c432-4043-a293-b00213924b85">