### PR TITLE
Fix accidentally removed checkbox hook

### DIFF
--- a/classes/views/frm-fields/front-end/checkbox-field.php
+++ b/classes/views/frm-fields/front-end/checkbox-field.php
@@ -56,6 +56,8 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 		?><input type="checkbox" name="<?php echo esc_attr( $field_name ); ?>[<?php echo esc_attr( $other_opt ? $opt_key : '' ); ?>]" id="<?php echo esc_attr( $html_id ); ?>-<?php echo esc_attr( $opt_key ); ?>" value="<?php echo esc_attr( $field_val ); ?>"<?php
 		echo $checked . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
+		do_action( 'frm_field_input_html', $field );
+		
 		if ( 0 === $option_index && FrmField::is_required( $field ) ) {
 			echo ' aria-required="true" ';
 		}


### PR DESCRIPTION
I accidentally removed this in https://github.com/Strategy11/formidable-forms/pull/1372/files

It was causing a unit test in Pro to break.