### PR TITLE
Pro issue 3967

### DIFF
--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -444,6 +444,8 @@ class FrmField {
 
 		if ( isset( $values['type'] ) ) {
 			if ( 'dropdown' === $values['type'] ) {
+				// TO avoid conflicts with security plugins the value "dropdown" is sent for select fields.
+				// This is because "select" gets matched for SQL injection attempts.
 				$values['type'] = 'select';
 			}
 

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -443,6 +443,10 @@ class FrmField {
 		self::preserve_format_option_backslashes( $values );
 
 		if ( isset( $values['type'] ) ) {
+			if ( 'dropdown' === $values['type'] ) {
+				$values['type'] = 'select';
+			}
+
 			$values = apply_filters( 'frm_clean_' . $values['type'] . '_field_options_before_update', $values );
 
 			if ( $values['type'] === 'hidden' && isset( $values['field_options'] ) && isset( $values['field_options']['clear_on_focus'] ) ) {

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -444,7 +444,7 @@ class FrmField {
 
 		if ( isset( $values['type'] ) ) {
 			if ( 'dropdown' === $values['type'] ) {
-				// TO avoid conflicts with security plugins the value "dropdown" is sent for select fields.
+				// To avoid conflicts with security plugins the value "dropdown" is sent for select fields.
 				// This is because "select" gets matched for SQL injection attempts.
 				$values['type'] = 'select';
 			}

--- a/classes/views/frm-fields/back-end/settings.php
+++ b/classes/views/frm-fields/back-end/settings.php
@@ -305,11 +305,16 @@ do_action( 'frm_before_field_options', $field, compact( 'field_obj', 'display', 
 				</label>
 				<select name="field_options[type_<?php echo esc_attr( $field['id'] ); ?>]" id="field_options_type_<?php echo esc_attr( $field['id'] ); ?>">
 					<?php foreach ( $field_types as $fkey => $ftype ) { ?>
-						<option value="<?php echo esc_attr( $fkey ); ?>" <?php echo ( $fkey === $field['type'] ) ? ' selected="selected"' : ''; ?> <?php echo array_key_exists( $fkey, $disabled_fields ) ? 'disabled="disabled"' : ''; ?>>
+						<?php
+						// We need to avoid the word "select" in POST requests.
+						// When "dropdown" is sent as a type value, we'll map it back to "select" with PHP.
+						$type_option_value = 'select' === $fkey ? 'dropdown' : $fkey;
+						?>
+						<option value="<?php echo esc_attr( $type_option_value ); ?>" <?php echo ( $fkey === $field['type'] ) ? ' selected="selected"' : ''; ?> <?php echo array_key_exists( $fkey, $disabled_fields ) ? 'disabled="disabled"' : ''; ?>>
 							<?php echo esc_html( is_array( $ftype ) ? $ftype['name'] : $ftype ); ?>
 						</option>
 						<?php
-						unset( $fkey, $ftype );
+						unset( $fkey, $ftype, $type_option_value );
 					}
 					?>
 				</select>


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/3967

Here's a basic snippet to simulate something similar to the issue from this ticket https://github.com/Strategy11/formidable-pro/issues/3967#issuecomment-1850615714

When any `$_POST` data includes the word "select", this will force a redirect to a 404 page.

```
foreach ( $_POST as $key => $value ) {
	if ( false !== strpos( $value, 'select' ) ) {
		wp_redirect( site_url() . '/404-page' );
		die();
	}
}
```

I tested this fix out as a beta on the customer's website, and it fixes the issue with their security plugin blocking saving a dropdown "select" field.

@stephywells What do you think? Is there anything else I'd need to do here to cover this?
