### PR TITLE
Avoid permanent deletion of forms from trash list on page refresh after emptying the trash

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -549,7 +549,7 @@ class FrmAppController {
 	 * @return void
 	 */
 	public static function admin_init() {
-		if ( FrmAppHelper::get_param( 'delete_all' ) ) {
+		if ( FrmAppHelper::get_param( 'delete_all' ) && FrmAppHelper::is_admin_page( 'formidable' ) && 'trash' === FrmAppHelper::get_param( 'form_type' ) ) {
 			FrmFormsController::delete_all();
 		}
 

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -549,6 +549,10 @@ class FrmAppController {
 	 * @return void
 	 */
 	public static function admin_init() {
+		if ( FrmAppHelper::get_param( 'delete_all' ) ) {
+			FrmFormsController::delete_all();
+		}
+
 		if ( FrmAppHelper::is_admin_page( 'formidable' ) && 'duplicate' === FrmAppHelper::get_param( 'frm_action' ) ) {
 			FrmFormsController::duplicate();
 		}

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1822,6 +1822,7 @@ class FrmFormsController {
 
 				if ( 'forms_permanently_deleted' === $message ) {
 					$count = FrmAppHelper::get_param( 'forms_deleted', 0, 'get', 'absint' );
+					/* translators: %1$s: Number of forms */
 					$message = sprintf( _n( '%1$s form permanently deleted.', '%1$s forms permanently deleted.', $count, 'formidable' ), $count );
 					self::display_forms_list( array(), $message, '' );
 					return;

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -645,7 +645,7 @@ class FrmFormsController {
 		return '';
 	}
 
-	private static function delete_all() {
+	public static function delete_all() {
 		// Check nonce url.
 		$permission_error = FrmAppHelper::permission_nonce_error( 'frm_delete_forms', '_wpnonce', 'bulk-toplevel_page_formidable' );
 		if ( $permission_error !== false ) {
@@ -656,6 +656,11 @@ class FrmFormsController {
 
 		$count   = FrmForm::scheduled_delete( time() );
 
+		$url = remove_query_arg( 'delete_all' );
+		$url .= '&message=forms_permanently_deleted&forms_deleted=' . $count;
+
+		wp_safe_redirect( $url );
+		die();
 		/* translators: %1$s: Number of forms */
 		$message = sprintf( _n( '%1$s form permanently deleted.', '%1$s forms permanently deleted.', $count, 'formidable' ), $count );
 
@@ -1785,7 +1790,6 @@ class FrmFormsController {
 			case 'trash':
 			case 'untrash':
 			case 'destroy':
-			case 'delete_all':
 			case 'settings':
 			case 'update_settings':
 				return self::$action( $vars );
@@ -1814,6 +1818,13 @@ class FrmFormsController {
 				$message = FrmAppHelper::get_param( 'message' );
 				if ( 'form_duplicate_error' === $message ) {
 					self::display_forms_list( array(), '', array( __( 'There was a problem duplicating the form', 'formidable' ) ) );
+					return;
+				}
+
+				if ( 'forms_permanently_deleted' === $message ) {
+					$count = FrmAppHelper::get_param( 'forms_deleted' );
+					$message = sprintf( _n( '%1$s form permanently deleted.', '%1$s forms permanently deleted.', $count, 'formidable' ), $count );
+					self::display_forms_list( array(), $message, '' );
 					return;
 				}
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -645,6 +645,9 @@ class FrmFormsController {
 		return '';
 	}
 
+	/**
+	 * @since x.x Function went from private to public
+	 */
 	public static function delete_all() {
 		// Check nonce url.
 		$permission_error = FrmAppHelper::permission_nonce_error( 'frm_delete_forms', '_wpnonce', 'bulk-toplevel_page_formidable' );
@@ -654,10 +657,10 @@ class FrmFormsController {
 			return;
 		}
 
-		$count   = FrmForm::scheduled_delete( time() );
-
-		$url = remove_query_arg( 'delete_all' );
-		$url .= '&message=forms_permanently_deleted&forms_deleted=' . $count;
+		$count = FrmForm::scheduled_delete( time() );
+		$url   = remove_query_arg( array( 'delete_all' ) );
+		
+		$url  .= '&message=forms_permanently_deleted&forms_deleted=' . $count;
 
 		wp_safe_redirect( $url );
 		die();
@@ -1818,7 +1821,7 @@ class FrmFormsController {
 				}
 
 				if ( 'forms_permanently_deleted' === $message ) {
-					$count = FrmAppHelper::get_param( 'forms_deleted' );
+					$count = FrmAppHelper::get_param( 'forms_deleted', 0, 'get', 'absint' );
 					$message = sprintf( _n( '%1$s form permanently deleted.', '%1$s forms permanently deleted.', $count, 'formidable' ), $count );
 					self::display_forms_list( array(), $message, '' );
 					return;

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -659,7 +659,7 @@ class FrmFormsController {
 
 		$count = FrmForm::scheduled_delete( time() );
 		$url   = remove_query_arg( array( 'delete_all' ) );
-		
+
 		$url  .= '&message=forms_permanently_deleted&forms_deleted=' . $count;
 
 		wp_safe_redirect( $url );

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -661,10 +661,6 @@ class FrmFormsController {
 
 		wp_safe_redirect( $url );
 		die();
-		/* translators: %1$s: Number of forms */
-		$message = sprintf( _n( '%1$s form permanently deleted.', '%1$s forms permanently deleted.', $count, 'formidable' ), $count );
-
-		self::display_forms_list( array(), $message );
 	}
 
 	/**

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -637,10 +637,12 @@ class FrmFormsController {
 			}
 		}
 
-		/* translators: %1$s: Number of forms */
-		$message = sprintf( _n( '%1$s form permanently deleted.', '%1$s forms permanently deleted.', $count, 'formidable' ), $count );
+		if ( $count ) {
+			/* translators: %1$s: Number of forms */
+			return sprintf( _n( '%1$s form permanently deleted.', '%1$s forms permanently deleted.', $count, 'formidable' ), $count );
+		}
 
-		return $message;
+		return '';
 	}
 
 	private static function delete_all() {


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/3184

Removing `delete_all` from the query args and redirecting to the resulting url fixes this issues like similar issues that used the same fix.

### Steps to test

1. Trash some forms, go to the 'Trash' tab from the form list page and then use the 'Empty Trash' button to permanently delete them.
2. Leave that tab as it is and trash more forms in a new tab.
3. Get back to the previous tab and refresh the page
4. Confirm that the forms deleted in step 2 are not deleted from trash