### PR TITLE
Remove aria hidden from honeypot container

### DIFF
--- a/classes/models/FrmHoneypot.php
+++ b/classes/models/FrmHoneypot.php
@@ -105,7 +105,7 @@ class FrmHoneypot extends FrmValidate {
 			$input_attrs['autocomplete'] = 'false';
 		}
 		?>
-			<div class="<?php echo esc_attr( $class_name ); ?>" <?php echo in_array( $honeypot, array( true, 'strict' ), true ) ? '' : 'aria-hidden="true"'; ?>>
+			<div class="<?php echo esc_attr( $class_name ); ?>">
 				<label for="frm_email_<?php echo esc_attr( $form->id ); ?>" <?php FrmFormsHelper::maybe_hide_inline(); ?>>
 					<?php esc_html_e( 'If you are human, leave this field blank.', 'formidable' ); ?>
 				</label>


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2430174033/180445/

The `aria-hidden="true"` attribute causes issues with Google PageSight. It also makes the honeypot more obvious. We're better off removing it.

Since nothing in the honeypot container should be tabbable, it shouldn't cause many issues with screen readers.