### PR TITLE
Add composite indexes for entries tables

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class FrmAppHelper {
-	public static $db_version     = 98; // Version of the database we are moving to.
+	public static $db_version     = 100; // Version of the database we are moving to.
 	public static $pro_db_version = 37; //deprecated
 	public static $font_version   = 7;
 

--- a/classes/models/FrmMigrate.php
+++ b/classes/models/FrmMigrate.php
@@ -165,6 +165,8 @@ class FrmMigrate {
 	/**
 	 * These indexes help optimize database queries for entries.
 	 *
+	 * @since x.x
+	 *
 	 * @return void
 	 */
 	private function add_composite_indexes_for_entries() {
@@ -183,6 +185,30 @@ class FrmMigrate {
 		if ( ! self::index_exists( $table_name, $index_name ) ) {
 			$wpdb->query( "CREATE INDEX idx_field_id_item_id ON `{$wpdb->prefix}frm_item_metas` (field_id, item_id)" );
 		}
+	}
+
+	/**
+	 * Check that an index exists in a database table before trying to add it (which results in an error).
+	 *
+	 * @since x.x
+	 *
+	 * @param string $table_name
+	 * @param string $index_name
+	 * @return bool
+	 */
+	private static function index_exists( $table_name, $index_name ) {
+		global $wpdb;
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT 1 FROM information_schema.statistics
+					WHERE table_schema = database()
+						AND table_name = %s
+						AND index_name = %s
+					LIMIT 1',
+				array( $table_name, $index_name )
+			)
+		);
+		return (bool) $row;
 	}
 
 	private function maybe_create_contact_form() {
@@ -623,29 +649,5 @@ DEFAULT_HTML;
 			}
 			unset( $form );
 		}
-	}
-
-	/**
-	 * Check that an index exists in a database table before trying to add it (which results in an error).
-	 *
-	 * @since x.x
-	 *
-	 * @param string $table_name
-	 * @param string $index_name
-	 * @return bool
-	 */
-	private static function index_exists( $table_name, $index_name ) {
-		global $wpdb;
-		$row = $wpdb->get_row(
-			$wpdb->prepare(
-				'SELECT 1 FROM information_schema.statistics
-					WHERE table_schema = database()
-						AND table_name = %s
-						AND index_name = %s
-					LIMIT 1',
-				array( $table_name, $index_name )
-			)
-		);
-		return (bool) $row;
 	}
 }

--- a/classes/models/FrmMigrate.php
+++ b/classes/models/FrmMigrate.php
@@ -158,6 +158,31 @@ class FrmMigrate {
 			}
 			unset( $q );
 		}
+
+		$this->add_composite_indexes_for_entries();
+	}
+
+	/**
+	 * These indexes help optimize database queries for entries.
+	 *
+	 * @return void
+	 */
+	private function add_composite_indexes_for_entries() {
+		global $wpdb;
+
+		$table_name = "{$wpdb->prefix}frm_items";
+		$index_name = 'idx_is_draft_created_at';
+
+		if ( ! self::index_exists( $table_name, $index_name ) ) {
+			$wpdb->query( "CREATE INDEX idx_is_draft_created_at ON `{$wpdb->prefix}frm_items` (is_draft, created_at)" );
+		}
+
+		$table_name = "{$wpdb->prefix}frm_item_metas";
+		$index_name = 'idx_field_id_item_id';
+
+		if ( ! self::index_exists( $table_name, $index_name ) ) {
+			$wpdb->query( "CREATE INDEX idx_field_id_item_id ON `{$wpdb->prefix}frm_item_metas` (field_id, item_id)" );
+		}
 	}
 
 	private function maybe_create_contact_form() {
@@ -598,5 +623,29 @@ DEFAULT_HTML;
 			}
 			unset( $form );
 		}
+	}
+
+	/**
+	 * Check that an index exists in a database table before trying to add it (which results in an error).
+	 *
+	 * @since x.x
+	 *
+	 * @param string $table_name
+	 * @param string $index_name
+	 * @return bool
+	 */
+	private static function index_exists( $table_name, $index_name ) {
+		global $wpdb;
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT 1 FROM information_schema.statistics
+					WHERE table_schema = database()
+						AND table_name = %s
+						AND index_name = %s
+					LIMIT 1',
+				array( $table_name, $index_name )
+			)
+		);
+		return (bool) $row;
 	}
 }


### PR DESCRIPTION
Related update https://github.com/Strategy11/formidable-pro/pull/4540#pullrequestreview-1730324322

This moves the indexes into Lite so database queries are optimized for all sites.

I run this after it creates the tables so it always runs. I tried getting it to work in the `dbDelta` call but I don't believe that's supported for this kind of index.