### PR TITLE
Avoid a db error when getting payments stats

### DIFF
--- a/stripe/models/FrmTransLitePayment.php
+++ b/stripe/models/FrmTransLitePayment.php
@@ -84,6 +84,10 @@ class FrmTransLitePayment extends FrmTransLiteDb {
 			'total' => array(),
 		);
 
+		if ( ! FrmTransLiteAppHelper::payments_table_exists() ) {
+			return $data;
+		}
+
 		$where = array(
 			'created_at >' => $from_date,
 			'created_at <' => $to_date . ' 23:59:59',


### PR DESCRIPTION
If you haven't connected Stripe Connect, and you're not using PayPal, the table may not exist at all.

I missed that we weren't checking that during review.

Related ticket https://wordpress.org/support/topic/database-errors-from-scheduled-frmemailsummaryhelper/