### PR TITLE
Add php unit xml dist file to zip plugin exceiptions

### DIFF
--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -58,6 +58,7 @@ zip -r $zipname $destination \
 	-x "*/package-lock.json" \
 	-x "*/phpcs.xml" \
 	-x "*/phpunit.xml" \
+	-x "*/phpunit.xml.dist" \
 	-x "*/psalm.xml" \
 	-x "*/phpstan.neon" \
 	-x "*/*.stubs.php" \


### PR DESCRIPTION
This was getting zipped with PayPal releases.