### PR TITLE
Stop using the Stripe Lite payments table when only PayPal has migrated

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -136,7 +136,7 @@ class FrmAppController {
 			'formidable-applications',
 		);
 
-		if ( ! class_exists( 'FrmTransHooksController', false ) ) {
+		if ( ! class_exists( 'FrmTransHooksController', false ) && ! FrmTransLiteAppHelper::should_fallback_to_paypal() ) {
 			// Only consider the payments page as a "white page" when the Payments submodule is off.
 			// Otherwise this causes a lot of styling issues when the Stripe add-on (or Authorize.Net) is active.
 			$white_pages[] = 'formidable-payments';

--- a/stripe/controllers/FrmTransLitePaymentsController.php
+++ b/stripe/controllers/FrmTransLitePaymentsController.php
@@ -9,6 +9,10 @@ class FrmTransLitePaymentsController extends FrmTransLiteCRUDController {
 	 * @return void
 	 */
 	public static function menu() {
+		if ( FrmTransLiteAppHelper::should_fallback_to_paypal() ) {
+			return;
+		}
+
 		$frm_settings = FrmAppHelper::get_settings();
 
 		// Remove the PayPal submenu (PayPal payments will just appear in the regular Payments page).

--- a/stripe/helpers/FrmTransLiteAppHelper.php
+++ b/stripe/helpers/FrmTransLiteAppHelper.php
@@ -6,6 +6,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmTransLiteAppHelper {
 
 	/**
+	 * @var bool|null
+	 */
+	private static $should_fallback_to_paypal;
+
+	/**
 	 * @return string
 	 */
 	public static function plugin_path() {
@@ -415,5 +420,32 @@ class FrmTransLiteAppHelper {
 		}
 
 		return $amount;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public static function should_fallback_to_paypal() {
+		if ( isset( self::$should_fallback_to_paypal ) ) {
+			return self::$should_fallback_to_paypal;
+		}
+
+		if ( ! class_exists( 'FrmPaymentsController' ) || ! isset( FrmPaymentsController::$db_opt_name ) ) {
+			self::$should_fallback_to_paypal = false;
+			return false;
+		}
+
+		$db     = new FrmTransLiteDb();
+		$option = get_option( $db->db_opt_name );
+		if ( false !== $option ) {
+			// Don't fallback to PayPal if Stripe migrations have run.
+			self::$should_fallback_to_paypal = false;
+			return false;
+		}
+
+		$option = get_option( FrmPaymentsController::$db_opt_name );
+		self::$should_fallback_to_paypal = false !== $option;
+
+		return self::$should_fallback_to_paypal;
 	}
 }


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2389539238/175949/

> WordPress database error Table 'wp_frm_subscriptions' doesn't exist for query SELECT COUNT(*) FROM wp_frm_subscriptions made by do_action('forms_page_formidable-payments'), WP_Hook->do_action, WP_Hook->apply_filters, FrmTransLitePaymentsController::route, FrmTransLiteListsController::route, FrmTransLiteListsController::display_list, include('/plugins/formidable/stripe/views/lists/list.php'), FrmListHelper->views, FrmTransLiteListHelper->get_views, FrmTransLiteDb->get_count [12-Oct-2023 14:55:13 UTC] PHP Warning: Undefined property: stdClass::$status in ../wp-content/plugins/formidable/stripe/helpers/FrmTransLiteAppHelper.php on line 74

The problem here is that PayPal only has the one payments table, not a subscriptions table.

So the UI of Stripe Lite kind of gets in the way.

With this update, if the PayPal migrations have run and not Stripe, I avoid the menu item and the routing, and let the PayPal add on take over as a fallback.

Once Stripe migrations have run, it will use Stripe Lite again.