### PR TITLE
Remove extra permission checks that break API

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -1024,8 +1024,6 @@ class FrmAddonsController {
 	 * @since 3.04.02
 	 */
 	protected static function install_addon() {
-		FrmAppHelper::permission_check( 'install_plugins' );
-
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
 		$download_url = self::get_current_plugin();
@@ -1180,15 +1178,11 @@ class FrmAddonsController {
 	 * @return bool
 	 */
 	public static function can_install_addon_api() {
-		if ( ! current_user_can( 'activate_plugins' ) ) {
-			return false;
-		}
-
 		// Verify params present (auth & download link).
 		$post_auth = FrmAppHelper::get_param( 'token', '', 'request', 'sanitize_text_field' );
 		$post_url  = FrmAppHelper::get_param( 'file_url', '', 'request', 'sanitize_text_field' );
 
-		if ( empty( $post_auth ) || empty( $post_url ) ) {
+		if ( ! $post_auth || ! $post_url ) {
 			return false;
 		}
 

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -248,7 +248,7 @@ function frmFrontFormJS() {
 	 *
 	 * @param {HTMLElement} field
 	 * @param {Array} errors
-	 * @returns 
+	 * @returns
 	 */
 	function checkValidity( field, errors ) {
 		var fieldID;
@@ -257,7 +257,7 @@ function frmFrontFormJS() {
 		}
 
 		fieldID = getFieldId( field, true );
-		if ( 'undefined' === typeof errors[ fieldID ] ) {
+		if ( 'undefined' === typeof errors[ fieldID ]) {
 			errors[ fieldID ] = getFieldValidationMessage( field, 'data-invmsg' );
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4485

These permission checks don't appear to be necessary.

The function `can_install_addon_api` is called from our API, so the user is not logged in and doesn't have this permission. Instead the token is verified using `hash_equals` against the DB record.

The `install_addon` function is called in one function only, `download_and_activate`.

`download_and_activate` is only called when the API token is valid, or via `ajax_install_addon` which goes through `install_addon_permissions` which handles the permission check, so this permission check happens twice.