### PR TITLE
Fix: Correct Placement of Support Footer Links on Lite-Reports Page

### DIFF
--- a/classes/views/shared/reports-info.php
+++ b/classes/views/shared/reports-info.php
@@ -4,34 +4,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <div class="frm_wrap">
-	<div class="frm_page_container">
-		<?php
-		FrmAppHelper::get_admin_header(
-			array(
-				'label'       => __( 'Reports', 'formidable' ),
-				'form'        => $form,
-				'close'       => $form ? admin_url( 'admin.php?page=formidable&frm_action=reports&form=' . $form->id ) : '',
-			)
-		);
-		?>
-		<div class="frmcenter" style="margin-top:10vh">
-			<h2><?php esc_html_e( 'Get Live Graphs and Reports', 'formidable' ); ?></h2>
-			<p style="max-width:400px;margin:20px auto">
-				<?php esc_html_e( 'Get more insight for surveys, polls, daily contacts, and more.', 'formidable' ); ?>
-			</p>
-			<a class="button button-primary frm-button-primary" href="<?php echo esc_url( FrmAppHelper::admin_upgrade_link( 'reports-info' ) ); ?>" target="_blank" rel="noopener">
-				<?php esc_html_e( 'Upgrade Now', 'formidable' ); ?>
-			</a>
-			<div class="frm-settings-screenshot-wrapper" style="margin-top: 30px;">
-				<div class="frm-settings-screenshot-toolbar">
-					<div class="frm-minmax-icon" style="background-color: #ED8181"></div>
-					<div class="frm-minmax-icon" style="background-color: #EDE06A"></div>
-					<div class="frm-minmax-icon" style="background-color: #80BE30"></div>
-					<img src="<?php echo esc_url( FrmAppHelper::plugin_url() . '/images/tab.svg' ); ?>" />
-				</div>
-				<div>
-					<img src="<?php echo esc_attr( FrmAppHelper::plugin_url() . '/images/screenshots/reports.png' ); ?>" alt="<?php esc_attr_e( 'View reports', 'formidable' ); ?>" height="243" />
-				</div>
+	<?php
+	FrmAppHelper::get_admin_header(
+		array(
+			'label'       => __( 'Reports', 'formidable' ),
+			'form'        => $form,
+			'close'       => $form ? admin_url( 'admin.php?page=formidable&frm_action=reports&form=' . $form->id ) : '',
+		)
+	);
+	?>
+	<div class="frmcenter" style="margin-top:10vh">
+		<h2><?php esc_html_e( 'Get Live Graphs and Reports', 'formidable' ); ?></h2>
+		<p style="max-width:400px;margin:20px auto">
+			<?php esc_html_e( 'Get more insight for surveys, polls, daily contacts, and more.', 'formidable' ); ?>
+		</p>
+		<a class="button button-primary frm-button-primary" href="<?php echo esc_url( FrmAppHelper::admin_upgrade_link( 'reports-info' ) ); ?>" target="_blank" rel="noopener">
+			<?php esc_html_e( 'Upgrade Now', 'formidable' ); ?>
+		</a>
+		<div class="frm-settings-screenshot-wrapper" style="margin-top: 30px;">
+			<div class="frm-settings-screenshot-toolbar">
+				<div class="frm-minmax-icon" style="background-color: #ED8181"></div>
+				<div class="frm-minmax-icon" style="background-color: #EDE06A"></div>
+				<div class="frm-minmax-icon" style="background-color: #80BE30"></div>
+				<img src="<?php echo esc_url( FrmAppHelper::plugin_url() . '/images/tab.svg' ); ?>" />
+			</div>
+			<div>
+				<img src="<?php echo esc_attr( FrmAppHelper::plugin_url() . '/images/screenshots/reports.png' ); ?>" alt="<?php esc_attr_e( 'View reports', 'formidable' ); ?>" height="243" />
 			</div>
 		</div>
 	</div>

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9489,7 +9489,7 @@ function frmAdminBuildJS() {
 	 */
 	function addAdminFooterLinks() {
 		const footerLinks = document.querySelector( '.frm-admin-footer-links' );
-		const container = document.querySelector( '.frm_page_container' ) ?? document.querySelector( '#wpbody-content' );
+		const container = document.querySelector( '.frm_page_container' ) ?? document.getElementById( 'wpbody-content' );
 
 		if ( ! footerLinks || ! container ) {
 			return;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9489,13 +9489,13 @@ function frmAdminBuildJS() {
 	 */
 	function addAdminFooterLinks() {
 		const footerLinks = document.querySelector( '.frm-admin-footer-links' );
-		const bodyContent = document.querySelector( '#wpbody-content' );
+		const container = document.querySelector( '.frm_page_container' ) ?? document.querySelector( '#wpbody-content' );
 
-		if ( ! footerLinks || ! bodyContent ) {
+		if ( ! footerLinks || ! container ) {
 			return;
 		}
 
-		bodyContent.appendChild( footerLinks );
+		container.appendChild( footerLinks );
 		footerLinks.classList.remove( 'frm_hidden' );
 	}
 


### PR DESCRIPTION
This PR addresses the issue where support footer links are not correctly positioned on the "lite-reports" page (#4714). Currently, these links appear at the top of the page, above the content, and move up and down when scrolling, rather than staying in a fixed position.

## QA URL:
https://qa.formidableforms.com/sherv/wp-admin/admin.php?page=formidable&frm_action=lite-reports&form=1162

## Related Issue:
[Support footer links don't appear in the right place on the "lite-reports" page](https://github.com/Strategy11/formidable-pro/issues/4714)

## Accessing the Issue:
To reproduce this issue:
1. Disable Pro.
2. Go to a form with entries.
3. Click on the greyed-out "Reports" tab.
   - Example URL: `https://example.com/wp-admin/admin.php?page=formidable&frm_action=lite-reports&form=1162`

## Changes Made:
This PR includes adjustments to ensure the support footer links appear in their correct position on the "lite-reports" page, enhancing the user interface and usability.

## Output:
### Before
<img width="1512" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/2e7619e0-5146-447a-8a80-de17d57e0906">

### After
<img width="1508" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/2dd96b3d-efd1-4ccb-9011-e48beaaa3ec8">
