### PR TITLE
Avoid a fatal error when using the Snuffleupagus security module

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -15,8 +15,15 @@ class FrmAppHelper {
 
 	/**
 	 * @since 2.0
+	 *
+	 * @var string
 	 */
 	public static $plug_version = '6.5.2';
+
+	/**
+	 * @var bool
+	 */
+	private static $included_svg = false;
 
 	/**
 	 * @since 1.07.02
@@ -1110,9 +1117,16 @@ class FrmAppHelper {
 	 * Include svg images.
 	 *
 	 * @since 4.0.02
+	 * @return void
 	 */
 	public static function include_svg() {
-		include_once self::plugin_path() . '/images/icons.svg';
+		if ( self::$included_svg ) {
+			return;
+		}
+
+		// Use readfile instead of include_once because of a default security rule in Snuffleupagus.
+		readfile( self::plugin_path() . '/images/icons.svg' );
+		self::$included_svg = true;
 	}
 
 	/**


### PR DESCRIPTION
**Related tickets**
https://secure.helpscout.net/conversation/1567213496/76049/
https://secure.helpscout.net/conversation/1763132632/90276

> Fatal error: [snuffleupagus][disabled_function] Aborted execution on call of the function 'include_once' in .../wp-content/plugins/formidable/classes/helpers/FrmAppHelper.php on line 1025

When the Snuffleupagus PHP security module is active (https://snuffleupagus.readthedocs.io/), `include` and `include_all` only work with PHP files. Other file types result in a fatal error.

Because of this rule,
`sp.disable_function.function("include_once").value_r("\.(inc|phtml|php)$").allow();`

Using `readfile` instead should fix this.