### PR TITLE
Remove `is_callable` checks from Stripe code where functions exist in Lite

### DIFF
--- a/stripe/controllers/FrmTransLiteActionsController.php
+++ b/stripe/controllers/FrmTransLiteActionsController.php
@@ -157,10 +157,6 @@ class FrmTransLiteActionsController {
 	 * @return void
 	 */
 	public static function trigger_actions_after_payment( $payment, $atts = array() ) {
-		if ( ! is_callable( 'FrmFormActionsController::trigger_actions' ) ) {
-			return;
-		}
-
 		if ( 'pending' === $payment->status ) {
 			// 3D Secure has a delayed payment status, so avoid sending a payment failed email for a pending payment.
 			return;

--- a/stripe/models/FrmTransLiteAction.php
+++ b/stripe/models/FrmTransLiteAction.php
@@ -89,10 +89,6 @@ class FrmTransLiteAction extends FrmFormAction {
 	 * @return string
 	 */
 	private function default_currency() {
-		if ( ! is_callable( 'FrmAppHelper::get_settings' ) ) {
-			return 'usd';
-		}
-
 		$frm_settings = FrmAppHelper::get_settings();
 		$currency     = trim( $frm_settings->currency );
 		if ( ! $currency ) {


### PR DESCRIPTION
These checks were copied from the Stripe plugin and are not necessary anymore as they exist in this repo.