### PR TITLE
Add tabindex to radio groups

### DIFF
--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -527,6 +527,10 @@ class FrmFieldFormHtml {
 			$attributes['aria-required'] = 'true';
 		}
 
+		if ( $is_radio ) {
+			$attributes['tabindex'] = 0;
+		}
+
 		// Concatenate attributes into a string, and replace the role="group" in the HTML with the attributes string.
 		$html_attributes = FrmAppHelper::array_to_html_params( $attributes );
 		$this->html      = str_replace( ' role="group"', $html_attributes, $this->html );

--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -527,6 +527,7 @@ class FrmFieldFormHtml {
 			$attributes['aria-required'] = 'true';
 		}
 
+		// Add 'tabindex = "0"' attribute to the radio field.
 		if ( $is_radio ) {
 			$attributes['tabindex'] = 0;
 		}


### PR DESCRIPTION
Related update https://github.com/Strategy11/formidable-forms/pull/1199

Based on this comment https://github.com/Strategy11/formidable-forms/pull/1199#issuecomment-1660288775

I'm trying to match the tabindex on https://github.com/Strategy11/formidable-pro/pull/4249