### PR TITLE
Check for the pro minified JS path instead when determining pro JS de…

### DIFF
--- a/stripe/controllers/FrmStrpLiteActionsController.php
+++ b/stripe/controllers/FrmStrpLiteActionsController.php
@@ -448,7 +448,7 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 			$script_url = FrmStrpLiteAppHelper::plugin_url() . 'js/frmstrp' . $suffix . '.js';
 		}
 
-		if ( class_exists( 'FrmProStrpLiteController' ) && ( ! $suffix || ! FrmFormsController::has_combo_js_file() ) ) {
+		if ( class_exists( 'FrmProStrpLiteController' ) && ( ! $suffix || ! FrmProAppController::has_combo_js_file() ) ) {
 			$dependencies[] = 'formidablepro';
 		}
 

--- a/stubs.php
+++ b/stubs.php
@@ -93,6 +93,14 @@ namespace {
 		public static function show_in_form( $field, $field_name, $atts ) {
 		}
 	}
+	class FrmProAppController {
+		/**
+		 * @return bool
+		 */
+		public static function has_combo_js_file() {
+		}
+	}
+	
 	class Akismet {
 	}
 	class PHPMailer {


### PR DESCRIPTION
…pendency when loading Stripe scripts

Related ticket https://secure.helpscout.net/conversation/2340633244/171329/

I'm checking for the wrong `frm.min.js` file. I didn't really realize there's a Pro and a Lite version. I was checking for the wrong one.