### PR TITLE
Stop using DATE FORMAT on created_at/updated_at queries

### DIFF
--- a/classes/models/FrmDb.php
+++ b/classes/models/FrmDb.php
@@ -93,17 +93,11 @@ class FrmDb {
 	 * @param string|array $value
 	 * @param string $where
 	 * @param array $values
+	 * @return void
 	 */
 	private static function interpret_array_to_sql( $key, $value, &$where, &$values ) {
-		$key = trim( $key );
-
-		if ( strpos( $key, 'created_at' ) !== false || strpos( $key, 'updated_at' ) !== false ) {
-			$k        = explode( ' ', $key );
-			$where    .= ' DATE_FORMAT(' . reset( $k ) . ', %s) ' . str_replace( reset( $k ), '', $key );
-			$values[] = '%Y-%m-%d %H:%i:%s';
-		} else {
-			$where .= ' ' . $key;
-		}
+		$key    = trim( $key );
+		$where .= ' ' . $key;
 
 		$lowercase_key = explode( ' ', strtolower( $key ) );
 		$lowercase_key = end( $lowercase_key );


### PR DESCRIPTION
I was looking at database queries while working on a ticket.

I noticed this query,
> SELECT e.id,e.created_at as meta_value
> FROM wp_frm_items e
> WHERE e.form_id=751
> AND e.is_draft=0
> AND DATE_FORMAT(e.created_at, '%Y-%m-%d %H:%i:%s') >='2023-10-03 00:00:00'
> AND DATE_FORMAT(e.created_at, '%Y-%m-%d %H:%i:%s') <='2023-11-03 23:59:59'

This `DATE_FORMAT` seems excessive. It's converting it from `Y-m-d H:i:s` to `Y-m-d H:i:s`.

If I for example run `SELECT * FROM wp_frm_items e WHERE e.created_at != DATE_FORMAT(e.created_at, '%Y-%m-%d %H:%i:%s')`, I get 0 results.

Removing this optimizes the query.

There are 2 queries that use this running on my reports page. They take `0.2732` and `0.2511` seconds.

With this PR, they took 0.1549 and 0.1555 seconds. 0.5243, saving ~.21 seconds.

I tried to trace back to understand why the `DATE_FORMAT` was added in the first place and found it included in https://github.com/Strategy11/formidable-forms/commit/3460ad2a8986c6b05ff5c4067c31e01243cbf697.

The commit is titled "More sanitizing and preparing" but this code doesn't add any security.