### PR TITLE
Exclude payments vendor folder from zip

### DIFF
--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -64,6 +64,7 @@ zip -r $zipname $destination \
 	-x "*/README.md" \
 	-x "*/tests/*" \
 	-x "$source/vendor/*" \
+	-x "$source/formidable-payments/vendor/*" \
 	-x "*/temp.xml" \
 	-x "formidable-pro/views/*" \
 	-x "formidable-views/js/dom.js" \


### PR DESCRIPTION
I noticed this was getting included when I made a stripe release.