### PR TITLE
Leave email the same way on the inbox page as we do for the new form …

### DIFF
--- a/classes/controllers/FrmInboxController.php
+++ b/classes/controllers/FrmInboxController.php
@@ -58,8 +58,6 @@ class FrmInboxController {
 		$messages = array_reverse( $messages );
 		$user     = wp_get_current_user();
 
-		wp_enqueue_script( 'frm-ac', FrmAppHelper::plugin_url() . '/js/ac.js', array(), FrmAppHelper::plugin_version(), true );
-
 		include( FrmAppHelper::plugin_path() . '/classes/views/inbox/list.php' );
 	}
 

--- a/classes/views/frm-forms/new-form-overlay/leave-email.php
+++ b/classes/views/frm-forms/new-form-overlay/leave-email.php
@@ -10,12 +10,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<img src="<?php echo esc_url( FrmAppHelper::plugin_url() . '/images/leave-email.svg' ); ?>" />
 	<h3><?php esc_html_e( 'Get 10+ Free Form Templates', 'formidable' ); ?></h3>
 	<p><?php esc_html_e( 'Just add your email address and you\'ll get a code for 10+ free form templates.', 'formidable' ); ?></p>
-	<div style="position: relative; width: 600px; margin: 0 auto;">
+	<div id="frm_leave_email_wrapper">
 		<span class="frm-with-left-icon">
 			<?php FrmAppHelper::icon_by_class( 'frmfont frm_email_icon' ); ?>
 			<input id="frm_leave_email" type="email" placeholder="<?php esc_html_e( 'Enter your email', 'formidable' ); ?>" value="<?php echo esc_attr( $user->user_email ); ?>" />
 		</span>
-		<span id="frm_leave_email_error" class="frm_hidden" style="position: absolute; right: 71px; top: 7px; color: #973937;">
+		<span id="frm_leave_email_error" class="frm_hidden">
 			<span frm-error="invalid"><?php esc_html_e( 'Email is invalid', 'formidable' ); ?></span>
 			<span frm-error="empty"><?php esc_html_e( 'Email is empty', 'formidable' ); ?></span>
 		</span>

--- a/classes/views/inbox/list.php
+++ b/classes/views/inbox/list.php
@@ -72,50 +72,10 @@ if ( $has_messages ) {
 		<?php esc_html_e( 'Get the details about new updates, tips, sales, and more. We\'ll keep you in the loop.', 'formidable' ); ?>
 		<?php esc_html_e( 'Want more news and email updates?', 'formidable' ); ?>
 	</p>
-<style>
-	#_form_3_ { font-size:14px; line-height:1.6; font-family:arial, helvetica, sans-serif; margin:0; }
-	._form_hide { display:none; visibility:hidden; }
-	._form_show { display:block; visibility:visible; }
-	#_form_3_ ._form_element { position:relative; }
-	#_form_3_ input[type="text"]._has_error { border-color:#f37c7b; }
-	#_form_3_ ._error { display:block; position:absolute; font-size:14px; z-index:10000001; }
-	#_form_3_ ._error._above { padding-bottom:4px; bottom:39px; right:0; }
-	#_form_3_ ._error._below { padding-top:4px; top:100%; right:0; }
-	#_form_3_ ._error._above ._error-arrow { bottom:0; right:15px; border-left:5px solid transparent; border-right:5px solid transparent; border-top:5px solid #f37c7b; }
-	#_form_3_ ._error._below ._error-arrow { top:0; right:15px; border-left:5px solid transparent; border-right:5px solid transparent; border-bottom:5px solid #f37c7b; }
-	#_form_3_ ._error-inner { padding:8px 12px; background-color:#f37c7b; font-size:14px; font-family:arial, sans-serif; color:#fff; text-align:center; text-decoration:none; -webkit-border-radius:4px; -moz-border-radius:4px; border-radius:4px; }
-	#_form_3_ ._error-inner._form_error { margin-bottom:5px; text-align:left; }
-	#_form_3_ ._button-wrapper ._error-inner._form_error { position:static; }
-	#_form_3_ ._error-inner._no_arrow { margin-bottom:10px; }
-	#_form_3_ ._error-arrow { position:absolute; width:0; height:0; }
-	#_form_3_ ._error-html { margin-bottom:10px; }
-	#_form_3_ { position:relative; }
-	#_form_3_:before,#_form_3_:after { content:" "; display:table; }
-	#_form_3_:after { clear:both; }
-	#_form_3_ ._form-thank-you { position:relative; left:0; right:0; text-align:center; font-size:18px; }
-</style>
-	<form method="POST" action="https://strategy1137274.activehosted.com/proc.php" id="_form_3_" class="_form _form_3 frm-fields frm-subscribe" novalidate>
-		<input type="hidden" name="u" value="3" />
-		<input type="hidden" name="f" value="3" />
-		<input type="hidden" name="s" />
-		<input type="hidden" name="c" value="0" />
-		<input type="hidden" name="m" value="0" />
-		<input type="hidden" name="act" value="sub" />
-		<input type="hidden" name="v" value="2" />
-		<div class="_form-content">
-			<p>
-				<input type="text" name="email" value="<?php echo esc_attr( $user->user_email ); ?>" placeholder="<?php esc_attr_e( 'Type your email', 'formidable' ); ?>" required/>
-			</p>
-			<div class="_button-wrapper">
-				<button id="_form_3_submit" type="submit" class="_submit button-primary frm-button-primary">
-					<?php esc_html_e( 'Subscribe', 'formidable' ); ?>
-				</button>
-			</div>
-			<div class="_clear-element"></div>
-		</div>
-		<div class="_form-thank-you" style="display:none;"></div>
-		<?php do_action( 'frm_page_footer', array( 'table' => 'inbox' ) ); ?>
-	</form>
+
+	<?php include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/new-form-overlay/leave-email.php'; ?>
+
+	<button id="frm-add-my-email-address" class="button-primary frm-button-primary"><?php esc_html_e( 'Subscribe', 'formidable' ); ?></button>
 </div>
 
 	</div>

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -9202,6 +9202,26 @@ Responsive Design
 	text-align: center;
 }
 
+#frm_leave_email_wrapper {
+	position: relative;
+	margin: 0 auto;
+}
+
+#frm_new_form_modal #frm_leave_email_wrapper {
+	width: 600px;
+}
+
+#frm_leave_email_wrapper .frmsvg {
+	top: 0;
+}
+
+#frm_leave_email_error {
+	position: absolute;
+	right: 71px;
+	top: 7px;
+	color: #973937;
+}
+
 .frm-ready-made-solution h3 ~ a {
 	color: var(--primary-500);
 }

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9703,18 +9703,18 @@ function frmAdminBuildJS() {
 					url: $hiddenForm.attr( 'action' ),
 					data: $hiddenForm.serialize() + '&action=frm_forms_preview'
 				}).done( function( data ) {
-					var message = jQuery( data ).find( '.frm_message' ).text().trim();
-					if ( message.indexOf( 'Thanks!' ) >= 0 ) {
-						const modal = document.getElementById( 'frm_new_form_modal' );
-						if ( modal ) {
-							$modal = jQuery( modal );
-							$modal.attr( 'frm-page', 'code' );
-						} else {
-							document.getElementById( 'frmapi-email-form' ).parentElement.innerHTML = 'Success';
-							document.getElementById( 'frm-add-my-email-address' ).remove();
-						}
-					} else {
+					const message = jQuery( data ).find( '.frm_message' ).text().trim();
+					if ( message.indexOf( 'Thanks!' ) === -1 ) {
 						handleEmailAddressError( 'invalid' );
+						return;
+					}
+
+					const modal = document.getElementById( 'frm_new_form_modal' );
+					if ( modal ) {
+						modal.setAttribute( 'frm-page', 'code' );
+					} else {
+						document.getElementById( 'frmapi-email-form' ).parentElement.innerHTML = 'Thank you for signing up!';
+						document.getElementById( 'frm-add-my-email-address' ).remove();
 					}
 				});
 			});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8763,6 +8763,9 @@ function frmAdminBuildJS() {
 				showFreeTemplatesForm();
 
 				$modal.attr( 'frm-page', 'email' );
+
+				$modal.attr( 'frm-this-form', $li.attr( 'data-key' ) );
+				$li.append( installFormTrigger );
 				return;
 			}
 
@@ -8897,9 +8900,9 @@ function frmAdminBuildJS() {
 					showFreeTemplatesForm();
 
 					$modal.attr( 'frm-page', 'email' );
-					$modal.attr( 'frm-this-form', $li.attr( 'data-key' ) );
+					$modal.attr( 'frm-this-form', firstLockedTemplate.attr( 'data-key' ) );
 
-					$li.append( installFormTrigger );
+					firstLockedTemplate.append( installFormTrigger );
 				}
 
 				// Hides the back button in the Free Template Modal and shows it when the cancel button is clicked

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8601,7 +8601,6 @@ function frmAdminBuildJS() {
 		var installFormTrigger,
 			activeHoverIcons,
 			$modal,
-			handleError,
 			handleConfirmEmailAddressError,
 			firstLockedTemplate,
 			isShowFreeTemplatesFormFirst,

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8898,7 +8898,7 @@ function frmAdminBuildJS() {
 
 					$modal.attr( 'frm-page', 'email' );
 					$modal.attr( 'frm-this-form', $li.attr( 'data-key' ) );
-			
+
 					$li.append( installFormTrigger );
 				}
 
@@ -9678,25 +9678,25 @@ function frmAdminBuildJS() {
 				const email = document.getElementById( 'frm_leave_email' ).value.trim();
 
 				event.preventDefault();
-	
+
 				if ( '' === email ) {
 					handleEmailAddressError( 'empty' );
 					return;
 				}
-	
+
 				const regex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/i;
-	
+
 				if ( regex.test( email ) === false ) {
 					handleEmailAddressError( 'invalid' );
 					return;
 				}
-	
+
 				const $hiddenForm = jQuery( '#frmapi-email-form' ).find( 'form' );
 				const $hiddenEmailField = $hiddenForm.find( '[type="email"]' ).not( '.frm_verify' );
 				if ( ! $hiddenEmailField.length ) {
 					return;
 				}
-	
+
 				$hiddenEmailField.val( email );
 				jQuery.ajax({
 					type: 'POST',


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4436

The inbox page was a big inconsistent. It was loading the active campaign JS and trying to simulate an active campaign form.

Whereas the modal was loading a form with AJAX.

I moved out some of the modal logic so it could be done the same way on the inbox page.