### PR TITLE
Update the payments page selector for modal overlay

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7809,7 +7809,7 @@ h2 .frm-sub-label {
 .frm-views-editor-body .ui-widget-overlay,
 .frm-white-body .ui-widget-overlay,
 .toplevel_page_formidable .ui-widget-overlay,
-.formidable_page_formidable-payments .ui-widget-overlay {
+body[class*=formidable-payments] .ui-widget-overlay {
 	position: fixed;
 	width: 100%;
 	height: 100%;


### PR DESCRIPTION
The whitelabel setting is used in the name so `.formidable_page_formidable-payments` may not exist,