### PR TITLE
Fix js Error when switching Product field type

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4977,7 +4977,11 @@ function frmAdminBuildJS() {
 		var link, lookupBlock,
 			fieldID = this.name.replace( 'field_options[data_type_', '' ).replace( ']', '' );
 
-		link = document.getElementById( 'frm_add_watch_lookup_link_' + fieldID ).parentNode;
+		link = document.getElementById( 'frm_add_watch_lookup_link_' + fieldID );
+		if ( ! link ) {
+			return;
+		}
+		link = link.parentNode;
 
 		if ( this.value === 'text' ) {
 			lookupBlock = document.getElementById( 'frm_watch_lookup_block_' + fieldID );


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/4329
Requires https://github.com/Strategy11/formidable-pro/pull/4639 to actually fix the issue.

Switching a Product field type from User defined to Checkbox triggers this error below and this PR fixes that.
<img width="636" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/df1ad863-b743-43ab-b03d-4edb867ab29d">
