### PR TITLE
Fix styling toggle appears enabled when disabled from global settings

### DIFF
--- a/classes/views/frm-forms/settings-buttons.php
+++ b/classes/views/frm-forms/settings-buttons.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <p class="howto">
-	<?php esc_html_e( 'Select a style for this form and set your button text.', 'formidable' ); ?>
+	<?php esc_html_e( 'Set your button text.', 'formidable' ); ?>
 </p>
 
 <input type="hidden" name="options[custom_style]" value="<?php echo esc_attr( $values['custom_style'] ); ?>" />

--- a/classes/views/styles/_styles-list.php
+++ b/classes/views/styles/_styles-list.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $frm_settings      = FrmAppHelper::get_settings();
 $globally_disabled = 'none' === $frm_settings->load_style;
-$enabled           = '0' !== $form->options['custom_style'] && ! $globally_disabled;
+$enabled           = 0 !== (int) $form->options['custom_style'] && ! $globally_disabled;
 $card_helper       = new FrmStylesCardHelper( $active_style, $default_style, $form->id, $enabled );
 $styles            = $card_helper->get_styles();
 $custom_styles     = $card_helper->filter_custom_styles( $styles );


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2472223781/185414/

It looks like the "Manage Styling" global settings section is saving "Styling disabled" as a empty string.

The check for this toggle was too strict, checking only for `'0'`. Now I do an `(int)` conversion first and check for `0`.

<img width="926" alt="Screen Shot 2024-01-08 at 9 32 35 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/ea2e873e-6800-4508-91de-35934cb31c35">
<img width="444" alt="Screen Shot 2024-01-08 at 9 34 33 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/3d6697b6-c11c-4232-be0e-f343e9a52cc9">

I also noticed that I forgot to remove the styling description from the Buttons section which no longer has styling settings. So I removed the styling part of the description,
<img width="462" alt="Screen Shot 2024-01-08 at 9 55 11 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/aa100acd-71fd-40e1-b633-86e84a63a83f">
