### PR TITLE
Avoid deprecation warnings when calling template functions

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -467,26 +467,7 @@ class FrmFormsController {
 			<link rel="stylesheet" href="<?php bloginfo( 'stylesheet_url' ); ?>" type="text/css" media="screen" />
 			<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
 
-			<?php if ( file_exists( get_stylesheet_directory() . '/images/kubrickbgwide.jpg' ) ) { ?>
-			<style type="text/css" media="screen">
-
-				<?php
-				// Checks to see whether it needs a sidebar.
-				/** @psalm-suppress UndefinedVariable */
-				if ( empty( $withcomments ) && ! is_single() ) { // phpstan-ignore-line
-					?>
-				#page { background: url("<?php bloginfo( 'stylesheet_directory' ); ?>/images/kubrickbg-<?php bloginfo( 'text_direction' ); ?>.jpg") repeat-y top; border: none; }
-			<?php } else { // No sidebar. ?>
-				#page { background: url("<?php bloginfo( 'stylesheet_directory' ); ?>/images/kubrickbgwide.jpg") repeat-y top; border: none; }
-			<?php } ?>
-
-			</style>
-			<?php } ?>
-
 			<?php
-			if ( is_singular() ) {
-				wp_enqueue_script( 'comment-reply' );
-			}
 			wp_head();
 			?>
 			</head>

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -460,7 +460,7 @@ class FrmFormsController {
 			<div id="page">
 				<div id="header" role="banner">
 					<div id="headerimg">
-						<h1><a href="<?php echo home_url(); ?>/"><?php bloginfo( 'name' ); ?></a></h1>
+						<h1><a href="<?php echo esc_url( home_url() ); ?>/"><?php bloginfo( 'name' ); ?></a></h1>
 						<div class="description"><?php bloginfo( 'description' ); ?></div>
 					</div>
 				</div>
@@ -478,8 +478,8 @@ class FrmFormsController {
 						<?php
 						printf(
 							/* translators: 1: Site name, 2: WordPress */
-							__( '%1$s is proudly powered by %2$s' ),
-							get_bloginfo( 'name' ),
+							esc_html__( '%1$s is proudly powered by %2$s', 'formidable' ),
+							esc_html( get_bloginfo( 'name' ) ),
 							'<a href="https://wordpress.org/">WordPress</a>'
 						);
 						?>

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -472,7 +472,8 @@ class FrmFormsController {
 
 				<?php
 				// Checks to see whether it needs a sidebar.
-				if ( empty( $withcomments ) && ! is_single() ) {
+				/** @psalm-suppress UndefinedVariable */
+				if ( empty( $withcomments ) && ! is_single() ) { // phpstan-ignore-line
 					?>
 				#page { background: url("<?php bloginfo( 'stylesheet_directory' ); ?>/images/kubrickbg-<?php bloginfo( 'text_direction' ); ?>.jpg") repeat-y top; border: none; }
 			<?php } else { // No sidebar. ?>

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -455,56 +455,12 @@ class FrmFormsController {
 		}
 
 		if ( 'header' === $template ) {
-			?>
-			<!DOCTYPE html>
-			<html <?php language_attributes(); ?>>
-			<head>
-			<link rel="profile" href="https://gmpg.org/xfn/11" />
-			<meta http-equiv="Content-Type" content="<?php bloginfo( 'html_type' ); ?>; charset=<?php bloginfo( 'charset' ); ?>" />
-
-			<title><?php echo wp_get_document_title(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></title>
-
-			<link rel="stylesheet" href="<?php bloginfo( 'stylesheet_url' ); ?>" type="text/css" media="screen" />
-			<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
-
-			<?php
-			wp_head();
-			?>
-			</head>
-			<body <?php body_class(); ?>>
-			<div id="page">
-				<div id="header" role="banner">
-					<div id="headerimg">
-						<h1><a href="<?php echo esc_url( home_url() ); ?>/"><?php bloginfo( 'name' ); ?></a></h1>
-						<div class="description"><?php bloginfo( 'description' ); ?></div>
-					</div>
-				</div>
-				<hr />
-			<?php
+			include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/preview/header.php';
 			return;
 		}
 
 		if ( 'footer' === $template ) {
-			wp_footer();
-			?>
-				<hr />
-				<div id="footer" role="contentinfo">
-					<p>
-						<?php
-						printf(
-							/* translators: 1: Site name, 2: WordPress */
-							esc_html__( '%1$s is proudly powered by %2$s', 'formidable' ),
-							esc_html( get_bloginfo( 'name' ) ),
-							'<a href="https://wordpress.org/">WordPress</a>'
-						);
-						?>
-					</p>
-				</div>
-			</div>
-			<?php wp_footer(); ?>
-			</body>
-			</html>
-			<?php
+			include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/preview/footer.php';
 		}
 	}
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -453,6 +453,37 @@ class FrmFormsController {
 		}
 
 		if ( 'header' === $template ) {
+			?>
+			<!DOCTYPE html>
+			<html <?php language_attributes(); ?>>
+			<head>
+			<link rel="profile" href="https://gmpg.org/xfn/11" />
+			<meta http-equiv="Content-Type" content="<?php bloginfo( 'html_type' ); ?>; charset=<?php bloginfo( 'charset' ); ?>" />
+
+			<title><?php echo wp_get_document_title(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></title>
+
+			<link rel="stylesheet" href="<?php bloginfo( 'stylesheet_url' ); ?>" type="text/css" media="screen" />
+			<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
+
+			<?php if ( file_exists( get_stylesheet_directory() . '/images/kubrickbgwide.jpg' ) ) { ?>
+			<style type="text/css" media="screen">
+
+				<?php
+				// Checks to see whether it needs a sidebar.
+				if ( empty( $withcomments ) && ! is_single() ) {
+					?>
+				#page { background: url("<?php bloginfo( 'stylesheet_directory' ); ?>/images/kubrickbg-<?php bloginfo( 'text_direction' ); ?>.jpg") repeat-y top; border: none; }
+			<?php } else { // No sidebar. ?>
+				#page { background: url("<?php bloginfo( 'stylesheet_directory' ); ?>/images/kubrickbgwide.jpg") repeat-y top; border: none; }
+			<?php } ?>
+
+			</style>
+			<?php } ?>
+
+			<?php
+			if ( is_singular() ) {
+				wp_enqueue_script( 'comment-reply' );
+			}
 			wp_head();
 			?>
 			</head>

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -465,8 +465,11 @@ class FrmFormsController {
 					</div>
 				</div>
 				<hr />
-		<?php
-		} else {
+			<?php
+			return;
+		}
+
+		if ( 'footer' === $template ) {
 			wp_footer();
 			?>
 				<hr />
@@ -486,7 +489,7 @@ class FrmFormsController {
 			<?php wp_footer(); ?>
 			</body>
 			</html>
-		<?php
+			<?php
 		}
 	}
 

--- a/classes/views/frm-forms/preview/footer.php
+++ b/classes/views/frm-forms/preview/footer.php
@@ -1,0 +1,31 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'You are not allowed to call this page directly.' );
+}
+
+/**
+ * This view is created to avoid deprecation warnings when previewing a form and the
+ * code in this view is mostly copied from "theme-compat/footer.php"
+ *
+ * @since 6.x
+ */
+wp_footer();
+?>
+	<hr />
+	<div id="footer" role="contentinfo">
+		<p>
+			<?php
+			printf(
+				/* translators: 1: Site name, 2: WordPress */
+				esc_html__( '%1$s is proudly powered by %2$s', 'formidable' ),
+				esc_html( get_bloginfo( 'name' ) ),
+				'<a href="https://wordpress.org/">WordPress</a>'
+			);
+			?>
+		</p>
+	</div>
+</div>
+<?php wp_footer(); ?>
+</body>
+</html>
+<?php

--- a/classes/views/frm-forms/preview/header.php
+++ b/classes/views/frm-forms/preview/header.php
@@ -1,0 +1,37 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'You are not allowed to call this page directly.' );
+}
+
+/**
+ * This view is created to avoid deprecation warnings when previewing a form and the
+ * code in this view is mostly copied from "theme-compat/header.php"
+ *
+ * @since 6.x
+ */
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+<link rel="profile" href="https://gmpg.org/xfn/11" />
+<meta http-equiv="Content-Type" content="<?php bloginfo( 'html_type' ); ?>; charset=<?php bloginfo( 'charset' ); ?>" />
+
+<title><?php echo wp_get_document_title(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></title>
+
+<link rel="stylesheet" href="<?php bloginfo( 'stylesheet_url' ); ?>" type="text/css" media="screen" />
+<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
+
+<?php
+wp_head();
+?>
+</head>
+<body <?php body_class(); ?>>
+<div id="page">
+	<div id="header" role="banner">
+		<div id="headerimg">
+			<h1><a href="<?php echo esc_url( home_url() ); ?>/"><?php bloginfo( 'name' ); ?></a></h1>
+			<div class="description"><?php bloginfo( 'description' ); ?></div>
+		</div>
+	</div>
+	<hr />
+<?php


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4478

We can know whether calling functions `get_header` and `get_footer` would cause deprecation warnings ahead of time and avoid it if so. We can instead copy pieces of code from core to call relevant functions and output html fragments required.

### Testing
Preview a form in theme and check the error log for deprecation warnings.

> PHP Deprecated: File Theme without header.php is deprecated since version 3.0.0 with no alternative available. Please include a header.php template in your theme. in /var/www/src/wp-includes/functions.php on line 5646
> PHP Deprecated: str_replace(): Passing null to parameter https://github.com/Strategy11/formidable-pro/issues/3 ($subject) of type array|string is deprecated in /var/www/src/wp-includes/post-template.php on line 257
> PHP Deprecated: File Theme without footer.php is deprecated since version 3.0.0 with no alternative available. Please include a footer.php template in your theme. in /var/www/src/wp-includes/functions.php on line 5646