### PR TITLE
Add more PayPall fallback checks

### DIFF
--- a/stripe/controllers/FrmTransLiteEntriesController.php
+++ b/stripe/controllers/FrmTransLiteEntriesController.php
@@ -12,9 +12,12 @@ class FrmTransLiteEntriesController {
 	 * @return void
 	 */
 	public static function sidebar_list( $entry ) {
+		if ( FrmTransLiteAppHelper::should_fallback_to_paypal() ) {
+			return;
+		}
+
 		// This line removes PayPal actions from the entries sidebar.
 		remove_action( 'frm_show_entry_sidebar', 'FrmPaymentsController::sidebar_list' );
-
 		add_action( 'frm_entry_shared_sidebar_middle', __CLASS__ . '::show_sidebar_list' );
 	}
 

--- a/stripe/controllers/FrmTransLiteListsController.php
+++ b/stripe/controllers/FrmTransLiteListsController.php
@@ -9,6 +9,10 @@ class FrmTransLiteListsController {
 	 * @return void
 	 */
 	public static function add_list_hooks() {
+		if ( FrmTransLiteAppHelper::should_fallback_to_paypal() ) {
+			return;
+		}
+
 		$hook_name = 'manage_' . sanitize_title( FrmAppHelper::get_menu_name() ) . '_page_formidable-payments_columns';
 		add_filter( $hook_name, __CLASS__ . '::payment_columns' );
 		add_filter( 'screen_options_show_screen', __CLASS__ . '::remove_screen_options', 10, 2 );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4476

I also added a check to fix https://secure.helpscout.net/conversation/2426376840/179938

> Warning: Undefined property: stdClass::$sub_id in .../plugins/formidable-paypal/helpers/FrmPaymentsListHelper.php on line 172
> Warning:  Undefined property: stdClass::$status in .../plugins/formidable-paypal/helpers/FrmPaymentsListHelper.php on line 172

