### PR TITLE
Stop hiding the gateway field when the payments submodule is active

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -704,6 +704,17 @@ class FrmAppController {
 
 		wp_register_script( 'bootstrap-multiselect', $plugin_url . '/js/bootstrap-multiselect.js', array( 'jquery', 'bootstrap_tooltip', 'popper' ), '1.1.1', true );
 
+		if ( ! class_exists( 'FrmTransHooksController', false ) ) {
+			/**
+			 * Gateway fields are included for add-on compatibility but we do not want it to be visible.
+			 * They do however need to be visible when the payments submodule is active.
+			 */
+			wp_add_inline_style(
+				'formidable-admin',
+				'#frm_builder_page li[data-ftype="gateway"] { display: none; }'
+			);
+		}
+
 		$post_type = FrmAppHelper::simple_get( 'post_type', 'sanitize_title' );
 
 		global $pagenow;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6202,11 +6202,6 @@ span.howto {
 	min-height: 50px;
 }
 
-#frm_builder_page li[data-ftype="gateway"] {
-	/* Gateway fields are included for add-on compatibility but we do not want it to be visible. */
-	display: none;
-}
-
 #frm_builder_page .frm-lite-credit-card-element,
 body.frm-admin-page-styles .frm-lite-credit-card-element {
 	position: relative;


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2374651794/174477/

I'm always hiding the gateway field. But I shouldn't if the payments submodule is active.