### PR TITLE
Fix Pirate forms importer style

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -9352,7 +9352,7 @@ Responsive Design
 #welcome-panel:has(#frm_form_pf_importer) .welcome-panel-content {
 	text-align: start !important;
 	min-height: unset;
-    display: block;
+	display: block;
 }
 
 #frm_form_pf_importer div {
@@ -9360,17 +9360,17 @@ Responsive Design
 }
 
 #frm_form_pf_importer button {
-    border: 1px solid var(--primary-500);
-    padding: 7px 16px;
-    min-height: 28px;
-    line-height: var(--leading);
-    margin-bottom: 0;
+	border: 1px solid var(--primary-500);
+	padding: 7px 16px;
+	min-height: 28px;
+	line-height: var(--leading);
+	margin-bottom: 0;
 	background: var(--primary-500);
-    color: #fff !important;
+	color: #fff !important;
 }
 
 #frm_form_pf_importer button:hover {
 	background: #135e96;
-    border-color: #135e96;
+	border-color: #135e96;
 }
 /* End Pirate forms importer */

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -9341,3 +9341,41 @@ Responsive Design
 	color: var(--grey-500);
 }
 /* End Field Group Message */
+
+/* Pirate forms importer */
+#welcome-panel:has(#frm_form_pf_importer) {
+	background-color: #fff;
+}
+
+#welcome-panel:has(#frm_form_pf_importer) .welcome-panel-content {
+	text-align: start !important;
+	min-height: unset;
+    display: block;
+}
+
+#frm_form_pf_importer div {
+	margin: 10px 0 !important;
+}
+
+#frm_form_pf_importer button {
+    border: 1px solid var(--primary-500);
+    font-size: var(--text-sm);
+    padding: 7px 16px;
+    min-height: 28px;
+    line-height: var(--leading);
+    margin-bottom: 0;
+	background: var(--primary-500);
+    color: #fff !important;
+}
+
+#frm_form_pf_importer button:hover {
+	background: #135e96;
+    border-color: #135e96;
+    color: #fff;
+}
+
+#welcome-panel {
+	margin: var(--gap-sm) var(--gap-md) var(--gap-md);
+	line-height: 2;
+}
+/* End Pirate forms importer */

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -9345,6 +9345,8 @@ Responsive Design
 /* Pirate forms importer */
 #welcome-panel:has(#frm_form_pf_importer) {
 	background-color: #fff;
+	margin: var(--gap-sm) var(--gap-md) var(--gap-md);
+	line-height: 2;
 }
 
 #welcome-panel:has(#frm_form_pf_importer) .welcome-panel-content {
@@ -9359,7 +9361,6 @@ Responsive Design
 
 #frm_form_pf_importer button {
     border: 1px solid var(--primary-500);
-    font-size: var(--text-sm);
     padding: 7px 16px;
     min-height: 28px;
     line-height: var(--leading);
@@ -9371,11 +9372,5 @@ Responsive Design
 #frm_form_pf_importer button:hover {
 	background: #135e96;
     border-color: #135e96;
-    color: #fff;
-}
-
-#welcome-panel:has(#frm_form_pf_importer)  {
-	margin: var(--gap-sm) var(--gap-md) var(--gap-md);
-	line-height: 2;
 }
 /* End Pirate forms importer */

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -9374,7 +9374,7 @@ Responsive Design
     color: #fff;
 }
 
-#welcome-panel {
+#welcome-panel:has(#frm_form_pf_importer)  {
 	margin: var(--gap-sm) var(--gap-md) var(--gap-md);
 	line-height: 2;
 }


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4362

**Before:**
![image](https://github.com/Strategy11/formidable-forms/assets/41271840/56204017-0920-492d-b93c-41c0bb2f070a)

**After:**
<img width="760" alt="CleanShot 2023-11-30 at 11 44 02@2x" src="https://github.com/Strategy11/formidable-forms/assets/41271840/20f97d77-433b-4264-8126-a0b836b83092">
