### PR TITLE
Update frm-new-pill to match tags

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3867,7 +3867,7 @@ class FrmAppHelper {
 		if ( null === $text ) {
 			$text = __( 'NEW', 'formidable' );
 		}
-		echo '<span class="frm-new-pill">' . esc_html( $text ) . '</span>';
+		echo '<span class="frm-meta-tag frm-new-pill">' . esc_html( $text ) . '</span>';
 	}
 
 	/**

--- a/classes/views/styles/_style-card.php
+++ b/classes/views/styles/_style-card.php
@@ -34,7 +34,7 @@ $include_info = $is_active_style;
 				</span>
 			<?php } ?>
 			<?php if ( ! empty( $is_new_template ) ) { ?>
-				<span class="frm-new-pill"><?php esc_html_e( 'NEW', 'formidable' ); ?></span>
+				<span class="frm-meta-tag frm-new-pill"><?php esc_html_e( 'NEW', 'formidable' ); ?></span>
 			<?php } ?>
 		</div>
 		<div class="frm-style-card-preview">

--- a/css/admin/applications.css
+++ b/css/admin/applications.css
@@ -67,8 +67,8 @@
 
 /* Card title */
 .frm-application-card h3 {
-	display: inline-flex;
-	max-width: 100%;
+	display: flex;
+	width: 100%;
 	align-items: center;
 	flex-wrap: nowrap;
 	gap: var(--gap-xs);

--- a/css/admin/applications.css
+++ b/css/admin/applications.css
@@ -61,27 +61,36 @@
 	box-shadow: var(--box-shadow-lg);
 }
 
-.frm-application-template-card:hover h4 {
+.frm-application-template-card:hover h3 {
 	color: var(--primary-500);
 }
 
 /* Card title */
-.frm-application-card h4 {
-	display: inline-block;
+.frm-application-card h3 {
+	display: inline-flex;
 	max-width: 100%;
+	align-items: center;
+	flex-wrap: nowrap;
+	gap: var(--gap-xs);
+	margin: 0;
+	font-size: var(--text-sm) !important;
+	font-weight: 500;
+}
+
+.frm-application-card h3 .frmsvg {
+	width: 11px;
+	height: 13px;
+}
+
+.frm-application-card h3 .frm-inner-text {
+	max-width: calc( 100% - 50px );
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
+}
+
+.frm-application-card h3 .frm-meta-tag {
 	margin: 0;
-}
-
-.frm-locked-application-template h4 {
-	opacity: 0.85;
-	max-width: calc( 100% - 30px );
-}
-
-.frm-application-card h4 .frmsvg {
-	margin-right: var(--gap-xs);
 }
 
 #frm_application_templates_grid .frm-application-card .frm-button-secondary {
@@ -106,17 +115,13 @@
 
 /* Card description */
 .frm-application-card > div:first-child > div {
-	font-size: 12px;
-}
-
-.frm-application-card > div {
-	padding: 0 10px;
+	font-size: var(--text-xs);
 }
 
 .frm-application-item-count {
-	font-size: 11px;
-	color: var(--medium-grey);
-	margin-top: 4px;
+	font-size: var(--text-xs);
+	color: var(--grey-500);
+	margin-top: var(--gap-xs);
 }
 
 #frm_view_application_modal .frm_warning_style {
@@ -183,10 +188,6 @@
 
 .frm-admin-page-applications #frm_bs_dropdown .install-now {
 	vertical-align: bottom;
-}
-
-.frm-application-card svg + h4 {
-	margin-left: 10px;
 }
 
 #frm_application_category_filter {

--- a/css/admin/frm_admin_global.css
+++ b/css/admin/frm_admin_global.css
@@ -3,7 +3,7 @@
 	border-radius: 13px;
 	padding: 2px 6px;
 	color: #fff;
-	margin-left: 5px;
+	margin-left: 8px;
 	font-size: 9px;
 	vertical-align: middle;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2840,6 +2840,11 @@ body.frm-body-with-open-modal {
 	color: var(--success-800);
 }
 
+.frm-meta-tag.frm-new-pill {
+	background-color: var(--success-500);
+	vertical-align: text-bottom;
+}
+
 #frm-create-footer {
     padding: 15px 20px;
 }

--- a/js/admin/applications.js
+++ b/js/admin/applications.js
@@ -285,11 +285,11 @@
 
 		function getCardHeader() {
 			const titleWrapper = tag(
-				'h4',
+				'h3',
 				{
 					children: [
 						svg({ href: '#frm_lock_icon' }),
-						document.createTextNode( data.name )
+						span({ className: 'frm-inner-text', text: data.name })
 					]
 				}
 			);

--- a/js/admin/applications.js
+++ b/js/admin/applications.js
@@ -301,7 +301,7 @@
 			});
 
 			if ( data.isNew ) {
-				titleWrapper.appendChild( span({ className: 'frm-new-pill', text: __( 'NEW', 'formidable' ) }) );
+				titleWrapper.appendChild( span({ className: 'frm-new-pill frm-meta-tag', text: __( 'NEW', 'formidable' ) }) );
 			}
 
 			const counter = getItemCounter();


### PR DESCRIPTION
I missed this one the first time around. The "New" tag is also green now.

Before:
<img width="414" alt="Screenshot 2024-01-11 at 9 18 06 AM" src="https://github.com/Strategy11/formidable-forms/assets/1116876/f542743e-b1e2-4a89-9427-8142e0dad547">

After:
<img width="411" alt="Screenshot 2024-01-11 at 9 17 53 AM" src="https://github.com/Strategy11/formidable-forms/assets/1116876/87caf399-7d79-4f47-a3ce-a51a8b0026c2">
<img width="419" alt="Screenshot 2024-01-11 at 9 19 28 AM" src="https://github.com/Strategy11/formidable-forms/assets/1116876/b1d23483-c6ca-45c3-b28b-3ef2f18d49e8">
<img width="951" alt="Screenshot 2024-01-11 at 9 52 21 AM" src="https://github.com/Strategy11/formidable-forms/assets/1116876/dc43e7e0-7f92-48e2-95d8-086f22da214c">

I had to make a few changes to the application list so this would fit. We'll need to circle back to this later to match the template page better since this isn't ideal.
<img width="313" alt="Screenshot 2024-01-11 at 10 16 18 AM" src="https://github.com/Strategy11/formidable-forms/assets/1116876/ad3cb73c-8366-4f7b-85ce-7a850c5ad3de">

