### PR TITLE
Use display name instead of title for addon cards when display name i…

### DIFF
--- a/classes/views/addons/list.php
+++ b/classes/views/addons/list.php
@@ -45,7 +45,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<div class="plugin-card-top">
 					<h2>
 						<?php
-						echo esc_html( $addon['title'] );
+						echo esc_html( ! empty( $addon['display_name'] ) ? $addon['display_name'] : $addon['title'] );
 
 						if ( ! empty( $addon['is_new'] ) ) {
 							FrmAppHelper::show_pill_text();


### PR DESCRIPTION
…s defined

Fixes https://github.com/Strategy11/formidable-activecampaign/issues/28

I looked at our site to see how this works and saw that there's a `display_name` of "ActiveCampaign" while `title` is "Active Campaign".

This update prioritizes `display_name` if it is not empty and uses that instead of the title.

<img width="437" alt="Screen Shot 2023-11-20 at 2 40 28 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/191e2b52-f5d3-48da-91a6-028d53cf3b01">

This changes a few add ons, not just Active Campaign. I did a check and I got the following list:
Before / After
- Abandonment / Form Abandonment
- Active Campaign / ActiveCampaign
- AI / AI Forms
- Signature / Digital Signatures
- Twilio / Twilio WordPress SMS
- User Tracking / User Flow

**Before**
<img width="403" alt="Screen Shot 2023-11-20 at 2 44 52 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/e2f597f5-1068-45e1-9b4d-6088a0a274a7">
<img width="401" alt="Screen Shot 2023-11-20 at 2 44 59 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/a40746d6-9258-471f-a96d-1311b3af2343">
<img width="396" alt="Screen Shot 2023-11-20 at 2 45 11 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/e26ad2cd-6169-4c85-aa02-c86e30c9cd64">
<img width="401" alt="Screen Shot 2023-11-20 at 2 44 48 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/8d49b8cc-2da4-4a87-befd-bc041dec0ed3">
<img width="397" alt="Screen Shot 2023-11-20 at 2 46 58 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/041b8419-181a-44cb-9c8e-7ee62e216be1">
<img width="397" alt="Screen Shot 2023-11-20 at 2 46 48 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/c5a68d68-4745-49be-891d-511c14b58ae8">

**After**
<img width="396" alt="Screen Shot 2023-11-20 at 2 46 03 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/fda84842-a158-4216-875b-29629529627c">
<img width="396" alt="Screen Shot 2023-11-20 at 2 46 06 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/f743a1d1-d20a-4e93-905a-a9bdf1996b4d">
<img width="396" alt="Screen Shot 2023-11-20 at 2 46 13 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/09e63cd6-9eff-458f-b986-fc8822860535">
<img width="397" alt="Screen Shot 2023-11-20 at 2 46 18 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/994fbaa3-d461-4bae-8f97-1999b77a6d27">
<img width="395" alt="Screen Shot 2023-11-20 at 2 46 28 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/0af94ef6-c2f8-4b06-8fdd-c8a3caa3f1d2">
<img width="397" alt="Screen Shot 2023-11-20 at 2 46 40 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/909c0270-62d6-40ff-b029-da9734bc95b5">
