### PR TITLE
Fix payments table does not exist error when viewing an entry

### DIFF
--- a/stripe/controllers/FrmStrpLiteAppController.php
+++ b/stripe/controllers/FrmStrpLiteAppController.php
@@ -53,38 +53,12 @@ class FrmStrpLiteAppController {
 	 * @return void
 	 */
 	public static function maybe_redirect_to_stripe_settings() {
-		if ( ! FrmAppHelper::is_admin_page( 'formidable-payments' ) || self::payments_are_installed() ) {
+		if ( ! FrmAppHelper::is_admin_page( 'formidable-payments' ) || FrmTransLiteAppHelper::payments_table_exists() ) {
 			return;
 		}
 
 		wp_safe_redirect( admin_url( 'admin.php?page=formidable-settings&t=stripe_settings' ) );
 		die();
-	}
-
-	/**
-	 * Check if the payments table has been created.
-	 * This includes either the frm_trans_db_version option (used in Stripe Lite and the Payments submodule) or frm_pay_db_version option (from the PayPal add on).
-	 *
-	 * @since 6.5
-	 * @since x.x A check for the PayPal add on option was added.
-	 *
-	 * @return bool
-	 */
-	private static function payments_are_installed() {
-		$db     = new FrmTransLiteDb();
-		$option = get_option( $db->db_opt_name );
-		if ( false !== $option ) {
-			return true;
-		}
-
-		if ( class_exists( 'FrmPaymentsController' ) && isset( FrmPaymentsController::$db_opt_name ) ) {
-			$option = get_option( FrmPaymentsController::$db_opt_name );
-			if ( false !== $option ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/stripe/helpers/FrmTransLiteAppHelper.php
+++ b/stripe/helpers/FrmTransLiteAppHelper.php
@@ -27,6 +27,33 @@ class FrmTransLiteAppHelper {
 	}
 
 	/**
+	 * Check if the payments table has been created.
+	 * This includes either the frm_trans_db_version option (used in Stripe Lite and the Payments submodule) or frm_pay_db_version option (from the PayPal add on).
+	 *
+	 * @since 6.5
+	 * @since x.x A check for the PayPal add on option
+	 * @since x.x This function was renamed and moved from FrmStrpLiteAppController::payments_are_installed and made public.
+	 *
+	 * @return bool
+	 */
+	public static function payments_table_exists() {
+		$db     = new FrmTransLiteDb();
+		$option = get_option( $db->db_opt_name );
+		if ( false !== $option ) {
+			return true;
+		}
+
+		if ( class_exists( 'FrmPaymentsController' ) && isset( FrmPaymentsController::$db_opt_name ) ) {
+			$option = get_option( FrmPaymentsController::$db_opt_name );
+			if ( false !== $option ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Get a payment status label.
 	 *
 	 * @param string $status The lowercase payment status value.

--- a/stripe/models/FrmTransLiteDb.php
+++ b/stripe/models/FrmTransLiteDb.php
@@ -195,6 +195,11 @@ class FrmTransLiteDb {
 	}
 
 	public function get_all_by( $value, $field = 'item_id' ) {
+		if ( ! FrmTransLiteAppHelper::payments_table_exists() ) {
+			// If no migrations have run yet return nothing.
+			return array();
+		}
+
 		$field = sanitize_text_field( $field );
 
 		if ( ! in_array( $field, array( 'receipt_id', 'sub_id', 'item_id' ), true ) ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-forms/issues/1292

When viewing an entry, we pull up payment details in the sidebar. However, if Stripe isn't connected, the table may not exist.