### PR TITLE
Fix honeypot causes inline submit button to break to a new line

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -73,6 +73,7 @@ form .<?php echo esc_html( FrmHoneypot::generate_class_name() ); ?> {
 	overflow: hidden;
 	width: 0;
 	height: 0;
+	position: absolute;
 }
 
 .with_frm_style fieldset{


### PR DESCRIPTION
Fixes https://secure.helpscout.net/conversation/2381207070/175134/

This can be patched as well with `div[class^="frm__"] { position: absolute; }`