### PR TITLE
Rename view forms permission

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1706,7 +1706,7 @@ class FrmAppHelper {
 	 */
 	private static function get_lite_capabilities() {
 		return array(
-			'frm_view_forms'      => __( 'View Forms', 'formidable' ),
+			'frm_view_forms'      => __( 'View Forms List', 'formidable' ),
 			'frm_edit_forms'      => __( 'Add and Edit Forms', 'formidable' ),
 			'frm_delete_forms'    => __( 'Delete Forms', 'formidable' ),
 			'frm_change_settings' => __( 'Access this Settings Page', 'formidable' ),


### PR DESCRIPTION
This is to make it less ambiguous since anyone can "view a form" on the front end to preview it.

I'm just renaming `View Forms` to `View Forms List`,

<img width="815" alt="Screen Shot 2023-12-14 at 4 49 45 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/5ae365db-5a67-40cf-982d-509f9c76904a">
