### PR TITLE
Optimize the join for record count query

### DIFF
--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -582,7 +582,7 @@ class FrmEntry {
 	 */
 	public static function getRecordCount( $where = '' ) {
 		global $wpdb;
-		$table_join = $wpdb->prefix . 'frm_items it LEFT OUTER JOIN ' . $wpdb->prefix . 'frm_forms fr ON it.form_id=fr.id';
+		$table_join = $wpdb->prefix . 'frm_items it JOIN ' . $wpdb->prefix . 'frm_forms fr ON it.form_id=fr.id';
 
 		if ( is_numeric( $where ) ) {
 			$table_join = 'frm_items';


### PR DESCRIPTION
I noticed this while testing the dashboard.

This is the database query
```
SELECT COUNT(*)
FROM wp_frm_items it
LEFT OUTER JOIN wp_frm_forms fr
ON it.form_id=fr.id
WHERE parent_form_id IS NULL
OR parent_form_id <=1
LIMIT 1
```

This query takes `0.1478` seconds.

Within the `LEFT OUTER JOIN`, using a `INNER JOIN` but omitting the word `INNER` since it's the default,
```
SELECT COUNT(*)
FROM wp_frm_items it
JOIN wp_frm_forms fr
ON it.form_id=fr.id
WHERE parent_form_id IS NULL
OR parent_form_id <=1
LIMIT 1
```

This query takes `0.0368` seconds.

It is 4 times faster in my Query Monitor times.

If I simply run this in my SQL browser it goes from 193ms to to 80ms, still about 2.4 times faster.

The `OUTER JOIN` is really slow.

Changing this means that the entry count will no longer include deleted forms - which seems more accurate to me anyway.
