### PR TITLE
Add phpcs check for php 5.6 and 8.1

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -27,3 +27,16 @@ jobs:
           $PHPCS_DIR/bin/phpcs -p -s -v -n . --standard=./phpcs.xml --extensions=php
       - name: Check PHP syntax
         run: find -L .  -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+      # get the PHP version
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 5.6
+      - name: Check PHP 5.6 syntax
+        run: find -L .  -path ./vendor -prune -o -path ./tests -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+      # get the PHP version
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+      - name: Check PHP 8.1 syntax
+        run: find -L .  -path ./vendor -prune -o -path ./tests -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+


### PR DESCRIPTION
I noticed when reviewing another PR that there was a php 5.6 syntax error that didn't get caught. @Crabcyborg do you want to make any modifications to this workflow before we merge it?