### PR TITLE
Output data-frmval for name fields

### DIFF
--- a/classes/views/frm-fields/front-end/combo-field/combo-field.php
+++ b/classes/views/frm-fields/front-end/combo-field/combo-field.php
@@ -64,7 +64,7 @@ $inputs_attrs = $this->get_inputs_container_attrs();
 							value="<?php echo esc_attr( isset( $field_value[ $name ] ) ? $field_value[ $name ] : '' ); ?>"
 							<?php
 							if ( ! empty( $field_value[ $name ] ) ) {
-								echo 'data-frmval=' . esc_attr( $field_value[ $name ] );
+								echo 'data-frmval="' . esc_attr( $field_value[ $name ] ) . '" ';
 							}
 							if ( empty( $args['remove_names'] ) ) {
 								echo 'name="' . esc_attr( $field_name ) . '[' . esc_attr( $name ) . ']" ';

--- a/classes/views/frm-fields/front-end/combo-field/combo-field.php
+++ b/classes/views/frm-fields/front-end/combo-field/combo-field.php
@@ -63,6 +63,9 @@ $inputs_attrs = $this->get_inputs_container_attrs();
 							id="<?php echo esc_attr( $html_id . '_' . $name ); ?>"
 							value="<?php echo esc_attr( isset( $field_value[ $name ] ) ? $field_value[ $name ] : '' ); ?>"
 							<?php
+							if ( ! empty( $field_value[ $name ] ) ) {
+								echo 'data-frmval=' . esc_attr( $field_value[ $name ] );
+							}
 							if ( empty( $args['remove_names'] ) ) {
 								echo 'name="' . esc_attr( $field_name ) . '[' . esc_attr( $name ) . ']" ';
 							}


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4323
`data-frmval` was missing from name field inputs when a default value is set and that caused issue which is fixed by this update.
![CleanShot 2023-11-08 at 21 54 25](https://github.com/Strategy11/formidable-forms/assets/41271840/c3367380-fd44-4920-9722-f4ac05ccc5ed)
