### PR TITLE
Add new JS hook frm_after_authorize

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -185,6 +185,7 @@ var FrmFormsConnect = window.FrmFormsConnect || ( function( document, window, $ 
 				input.value = '•••••••••••••••••••';
 			}
 
+			wp.hooks.doAction( 'frm_after_authorize', msg );
 			app.showMessage( msg );
 		},
 


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/4706
The logic is all in Pro, but this hook is required.