### PR TITLE
Check that overlay controller exists just in case

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -645,7 +645,10 @@ class FrmAppController {
 		$version    = FrmAppHelper::plugin_version();
 
 		FrmAppHelper::load_admin_wide_js();
-		FrmOverlayController::register_assets();
+
+		if ( class_exists( 'FrmOverlayController' ) ) {
+			FrmOverlayController::register_assets();
+		}
 
 		wp_register_style( 'formidable_admin_global', $plugin_url . '/css/admin/frm_admin_global.css', array(), $version );
 		wp_enqueue_style( 'formidable_admin_global' );

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -647,6 +647,8 @@ class FrmAppController {
 		FrmAppHelper::load_admin_wide_js();
 
 		if ( class_exists( 'FrmOverlayController' ) ) {
+			// This should always exist.
+			// But it may not have loaded properly when updating the plugin.
 			FrmOverlayController::register_assets();
 		}
 


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2382420517/175264

This shouldn't really be possible, but I've seen errors like this come up that seem to happen when updating the plugin, when some code has loaded and other code hasn't.

> Error Message: Uncaught Error: Class 'FrmOverlayController' not found
> File Path: .../plugins/formidable/classes/controllers/FrmAppController.php