### PR TITLE
Fix issue with toggling styles for form

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 == Changelog ==
+= 6.7.2 =
+* Fix: The setting to disable Formidable styling on a form was not working and the Formidable styling would still getting applied.
+
 = 6.7.1 =
 * Security: Form input from unprivileged users will now be sanitized more with strict rules and filtered more on display, allowing only a few basic HTML tags (p, i, b, strong and br) with no support for attributes. The allowed tags can be modified using a new frm_allowed_form_input_html filter.
 * Security: Additional sanitizing has been added when making live form builder updates to avoid malicious changes from privileged users.

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -33,7 +33,7 @@ class FrmAppHelper {
 	 *
 	 * @var string
 	 */
-	public static $plug_version = '6.7.1';
+	public static $plug_version = '6.7.2';
 
 	/**
 	 * @var bool

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -951,7 +951,7 @@ BEFORE_HTML;
 			$form = $form->parent_form_id;
 		} elseif ( is_array( $form ) && ! empty( $form['parent_form_id'] ) ) {
 			$form = $form['parent_form_id'];
-		} elseif ( is_array( $form ) && ! empty( $form['custom_style'] ) ) {
+		} elseif ( is_array( $form ) && isset( $form['custom_style'] ) ) {
 			$style = $form['custom_style'];
 		}
 

--- a/formidable.php
+++ b/formidable.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Formidable Forms
  * Description: Quickly and easily create drag-and-drop forms
- * Version: 6.7.1
+ * Version: 6.7.2
  * Plugin URI: https://formidableforms.com/
  * Author URI: https://formidableforms.com/
  * Author: Strategy11 Form Builder Team

--- a/languages/formidable.pot
+++ b/languages/formidable.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the Formidable Forms plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Formidable Forms 6.7.1\n"
+"Project-Id-Version: Formidable Forms 6.7.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/formidable\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-01-03T19:57:32+00:00\n"
+"POT-Creation-Date: 2024-01-05T12:53:33+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.9.0\n"
 "X-Domain: formidable\n"
@@ -6308,7 +6308,7 @@ msgid "Uninstall Now"
 msgstr ""
 
 #: classes/views/frm-settings/permissions.php:7
-msgid "Select users that are allowed access to Formidable. Without access to View Forms, users will be unable to see the Formidable menu."
+msgid "Select users that are allowed access to Formidable. Without access to View Forms List, users will be unable to see the Formidable menu."
 msgstr ""
 
 #: classes/views/frm-settings/settings_cta.php:14

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -63,4 +63,4 @@ parameters:
 		- '#of method FrmFieldName::\_\_construct#'
 		- '#callback of function spl_autoload_register expects#'
 		- '#customer\_id\_error\_message#'
-		- '#Offset 'custom_style' on#'
+		- "#Offset 'custom_style' on#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -63,3 +63,4 @@ parameters:
 		- '#of method FrmFieldName::\_\_construct#'
 		- '#callback of function spl_autoload_register expects#'
 		- '#customer\_id\_error\_message#'
+		- '#Offset 'custom_style' on#'

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: forms, form builder, survey, free, custom form, contact form, form maker, 
 Requires at least: 5.2
 Tested up to: 6.4.2
 Requires PHP: 5.6
-Stable tag: 6.7.1
+Stable tag: 6.7.2
 
 The most advanced WordPress forms plugin. Go beyond contact forms with our drag and drop form builder for surveys, quizzes, and more.
 
@@ -442,6 +442,9 @@ Using our Zapier integration, you can easily connect your website with over 5,00
 See all <a href="https://zapier.com/apps/formidable/integrations">Formidable Zapier Integrations</a>.
 
 == Changelog ==
+= 6.7.2 =
+* Fix: The setting to disable Formidable styling on a form was not working and the Formidable styling would still getting applied.
+
 = 6.7.1 =
 * Security: Form input from unprivileged users will now be sanitized more with strict rules and filtered more on display, allowing only a few basic HTML tags (p, i, b, strong and br) with no support for attributes. The allowed tags can be modified using a new frm_allowed_form_input_html filter.
 * Security: Additional sanitizing has been added when making live form builder updates to avoid malicious changes from privileged users.


### PR DESCRIPTION
Related Slack conversation https://strategy11.slack.com/archives/C799A2R61/p1704452914859179

Custom styles cannot be disabled because this `isset` was changed to a `! empty`.

We need to support "0" as well.

This was introduced with https://github.com/Strategy11/formidable-forms/pull/1415