### PR TITLE
Fix Vertical Centering of Dropdown Arrows for All Themes

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -353,7 +353,7 @@ legend.frm_hidden{
 	width:<?php echo esc_html( $defaults['auto_width'] ); ?>;
 	width:var(--auto-width)<?php echo esc_html( $important ); ?>;
 	max-width:100%;
-	background-position-y: center;
+	background-position-y: calc(50% + 3px);
 }
 
 .with_frm_style input[disabled],


### PR DESCRIPTION
This PR resolves the vertical centering issue of dropdown arrows across all supported themes.

## Related Issue:
[Only try to vertically center dropdown arrows for certain themes](https://github.com/Strategy11/formidable-pro/issues/4066)

## QA URL
https://qa.formidableforms.com/sherv7/wp-admin/admin-ajax.php?action=frm_forms_preview&form=fixverticalcenteringofdropdownarrows&theme=1

## Testing Instruction:
1. Activate any supported theme (Ex: Astra, Default Themes).
2. Navigate to `WP Admin > Formidable > Forms`.
3. Open an existing form or create a new form.
4. Add a dropdown field.
5. Verify that the dropdown arrow is vertically centered.

## Output Images
### Before
<img width="661" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/24c11b6f-7dbb-4cba-a89e-a862d55e46a4">

### After
<img width="653" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/cc2d2f3e-4225-48be-870a-da5cc55b6547">
