### PR TITLE
Fix Alignment Issues for Image-based Radio Buttons in Multipage Forms

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -848,7 +848,6 @@ a.frm_save_draft{
 	text-indent: -20px;
 }
 
-<!-- Removing left padding for radio label in vertical layout -->
 .with_frm_style .vertical_radio .frm_opt_container > .frm_radio label {
 	padding-left: 0;
 }

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -848,6 +848,11 @@ a.frm_save_draft{
 	text-indent: -20px;
 }
 
+<!-- Removing left padding for radio label in vertical layout -->
+.with_frm_style .vertical_radio .frm_opt_container > .frm_radio label {
+	padding-left: 0;
+}
+
 .with_frm_style .frm_radio label,
 .with_frm_style .frm_checkbox label{
 <?php if ( ! empty( $defaults['font'] ) ) { ?>


### PR DESCRIPTION
This PR addresses the misalignment of radio buttons displayed as images in centered multipage forms. It aims for a consistent layout across different screen sizes.

## Related Issue:
[Pro Issue - #3626](https://github.com/Strategy11/formidable-pro/issues/3626)

## QA URL
https://qa.formidableforms.com/sherv6/wp-admin/admin-ajax.php?action=frm_forms_preview&form=image-basedradiobuttons&theme=1

## Testing Instructions:
1. Activate "Formidable Pro" plugin.
2. Navigate to "WP Admin > Formidable > Forms".
3. Create a form with a multipage setup and make sure the form is centered on the page.
4. Add a "Radio Buttons" field and change the display format option to images.
5. Ensure everything is centered and aligned correctly with the radio buttons.

## Output Images
### Before
<img width="203" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/e85b9748-6b29-48c1-a2d3-54043cea1bfe">

### After
<img width="231" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/766fa1ce-67ce-4cbb-96fa-4b1cb4a38a50">
