### PR TITLE
Fix Column Checkboxes on Form Entries for iPad Landscape

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8738,6 +8738,13 @@ Responsive Design
 	#wp-content-media-buttons a.frm_insert_form {
 		padding: 0 var(--gap-sm);
 	}
+
+	.frm-white-body input[type="checkbox"]:checked::before,
+	.frm_wrap input[type="checkbox"]:checked::before {
+		width: 1.2rem;
+		height: 1.2rem;
+		margin: 0.125rem;
+	}
 }
 
 @media only screen and (max-width: 700px) {


### PR DESCRIPTION
This PR resolves the display issue of column checkboxes in the Form Entries on iPads in landscape mode, ensuring they are responsive and display correctly on all devices.

## Related Issue:
[Issue #2567](https://github.com/Strategy11/formidable-pro/issues/2567)

## QA URL
https://qa.formidableforms.com/sherv13/wp-admin/admin.php?page=formidable-entries&frm_action=list&form=30

## Testing Instructions:
1. Go to `WP Admin > Formidable > Entries`.
2. Use an iPad in landscape mode to view the page.
3. Check that the column checkboxes are displaying correctly.

## Output
### Before
<img width="769" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/2edbf1ca-c293-4747-884c-28b8784e0dbc">

### After
<img width="769" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/6ca92506-7d17-4136-86aa-a7af04f2c185">