### PR TITLE
Stop dying when showing error modal

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -1158,7 +1158,6 @@ class FrmAppController {
 		}
 
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/error-modal.php';
-		die();
 	}
 
 	/**

--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -489,6 +489,7 @@ class FrmEntriesController {
 				'cancel_url'  => admin_url( 'admin.php?page=formidable-entries' ),
 			);
 			FrmAppController::show_error_modal( $error_args );
+			return;
 		}
 
 		$params = FrmForm::get_admin_params();

--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -423,6 +423,7 @@ class FrmFormActionsController {
 				),
 			);
 			FrmAppController::show_error_modal( $error_args );
+			return;
 		}
 
 		global $wpdb;

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1114,7 +1114,7 @@ class FrmFormsController {
 		);
 		if ( ! $form ) {
 			FrmAppController::show_error_modal( $error_args );
-			wp_die( esc_html__( 'You are trying to edit a form that does not exist.', 'formidable' ) );
+			return;
 		}
 
 		if ( 'trash' === $form->status ) {

--- a/classes/controllers/FrmSettingsController.php
+++ b/classes/controllers/FrmSettingsController.php
@@ -275,6 +275,7 @@ class FrmSettingsController {
 				'cancel_text' => __( 'Cancel', 'formidable' ),
 			);
 			FrmAppController::show_error_modal( $error_args );
+			return;
 		}
 
 		$errors  = array();


### PR DESCRIPTION
Related comment https://github.com/Strategy11/formidable-forms/pull/1280#issuecomment-1781227228

I think the issue is that the full markup isn't loaded.

Now instead of dying I just return everywhere.

I also removed a `wp_die` that was dead code that now would show a second error message.