### PR TITLE
Apply margin to image option containers in #frm-new-template page

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -4451,11 +4451,6 @@ li.frm_field_box > ul.frm_grid_container {
 	--border-radius: var(--small-radius);
 }
 
-.frm_image_option_container svg {
-	height: 50px;
-	margin: 10px auto 0;
-}
-
 #form_show_entry_page .frm_file_link,
 #form_show_entry_page .frm_image_option_container {
 	display: inline-flex;
@@ -4530,6 +4525,12 @@ li.frm_field_box > ul.frm_grid_container {
 #frm-welcome .frm_image_option_container svg,
 #form_global_settings .frm_image_option_container svg {
 	max-width: calc( 100% - 20px );
+}
+
+/* Style image option container for Directory add on. */
+#frm-new-template .frm_image_option_container svg {
+	height: 50px;
+	margin: 10px auto 0;
 }
 
 /* Show an icon on top */


### PR DESCRIPTION
This ID is hard coded in the `FrmSolution.php` file.

The style is used for these icons,
<img width="677" alt="Screen Shot 2023-11-10 at 10 49 30 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/2d16fadf-8245-4fcd-aea7-df71d04bacc8">

Without the margin, it looks like this.
<img width="573" alt="Screen Shot 2023-11-10 at 10 49 51 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/ae1cde2e-82d1-4fb1-919d-1c708afd1c56">

I've added `#frm-new-template` in front of this so it only happens on `FrmSolution.php` pages like the Directory page here.

**Before**
![image](https://github.com/Strategy11/formidable-forms/assets/9134515/452e3956-5621-4985-a11c-86fed6790b4b)

**After**
<img width="411" alt="Screen Shot 2023-11-10 at 10 52 45 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/714dd58e-4f21-422d-a89b-7e9c8a8d07e8">
