### PR TITLE
Fix a couple admin spacing issues

### DIFF
--- a/classes/views/frm-fields/back-end/settings.php
+++ b/classes/views/frm-fields/back-end/settings.php
@@ -7,9 +7,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<input type="hidden" name="frm_fields_submitted[]" value="<?php echo esc_attr( $field['id'] ); ?>" />
 	<input type="hidden" name="field_options[field_order_<?php echo esc_attr( $field['id'] ); ?>]" value="<?php echo esc_attr( $field['field_order'] ); ?>"/>
 
-	<div class="frm-sub-label alignright">
-		(ID <?php echo esc_html( $field['id'] ); ?>)
-	</div>
 	<h3 aria-expanded="true">
 		<?php
 		printf(
@@ -18,6 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 			esc_html( $type_name )
 		);
 		?>
+		<span class="frm-sub-label frm-text-sm">
+			(ID <?php echo esc_html( $field['id'] ); ?>)
+		</span>
 	</h3>
 
 	<div class="frm_grid_container frm-collapse-me" role="group">

--- a/classes/views/frm-forms/add_field_links.php
+++ b/classes/views/frm-forms/add_field_links.php
@@ -127,7 +127,7 @@ foreach ( $pro_fields as $field_key => $field_type ) {
 		</div>
 		<?php do_action( 'frm_extra_form_instructions' ); ?>
 
-		<div id="frm-options-panel" class="frm-p-6 tabs-panel frm_hidden">
+		<div id="frm-options-panel" class="tabs-panel frm_hidden">
 			<div class="frm-single-settings">
 				<div class="frm-embed-field-placeholder">
 					<div class="frm-embed-message">

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -65,6 +65,9 @@
 	--box-shadow-md: 0px 1.88298px 3.76596px -0.941489px rgba(16, 24, 40, 0.1), 0px 0.941489px 1.88298px -0.941489px rgba(16, 24, 40, 0.06);
 	--box-shadow-lg: 0px 6px 8px -2px rgba(16, 24, 40, 0.08), 0px 1.88298px 4px -1px rgba(16, 24, 40, 0.03), 0px 0.470745px 1.41223px rgba(16, 24, 40, 0.1), 0px 0.470745px 0.941489px rgba(16, 24, 40, 0.06);
 	--box-shadow-xl: 0px 9.41489px 11.2979px -1.88298px rgba(16, 24, 40, 0.08), 0px 3.76596px 3.76596px -1.88298px rgba(16, 24, 40, 0.03);
+
+	/* Override front-end CSS */
+	--check-label-color: var(--grey-700);
 }
 
 @font-face {
@@ -4833,7 +4836,7 @@ To use this element, you can call the FrmHtmlHelper::toggle function.
 
 .frm_on_label,
 .frm_off_label {
-	color: #444444;
+	color: var(--grey-700);
 }
 
 .frm_toggle {
@@ -4845,7 +4848,7 @@ To use this element, you can call the FrmHtmlHelper::toggle function.
 }
 
 .frm_toggle_block {
-	display: inline-flex;
+	display: inline-flex !important;
     gap: var(--gap-sm);
 	align-items: center;
 }


### PR DESCRIPTION
Toggle field label (add spacing)
Before:
<img width="246" alt="Screenshot 2023-12-27 at 10 57 06 AM" src="https://github.com/Strategy11/formidable-forms/assets/1116876/679ae7a9-cd2c-4588-9b61-53e53d2c63bd">

After:
<img width="274" alt="Screenshot 2023-12-27 at 10 53 00 AM" src="https://github.com/Strategy11/formidable-forms/assets/1116876/1d508a03-c232-4ff3-a286-dd7dbd8ab3be">


Field options heading
Before:
<img width="449" alt="Screenshot 2023-12-27 at 10 55 48 AM" src="https://github.com/Strategy11/formidable-forms/assets/1116876/9e6d05f5-6a2d-4942-80ea-53b0bcb51b20">

After:
<img width="449" alt="Screenshot 2023-12-27 at 10 56 01 AM" src="https://github.com/Strategy11/formidable-forms/assets/1116876/b20874f2-675a-4666-a356-6967ff47afb5">
