### PR TITLE
Remove tabindex from radio button groups

### DIFF
--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -528,11 +528,6 @@ class FrmFieldFormHtml {
 			$attributes['aria-required'] = 'true';
 		}
 
-		// Add 'tabindex = "0"' attribute to the radio field.
-		if ( $is_radio ) {
-			$attributes['tabindex'] = 0;
-		}
-
 		// Concatenate attributes into a string, and replace the role="group" in the HTML with the attributes string.
 		$html_attributes = FrmAppHelper::array_to_html_params( $attributes );
 		$this->html      = str_replace( ' role="group"', $html_attributes, $this->html );


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2369627291/173981/

I had added this with https://github.com/Strategy11/formidable-forms/pull/1252
To be consistent with our update here https://github.com/Strategy11/formidable-pro/pull/4249

Here's a related stack overflow question I found https://stackoverflow.com/questions/36776126/whats-an-accessible-way-to-group-items-within-a-radiogroup-html5-wai-aria

The top answer there agrees with the ticket,
> So suggest using role=group and removing the tabindex=0 as the div container isn't itself an interactive object and should not be in the focus order:
