### PR TITLE
Hide honeypot using overflow and randomize class and name

### DIFF
--- a/classes/models/FrmHoneypot.php
+++ b/classes/models/FrmHoneypot.php
@@ -27,11 +27,27 @@ class FrmHoneypot extends FrmValidate {
 	 * @return boolean
 	 */
 	private function is_honeypot_spam() {
-		$honeypot_value   = FrmAppHelper::get_param( 'frm_verify', '', 'get', 'sanitize_text_field' );
-		$is_honeypot_spam = $honeypot_value !== '';
+		$is_honeypot_spam = $this->is_legacy_honeypot_spam();
+		if ( ! $is_honeypot_spam ) {
+			// Check the newer honeypot input name which is randomly generated so it's more difficult to detect.
+			$class_name       = $this->get_honeypot_class_name();
+			$honeypot_value   = FrmAppHelper::get_param( $class_name, '', 'get', 'sanitize_text_field' );
+			$is_honeypot_spam = '' !== $honeypot_value;
+		}
+
 		$form             = $this->get_form();
 		$atts             = compact( 'form' );
 		return apply_filters( 'frm_process_honeypot', $is_honeypot_spam, $atts );
+	}
+
+	/**
+	 * Check the old frm_verify key. We'll continue to consider any entry with an frm_verify value as spam.
+	 *
+	 * @return bool
+	 */
+	private function is_legacy_honeypot_spam() {
+		$legacy_honeypot_value = FrmAppHelper::get_param( 'frm_verify', '', 'get', 'sanitize_text_field' );
+		return '' !== $legacy_honeypot_value;
 	}
 
 	/**
@@ -74,15 +90,40 @@ class FrmHoneypot extends FrmValidate {
 	 * @return void
 	 */
 	public function render_field() {
-		$honeypot = $this->check_honeypot_setting();
-		$form     = $this->get_form();
+		$honeypot   = $this->check_honeypot_setting();
+		$form       = $this->get_form();
+		$class_name = $this->get_honeypot_class_name();
 		?>
-			<div class="frm_verify" <?php echo in_array( $honeypot, array( true, 'strict' ), true ) ? '' : 'aria-hidden="true"'; ?>>
+			<div class="<?php echo esc_attr( $class_name ); ?>" <?php echo in_array( $honeypot, array( true, 'strict' ), true ) ? '' : 'aria-hidden="true"'; ?>>
 				<label for="frm_email_<?php echo esc_attr( $form->id ); ?>">
 					<?php esc_html_e( 'If you are human, leave this field blank.', 'formidable' ); ?>
 				</label>
-				<input type="<?php echo esc_attr( 'strict' === $honeypot ? 'email' : 'text' ); ?>" class="frm_verify" id="frm_email_<?php echo esc_attr( $form->id ); ?>" name="frm_verify" value="<?php echo esc_attr( FrmAppHelper::get_param( 'frm_verify', '', 'get', 'wp_kses_post' ) ); ?>" <?php FrmFormsHelper::maybe_hide_inline(); ?> />
+				<input type="<?php echo esc_attr( 'strict' === $honeypot ? 'email' : 'text' ); ?>" id="frm_email_<?php echo esc_attr( $form->id ); ?>" class="<?php echo esc_attr( $class_name ); ?>" name="<?php echo esc_attr( $class_name ); ?>" value="<?php echo esc_attr( FrmAppHelper::get_param( $class_name, '', 'get', 'wp_kses_post' ) ); ?>" <?php FrmFormsHelper::maybe_hide_inline(); ?> />
 			</div>
 		<?php
+	}
+
+	/**
+	 * Generate a random class name for our honeypot so it is less easy to detect.
+	 *
+	 * @return string The generated class name.
+	 */
+	public static function generate_class_name() {
+		$prefix     = 'frm__';
+		$class_name = $prefix . uniqid();
+		update_option( 'frm_honeypot_class', $class_name );
+		return $class_name;
+	}
+
+	/**
+	 * @return string The current class name to use the for Honeypot field.
+	 */
+	private function get_honeypot_class_name() {
+		$option = get_option( 'frm_honeypot_class' );
+		if ( ! is_string( $option ) ) {
+			// For backward compatibility use the old class name.
+			return 'frm_verify';
+		}
+		return $option;
 	}
 }

--- a/classes/models/FrmHoneypot.php
+++ b/classes/models/FrmHoneypot.php
@@ -90,15 +90,26 @@ class FrmHoneypot extends FrmValidate {
 	 * @return void
 	 */
 	public function render_field() {
-		$honeypot   = $this->check_honeypot_setting();
-		$form       = $this->get_form();
-		$class_name = $this->get_honeypot_class_name();
+		$honeypot    = $this->check_honeypot_setting();
+		$form        = $this->get_form();
+		$class_name  = $this->get_honeypot_class_name();
+		$input_attrs = array(
+			'id'    => 'frm_email_' . absint( $form->id ),
+			'type'  => 'strict' === $honeypot ? 'email' : 'text',
+			'class' => 'frm_verify',
+			'name'  => $class_name,
+			'value' => FrmAppHelper::get_param( $class_name, '', 'get', 'wp_kses_post' ),
+		);
+
+		if ( 'strict' !== $honeypot ) {
+			$input_attrs['autocomplete'] = 'false';
+		}
 		?>
 			<div class="<?php echo esc_attr( $class_name ); ?>" <?php echo in_array( $honeypot, array( true, 'strict' ), true ) ? '' : 'aria-hidden="true"'; ?>>
 				<label for="frm_email_<?php echo esc_attr( $form->id ); ?>">
 					<?php esc_html_e( 'If you are human, leave this field blank.', 'formidable' ); ?>
 				</label>
-				<input type="<?php echo esc_attr( 'strict' === $honeypot ? 'email' : 'text' ); ?>" id="frm_email_<?php echo esc_attr( $form->id ); ?>" class="frm_verify" name="<?php echo esc_attr( $class_name ); ?>" value="<?php echo esc_attr( FrmAppHelper::get_param( $class_name, '', 'get', 'wp_kses_post' ) ); ?>" <?php FrmFormsHelper::maybe_hide_inline(); ?> />
+				<input <?php FrmAppHelper::array_to_html_params( $input_attrs, true ); ?> <?php FrmFormsHelper::maybe_hide_inline(); ?> />
 			</div>
 		<?php
 	}

--- a/classes/models/FrmHoneypot.php
+++ b/classes/models/FrmHoneypot.php
@@ -98,7 +98,7 @@ class FrmHoneypot extends FrmValidate {
 				<label for="frm_email_<?php echo esc_attr( $form->id ); ?>">
 					<?php esc_html_e( 'If you are human, leave this field blank.', 'formidable' ); ?>
 				</label>
-				<input type="<?php echo esc_attr( 'strict' === $honeypot ? 'email' : 'text' ); ?>" id="frm_email_<?php echo esc_attr( $form->id ); ?>" class="<?php echo esc_attr( $class_name ); ?>" name="<?php echo esc_attr( $class_name ); ?>" value="<?php echo esc_attr( FrmAppHelper::get_param( $class_name, '', 'get', 'wp_kses_post' ) ); ?>" <?php FrmFormsHelper::maybe_hide_inline(); ?> />
+				<input type="<?php echo esc_attr( 'strict' === $honeypot ? 'email' : 'text' ); ?>" id="frm_email_<?php echo esc_attr( $form->id ); ?>" class="frm_verify" name="<?php echo esc_attr( $class_name ); ?>" value="<?php echo esc_attr( FrmAppHelper::get_param( $class_name, '', 'get', 'wp_kses_post' ) ); ?>" <?php FrmFormsHelper::maybe_hide_inline(); ?> />
 			</div>
 		<?php
 	}

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -69,9 +69,10 @@ input:-webkit-autofill {
 <?php } ?>
 }
 
-form input.frm_verify{
-	position:absolute;
-	left:-3000px;
+form .<?php echo esc_html( FrmHoneypot::generate_class_name() ); ?> {
+	overflow: hidden;
+	width: 0;
+	height: 0;
 }
 
 .with_frm_style fieldset{

--- a/css/frm_grids.css
+++ b/css/frm_grids.css
@@ -15,11 +15,6 @@
 	display:initial;
 }
 
-.frm_verify{
-	position:absolute;
-	left:-3000px;
-}
-
 .frm_clear_none{
     clear:none;
 }

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1129,9 +1129,8 @@ function frmFrontFormJS() {
 
 		function makeHoneypotFieldsUntabbable() {
 			document.querySelectorAll( '.frm_verify' ).forEach(
-				function( wrapper ) {
-					var input = wrapper.querySelector( 'input[id^=frm_email]' );
-					if ( input ) {
+				function( input ) {
+					if ( input.id && 0 === input.id.indexOf( 'frm_email_' ) ) {
 						input.setAttribute( 'tabindex', -1 );
 					}
 				}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-wpml/issues/104 by changing how the Honeypot is hidden using overflow style rules and a 0 size.

I also made the honeypot more difficult to predict, giving it a randomly generated class/name value.