### PR TITLE
Add a sent mothership request flag to FrmAddon to limit requests to o…

### DIFF
--- a/classes/models/FrmAddon.php
+++ b/classes/models/FrmAddon.php
@@ -20,6 +20,16 @@ class FrmAddon {
 	public $license;
 	protected $get_beta = false;
 
+	/**
+	 * This is used to flag other add ons not to send a request.
+	 * We only want to send a single API request per HTTP request.
+	 *
+	 * @since x.x
+	 *
+	 * @var bool
+	 */
+	private static $sent_mothership_request = false;
+
 	public function __construct() {
 
 		if ( empty( $this->plugin_slug ) ) {
@@ -463,6 +473,10 @@ class FrmAddon {
 	}
 
 	private function is_license_revoked() {
+		if ( self::$sent_mothership_request ) {
+			return;
+		}
+
 		if ( empty( $this->license ) || empty( $this->plugin_slug ) || isset( $_POST['license'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			return;
 		}
@@ -472,6 +486,7 @@ class FrmAddon {
 			return;
 		}
 
+		self::$sent_mothership_request = true;
 		$this->update_last_checked();
 
 		$response = $this->get_license_status();


### PR DESCRIPTION
…ur API

Related Slack conversation https://strategy11.slack.com/archives/G01KDLFJTJS/p1703078624583319?thread_ts=1702904869.778139&cid=G01KDLFJTJS

Now instead of all ~20 requests happening at once, it makes a single request and spreads the 20 requests across 20 HTTP requests.

It took me about 12 seconds to load a page with the 20 requests as well, so this update helps take a lot of the load off a single user's request that may make their site seem really slow.

I left some of the requests alone. This is just when calling `is_license_revoked` which can get called a lot in a single request because it's part of the `FrmAddon` constructor.