### PR TITLE
Resolve Zebra Stripe Styling Issue on Bottom Row of View Entry Tables - Issue #4210

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -4497,6 +4497,10 @@ li.frm_field_box > ul.frm_grid_container {
 	padding: 10px;
 }
 
+#form_show_entry_page.frm_wrap .postbox {
+	overflow: hidden;
+}
+
 .frm_image_option_container .frm_image_placeholder_icon svg{
 	height: 150px;
 }


### PR DESCRIPTION
This PR addresses a styling issue identified in [#4210](https://github.com/Strategy11/formidable-pro/issues/4210), which is particularly noticeable when the bottom row of the "View entry" tables has a darker zebra stripe. The problem involves the table corners appearing improperly due to the overlap of background colors on the table's `border-radius` styling.

## QA URL:
https://qa.formidableforms.com/sherv/wp-admin/admin.php?page=formidable-entries&frm_action=show&id=2&form=53

## Related Issue:
[View entry table corners look bad #4210](https://github.com/Strategy11/formidable-pro/issues/4210)

## Testing Instructions:
1. Go to the "View entry" page within the Formidable Forms.
2. Check tables with zebra striping, especially those where the bottom row has a darker stripe.
3. Confirm that the table corners now render cleanly, with no background color extending beyond the rounded corners.

## Output:
### Before
<img width="964" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/c644e842-612a-439a-95ef-fd9f16c3de1d">

### After
<img width="962" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/7960b850-6fc5-4c03-b13b-79a8d3257c50">