### PR TITLE
Support string $upgrade_link_args in FrmAddonsController::conditional_action_button

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -1258,10 +1258,10 @@ class FrmAddonsController {
 		$upgrade_link = FrmAppHelper::admin_upgrade_link( $upgrade_link_args );
 
 		if ( ! is_array( $upgrade_link_args ) ) {
-			// A string $args in FrmAppHelper::admin_upgrade_link sets $args as the utm-medium value.
-			$upgrade_link_args = array(
-				'medium' => $upgrade_link_args,
-			);
+			// A string $upgrade_link_args is used for the utm-medium value when calling
+			// FrmAppHelper::admin_upgrade_link above.
+			// For self::addon_upgrade_link, we'll pass just an empty array with the link key (set below).
+			$upgrade_link_args = array();
 		}
 
 		$upgrade_link_args['link'] = $upgrade_link;

--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -1257,7 +1257,15 @@ class FrmAddonsController {
 		$addon        = self::get_addon( $plugin );
 		$upgrade_link = FrmAppHelper::admin_upgrade_link( $upgrade_link_args );
 
+		if ( ! is_array( $upgrade_link_args ) ) {
+			// A string $args in FrmAppHelper::admin_upgrade_link sets $args as the utm-medium value.
+			$upgrade_link_args = array(
+				'medium' => $upgrade_link_args,
+			);
+		}
+
 		$upgrade_link_args['link'] = $upgrade_link;
+
 		self::addon_upgrade_link( $addon, $upgrade_link_args );
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-forms/issues/1405

The welcome page passes `views-info` for the upgrade link args. The function was setting an array key, which causes issues when the variable isn't an array.

This update sets it to an array. By the time `FrmAppHelper::admin_upgrade_link` is called, we no longer need the `medium` value being passed in `$upgrade_link_args`. If it's a string, it's fine to set it to an empty array.

The next line sets the link as before, now with an array value.