### PR TITLE
Add edit link to payments table when paypal is active

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -139,7 +139,12 @@ class FrmAppController {
 		if ( ! class_exists( 'FrmTransHooksController', false ) && ! FrmTransLiteAppHelper::should_fallback_to_paypal() ) {
 			// Only consider the payments page as a "white page" when the Payments submodule is off.
 			// Otherwise this causes a lot of styling issues when the Stripe add-on (or Authorize.Net) is active.
-			$white_pages[] = 'formidable-payments';
+
+			// Add an extra check to avoid white page styling on the PayPal "edit" action.
+			// We fallback to the PayPal add on for the "edit" action since Stripe Lite does not have an edit view.
+			if ( 'edit' !== FrmAppHelper::simple_get( 'action' ) || ! is_callable( 'FrmPaymentsController::route' ) ) {
+				$white_pages[] = 'formidable-payments';
+			}
 		}
 
 		$get_page      = FrmAppHelper::simple_get( 'page', 'sanitize_title' );

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -142,7 +142,7 @@ class FrmAppController {
 
 			// Add an extra check to avoid white page styling on the PayPal "edit" action.
 			// We fallback to the PayPal add on for the "edit" action since Stripe Lite does not have an edit view.
-			if ( 'edit' !== FrmAppHelper::simple_get( 'action' ) || ! is_callable( 'FrmPaymentsController::route' ) ) {
+			if ( ! in_array( FrmAppHelper::simple_get( 'action' ), array( 'edit', 'new' ), true ) || ! is_callable( 'FrmPaymentsController::route' ) ) {
 				$white_pages[] = 'formidable-payments';
 			}
 		}

--- a/stripe/controllers/FrmTransLitePaymentsController.php
+++ b/stripe/controllers/FrmTransLitePaymentsController.php
@@ -18,7 +18,15 @@ class FrmTransLitePaymentsController extends FrmTransLiteCRUDController {
 		// Remove the PayPal submenu (PayPal payments will just appear in the regular Payments page).
 		remove_action( 'admin_menu', 'FrmPaymentsController::menu', 26 );
 
-		add_submenu_page( 'formidable', $frm_settings->menu . ' | Payments', 'Payments', 'frm_view_entries', 'formidable-payments', 'FrmTransLitePaymentsController::route' );
+		if ( 'edit' === FrmAppHelper::simple_get( 'action' ) && is_callable( 'FrmPaymentsController::route' ) ) {
+			// Use the PayPal addon for edit routing if it is active.
+			// This is required to support the "edit" link when using the Stripe Lite table view.
+			$menu_route = 'FrmPaymentsController::route';
+		} else {
+			$menu_route = 'FrmTransLitePaymentsController::route';
+		}
+
+		add_submenu_page( 'formidable', $frm_settings->menu . ' | Payments', 'Payments', 'frm_view_entries', 'formidable-payments', $menu_route );
 	}
 
 	/**

--- a/stripe/controllers/FrmTransLitePaymentsController.php
+++ b/stripe/controllers/FrmTransLitePaymentsController.php
@@ -18,7 +18,7 @@ class FrmTransLitePaymentsController extends FrmTransLiteCRUDController {
 		// Remove the PayPal submenu (PayPal payments will just appear in the regular Payments page).
 		remove_action( 'admin_menu', 'FrmPaymentsController::menu', 26 );
 
-		if ( 'edit' === FrmAppHelper::simple_get( 'action' ) && is_callable( 'FrmPaymentsController::route' ) ) {
+		if ( in_array( FrmAppHelper::simple_get( 'action' ), array( 'edit', 'new' ), true ) && is_callable( 'FrmPaymentsController::route' ) ) {
 			// Use the PayPal addon for edit routing if it is active.
 			// This is required to support the "edit" link when using the Stripe Lite table view.
 			$menu_route = 'FrmPaymentsController::route';

--- a/stripe/controllers/FrmTransLitePaymentsController.php
+++ b/stripe/controllers/FrmTransLitePaymentsController.php
@@ -19,8 +19,9 @@ class FrmTransLitePaymentsController extends FrmTransLiteCRUDController {
 		remove_action( 'admin_menu', 'FrmPaymentsController::menu', 26 );
 
 		if ( in_array( FrmAppHelper::simple_get( 'action' ), array( 'edit', 'new' ), true ) && is_callable( 'FrmPaymentsController::route' ) ) {
-			// Use the PayPal addon for edit routing if it is active.
+			// Use the PayPal addon for add new and edit routing if it is active.
 			// This is required to support the "edit" link when using the Stripe Lite table view.
+			// It is also required for the "Add New" button to work on the payments table page.
 			$menu_route = 'FrmPaymentsController::route';
 		} else {
 			$menu_route = 'FrmTransLitePaymentsController::route';

--- a/stripe/helpers/FrmTransLiteListHelper.php
+++ b/stripe/helpers/FrmTransLiteListHelper.php
@@ -372,7 +372,7 @@ class FrmTransLiteListHelper extends FrmListHelper {
 		$actions           = array();
 		$actions['view']   = '<a href="' . esc_url( $view_link ) . '">' . esc_html__( 'View', 'formidable' ) . '</a>';
 
-		if ( $this->table !== 'subscriptions' && class_exists( 'FrmPaymentsController', false ) ) {
+		if ( $this->table !== 'subscriptions' && 'stripe' !== $item->paysys && class_exists( 'FrmPaymentsController', false ) ) {
 			$edit_link       = $base_link . 'edit&id=' . $item->id;
 			$actions['edit'] = '<a href="' . esc_url( $edit_link ) . '">' . esc_html__( 'Edit', 'formidable-payments' ) . '</a>';
 		}

--- a/stripe/helpers/FrmTransLiteListHelper.php
+++ b/stripe/helpers/FrmTransLiteListHelper.php
@@ -371,6 +371,12 @@ class FrmTransLiteListHelper extends FrmListHelper {
 
 		$actions           = array();
 		$actions['view']   = '<a href="' . esc_url( $view_link ) . '">' . esc_html__( 'View', 'formidable' ) . '</a>';
+
+		if ( $this->table !== 'subscriptions' && class_exists( 'FrmPaymentsController', false ) ) {
+			$edit_link       = $base_link . 'edit&id=' . $item->id;
+			$actions['edit'] = '<a href="' . esc_url( $edit_link ) . '">' . esc_html__( 'Edit', 'formidable-payments' ) . '</a>';
+		}
+
 		$actions['delete'] = '<a href="' . esc_url( wp_nonce_url( $delete_link ) ) . '" data-frmverify="' . esc_attr__( 'Permanently delete this payment?', 'formidable' ) . '" data-frmverify-btn="frm-button-red">' . esc_html__( 'Delete', 'formidable' ) . '</a>';
 
 		return $actions;

--- a/stripe/views/lists/list.php
+++ b/stripe/views/lists/list.php
@@ -6,10 +6,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <div class="frm_wrap">
 	<?php
+	$should_show_add_new_button = class_exists( 'FrmPaymentsController', false );
 	FrmAppHelper::get_admin_header(
 		array(
-			'label' => __( 'Payments', 'formidable' ),
-			'form'  => FrmAppHelper::simple_get( 'form', 'absint', 0 ),
+			'label'    => __( 'Payments', 'formidable' ),
+			'form'     => FrmAppHelper::simple_get( 'form', 'absint', 0 ),
+			'publish'  => ! $should_show_add_new_button ? true : array(
+				'FrmAppHelper::add_new_item_link',
+				array(
+					'new_link' => admin_url( 'admin.php?page=formidable-payments&amp;action=new' ),
+				),
+			),
 		)
 	);
 	?>


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2428049678/180141/

We only show the "Edit" link when the Stripe add on is active.

But this means that the "Edit" link isn't displayed when the PayPal add on is active and we're using the Stripe Lite view (which happens if Stripe migrations have run).
