### PR TITLE
Change modal in-product education link

### DIFF
--- a/classes/controllers/FrmSimpleBlocksController.php
+++ b/classes/controllers/FrmSimpleBlocksController.php
@@ -42,7 +42,7 @@ class FrmSimpleBlocksController {
 			'link'  => FrmAppHelper::admin_upgrade_link( 'block' ),
 			'url'   => FrmAppHelper::plugin_url(),
 			'modalAddon' => array(
-				'link'      => FrmAppHelper::admin_upgrade_link( 'addons', $modal_addon['link'] ),
+				'link'      => FrmAppHelper::admin_upgrade_link( 'block', $modal_addon['link'] ),
 				'hasAccess' => ! empty( $modal_addon['url'] ),
 			),
 		);


### PR DESCRIPTION
Based on Steph's request: https://github.com/Strategy11/formidable-forms/pull/1217#discussion_r1279662745