### PR TITLE
Fix for Blank "View Payment" Page

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -4198,7 +4198,7 @@ label input[type="checkbox"], label input[type="radio"] {
 }
 
 /* Before `applyZebraStriping` is executed, an empty space is displayed */
-.frm-alt-table:not(.frm-zebra-striping)::before {
+#form_show_entry_page .frm-alt-table:not(.frm-zebra-striping)::before {
 	content: '';
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
This PR addresses the issue where the "View Payment" page appears blank in Lite v6.7.

## Related Issue:
[Issue #4710 - "View Payment" page is blank as of Lite v6.7](https://github.com/Strategy11/formidable-pro/issues/4710)

## QA URL:
https://qa.formidableforms.com/sherv/wp-admin/admin.php?page=formidable-payments&action=show&id=1&type

## Testing Instructions:
1. Navigate to `WP Admin > Formidable > Payments`.
2. Click on any payment to view its details.
3. Verify that the "View Payment" page now displays the content correctly.

## Comparison Output:
### Before Fix (Blank Page):
<img width="1481" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/617a3628-63c8-479b-a038-e41b8b206d40">

### After Fix (Page with Visible Content):
<img width="1466" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/8ab77c72-fa5d-49ee-8f3d-741837fa9983">
