### PR TITLE
Add slimselect to basic field style settings

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -281,7 +281,7 @@ legend.frm_hidden{
 .frm_form_fields_error_style,
 .with_frm_style .frm-card-element.StripeElement,
 .with_frm_style .chosen-container-multi .chosen-choices,
-.with_frm_style .-single .chosen-single{
+.with_frm_style .chosen-container-single .chosen-single{
 	background-image:none !important;
 }
 <?php } ?>

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -233,7 +233,8 @@ legend.frm_hidden{
 .frm_form_fields_error_style,
 .with_frm_style .frm-card-element.StripeElement,
 .with_frm_style .chosen-container-multi .chosen-choices,
-.with_frm_style .chosen-container-single .chosen-single{
+.with_frm_style .chosen-container-single .chosen-single,
+.with_frm_style .frm_slimselect.ss-main {
 	color:<?php echo esc_html( $defaults['text_color'] ); ?>;
 	color:var(--text-color)<?php echo esc_html( $important ); ?>;
 	background-color:<?php echo esc_html( $defaults['bg_color'] . $important ); ?>;
@@ -280,7 +281,7 @@ legend.frm_hidden{
 .frm_form_fields_error_style,
 .with_frm_style .frm-card-element.StripeElement,
 .with_frm_style .chosen-container-multi .chosen-choices,
-.with_frm_style .chosen-container-single .chosen-single{
+.with_frm_style .-single .chosen-single{
 	background-image:none !important;
 }
 <?php } ?>


### PR DESCRIPTION
Related PR https://github.com/Strategy11/formidable-pro/pull/4635

This update adds some basic styling rules for the slim select element, like borders, to make it more consistent with other Formidable fields.