### PR TITLE
Load error in a dialog

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1090,6 +1090,15 @@ class FrmFormsController {
 			wp_die( esc_html__( 'You are trying to edit a form that does not exist.', 'formidable' ) );
 		}
 
+		if ( 'trash' === $form->status ) {
+			$error = array(
+				'title' => __( 'You can\'t edit the form', 'formidable' ),
+				'body'  => __( 'The form you\'re trying to edit is in trash. You must restore it first before you can make changes', 'formidable' ),
+			);
+			include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/error-modal.php';
+			return;
+		}
+
 		if ( $form->parent_form_id ) {
 			/* translators: %1$s: Start link HTML, %2$s: End link HTML */
 			wp_die( sprintf( esc_html__( 'You are trying to edit a child form. Please edit from %1$shere%2$s', 'formidable' ), '<a href="' . esc_url( FrmForm::get_edit_link( $form->parent_form_id ) ) . '">', '</a>' ) );

--- a/classes/views/frm-forms/error-modal.php
+++ b/classes/views/frm-forms/error-modal.php
@@ -1,0 +1,38 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'You are not allowed to call this page directly.' );
+}
+?>
+<div id="frm_error_modal" class="frm-modal frm_common_modal" style="display: block;">
+	<div class="metabox-holder">
+		<div class="inside">
+			<div style="padding: 16px;">
+				<div style="font-size: var(--text-xl); font-weight: 400; color: var(--grey-900);"><?php echo esc_html( $error['title'] ); ?></div>
+				<?php echo esc_html( $error['body'] ); ?>
+				<script src="<?php echo esc_attr( includes_url() ); ?>js/jquery/ui/core.js?ver=1.13.2" id="jquery-ui-core-js"></script>
+				<script src="<?php echo esc_attr( includes_url() ); ?>js/jquery/ui/dialog.js?ver=1.13.2" id="jquery-ui-dialog-js"></script>
+				<script>
+					jQuery( document ).ready(
+						function() {
+							const modal = document.querySelector( '#frm_error_modal' );
+							jQuery( modal ).dialog(
+								{
+									dialogClass: 'frm-dialog',
+									modal: true,
+									autoOpen: true,
+									closeOnEscape: false,
+									width: '550px',
+									resizable: false,
+									draggable: false,
+									open: function() {
+										jQuery( '.ui-dialog-titlebar' ).addClass( 'frm_hidden' ).removeClass( 'ui-helper-clearfix' );
+									}
+								}
+							);
+						}
+					);
+				</script>
+			</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
This can be improved a lot but this is what I'm picturing instead of https://github.com/Strategy11/formidable-forms/pull/1233

<img width="1147" alt="Screen Shot 2023-09-05 at 3 13 09 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/25b3d077-5146-40d2-a70c-307aea6a621e">
