### PR TITLE
Ensure Proper Zebra Striping with Blank Fields

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -4142,18 +4142,35 @@ label input[type="checkbox"], label input[type="radio"] {
 }
 
 .frm-alt-table {
+	position: relative;
 	width:100%;
 	border-collapse:collapse;
 	margin-top:0.5em;
 	font-size:15px;
 }
 
+/* Before `applyZebraStriping` is executed, an empty space is displayed */
+.frm-alt-table:not(.frm-zebra-striping)::before {
+	content: '';
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	background-color: #fff;
+}
+
 .frm-alt-table th {
 	width:200px;
 }
 
-.frm-alt-table tr {
+.frm-alt-table tr,
+.frm-alt-table tr.frm-odd {
 	background-color:transparent;
+}
+
+.frm-alt-table tr.frm-even {
+	background-color: var(--sidebar-color);
 }
 
 .frm-alt-table th,
@@ -4162,10 +4179,6 @@ label input[type="checkbox"], label input[type="radio"] {
 	vertical-align:top;
 	text-align:left;
 	padding:20px;
-}
-
-.frm-alt-table tr:nth-child(even) {
-	background-color: var(--sidebar-color);
 }
 
 .frm-alt-table h3 {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9819,10 +9819,34 @@ function frmAdminBuildJS() {
 		footerLinks.classList.remove( 'frm_hidden' );
 	}
 
+	/**
+	 * Apply zebra striping to a table while ignoring empty rows.
+	 *
+	 * @param {string} tableSelector The CSS selector for the table.
+	 * @param {string} emptyRowClass The class name used to identify empty rows.
+	 */
+	function applyZebraStriping( tableSelector, emptyRowClass ) {
+		// Get all non-empty table rows within the specified table
+		const rows = document.querySelectorAll( `${tableSelector} tr:not(.${emptyRowClass})` );
+		if ( rows?.length < 1 ) {
+			return;
+		}
+
+		let isOdd = true;
+		rows.forEach( row => {
+			row.classList.add( isOdd ? 'frm-odd' : 'frm-even' );
+			isOdd = !isOdd;
+		});
+
+		const tables = document.querySelectorAll( tableSelector );
+		tables.forEach( table => table.classList.add( 'frm-zebra-striping' ) );
+	};
+
 	return {
 		init: function() {
 			initAddMyEmailAddress();
 			addAdminFooterLinks();
+			applyZebraStriping( '.frm-alt-table', 'frm-empty-row' );
 
 			s = {};
 


### PR DESCRIPTION
This PR ensures that zebra striping remains consistent in repeater fields, even when some fields are left blank. The visual integrity of forms will be preserved.

## Related Issue:
[Issue #3688](https://github.com/Strategy11/formidable-pro/issues/3688)

## QA URL

## Testing Instruction:
1. Navigate to `WP Admin > Formidable > Forms`.
2. Create an entry for a form ensuring some fields are left blank.
3. Verify the zebra striping remains correct as shown in the 'After' output.

## Output Images
### Before
<img width="1494" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/b7445b00-a4a6-419c-a915-a204a66643e6">

---

<img width="1127" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/1d5cf7b9-4c8b-48e9-b5a4-d741a6f7a4fb">


### After
<img width="1502" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/48c438fd-6441-4125-8599-bddf10cd6bbe">

---

<img width="1126" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/ff70f0af-d8df-4d63-944a-7cca2451f3f6">

