### PR TITLE
Stop forcing white icons for repeater add buttons on the entry view page

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6409,8 +6409,8 @@ li.selected .divider_section_only:before {
 
 #frm_builder_page .frm_remove_form_row .frmsvg,
 #frm_builder_page .frm_remove_form_row i:before,
-.frm_wrap .frm_add_form_row .frmsvg,
-.frm_add_form_row i:before {
+#frm_builder_page .frm_add_form_row .frmsvg,
+#frm_builder_page .frm_add_form_row i:before {
 	color: var(--primary-700);
 }
 


### PR DESCRIPTION
Related update https://github.com/Strategy11/formidable-pro/pull/3829

This rule is really only intended for the builder page where the button is another style.
<img width="310" alt="Screen Shot 2023-08-09 at 3 11 44 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/54e4a8cf-2527-411d-8f45-2353cb5a20a1">

**Before**
<img width="313" alt="Screen Shot 2023-08-09 at 3 11 26 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/2c00e597-76aa-4e5d-8220-a8fb62028771">

**After**
<img width="333" alt="Screen Shot 2023-08-09 at 3 10 56 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/9de3b175-7d6e-4579-b7c2-de94eb191af3">
