### PR TITLE
Set a no_update value on update plugins transient so auto update is a…

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -352,12 +352,11 @@ class FrmAddonsController {
 				continue;
 			}
 
-			$wp_plugin  = isset( $wp_plugins[ $folder ] ) ? $wp_plugins[ $folder ] : array();
-			$wp_version = isset( $wp_plugin['Version'] ) ? $wp_plugin['Version'] : '1.0';
+			$wp_plugin    = isset( $wp_plugins[ $folder ] ) ? $wp_plugins[ $folder ] : array();
+			$wp_version   = isset( $wp_plugin['Version'] ) ? $wp_plugin['Version'] : '1.0';
+			$plugin->slug = explode( '/', $folder )[0];
 
 			if ( version_compare( $wp_version, $plugin->new_version, '<' ) ) {
-				$slug                           = explode( '/', $folder );
-				$plugin->slug                   = $slug[0];
 				$transient->response[ $folder ] = $plugin;
 			} else {
 				$transient->no_update[ $folder ] = $plugin;

--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -359,6 +359,8 @@ class FrmAddonsController {
 				$slug                           = explode( '/', $folder );
 				$plugin->slug                   = $slug[0];
 				$transient->response[ $folder ] = $plugin;
+			} else {
+				$transient->no_update[ $folder ] = $plugin;
 			}
 
 			$transient->checked[ $folder ] = $wp_version;


### PR DESCRIPTION
…vailable when up to date

Related issue https://github.com/Strategy11/formidable-pro/issues/2624

Prior to this update, the Enabled/Disable auto-updates options were only visible when a form was not up to date (when it shows an option to Update Now).

I looked at https://github.com/Strategy11/business-directory-premium/blob/main/models/class-wpbdp-addons.php#L107-L111 and saw it had this `else` condition so I added something similar. Now it always shows the Disable/Enable options.

<img width="1219" alt="Screen Shot 2023-11-21 at 4 07 24 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/44f2cf4f-6d81-42f5-9e81-745272655357">

I don't know if this is all that needs to change though. I didn't have any luck getting it to auto-update on my local environment.

According to my Site Health it doesn't try to auto-update when you're using Git.
<img width="655" alt="Screen Shot 2023-11-21 at 4 09 08 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/3d882caf-00d0-4745-b45e-28b8052d4448">

@stephywells Is this all that we should need to do? What's the best way to test this?