### PR TITLE
Add screen reader text for more options dropdown toggles

### DIFF
--- a/classes/views/frm-forms/add_field.php
+++ b/classes/views/frm-forms/add_field.php
@@ -35,6 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="dropdown">
 			<a href="#" class="frm_bstooltip frm-hover-icon frm-dropdown-toggle dropdown-toggle" title="<?php esc_attr_e( 'More Options', 'formidable' ); ?>" data-toggle="dropdown" data-container="body" aria-expanded="false">
 				<?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_thick_more_vert_icon' ); ?>
+				<span class="screen-reader-text"><?php esc_html_e( 'Toggle More Options Dropdown', 'formidable' ); ?></span>
 			</a>
 			<ul class="frm-dropdown-menu frm-p-1 <?php echo esc_attr( is_rtl() ? 'dropdown-menu-left' : 'dropdown-menu-right' ); ?>" role="menu"></ul>
 		</div>

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1453,22 +1453,34 @@ function frmAdminBuildJS() {
 	}
 
 	function getFieldControlsDropdown() {
-		var dropdown, trigger, ul;
+		const dropdown = span({ className: 'dropdown' });
+		const trigger  = a({
+			className: 'frm_bstooltip frm-hover-icon frm-dropdown-toggle dropdown-toggle',
+			children: [
+				span({
+					child: svg({ href: '#frm_thick_more_vert_icon' })
+				}),
+				span({
+					className: 'screen-reader-text',
+					text: __( 'Toggle More Options Dropdown', 'formidable' )
+				})
+			]
+		});
 
-		dropdown = document.createElement( 'span' );
-		dropdown.classList.add( 'dropdown' );
-
-		trigger = document.createElement( 'a' );
-		trigger.classList.add( 'frm_bstooltip', 'frm-hover-icon', 'frm-dropdown-toggle', 'dropdown-toggle' );
-		trigger.setAttribute( 'title', __( 'More Options', 'formidable' ) );
-		trigger.setAttribute( 'data-toggle', 'dropdown' );
-		trigger.setAttribute( 'data-container', 'body' );
+		frmDom.setAttributes(
+			trigger,
+			{
+				'title': __( 'More Options', 'formidable' ),
+				'data-toggle': 'dropdown',
+				'data-container': 'body'
+			}
+		);
 		makeTabbable( trigger, __( 'More Options', 'formidable' ) );
-		trigger.innerHTML = '<span><svg class="frmsvg"><use xlink:href="#frm_thick_more_vert_icon"></use></svg></span>';
 		dropdown.appendChild( trigger );
 
-		ul = document.createElement( 'div' );
-		ul.classList.add( 'frm-dropdown-menu', 'dropdown-menu', 'dropdown-menu-right' );
+		const ul = div({
+			className: 'frm-dropdown-menu dropdown-menu dropdown-menu-right'
+		});
 		ul.setAttribute( 'role', 'menu' );
 		dropdown.appendChild( ul );
 


### PR DESCRIPTION
When using axe DevTools (https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?pli=1), the "More Options" toggles have an accessibility error, "Links must have discernible text".

<img width="1296" alt="Screen Shot 2023-11-17 at 9 56 38 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/698e39dc-f96f-4816-85cd-126b32db97aa">

This update adds screen reader text ("Toggle More Options Dropdown") to the toggles, fixing the issue.

I also refactored a bit, using more `frmDom` functions.

_There's still one instance of this error coming from the header logo. I'm working on that separately. I'm trying to determine the best text to use there still._