### PR TITLE
Fix how 'other' option checked state is determined

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1236,6 +1236,10 @@ class FrmFieldsHelper {
 			$checked = 'checked="checked" ';
 		}
 
+		if ( ! $checked && is_array( $args['field']['value'] ) && in_array( $args['field_val'], $args['field']['value'], true ) ) {
+			$checked = 'checked="checked" ';
+		}
+
 		return $other_args;
 	}
 

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1236,7 +1236,13 @@ class FrmFieldsHelper {
 			$checked = 'checked="checked" ';
 		}
 
-		if ( ! $checked && is_array( $args['field']['value'] ) && isset( $args['field_val'] ) && in_array( $args['field_val'], $args['field']['value'], true ) ) {
+		// If 'other' is selected as one of the default values for a checkbox field, 'checked' attribute should be on.
+		if ( ! $checked &&
+			$args['field']['type'] === 'checkbox' &&
+			is_array( $args['field']['value'] ) &&
+			isset( $args['field_val'] ) &&
+			in_array( $args['field_val'], $args['field']['value'], true )
+		) {
 			$checked = 'checked="checked" ';
 		}
 

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1236,7 +1236,7 @@ class FrmFieldsHelper {
 			$checked = 'checked="checked" ';
 		}
 
-		if ( ! $checked && is_array( $args['field']['value'] ) && in_array( $args['field_val'], $args['field']['value'], true ) ) {
+		if ( ! $checked && is_array( $args['field']['value'] ) && isset( $args['field_val'] ) && in_array( $args['field_val'], $args['field']['value'], true ) ) {
 			$checked = 'checked="checked" ';
 		}
 

--- a/classes/views/frm-fields/front-end/checkbox-field.php
+++ b/classes/views/frm-fields/front-end/checkbox-field.php
@@ -57,7 +57,6 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 		echo $checked . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		do_action( 'frm_field_input_html', $field );
-		
 		if ( 0 === $option_index && FrmField::is_required( $field ) ) {
 			echo ' aria-required="true" ';
 		}

--- a/classes/views/frm-fields/front-end/checkbox-field.php
+++ b/classes/views/frm-fields/front-end/checkbox-field.php
@@ -44,7 +44,7 @@ if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' ) 
 
 		// Check if other opt, and get values for other field if needed
 		$other_opt = false;
-		$other_args = FrmFieldsHelper::prepare_other_input( compact( 'field', 'field_name', 'opt_key' ), $other_opt, $checked );
+		$other_args = FrmFieldsHelper::prepare_other_input( compact( 'field', 'field_name', 'opt_key', 'field_val' ), $other_opt, $checked );
 
 		?>
 		<div class="<?php echo esc_attr( apply_filters( 'frm_checkbox_class', 'frm_checkbox', $field, $field_val ) ); ?>" id="<?php echo esc_attr( FrmFieldsHelper::get_checkbox_id( $field, $opt_key ) ); ?>"><?php


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4578 together with https://github.com/Strategy11/formidable-pro/pull/4584

I believe this fix would ideally be in Pro but since most of the stuff is built into Lite, I'm just updating lite.

Fixes in this update:
- Checked state of other option on front end page load.

### Screencast
https://github.com/Strategy11/formidable-forms/assets/41271840/e652528c-94ab-45dd-adbe-0922763d0ffc
