### PR TITLE
Fix: Display "Add Fields Here" Message After Deleting All Fields

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4606,15 +4606,18 @@ function frmAdminBuildJS() {
 						// a product field attached to a quantity field earlier might be the one deleted, so re-populate
 						popAllProductFields();
 					}
-					if ( jQuery( '#frm-show-fields li' ).length === 0 ) {
-						document.getElementById( 'frm_form_editor_container' ).classList.remove( 'frm-has-fields' );
-					} else if ( $section.length ) {
-						toggleOneSectionHolder( $section );
-					}
 					if ( $adjacentFields.length ) {
 						syncLayoutClasses( $adjacentFields.first() );
 					} else {
 						$liWrapper.remove();
+					}
+
+					if ( jQuery( '#frm-show-fields li' ).length === 0 ) {
+						const formEditorContainer = document.getElementById( 'frm_form_editor_container' );
+						formEditorContainer.classList.remove( 'frm-has-fields' );
+						formEditorContainer.classList.add( 'frm-empty-fields' );
+					} else if ( $section.length ) {
+						toggleOneSectionHolder( $section );
 					}
 
 					// prevent "More Options" tooltips from staying around after their target field is deleted.


### PR DESCRIPTION
This PR fixes the issue where the "Add Fields Here" message was not displaying after all form fields were deleted.

## Related Issue:
["Add Fields Here" Message Not Displaying After Deleting All Fields](https://github.com/Strategy11/formidable-pro/issues/4509)

## QA URL
https://qa.formidableforms.com/sherv10/wp-admin/admin.php?page=formidable&frm_action=edit&id=1

## Testing Instructions:
1. Go to the form builder
2. Delete all form fields
3. Verify that the "Add Fields Here" message displays correctly

## Output Comparison:
### Before
![2023-10-23 10 38 44](https://github.com/Strategy11/formidable-forms/assets/69119241/3619b242-010e-4b32-bdfc-638e26681dde)

### After
![2023-10-23 10 47 12](https://github.com/Strategy11/formidable-forms/assets/69119241/0cf726cd-18a2-470e-9ac4-6f4ca356625e)
