### PR TITLE
Fix Missing Dropdown Arrows

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -238,9 +238,6 @@ legend.frm_hidden{
 	color:var(--text-color)<?php echo esc_html( $important ); ?>;
 	background-color:<?php echo esc_html( $defaults['bg_color'] . $important ); ?>;
 	background-color:var(--bg-color)<?php echo esc_html( $important ); ?>;
-<?php if ( ! empty( $important ) ) { ?>
-	background-image:none !important;
-<?php } ?>
 	border-color:<?php echo esc_html( $defaults['border_color'] ); ?>;
 	border-color:var(--border-color)<?php echo esc_html( $important ); ?>;
 	border-width:<?php echo esc_html( $defaults['field_border_width'] ); ?>;
@@ -266,6 +263,27 @@ legend.frm_hidden{
 	font-weight:var(--field-weight);
 	box-shadow:var(--box-shadow)<?php echo esc_html( $important ); ?>;
 }
+
+<?php if ( ! empty( $important ) ) { ?>
+.with_frm_style input[type=text],
+.with_frm_style input[type=password],
+.with_frm_style input[type=email],
+.with_frm_style input[type=number],
+.with_frm_style input[type=url],
+.with_frm_style input[type=tel],
+.with_frm_style input[type=phone],
+.with_frm_style input[type=search],
+.with_frm_style textarea,
+.frm_form_fields_style,
+.with_frm_style .frm_scroll_box .frm_opt_container,
+.frm_form_fields_active_style,
+.frm_form_fields_error_style,
+.with_frm_style .frm-card-element.StripeElement,
+.with_frm_style .chosen-container-multi .chosen-choices,
+.with_frm_style .chosen-container-single .chosen-single{
+	background-image:none !important;
+}
+<?php } ?>
 
 .with_frm_style select option {
 	color:<?php echo esc_html( $defaults['text_color'] ); ?>;


### PR DESCRIPTION
This PR addresses the issue of missing dropdown arrows since the 6.0 updates.

## Related Issue:
[Dropdown arrows missing](https://github.com/Strategy11/formidable-pro/issues/4065)

## QA URL

## Testing Instruction:
1. Activate the "Twenty Twenty One" theme.
2. Navigate to "WP Admin > Formidable > Forms".
3. Open an existing form or create a new form.
4. Add a dropdown field.
5. Verify that the issue of missing dropdown arrows is fixed.

## Output Images
### Before
<img width="702" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/9dcb82fa-9219-4c7f-8096-2f76af35e1f4">

### After
<img width="696" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/4e6a050f-1b81-49d9-8fbb-b7472cb98d15">
