### PR TITLE
Force truncate for strings way over the limit with no spaces

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2408,7 +2408,33 @@ class FrmAppHelper {
 			unset( $total_len, $word );
 		}
 
+		$sub = self::maybe_force_truncate_on_string_with_no_spaces( $sub, $length );
+
 		return $sub . ( ( $len < $original_len ) ? $continue : '' );
+	}
+
+	/**
+	 * If the string is still too long because there may not have been any spaces, force truncate.
+	 *
+	 * @since x.x
+	 *
+	 * @param string $sub    Current substring.
+	 * @param int    $length The length limit.
+	 * @return string
+	 */
+	private static function maybe_force_truncate_on_string_with_no_spaces( $sub, $length ) {
+		if ( strlen( $sub ) < $length + 50 ) {
+			// If the string isn't way over the limit, leave it.
+			return $sub;
+		}
+
+		$first_space = strpos( $sub, ' ', $length );
+		if ( false !== $first_space ) {
+			// Ignore anything with spaces.
+			return $sub;
+		}
+
+		return substr( $sub, 0, $length + 10 );
 	}
 
 	public static function mb_function( $function_names, $args ) {

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -728,4 +728,27 @@ class test_FrmAppHelper extends FrmUnitTest {
 		$messages = apply_filters( 'frm_message_list', array() );
 		$this->assertEmpty( $messages );
 	}
+
+	/**
+	 * @covers FrmAppHelper::truncate
+	 */
+	public function test_truncate() {
+		$assertions = array(
+			array(
+				'string'   => 'This is my first example string',
+				'length'   => 10,
+				'expected' => 'This is my...'
+			),
+			array(
+				'string'   => htmlentities( '<img src="data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoV2luZG93cykiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MEVBMTczNDg3QzA5MTFFNjk3ODM5NjQyRjE2RjA3QTkiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MEVBMTczNDk3QzA5MTFFNjk3ODM5NjQyRjE2RjA3QTkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowRUExNzM0NjdDMDkxMUU2OTc4Mzk2NDJGMTZGMDdBOSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDowRUExNzM0NzdDMDkxMUU2OTc4Mzk2NDJGMTZGMDdBOSIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PjjUmssAAAGASURBVHjatJaxTsMwEIbpIzDA6FaMMPYJkDKzVYU+QFeEGPIKfYU8AETkCYI6wANkZQwIKRNDB1hA0Jrf0rk6WXZ8BvWkb4kv99vn89kDrfVexBSYgVNwDA7AN+jAK3gEd+AlGMGIBFDgFvzouK3JV/lihQTOwLtOtw9wIRG5pJn91Tbgqk9kSk7GViADrTD4HCyZ0NQnomi51sb0fUyCMQEbp2WpU67IjfNjwcYyoUDhjJVcZBjYBy40j4wXgaobWoe8Z6Y80CJBwFpunepIzt2AUgFjtXXshNXjVmMh+K+zzp/CMs0CqeuzrxSRpbOKfdCkiMTS1VBQ41uxMyQR2qbrXiiwYN3ACh1FDmsdK2Eu4J6Tlo31dYVtCY88h5ELZIJJ+IRMzBHfyJINrigNkt5VsRiub9nXICdsYyVd2NcVvA3ScE5t2rb5JuEeyZnAhmLt9NK63vX1O5Pe8XaPSuGq1uTrfUgMEp9EJ+CQvr+BJ/AAKvAcCiAR+bf9CjAAluzmdX4AEIIAAAAASUVORK5CYII=">' ),
+				'length'   => 60,
+				'expected' => '&lt;img src=&quot;data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAABkAA',
+			)
+		);
+
+		foreach ( $assertions as $assertion ) {
+			$result = FrmAppHelper::truncate( $assertion['string'], $assertion['length'] );
+			$this->assertEquals( $assertion['expected'], $result );
+		}
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3811

I chose some hard coded values here.

If the length is 50 characters over what it should be, and I can't detect any spaces, then I truncate at the limit + 10.

**Before**
<img width="642" alt="Screen Shot 2023-10-30 at 1 35 25 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/8ec424c5-3aaf-4488-8a22-2eb5b73155c9">

**After**
<img width="628" alt="Screen Shot 2023-10-30 at 1 35 16 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/62306a90-1111-4d93-9469-426659e6f6e2">
