### PR TITLE
Stop adding aria-required to role="group" and add aria-required to th…

### DIFF
--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -501,30 +501,22 @@ class FrmFieldFormHtml {
 			return;
 		}
 
-		$field                       = (array) $this->field_obj->get_field();
-		$attributes                  = array();
-		$is_radio                    = 'radio' === $field_type || 'scale' === $field_type;
-		$type_requires_aria_required = true;
+		$field      = (array) $this->field_obj->get_field();
+		$attributes = array();
 
 		// Check if the field type is 'data' or 'product'.
 		if ( in_array( $field_type, array( 'data', 'product' ), true ) ) {
 			$data_type = FrmField::get_option( $field, 'data_type' );
-			// Check if the data type isn't 'radio' or 'checkbox'.
-			if ( 'radio' !== $data_type && 'checkbox' !== $data_type ) {
-				// If data type aren't 'radio' or 'checkbox', doesn't need to add 'aria-required' to multiple input container.
-				$type_requires_aria_required = false;
-			}
-			// Check if data type is 'radio'
-			if ( 'radio' === $data_type ) {
-				$is_radio = true;
-			}
+			$is_radio  = 'radio' === $data_type;
+		} else {
+			$is_radio = 'radio' === $field_type || 'scale' === $field_type;
 		}
 
 		// Add 'role' attribute to the field.
 		$attributes['role'] = $is_radio ? 'radiogroup' : 'group';
 
 		// Add 'aria-required' attribute to the field if required.
-		if ( $type_requires_aria_required && '1' === $field['required'] ) {
+		if ( $is_radio && '1' === $field['required'] ) {
 			$attributes['aria-required'] = 'true';
 		}
 

--- a/classes/views/frm-fields/front-end/checkbox-field.php
+++ b/classes/views/frm-fields/front-end/checkbox-field.php
@@ -57,7 +57,7 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 		echo $checked . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		if ( 0 === $option_index && FrmField::is_required( $field ) ) {
-			echo 'aria-required="true"';
+			echo ' aria-required="true" ';
 		}
 
 		?> /><?php

--- a/classes/views/frm-fields/front-end/checkbox-field.php
+++ b/classes/views/frm-fields/front-end/checkbox-field.php
@@ -15,7 +15,7 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 	$type = $field['type'];
 	do_action( 'frm_after_checkbox', compact( 'field', 'field_name', 'type' ) );
 } elseif ( $field['options'] ) {
-	$index = 0;
+	$option_index = 0;
 	foreach ( $field['options'] as $opt_key => $opt ) {
 		if ( isset( $shortcode_atts ) && isset( $shortcode_atts['opt'] ) && ( $shortcode_atts['opt'] !== $opt_key ) ) {
 			continue;
@@ -56,7 +56,7 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 		?><input type="checkbox" name="<?php echo esc_attr( $field_name ); ?>[<?php echo esc_attr( $other_opt ? $opt_key : '' ); ?>]" id="<?php echo esc_attr( $html_id ); ?>-<?php echo esc_attr( $opt_key ); ?>" value="<?php echo esc_attr( $field_val ); ?>"<?php
 		echo $checked . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-		if ( 0 === $index && FrmField::is_required( $field ) ) {
+		if ( 0 === $option_index && FrmField::is_required( $field ) ) {
 			echo 'aria-required="true"';
 		}
 
@@ -83,6 +83,6 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 
 		?></div>
 <?php
-		++$index;
+		++$option_index;
 	}
 }

--- a/classes/views/frm-fields/front-end/checkbox-field.php
+++ b/classes/views/frm-fields/front-end/checkbox-field.php
@@ -15,6 +15,7 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 	$type = $field['type'];
 	do_action( 'frm_after_checkbox', compact( 'field', 'field_name', 'type' ) );
 } elseif ( $field['options'] ) {
+	$index = 0;
 	foreach ( $field['options'] as $opt_key => $opt ) {
 		if ( isset( $shortcode_atts ) && isset( $shortcode_atts['opt'] ) && ( $shortcode_atts['opt'] !== $opt_key ) ) {
 			continue;
@@ -54,7 +55,11 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 
 		?><input type="checkbox" name="<?php echo esc_attr( $field_name ); ?>[<?php echo esc_attr( $other_opt ? $opt_key : '' ); ?>]" id="<?php echo esc_attr( $html_id ); ?>-<?php echo esc_attr( $opt_key ); ?>" value="<?php echo esc_attr( $field_val ); ?>"<?php
 		echo $checked . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		do_action( 'frm_field_input_html', $field );
+
+		if ( 0 === $index && FrmField::is_required( $field ) ) {
+			echo 'aria-required="true"';
+		}
+
 		?> /><?php
 
 		if ( ! isset( $shortcode_atts ) || ! isset( $shortcode_atts['label'] ) || $shortcode_atts['label'] ) {
@@ -78,5 +83,6 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 
 		?></div>
 <?php
+		++$index;
 	}
 }


### PR DESCRIPTION
…e first checkbox instead

Fixes https://github.com/Strategy11/formidable-pro/issues/4450

In the more recent ticket, they're using axe. The same error appears there as it does in Pagespeed.

<img width="539" alt="Screen Shot 2023-11-13 at 10 28 20 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/63ee0127-9832-4371-bf5e-7f6c34d417fd">

This update fixes both of those.

The issue is that `role="group"` doesn't support `aria-required`. There is no good role for a group of checkboxes that works like `radiogroup`. A `radiogroup` with `aria-required` is totally valid, and passes in both accessibility tests, but `group` doesn't.

What I've done now, is I add the `aria-required="true"` attribute to the **first** checkbox in a group only. This way it isn't read for each option.