### PR TITLE
Set item meta to an empty array if it is not an array

### DIFF
--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -25,6 +25,7 @@ class FrmEntryValidate {
 			$errors['form'] = $frm_settings->admin_permission;
 		}
 
+		self::maybe_fix_item_meta();
 		self::set_item_key( $values );
 
 		$posted_fields = self::get_fields_to_validate( $values, $exclude );
@@ -59,6 +60,20 @@ class FrmEntryValidate {
 		}
 
 		return $errors;
+	}
+
+	/**
+	 * In case $_POST['item_meta'] is not an array, change it to an empty array.
+	 * This helps to avoid some warnings and errors when $_POST['item_meta'] is updated.
+	 *
+	 * @since x.x
+	 *
+	 * @return void
+	 */
+	private static function maybe_fix_item_meta() {
+		if ( ! is_array( $_POST['item_meta'] ) ) {
+			$_POST['item_meta'] = array();
+		}
 	}
 
 	private static function set_item_key( &$values ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4539

This it likely caused by custom code. I couldn't find anywhere where we set `$_POST['item_meta']` to a string, but it's also possible that `$_POST['item_meta']` is just being sent as a string, possibly because of a misuse of an API action or something.