### PR TITLE
Fix Overlapping Field Controls When Label is Empty in Form Builder

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1747,6 +1747,10 @@ a.frm_hidden,
 	line-height: var(--leading);
 }
 
+#frm_form_editor_container #frm-show-fields .frm_primary_label {
+	min-height: 21px;
+}
+
 .frm-fields td input + label {
 	display: inline;
 }


### PR DESCRIPTION
Fixes the issue where field controls overlap input in the builder if no label is set. Forces the label space to remain, ensuring no overlap.

## Related Issue:
https://github.com/Strategy11/formidable-pro/issues/4285

## QA URL:

## Testing Instructions:
1. Navigate to `WP Admin > Formidable > Forms`.
2. Open an existing form or create a new form.
3. Add a new field or use an existing one.
4. Remove the "Field Label" from the field settings.
5. Confirm that the field controls no longer overlap the input area.

## Visual Output:
### Before
<img width="566" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/264798b7-cf95-40fc-b233-4d31d7b42b43">

### After
<img width="563" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/1da4838d-d0bd-40a7-83f2-1e1c8b3d5a8b">
