### PR TITLE
Avoid automatic conversion of false to array when saving styles

### DIFF
--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -917,7 +917,7 @@ class FrmStylesController {
 		check_ajax_referer( 'frm_ajax', 'nonce' );
 
 		$frm_style = new FrmStyle();
-		$defaults  = false; // Intentionally avoid defaults here so nothing gets removed from our style.
+		$defaults  = array(); // Intentionally avoid defaults here so nothing gets removed from our style.
 		$style     = '';
 
 		echo '<style type="text/css">';


### PR DESCRIPTION
I noticed this while testing.

The `output_vars` function expects that `$defaults` is an array. But `false` is getting passed here.

It throws a warning on this code:
```
if ( ! isset( $defaults[ $var ] ) ) {
    $defaults[ $var ] = '';
}
```

> PHP Deprecated:  Automatic conversion of false to array is deprecated in /var/www/src/wp-content/plugins/formidable/classes/helpers/FrmStylesHelper.php on line 313