### PR TITLE
Check select option before check hasClass

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -542,7 +542,7 @@ function frmFrontFormJS() {
 
 		// Function to change the color of a select element
 		changeSelectColor = function( select ) {
-			if ( hasClass( select.options[select.selectedIndex], 'frm-select-placeholder' ) ) {
+			if ( select.options[select.selectedIndex] && hasClass( select.options[select.selectedIndex], 'frm-select-placeholder' ) ) {
 				select.style.setProperty( 'color', textColorDisabled, 'important' );
 			} else {
 				select.style.color = '';


### PR DESCRIPTION
I noticed this JS error with geolocation fields.

I'm just adding a check so this doesn't trigger an error.

<img width="1318" alt="Screen Shot 2023-11-01 at 2 10 49 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/0e2166b7-4964-4433-b306-80555a48b419">
