### PR TITLE
Fix PHP Notice in form action

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2281,7 +2281,11 @@ class FrmFormsController {
 			return array( FrmOnSubmitHelper::get_fallback_action_after_open_in_new_tab( $event ) );
 		}
 
-		$entry       = FrmEntry::getOne( $args['entry_id'], true );
+		$entry = FrmEntry::getOne( $args['entry_id'], true );
+		if ( ! $entry ) {
+			return array();
+		}
+
 		$actions     = FrmOnSubmitHelper::get_actions( $args['form']->id );
 		$met_actions = array();
 		$has_redirect = false;


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4469

I can't replicate this. After checking the code, I think that the entry ID we use might be mismatched or the entry is deleted. So I added one more check for the `$entry`.