### PR TITLE
Fix deprecated phpunit message

### DIFF
--- a/tests/base/FrmAjaxUnitTest.php
+++ b/tests/base/FrmAjaxUnitTest.php
@@ -41,7 +41,7 @@ class FrmAjaxUnitTest extends WP_Ajax_UnitTestCase {
 
 		// log in as user
 		wp_set_current_user( $user_id );
-		$this->$user_id = $user_id;
+		$this->user_id = $user_id;
 		$this->assertTrue( current_user_can( $role ) );
 	}
 

--- a/tests/misc/test_FrmOverlayController.php
+++ b/tests/misc/test_FrmOverlayController.php
@@ -2,6 +2,8 @@
 
 class test_FrmOverlayController extends FrmUnitTest {
 
+	private $time_mock;
+
 	public function setUp(): void {
 		parent::setUp();
 		$this->time_mock = $this->getMockBuilder( 'FrmOverlayController' )


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/4282

This fixes this deprecated message
> PHP Deprecated: Creation of dynamic property test_FrmProFieldsAjax::$53 is deprecated in ...plugins/formidable/tests/base/FrmAjaxUnitTest.php on line 44

I also made an update to fix a message when the LIte unit tests run
> Deprecated: Creation of dynamic property test_FrmOverlayController::$time_mock is deprecated in .../plugins/formidable/tests/misc/test_FrmOverlayController.php on line 7
