### PR TITLE
Enhanced Compliance with White Labeling Settings in Admin Floating and Footer Links

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -28,13 +28,13 @@ jobs:
       - name: Check PHP syntax
         run: find -L .  -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
       # get the PHP version
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@2.25.5
         with:
           php-version: 5.6
       - name: Check PHP 5.6 syntax
         run: find -L .  -path ./vendor -prune -o -path ./tests -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
       # get the PHP version
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@2.25.5
         with:
           php-version: 8.1
       - name: Check PHP 8.1 syntax

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -644,7 +644,7 @@ class FrmAppController {
 			! FrmAppHelper::is_style_editor_page() &&
 			! FrmAppHelper::is_admin_page( 'formidable-views-editor' ) &&
 			! FrmAppHelper::simple_get( 'frm_action', 'sanitize_title' );
-		if ( $is_valid_page ) {
+		if ( $is_valid_page && FrmAppHelper::is_formidable_branding() ) {
 			self::enqueue_floating_links( $plugin_url, $version );
 		}
 		unset( $is_valid_page );

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -1046,7 +1046,13 @@ class FrmAppController {
 	public static function add_admin_footer_links() {
 		$post_type = FrmAppHelper::simple_get( 'post_type', 'sanitize_title' );
 
-		if ( ( ! FrmAppHelper::is_formidable_admin() && $post_type !== 'frm_logs' ) || FrmAppHelper::is_full_screen() ) {
+		// Check admin privileges, screen mode, and branding
+		$is_not_admin = ! FrmAppHelper::is_formidable_admin() && $post_type !== 'frm_logs';
+		$is_full_screen = FrmAppHelper::is_full_screen();
+		$is_not_formidable_branding = ! FrmAppHelper::is_formidable_branding();
+
+		// Exit if any of the above conditions are met
+		if ( $is_not_admin || $is_full_screen || $is_not_formidable_branding ) {
 			return;
 		}
 

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -153,6 +153,22 @@ class FrmAppHelper {
 	}
 
 	/**
+	 * Determine if the current branding is set to 'formidable'.
+	 *
+	 * Checks the menu title, retrieved through get_menu_name,
+	 * and verifies if it matches the 'formidable' branding.
+	 *
+	 * @since x.x
+	 *
+	 * @return bool True if the menu title is 'formidable', false otherwise.
+	 */
+	public static function is_formidable_branding() {
+		$menu_title = self::get_menu_name();
+
+		return 'formidable' === strtolower( trim( $menu_title ) );
+	}
+
+	/**
 	 * @since 3.05
 	 */
 	public static function svg_logo( $atts = array() ) {

--- a/classes/views/shared/admin-footer-links.php
+++ b/classes/views/shared/admin-footer-links.php
@@ -8,37 +8,44 @@ $support_link = ! FrmAppHelper::pro_is_installed() ? 'https://wordpress.org/supp
 
 // Determine the upgrade link based on lite vs pro.
 $upgrade_link = ! FrmAppHelper::pro_is_installed() ? 'https://formidableforms.com/lite-upgrade/' : 'https://formidableforms.com/account/downloads/';
+
+// Menu title.
+$menu_title = FrmAppHelper::get_menu_name();
 ?>
 
 <div class="frm-admin-footer-links">
 	<span class="frm-admin-footer-links-text">
 		<?php
 		printf(
-			/* translators: %1$s: Heart icon */
-			esc_html__( 'Made with %1$s by the Formidable Team', 'formidable' ),
-			'<span class="dashicons dashicons-heart"></span>'
+			/* translators: %1$s: Heart icon, %2$s: Menu title, %3$s: 'Team' or null */
+			esc_html__( 'Made with %1$s by the %2$s %3$s', 'formidable' ),
+			'<span class="dashicons dashicons-heart"></span>',
+			esc_html( $menu_title ),
+			FrmAppHelper::is_formidable_branding() ? esc_html( 'Team' ) : ''
 		);
 		?>
 	</span><!-- .frm-admin-footer-links-text -->
 
-	<div class="frm-admin-footer-links-nav">
-		<a href="<?php echo esc_url( $support_link ); ?>" target="_blank"><?php esc_html_e( 'Support', 'formidable' ); ?></a>
-		<span>/</span>
-		<a href="https://formidableforms.com/knowledgebase/" target="_blank"><?php esc_html_e( 'Docs', 'formidable' ); ?></a>
-		<?php if ( 'elite' !== FrmAddonsController::license_type() ) : ?>
+	<?php if ( FrmAppHelper::is_formidable_branding() ) : ?>
+		<div class="frm-admin-footer-links-nav">
+			<a href="<?php echo esc_url( $support_link ); ?>" target="_blank"><?php esc_html_e( 'Support', 'formidable' ); ?></a>
 			<span>/</span>
-			<a href="<?php echo esc_url( $upgrade_link ); ?>" target="_blank"><?php esc_html_e( 'Upgrade', 'formidable' ); ?></a>
-		<?php endif; ?>
-	</div><!-- .frm-admin-footer-links-nav -->
+			<a href="https://formidableforms.com/knowledgebase/" target="_blank"><?php esc_html_e( 'Docs', 'formidable' ); ?></a>
+			<?php if ( 'elite' !== FrmAddonsController::license_type() ) : ?>
+				<span>/</span>
+				<a href="<?php echo esc_url( $upgrade_link ); ?>" target="_blank"><?php esc_html_e( 'Upgrade', 'formidable' ); ?></a>
+			<?php endif; ?>
+		</div><!-- .frm-admin-footer-links-nav -->
 
-	<div class="frm-admin-footer-links-socials">
-		<!-- Facebook link -->
-		<a href="https://www.facebook.com/formidableforms/" target="_blank"><span class="dashicons dashicons-facebook"></span></a>
-		<!-- Instagram link -->
-		<a href="https://www.instagram.com/formidableforms/" target="_blank"><span class="dashicons dashicons-instagram"></span></a>
-		<!-- Twitter link -->
-		<a href="https://twitter.com/formidableforms/" target="_blank"><span class="dashicons dashicons-twitter"></span></a>
-		<!-- Youtube link -->
-		<a href="https://www.youtube.com/c/FormidableFormsPlugin/" target="_blank"><span class="dashicons dashicons-youtube"></span></a>
-	</div><!-- .frm-admin-footer-links-socials -->
+		<div class="frm-admin-footer-links-socials">
+			<!-- Facebook link -->
+			<a href="https://www.facebook.com/formidableforms/" target="_blank"><span class="dashicons dashicons-facebook"></span></a>
+			<!-- Instagram link -->
+			<a href="https://www.instagram.com/formidableforms/" target="_blank"><span class="dashicons dashicons-instagram"></span></a>
+			<!-- Twitter link -->
+			<a href="https://twitter.com/formidableforms/" target="_blank"><span class="dashicons dashicons-twitter"></span></a>
+			<!-- Youtube link -->
+			<a href="https://www.youtube.com/c/FormidableFormsPlugin/" target="_blank"><span class="dashicons dashicons-youtube"></span></a>
+		</div><!-- .frm-admin-footer-links-socials -->
+	<?php endif; ?>
 </div><!-- .frm-admin-footer-links -->

--- a/classes/views/shared/admin-footer-links.php
+++ b/classes/views/shared/admin-footer-links.php
@@ -8,44 +8,37 @@ $support_link = ! FrmAppHelper::pro_is_installed() ? 'https://wordpress.org/supp
 
 // Determine the upgrade link based on lite vs pro.
 $upgrade_link = ! FrmAppHelper::pro_is_installed() ? 'https://formidableforms.com/lite-upgrade/' : 'https://formidableforms.com/account/downloads/';
-
-// Menu title.
-$menu_title = FrmAppHelper::get_menu_name();
 ?>
 
 <div class="frm-admin-footer-links">
 	<span class="frm-admin-footer-links-text">
 		<?php
 		printf(
-			/* translators: %1$s: Heart icon, %2$s: Menu title, %3$s: 'Team' or null */
-			esc_html__( 'Made with %1$s by the %2$s %3$s', 'formidable' ),
-			'<span class="dashicons dashicons-heart"></span>',
-			esc_html( $menu_title ),
-			FrmAppHelper::is_formidable_branding() ? esc_html( 'Team' ) : ''
+			/* translators: %1$s: Heart icon */
+			esc_html__( 'Made with %1$s by the Formidable Team', 'formidable' ),
+			'<span class="dashicons dashicons-heart"></span>'
 		);
 		?>
 	</span><!-- .frm-admin-footer-links-text -->
 
-	<?php if ( FrmAppHelper::is_formidable_branding() ) : ?>
-		<div class="frm-admin-footer-links-nav">
-			<a href="<?php echo esc_url( $support_link ); ?>" target="_blank"><?php esc_html_e( 'Support', 'formidable' ); ?></a>
+	<div class="frm-admin-footer-links-nav">
+		<a href="<?php echo esc_url( $support_link ); ?>" target="_blank"><?php esc_html_e( 'Support', 'formidable' ); ?></a>
+		<span>/</span>
+		<a href="https://formidableforms.com/knowledgebase/" target="_blank"><?php esc_html_e( 'Docs', 'formidable' ); ?></a>
+		<?php if ( 'elite' !== FrmAddonsController::license_type() ) : ?>
 			<span>/</span>
-			<a href="https://formidableforms.com/knowledgebase/" target="_blank"><?php esc_html_e( 'Docs', 'formidable' ); ?></a>
-			<?php if ( 'elite' !== FrmAddonsController::license_type() ) : ?>
-				<span>/</span>
-				<a href="<?php echo esc_url( $upgrade_link ); ?>" target="_blank"><?php esc_html_e( 'Upgrade', 'formidable' ); ?></a>
-			<?php endif; ?>
-		</div><!-- .frm-admin-footer-links-nav -->
+			<a href="<?php echo esc_url( $upgrade_link ); ?>" target="_blank"><?php esc_html_e( 'Upgrade', 'formidable' ); ?></a>
+		<?php endif; ?>
+	</div><!-- .frm-admin-footer-links-nav -->
 
-		<div class="frm-admin-footer-links-socials">
-			<!-- Facebook link -->
-			<a href="https://www.facebook.com/formidableforms/" target="_blank"><span class="dashicons dashicons-facebook"></span></a>
-			<!-- Instagram link -->
-			<a href="https://www.instagram.com/formidableforms/" target="_blank"><span class="dashicons dashicons-instagram"></span></a>
-			<!-- Twitter link -->
-			<a href="https://twitter.com/formidableforms/" target="_blank"><span class="dashicons dashicons-twitter"></span></a>
-			<!-- Youtube link -->
-			<a href="https://www.youtube.com/c/FormidableFormsPlugin/" target="_blank"><span class="dashicons dashicons-youtube"></span></a>
-		</div><!-- .frm-admin-footer-links-socials -->
-	<?php endif; ?>
+	<div class="frm-admin-footer-links-socials">
+		<!-- Facebook link -->
+		<a href="https://www.facebook.com/formidableforms/" target="_blank"><span class="dashicons dashicons-facebook"></span></a>
+		<!-- Instagram link -->
+		<a href="https://www.instagram.com/formidableforms/" target="_blank"><span class="dashicons dashicons-instagram"></span></a>
+		<!-- Twitter link -->
+		<a href="https://twitter.com/formidableforms/" target="_blank"><span class="dashicons dashicons-twitter"></span></a>
+		<!-- Youtube link -->
+		<a href="https://www.youtube.com/c/FormidableFormsPlugin/" target="_blank"><span class="dashicons dashicons-youtube"></span></a>
+	</div><!-- .frm-admin-footer-links-socials -->
 </div><!-- .frm-admin-footer-links -->


### PR DESCRIPTION
This PR makes sure that the Floating and Footer Links in the admin panel match the chosen brand name. If the brand isn't 'formidable', Floating links won't be shown, and social media and docs links in the Footer Links will be turned off.

## QA URL:
[QA link for testing](https://qa.formidableforms.com/sherv/wp-admin/admin.php?page=formidable-settings&t=white_label_settings)

## Related Issue:
[White labeling needs to comply in the backend](https://github.com/Strategy11/formidable-pro/issues/4058)

## Testing Instructions:
1. Go to `WP Admin > Formidable > Global Settings > White Labeling`.
2. If the brand name set under `Plugin Label` isn't `formidable`, make sure Floating links are not shown.
3. Check that the Footer Links show the correct brand name from the 'Plugin Label'.
4. See that social media and docs links in the Footer Links are off if the brand isn't 'formidable'.
5. For a detailed view, please see the gif in the 'GIF Overview' section.


## GIF Overview:
![2023-08-24 12 54 35](https://github.com/Strategy11/formidable-forms/assets/69119241/b5e69a3c-8772-4c3e-a892-ad780c9ba49f)
