### PR TITLE
Fix fallback currency in wrong case

### DIFF
--- a/classes/helpers/FrmCurrencyHelper.php
+++ b/classes/helpers/FrmCurrencyHelper.php
@@ -21,7 +21,7 @@ class FrmCurrencyHelper {
 		} elseif ( isset( $currencies[ strtolower( $currency ) ] ) ) {
 			$currency = $currencies[ strtolower( $currency ) ];
 		} else {
-			$currency = $currencies['usd'];
+			$currency = $currencies['USD'];
 		}
 		return $currency;
 	}


### PR DESCRIPTION
I noticed this `Undefined array key "usd"` warning when looking at a manually entered payment.

The index key is `USD`, not `usd`. This just fixes the case.