### PR TITLE
Add view forms screen reader text for header logo

### DIFF
--- a/classes/views/applications/header.php
+++ b/classes/views/applications/header.php
@@ -6,6 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div id="frm_top_bar">
 	<a href="<?php echo esc_url( admin_url( 'admin.php?page=formidable' ) ); ?>" class="frm-header-logo">
 		<?php FrmAppHelper::show_header_logo(); ?>
+		<span class="screen-reader-text"><?php esc_html_e( 'View Forms', 'formidable' ); ?></span>
 	</a>
 	<div id="frm_bs_dropdown">
 		<h1>

--- a/classes/views/shared/admin-header.php
+++ b/classes/views/shared/admin-header.php
@@ -8,6 +8,7 @@ FrmAppHelper::print_admin_banner( ! $has_nav && empty( $atts['switcher'] ) );
 <div id="frm_top_bar" class="<?php echo esc_attr( 'frm_nav_bar' ); ?>">
 	<a href="<?php echo esc_url( admin_url( 'admin.php?page=formidable' ) ); ?>" class="frm-header-logo">
 		<?php FrmAppHelper::show_header_logo(); ?>
+		<span class="screen-reader-text"><?php esc_html_e( 'View Forms', 'formidable' ); ?></span>
 	</a>
 
 	<?php


### PR DESCRIPTION
This update adds screen reader text for the header logo link.

This fixes an issue caught by the axe DevTools extension.

"Links must have discernible text"

![image](https://github.com/Strategy11/formidable-forms/assets/9134515/6e54ece7-84ea-4fb2-9346-bc32f990b834)
