### PR TITLE
Add left styling rule when auto fold class is not set on body

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -76,6 +76,10 @@ class FrmAppController {
 			$classes .= ' frm-lite ';
 		}
 
+		if ( get_user_setting( 'unfold' ) && 'f' !== get_user_setting( 'mfold' ) ) {
+			$classes .= ' frm-unfold ';
+		}
+
 		return $classes;
 	}
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -676,7 +676,9 @@ ul.frm_form_nav > li {
 }
 
 .auto-fold.frm-admin-page-styles .frm_page_container,
-.auto-fold .frm_wrap .frm_page_container {
+.auto-fold .frm_wrap .frm_page_container,
+.frm-unfold.frm-admin-page-styles .frm_page_container,
+.frm-unfold .frm_wrap .frm_page_container {
 	left: 160px;
 }
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4464

To replicate Kristine's issue, you can use this snippet:
```
global $_updated_user_settings;
$_updated_user_settings['unfold'] = true;
```

Basically she has the "unfold" user setting on. I'm not totally sure how this gets set though.

This update adds a new `frm-unfold` class when this `unfold` setting is on (so `auto-fold` is never added) and that the `mfold` user preference is not set to `f` which adds the `folded`.

Maybe this is complicating it though. May we just want to not check for the `.auto-fold` class and always set `left: 160px;` by default?