### PR TITLE
Switch a few options to not autoload for performance

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -1158,7 +1158,7 @@ class FrmAddonsController {
 		$auth = get_option( 'frm_connect_token' );
 		if ( empty( $auth ) ) {
 			$auth = hash( 'sha512', wp_rand() );
-			update_option( 'frm_connect_token', $auth );
+			update_option( 'frm_connect_token', $auth, 'no' );
 		}
 		$link = FrmAppHelper::admin_upgrade_link( 'connect', 'api-connect' );
 		$args = array(

--- a/classes/models/FrmFormState.php
+++ b/classes/models/FrmFormState.php
@@ -219,7 +219,7 @@ class FrmFormState {
 
 		// We don't have a secret, so let's generate one.
 		$secret_key = is_callable( 'sodium_crypto_secretbox_keygen' ) ? sodium_crypto_secretbox_keygen() : wp_generate_password( 32, true, true );
-		add_option( 'frm_form_state_key', base64_encode( $secret_key ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		update_option( 'frm_form_state_key', base64_encode( $secret_key ), 'no' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 
 		return $secret_key;
 	}

--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -59,7 +59,7 @@ class FrmSettings {
 			die( 'You are not allowed to call this page directly.' );
 		}
 
-		$settings = get_transient( $this->option_name );
+		$settings = get_option( $this->option_name );
 
 		if ( ! is_object( $settings ) ) {
 			$settings = $this->translate_settings( $settings );
@@ -81,23 +81,10 @@ class FrmSettings {
 			return unserialize( serialize( $settings ) );
 		}
 
-		$settings = get_option( $this->option_name );
-		if ( is_object( $settings ) ) {
-			set_transient( $this->option_name, $settings );
+		// If unserializing didn't work.
+		$settings = $this;
 
-			return $settings;
-		}
-
-		// If unserializing didn't work
-		if ( $settings ) {
-			// Workaround for W3 total cache conflict.
-			$settings = unserialize( serialize( $settings ) );
-		} else {
-			$settings = $this;
-		}
-
-		update_option( $this->option_name, $settings, 'no' );
-		set_transient( $this->option_name, $settings );
+		update_option( $this->option_name, $settings, 'yes' );
 
 		return $settings;
 	}

--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -96,7 +96,7 @@ class FrmSettings {
 			$settings = $this;
 		}
 
-		update_option( $this->option_name, $settings );
+		update_option( $this->option_name, $settings, 'no' );
 		set_transient( $this->option_name, $settings );
 
 		return $settings;


### PR DESCRIPTION
I'm going through a list of autoload options, and removing what isn't needed on every page.

Also, the settings are duplicated in the autoloading with both the transient and the option. This PR simplifies and optimizes getting the global settings. I'm not seeing a good reason to muddy this up with an extra transient when the option is being auto loaded.

@Crabcyborg do you see any possible issues with this?