### PR TITLE
Make sure all search terms are found in addon terms during plugin search

### DIFF
--- a/classes/models/FrmPluginSearch.php
+++ b/classes/models/FrmPluginSearch.php
@@ -126,9 +126,7 @@ class FrmPluginSearch {
 			$addon_terms = $this->search_to_array( $addon_opts['search_terms'] . ' ' . $addon_opts['name'] );
 
 			$matched_terms = array_intersect( $addon_terms, $normalized_term );
-			if ( empty( $matched_terms ) ) {
-				continue;
-			}
+
 			if ( count( $matched_terms ) === count( $normalized_term ) ) {
 				$matching_addon = $addon_id;
 				break;

--- a/classes/models/FrmPluginSearch.php
+++ b/classes/models/FrmPluginSearch.php
@@ -125,9 +125,11 @@ class FrmPluginSearch {
 
 			$addon_terms = $this->search_to_array( $addon_opts['search_terms'] . ' ' . $addon_opts['name'] );
 
-			$matches = ! empty( array_intersect( $addon_terms, $normalized_term ) );
-
-			if ( $matches ) {
+			$matched_terms = array_intersect( $addon_terms, $normalized_term );
+			if ( empty( $matched_terms ) ) {
+				continue;
+			}
+			if ( count( $matched_terms ) === count( $normalized_term ) ) {
 				$matching_addon = $addon_id;
 				break;
 			}


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4407

I tried to make sure all search terms are found in the terms for an addon before it is matched when searching for a plugin.

### Steps to test
1. Go to the Plugins -> Add New and search for "Download monitor"
2. Our Campaign monitor plugin should not show up in the result
3. Do another search with "Campaign monitor" and our "Campaign monitor" should show up
Basically, you should not see any of our plugins in the search suggestion unless all of the terms in the addon name are found in the query term.

### Screenshots
This is the suggestion we are talking about in the search result.
![CleanShot 2023-09-22 at 11 40 14](https://github.com/Strategy11/formidable-forms/assets/41271840/916804bc-343f-4380-b503-347cde452482)