### PR TITLE
Add overlay css for payments page

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7749,7 +7749,8 @@ h2 .frm-sub-label {
 
 .frm-views-editor-body .ui-widget-overlay,
 .frm-white-body .ui-widget-overlay,
-.toplevel_page_formidable .ui-widget-overlay {
+.toplevel_page_formidable .ui-widget-overlay,
+.formidable_page_formidable-payments .ui-widget-overlay {
 	position: fixed;
 	width: 100%;
 	height: 100%;


### PR DESCRIPTION
Related update https://github.com/Strategy11/formidable-payments/pull/43

Following Truong's idea this update allows us to show the overlay when confirming deleting a payment in a way that doesn't require deprecations and it works for both the Stripe add on and the Stripe Lite update.