### PR TITLE
Remove unconditional view permission set from global settings

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1674,6 +1674,11 @@ class FrmAppHelper {
 		 */
 		$pro_cap = apply_filters( 'frm_pro_capabilities', $pro_cap );
 
+		if ( ! array_key_exists( 'frm_edit_displays', $pro_cap ) && is_callable( 'FrmProAppHelper::views_is_installed' ) && FrmProAppHelper::views_is_installed() ) {
+			// For backward compatibility, add the Add/Edit Views permission if Pro is not up to date.
+			$pro_cap['frm_edit_displays'] = __( 'Add/Edit Views', 'formidable' );
+		}
+
 		if ( 'pro_only' === $type ) {
 			return $pro_cap;
 		}

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1666,7 +1666,6 @@ class FrmAppHelper {
 			'frm_create_entries' => __( 'Add Entries from Admin Area', 'formidable' ),
 			'frm_edit_entries'   => __( 'Edit Entries from Admin Area', 'formidable' ),
 			'frm_view_reports'   => __( 'View Reports', 'formidable' ),
-			'frm_edit_displays'  => __( 'Add/Edit Views', 'formidable' ),
 		);
 		/**
 		 * @since 5.3.1

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1676,6 +1676,7 @@ class FrmAppHelper {
 
 		if ( ! array_key_exists( 'frm_edit_displays', $pro_cap ) && is_callable( 'FrmProAppHelper::views_is_installed' ) && FrmProAppHelper::views_is_installed() ) {
 			// For backward compatibility, add the Add/Edit Views permission if Pro is not up to date.
+			// This was added in x.x. Remove this in the future.
 			$pro_cap['frm_edit_displays'] = __( 'Add/Edit Views', 'formidable' );
 		}
 


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/3591
Related pull request https://github.com/Strategy11/formidable-pro/pull/4490

The View permission removed from lite to be handled conditionally in pro.