### PR TITLE
Stop redirecting to Stripe settings when PayPal migrations have run

### DIFF
--- a/stripe/controllers/FrmStrpLiteAppController.php
+++ b/stripe/controllers/FrmStrpLiteAppController.php
@@ -62,12 +62,29 @@ class FrmStrpLiteAppController {
 	}
 
 	/**
+	 * Check if the payments table has been created.
+	 * This includes either the frm_trans_db_version option (used in Stripe Lite and the Payments submodule) or frm_pay_db_version option (from the PayPal add on).
+	 *
+	 * @since 6.5
+	 * @since x.x A check for the PayPal add on option was added.
+	 *
 	 * @return bool
 	 */
 	private static function payments_are_installed() {
 		$db     = new FrmTransLiteDb();
 		$option = get_option( $db->db_opt_name );
-		return false !== $option;
+		if ( false !== $option ) {
+			return true;
+		}
+
+		if ( class_exists( 'FrmPaymentsController' ) && isset( FrmPaymentsController::$db_opt_name ) ) {
+			$option = get_option( FrmPaymentsController::$db_opt_name );
+			if ( false !== $option ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/stubs.php
+++ b/stubs.php
@@ -99,6 +99,9 @@ namespace {
 		public function __construct( $exceptions = null ) {
 		}
 	}
+	class FrmPaymentsController {
+		public static $db_opt_name = 'frm_pay_db_version';
+	}
 	/**
 	 * @return void
 	 */


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2359769162/173015

The issue is that I'm only checking the one option name. Not the one for PayPal.

To patch this, here's a snippet:
```
if ( false === get_option( 'frm_trans_db_version' ) ) {
	update_option( 'frm_trans_db_version', 0 );
}
```