### PR TITLE
Offset verication field vertically

### DIFF
--- a/css/frm_grids.css
+++ b/css/frm_grids.css
@@ -17,7 +17,7 @@
 
 .frm_verify{
 	position:absolute;
-	left:-3000px;
+	top:-3000px;
 }
 
 .frm_clear_none{


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-wpml/issues/104

The issue is caused by the positioning of `frm_verify` element. I believe we can offset it vertically to avoid the extra 3000px wide whitespace.