### PR TITLE
Override tinymce full screen position when admin sidebar is shown

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -140,7 +140,7 @@ a, .widget .widget-top, .stuffbox h3, .frm-collapsed {
 	display: none;
 }
 
-body.frm-admin-page-formidableedit:not(.frm-full-screen) .mce-fullscreen {
+body.frm-white-body:not(.frm-full-screen) .mce-fullscreen {
 	top: 32px;
 	left: 160px;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -140,7 +140,7 @@ a, .widget .widget-top, .stuffbox h3, .frm-collapsed {
 	display: none;
 }
 
-body:not(.frm-full-screen) .mce-fullscreen {
+body.frm-admin-page-formidableedit:not(.frm-full-screen) .mce-fullscreen {
 	top: 32px;
 	left: 160px;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -140,6 +140,11 @@ a, .widget .widget-top, .stuffbox h3, .frm-collapsed {
 	display: none;
 }
 
+body:not(.frm-full-screen) .mce-fullscreen {
+	top: 32px;
+	left: 160px;
+}
+
 .frm-full-screen #wpbody-content,
 .frm-full-screen #wpbody,
 .frm-full-screen #wpcontent {


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4417

### Testing

- Add code snippet to show admin menu
- Add an HTML field to a form and try going full screen

### Before

<img width="1097" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/5b1a046f-1c9c-4f42-a729-ec2c23f22b9f">

### After
<img width="1060" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/305f5e7d-250b-4e6b-a8ec-5e3cab6f99cf">
