### PR TITLE
Fix Layout for Email Settings: CC, BCC, and From Fields

### DIFF
--- a/classes/views/frm-form-actions/_email_settings.php
+++ b/classes/views/frm-form-actions/_email_settings.php
@@ -4,13 +4,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<p class="frm_has_shortcodes frm_to_row frm_email_row">
-	<label for="<?php echo esc_attr( $this->get_field_id( 'email_to' ) ); ?>" <?php FrmAppHelper::maybe_add_tooltip( 'email_to' ); ?>>
-		<?php esc_html_e( 'To', 'formidable' ); ?>
-	</label>
-	<input type="text" name="<?php echo esc_attr( $this->get_field_name( 'email_to' ) ); ?>" value="<?php echo esc_attr( $form_action->post_content['email_to'] ); ?>" class="frm_not_email_to frm_email_blur large-text <?php FrmAppHelper::maybe_add_tooltip( 'email_to', 'open' ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'email_to' ) ); ?>" />
-</p>
-
 <p class="frm_bcc_cc_container">
 	<a href="javascript:void(0)" class="button frm_email_buttons frm_cc_button <?php echo esc_attr( ! empty( $form_action->post_content['cc'] ) ? 'frm_hidden' : '' ); ?>" data-emailrow="cc">
 		<?php esc_html_e( 'CC', 'formidable' ); ?>
@@ -18,6 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<a href="javascript:void(0)" class="button frm_email_buttons frm_bcc_button <?php echo esc_attr( ! empty( $form_action->post_content['bcc'] ) ? 'frm_hidden' : '' ); ?>" data-emailrow="bcc">
 		<?php esc_html_e( 'BCC', 'formidable' ); ?>
 	</a>
+</p>
+
+<p class="frm_has_shortcodes frm_to_row frm_email_row">
+	<label for="<?php echo esc_attr( $this->get_field_id( 'email_to' ) ); ?>" <?php FrmAppHelper::maybe_add_tooltip( 'email_to' ); ?>>
+		<?php esc_html_e( 'To', 'formidable' ); ?>
+	</label>
+	<input type="text" name="<?php echo esc_attr( $this->get_field_name( 'email_to' ) ); ?>" value="<?php echo esc_attr( $form_action->post_content['email_to'] ); ?>" class="frm_not_email_to frm_email_blur large-text <?php FrmAppHelper::maybe_add_tooltip( 'email_to', 'open' ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'email_to' ) ); ?>" />
 </p>
 
 <p class="frm_has_shortcodes frm_cc_row frm_email_row<?php echo empty( $form_action->post_content['cc'] ) ? ' frm_hidden' : ''; ?>" >

--- a/classes/views/frm-form-actions/_email_settings.php
+++ b/classes/views/frm-form-actions/_email_settings.php
@@ -38,6 +38,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<input type="text" name="<?php echo esc_attr( $this->get_field_name( 'bcc' ) ); ?>" value="<?php echo esc_attr( $form_action->post_content['bcc'] ); ?>" class="frm_not_email_to large-text <?php FrmAppHelper::maybe_add_tooltip( 'bcc', 'open' ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'bcc' ) ); ?>" />
 </p>
 
+<p class="frm_reply_to_container">
+	<a href="javascript:void(0)" class="button frm_email_buttons frm_reply_to_button <?php echo ( ! empty( $form_action->post_content['reply_to'] ) ? 'frm_hidden' : '' ); ?>" data-emailrow="reply_to">
+		<?php esc_html_e( 'Reply To', 'formidable' ); ?>
+	</a>
+</p>
+
 <p class="frm_has_shortcodes frm_from_row frm_email_row">
 	<label for="<?php echo esc_attr( $this->get_field_id( 'from' ) ); ?>" <?php FrmAppHelper::maybe_add_tooltip( 'from' ); ?>>
 		<?php esc_html_e( 'From', 'formidable' ); ?>
@@ -48,12 +54,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <p class="frm_error_style frm_from_to_match_row <?php echo ( ( $form_action->post_content['from'] !== $form_action->post_content['email_to'] ) ? 'frm_hidden' : '' ); ?>" data-emailrow="from_to_warning">
 	<?php esc_html_e( 'Warning: If you are sending an email to the user, the To and From fields should not match.', 'formidable' ); ?>
-</p>
-
-<p class="frm_reply_to_container">
-	<a href="javascript:void(0)" class="button frm_email_buttons frm_reply_to_button <?php echo ( ! empty( $form_action->post_content['reply_to'] ) ? 'frm_hidden' : '' ); ?>" data-emailrow="reply_to">
-		<?php esc_html_e( 'Reply To', 'formidable' ); ?>
-	</a>
 </p>
 
 <p class="frm_has_shortcodes frm_reply_to_row frm_email_row<?php echo empty( $form_action->post_content['reply_to'] ) ? ' frm_hidden' : ''; ?>">

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5775,12 +5775,19 @@ table td, .form-table tr td {
 	box-shadow: none;
 }
 
-.frm_reply_to_container,
-.frm_bcc_cc_container {
+p.frm_bcc_cc_container,
+p.frm_reply_to_container {
 	float: right;
-	margin: -4px 0 0;
 	z-index: 1;
 	position: relative;
+}
+
+p.frm_bcc_cc_container {
+	margin: 14px 0 0;
+}
+
+p.frm_reply_to_container {
+	margin: -4px 0 0;
 }
 
 .frm_email_row .frm_cancel1_icon:before {
@@ -8469,8 +8476,8 @@ button.frm_choose_image_box,
 	left: 5px;
 }
 
-.rtl .frm_reply_to_container,
-.rtl .frm_bcc_cc_container {
+.rtl p.frm_reply_to_container,
+.rtl p.frm_bcc_cc_container {
 	float: left;
 }
 


### PR DESCRIPTION
This PR addresses the layout issue reported in [Issue #4673](https://github.com/Strategy11/formidable-pro/issues/4673), concerning the misplacement of the CC, BCC, and From fields in the email settings. The objective is to realign these fields for better user experience and interface consistency.

## QA URL:
https://qa.formidableforms.com/sherv/wp-admin/admin.php?page=formidable&frm_action=settings&id=53

## Related Issue:
[Email settings for cc, bcc, and from are out of place #4673](https://github.com/Strategy11/formidable-pro/issues/4673)

## Testing Instructions:
1. Navigate to `WP Admin > Formidable > Forms`.
2. Open an existing form or create a new one and go to its settings.
3. Navigate to `Actions & Notifications > Email Notification`.
4. Verify that the CC, BCC, and From fields are correctly aligned with the "To" field, reflecting the style and layout shown in the provided screenshot.

## Expected Output:
### Before
<img width="1226" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/52cf53ea-34d0-4250-9db0-8e593ee9f86e">

### After
<img width="1222" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/32746586-94d5-46e9-b3b9-c77ede1fceb0">