### PR TITLE
Query for created at only when the string looks like a datetime

### DIFF
--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -79,14 +79,19 @@ class FrmFormsListHelper extends FrmListHelper {
 			preg_match_all( '/".*?("|$)|((?<=[\\s",+])|^)[^\\s",+]+/', $s, $matches );
 			$search_terms = array_map( 'trim', $matches[0] );
 			foreach ( (array) $search_terms as $term ) {
-				$s_query[] = array(
+				$query_part = array(
 					'or'               => true,
 					'name LIKE'        => $term,
 					'description LIKE' => $term,
-					'created_at LIKE'  => $term,
 					'form_key LIKE'    => $term,
 					'id'               => $term,
 				);
+
+				if ( preg_match( '/^[0-9\-: ]+$/', $term ) ) {
+					$query_part['created_at LIKE'] = $term;
+				}
+
+				$s_query[] = $query_part;
 				unset( $term );
 			}
 		}


### PR DESCRIPTION
This fixes https://github.com/Strategy11/formidable-pro/issues/4616

I can trigger this error if I use a query like:

```
SELECT *
FROM wp_frm_forms
WHERE created_at = ''
```

For some reason, `LIKE` doesn't throw this error on my database.

By only querying when the `$term` looks date-like (includes only numbers, dashes, colons, and spaces), the invalid date comparison won't happen.