### PR TITLE
Fix Warning for modal.php Inclusion in Form Templates on QA Upload

### DIFF
--- a/classes/controllers/FrmFormTemplatesController.php
+++ b/classes/controllers/FrmFormTemplatesController.php
@@ -138,6 +138,8 @@ class FrmFormTemplatesController {
 	 * @since 6.7
 	 */
 	public static function load_admin_hooks() {
+		self::init_template_resources();
+
 		add_action( 'admin_menu', __CLASS__ . '::menu', 14 ); // Use the same priority as Applications so Form Templates appear directly under Applications.
 		add_action( 'admin_footer', __CLASS__ . '::render_modal' );
 		add_filter( 'frm_form_nav_list', __CLASS__ . '::append_new_template_to_nav', 10, 2 );
@@ -167,8 +169,6 @@ class FrmFormTemplatesController {
 			self::PAGE_SLUG,
 			array( __CLASS__, 'render' )
 		);
-
-		self::init_template_resources();
 	}
 
 	/**


### PR DESCRIPTION
This PR addresses the issue reported in [#4640](https://github.com/Strategy11/formidable-pro/issues/4640), where warnings were logged due to the failure in including `modal.php` in `FrmFormTemplatesController.php`. The modification involves moving `self::init_template_resources();` to the `load_admin_hooks` method. This ensures the correct initialization and inclusion of `modal.php`, thereby resolving the warning during plugin upload on the QA site.

## Related Issue
[#4640](https://github.com/Strategy11/formidable-pro/issues/4640)