### PR TITLE
Use FrmFormsHelper::maybe_hide_inline on honeypot label too

### DIFF
--- a/classes/models/FrmHoneypot.php
+++ b/classes/models/FrmHoneypot.php
@@ -106,7 +106,7 @@ class FrmHoneypot extends FrmValidate {
 		}
 		?>
 			<div class="<?php echo esc_attr( $class_name ); ?>" <?php echo in_array( $honeypot, array( true, 'strict' ), true ) ? '' : 'aria-hidden="true"'; ?>>
-				<label for="frm_email_<?php echo esc_attr( $form->id ); ?>">
+				<label for="frm_email_<?php echo esc_attr( $form->id ); ?>" <?php FrmFormsHelper::maybe_hide_inline(); ?>>
 					<?php esc_html_e( 'If you are human, leave this field blank.', 'formidable' ); ?>
 				</label>
 				<input <?php FrmAppHelper::array_to_html_params( $input_attrs, true ); ?> <?php FrmFormsHelper::maybe_hide_inline(); ?> />


### PR DESCRIPTION
This update applies the same solution that's applied to the honeypot input to the label.

When form styling is disabled, it adds an inline `style="display:none;"` style.
<img width="412" alt="Screen Shot 2023-10-25 at 12 44 15 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/4968a4e9-6a8e-4937-af33-6b9d2e537fd0">
