### PR TITLE
Support saving blank options for radio fields and checkbox field

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -227,7 +227,6 @@ class FrmFieldsController {
 		$field = FrmFieldsHelper::setup_edit_vars( $field );
 		$opts  = FrmAppHelper::get_param( 'opts', '', 'post', 'wp_kses_post' );
 		$opts  = explode( "\n", rtrim( $opts, "\n" ) );
-		$opts  = array_map( 'trim', $opts );
 
 		$separate = FrmAppHelper::get_param( 'separate', '', 'post', 'sanitize_text_field' );
 		$field['separate_value'] = ( $separate === 'true' );

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1876,6 +1876,20 @@ class FrmAppHelper {
 		}
 	}
 
+	/**
+	 * @since x.x
+	 *
+	 * @param string $value
+	 * @return string
+	 */
+	public static function trim_if_not_blank( $value ) {
+		if ( trim( $value ) === '' ) {
+			return $value;
+		}
+
+		return trim( $value );
+	}
+
 	public static function check_selected( $values, $current ) {
 		$values  = self::recursive_function_map( $values, 'trim' );
 		$values  = self::recursive_function_map( $values, 'htmlspecialchars_decode' );

--- a/classes/models/FrmEntryMeta.php
+++ b/classes/models/FrmEntryMeta.php
@@ -20,7 +20,7 @@ class FrmEntryMeta {
 		}
 
 		$new_values = array(
-			'meta_value' => is_array( $meta_value ) ? serialize( array_filter( $meta_value, 'FrmAppHelper::is_not_empty_value' ) ) : $meta_value,
+			'meta_value' => is_array( $meta_value ) ? serialize( array_filter( $meta_value, 'FrmAppHelper::is_not_empty_value' ) ) : FrmAppHelper::trim_if_not_blank( $meta_value ),
 			'item_id'    => $entry_id,
 			'field_id'   => $field_id,
 			'created_at' => current_time( 'mysql', 1 ),

--- a/classes/models/FrmEntryMeta.php
+++ b/classes/models/FrmEntryMeta.php
@@ -20,7 +20,7 @@ class FrmEntryMeta {
 		}
 
 		$new_values = array(
-			'meta_value' => is_array( $meta_value ) ? serialize( array_filter( $meta_value, 'FrmAppHelper::is_not_empty_value' ) ) : trim( $meta_value ),
+			'meta_value' => is_array( $meta_value ) ? serialize( array_filter( $meta_value, 'FrmAppHelper::is_not_empty_value' ) ) : $meta_value,
 			'item_id'    => $entry_id,
 			'field_id'   => $field_id,
 			'created_at' => current_time( 'mysql', 1 ),

--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -119,6 +119,10 @@ class FrmEntryValidate {
 			$value = reset( $value );
 		}
 
+		if ( ! is_array( $value ) ) {
+			$value = FrmAppHelper::trim_if_not_blank( $value );
+		}
+
 		if ( $posted_field->required == '1' && FrmAppHelper::is_empty_value( $value ) ) {
 			$errors[ 'field' . $args['id'] ] = FrmFieldsHelper::get_error_msg( $posted_field, 'blank' );
 		} elseif ( ! isset( $_POST['item_name'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing

--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -119,10 +119,6 @@ class FrmEntryValidate {
 			$value = reset( $value );
 		}
 
-		if ( ! is_array( $value ) ) {
-			$value = trim( $value );
-		}
-
 		if ( $posted_field->required == '1' && FrmAppHelper::is_empty_value( $value ) ) {
 			$errors[ 'field' . $args['id'] ] = FrmFieldsHelper::get_error_msg( $posted_field, 'blank' );
 		} elseif ( ! isset( $_POST['item_name'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing

--- a/classes/views/frm-fields/front-end/checkbox-field.php
+++ b/classes/views/frm-fields/front-end/checkbox-field.php
@@ -38,10 +38,9 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 			// Let the checked state of 'Other' fields be determined solely by FrmFieldsHelper::prepare_other_input as below.
 			// Without this check, one 'Other' field being checked leads to making all 'Other' fields checked on submit error
 			// since they all have the same value attr of 'Other'.
-			// $checked = FrmAppHelper::check_selected( $field['value'], $field_val ) ? ' checked="checked"' : '';
 			$checked = is_array( $field['value'] ) ? in_array( $field_val, $field['value'], true ) : $field['value'] === $field_val;
+			$checked = $checked ? 'checked="checked" ' : ' ';
 		}
-		$checked = $checked ? 'checked="checked" ' : ' ';
 
 		// Check if other opt, and get values for other field if needed
 		$other_opt = false;

--- a/classes/views/frm-fields/front-end/checkbox-field.php
+++ b/classes/views/frm-fields/front-end/checkbox-field.php
@@ -38,8 +38,10 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 			// Let the checked state of 'Other' fields be determined solely by FrmFieldsHelper::prepare_other_input as below.
 			// Without this check, one 'Other' field being checked leads to making all 'Other' fields checked on submit error
 			// since they all have the same value attr of 'Other'.
-			$checked = FrmAppHelper::check_selected( $field['value'], $field_val ) ? ' checked="checked"' : '';
+			// $checked = FrmAppHelper::check_selected( $field['value'], $field_val ) ? ' checked="checked"' : '';
+			$checked = is_array( $field['value'] ) ? in_array( $field_val, $field['value'], true ) : $field['value'] === $field_val;
 		}
+		$checked = $checked ? 'checked="checked" ' : ' ';
 
 		// Check if other opt, and get values for other field if needed
 		$other_opt = false;

--- a/classes/views/frm-fields/front-end/radio-field.php
+++ b/classes/views/frm-fields/front-end/radio-field.php
@@ -38,7 +38,14 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 		if ( ! isset( $shortcode_atts ) || ! isset( $shortcode_atts['label'] ) || $shortcode_atts['label'] ) {
 			?><label for="<?php echo esc_attr( $html_id ); ?>-<?php echo esc_attr( $opt_key ); ?>"><?php
 		}
-		$checked = FrmAppHelper::check_selected( $field['value'], $field_val ) ? 'checked="checked" ' : ' ';
+
+		if ( get_called_class() === 'FrmSurveys\models\fields\Radio' ) {
+			$checked = $field['value'] === $field_val;
+		} else {
+			$checked = FrmAppHelper::check_selected( $field['value'], $field_val );
+		}
+
+		$checked = $checked ? 'checked="checked" ' : ' ';
 
 		$other_opt = false;
 		$other_args = FrmFieldsHelper::prepare_other_input( compact( 'field_name', 'opt_key', 'field' ), $other_opt, $checked );

--- a/classes/views/frm-fields/front-end/radio-field.php
+++ b/classes/views/frm-fields/front-end/radio-field.php
@@ -40,7 +40,7 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 		}
 
 		if ( get_called_class() === 'FrmSurveys\models\fields\Radio' ) {
-			$checked = $field['value'] === $field_val;
+			$checked = is_array( $field['value'] ) ? in_array( $field_val, $field['value'], true ) : $field['value'] === $field_val;
 		} else {
 			$checked = FrmAppHelper::check_selected( $field['value'], $field_val );
 		}


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/3385

Since I noticed there were other proposed solutions to this like the one in https://github.com/Strategy11/formidable-forms/pull/1171, I'm just trying a different approach of allowing blank options to be saved/retrieved without being trimmed.

I'm not quite sure if this is worth consider or not but it could be used to brainstorm on it.

Screencast shared by Mike on how to replicate it:
![HUMIJ1WBdr](https://user-images.githubusercontent.com/9134515/232853630-ece100a7-831f-4520-ae65-5387c41262a4.gif)