### PR TITLE
Pro issue 4713 / Add a draft flag to new fields and hide them from the front end except for on preview

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -81,6 +81,9 @@ class FrmFieldsController {
 	public static function include_new_field( $field_type, $form_id ) {
 		$field_values = FrmFieldsHelper::setup_new_vars( $field_type, $form_id );
 
+		// When a new field is added to the form, flag it as draft and hide it from the front-end.
+		$field_values['field_options']['draft'] = 1;
+
 		/**
 		 * @param array $field_values
 		 */

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -213,6 +213,24 @@ class FrmFormsController {
 		if ( count( $errors ) > 0 ) {
 			return self::get_edit_vars( $id, $errors );
 		} else {
+			$draft_field_rows = FrmDb::get_results(
+				'frm_fields',
+				array(
+					'form_id'            => $id,
+					'field_options LIKE' => 's:5:"draft";i:1;',
+				),
+				'id, field_options'
+			);
+			foreach ( $draft_field_rows as $row ) {
+				FrmAppHelper::unserialize_or_decode( $row->field_options );
+				if ( ! is_array( $row->field_options ) || empty( $row->field_options['draft'] ) ) {
+					continue;
+				}
+
+				$row->field_options['draft'] = 0;
+				FrmField::update( $row->id, array( 'field_options' => $row->field_options ) );
+			}
+
 			FrmForm::update( $id, $values );
 			$message = __( 'Form was successfully updated.', 'formidable' );
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -213,23 +213,7 @@ class FrmFormsController {
 		if ( count( $errors ) > 0 ) {
 			return self::get_edit_vars( $id, $errors );
 		} else {
-			$draft_field_rows = FrmDb::get_results(
-				'frm_fields',
-				array(
-					'form_id'            => $id,
-					'field_options LIKE' => 's:5:"draft";i:1;',
-				),
-				'id, field_options'
-			);
-			foreach ( $draft_field_rows as $row ) {
-				FrmAppHelper::unserialize_or_decode( $row->field_options );
-				if ( ! is_array( $row->field_options ) || empty( $row->field_options['draft'] ) ) {
-					continue;
-				}
-
-				$row->field_options['draft'] = 0;
-				FrmField::update( $row->id, array( 'field_options' => $row->field_options ) );
-			}
+			self::remove_draft_option_from_all_fields( $id );
 
 			FrmForm::update( $id, $values );
 			$message = __( 'Form was successfully updated.', 'formidable' );
@@ -249,6 +233,32 @@ class FrmFormsController {
 
 			return self::get_edit_vars( $id, array(), $message );
 		}//end if
+	}
+
+	/**
+	 * @since x.x
+	 *
+	 * @param int $id
+	 * @return void
+	 */
+	private static function remove_draft_option_from_all_fields( $form_id ) {
+		$draft_field_rows = FrmDb::get_results(
+			'frm_fields',
+			array(
+				'form_id'            => $form_id,
+				'field_options LIKE' => 's:5:"draft";i:1;',
+			),
+			'id, field_options'
+		);
+		foreach ( $draft_field_rows as $row ) {
+			FrmAppHelper::unserialize_or_decode( $row->field_options );
+			if ( ! is_array( $row->field_options ) || empty( $row->field_options['draft'] ) ) {
+				continue;
+			}
+
+			$row->field_options['draft'] = 0;
+			FrmField::update( $row->id, array( 'field_options' => $row->field_options ) );
+		}
 	}
 
 	/**

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -256,21 +256,8 @@ class FrmFormsController {
 			return;
 		}
 
-		$draft_field_rows = FrmDb::get_results(
-			'frm_fields',
-			array(
-				'id'                 => $draft_field_ids,
-				'form_id'            => $form_id,
-				'field_options LIKE' => 's:5:"draft";i:1;',
-			),
-			'id, field_options'
-		);
+		$draft_field_rows = FrmFieldsHelper::get_draft_field_results( $form_id, $draft_field_ids );
 		foreach ( $draft_field_rows as $row ) {
-			FrmAppHelper::unserialize_or_decode( $row->field_options );
-			if ( ! is_array( $row->field_options ) || empty( $row->field_options['draft'] ) ) {
-				continue;
-			}
-
 			$row->field_options['draft'] = 0;
 			FrmField::update( $row->id, array( 'field_options' => $row->field_options ) );
 		}

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -238,7 +238,7 @@ class FrmFormsController {
 	/**
 	 * @since x.x
 	 *
-	 * @param int $id
+	 * @param int $form_id
 	 * @return void
 	 */
 	private static function remove_draft_option_from_all_fields( $form_id ) {

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -236,6 +236,8 @@ class FrmFormsController {
 	}
 
 	/**
+	 * Remove the draft flag from any new fields from this current session.
+	 *
 	 * @since x.x
 	 *
 	 * @param int $form_id
@@ -244,11 +246,13 @@ class FrmFormsController {
 	private static function maybe_remove_draft_option_from_fields( $form_id ) {
 		$draft_field_ids_csv = FrmAppHelper::get_post_param( 'draft_fields', '', 'sanitize_text_field' );
 		if ( ! $draft_field_ids_csv ) {
+			// If the draft_fields input is empty there are no new fields in the session.
 			return;
 		}
 
 		$draft_field_ids = array_filter( explode( ',', $draft_field_ids_csv ), 'is_numeric' );
 		if ( ! $draft_field_ids ) {
+			// Exit early if the draft fields input is invalid. It should be a CSV of integer values.
 			return;
 		}
 

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -2162,7 +2162,6 @@ class FrmFieldsHelper {
 	 * @since x.x
 	 *
 	 * @param string|int $form_id
-	 * @param array      $field_ids
 	 * @return array
 	 */
 	public static function get_all_draft_field_ids( $form_id ) {

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -2132,8 +2132,9 @@ class FrmFieldsHelper {
 		$draft_field_rows = FrmDb::get_results(
 			'frm_fields',
 			array(
-				'form_id'            => $form_id,
-				'field_options LIKE' => 's:5:"draft";i:1;', // Do a soft check for fields that look like drafts only.
+				'form_id' => $form_id,
+				// Do a soft check for fields that look like drafts only.
+				'field_options LIKE' => 's:5:"draft";i:1;',
 			),
 			'id, field_options'
 		);

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -2120,25 +2120,54 @@ class FrmFieldsHelper {
 	}
 
 	/**
+	 * @since x.x
+	 *
+	 * @param string|int $form_id
+	 * @param array      $field_ids If this is not empty, the results will be filtered by field id.
+	 * @return array
+	 */
+	public static function get_draft_field_results( $form_id, $field_ids = array() ) {
+		if ( FrmAppHelper::pro_is_installed() ) {
+			$child_form_ids = FrmDb::get_col( 'frm_forms', array( 'parent_form_id' => $form_id ) );
+			$form_ids       = array_merge( array( $form_id ), $child_form_ids );
+		} else {
+			$form_ids = array( $form_id );
+		}
+
+		$where = array(
+			'form_id' => $form_ids,
+			// Do a soft check for fields that look like drafts only.
+			'field_options LIKE' => 's:5:"draft";i:1;',
+		);
+
+		if ( $field_ids ) {
+			$where['id'] = $field_ids;
+		}
+
+		$rows = FrmDb::get_results( 'frm_fields', $where, 'id, field_options' );
+
+		return array_filter(
+			$rows,
+			function( $row ) {
+				FrmAppHelper::unserialize_or_decode( $row->field_options );
+				return is_array( $row->field_options ) && ! empty( $row->field_options['draft'] );
+			}
+		);
+	}
+
+	/**
 	 * This is called when loading the form builder.
 	 * Any unsaved draft fields get added to a hidden draft_fields input on load.
 	 *
 	 * @since x.x
 	 *
 	 * @param string|int $form_id
+	 * @param array      $field_ids
 	 * @return array
 	 */
 	public static function get_all_draft_field_ids( $form_id ) {
-		$draft_field_rows = FrmDb::get_results(
-			'frm_fields',
-			array(
-				'form_id' => $form_id,
-				// Do a soft check for fields that look like drafts only.
-				'field_options LIKE' => 's:5:"draft";i:1;',
-			),
-			'id, field_options'
-		);
-		$draft_field_ids = array();
+		$draft_field_rows = self::get_draft_field_results( $form_id );
+		$draft_field_ids  = array();
 		// Unserialzie field options and confirm that fields are actually draft.
 		foreach ( $draft_field_rows as $row ) {
 			FrmAppHelper::unserialize_or_decode( $row->field_options );

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -2167,17 +2167,7 @@ class FrmFieldsHelper {
 	 */
 	public static function get_all_draft_field_ids( $form_id ) {
 		$draft_field_rows = self::get_draft_field_results( $form_id );
-		$draft_field_ids  = array();
-		// Unserialzie field options and confirm that fields are actually draft.
-		foreach ( $draft_field_rows as $row ) {
-			FrmAppHelper::unserialize_or_decode( $row->field_options );
-			if ( ! is_array( $row->field_options ) || empty( $row->field_options['draft'] ) ) {
-				continue;
-			}
-
-			$draft_field_ids[] = $row->id;
-		}
-		return $draft_field_ids;
+		return wp_list_pluck( $draft_field_rows, 'id' );
 	}
 
 	/**

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -2120,6 +2120,11 @@ class FrmFieldsHelper {
 	}
 
 	/**
+	 * This is called when loading the form builder.
+	 * Any unsaved draft fields get added to a hidden draft_fields input on load.
+	 *
+	 * @since x.x
+	 *
 	 * @param string|int $form_id
 	 * @return array
 	 */
@@ -2128,11 +2133,12 @@ class FrmFieldsHelper {
 			'frm_fields',
 			array(
 				'form_id'            => $form_id,
-				'field_options LIKE' => 's:5:"draft";i:1;',
+				'field_options LIKE' => 's:5:"draft";i:1;', // Do a soft check for fields that look like drafts only.
 			),
 			'id, field_options'
 		);
 		$draft_field_ids = array();
+		// Unserialzie field options and confirm that fields are actually draft.
 		foreach ( $draft_field_rows as $row ) {
 			FrmAppHelper::unserialize_or_decode( $row->field_options );
 			if ( ! is_array( $row->field_options ) || empty( $row->field_options['draft'] ) ) {

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -2120,6 +2120,31 @@ class FrmFieldsHelper {
 	}
 
 	/**
+	 * @param string|int $form_id
+	 * @return array
+	 */
+	public static function get_all_draft_field_ids( $form_id ) {
+		$draft_field_rows = FrmDb::get_results(
+			'frm_fields',
+			array(
+				'form_id'            => $form_id,
+				'field_options LIKE' => 's:5:"draft";i:1;',
+			),
+			'id, field_options'
+		);
+		$draft_field_ids = array();
+		foreach ( $draft_field_rows as $row ) {
+			FrmAppHelper::unserialize_or_decode( $row->field_options );
+			if ( ! is_array( $row->field_options ) || empty( $row->field_options['draft'] ) ) {
+				continue;
+			}
+
+			$draft_field_ids[] = $row->id;
+		}
+		return $draft_field_ids;
+	}
+
+	/**
 	 * @deprecated 4.0
 	 */
 	public static function show_icon_link_js( $atts ) {

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -719,6 +719,7 @@ DEFAULT_HTML;
 			'step'               => 1,
 			'format'             => '',
 			'placeholder'        => '',
+			'draft'              => 0,
 		);
 		$field_opts = $this->extra_field_opts();
 		$opts       = array_merge( $opts, $field_opts );
@@ -813,6 +814,11 @@ DEFAULT_HTML;
 	 * @return string
 	 */
 	public function prepare_field_html( $args ) {
+		if ( FrmField::get_option( $this->field, 'draft' ) ) {
+			// A draft field is never shown on the front-end.
+			return '';
+		}
+
 		$args = $this->fill_display_field_values( $args );
 		if ( $this->has_html ) {
 			$args['html']      = $this->before_replace_html_shortcodes( $args, FrmAppHelper::maybe_kses( FrmField::get_option( $this->field, 'custom_html' ) ) );

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -83,6 +83,11 @@ abstract class FrmFieldType {
 	protected $array_allowed = true;
 
 	/**
+	 * @var bool|null Whether or not draft fields should be hidden on the front end.
+	 */
+	private static $should_hide_draft_fields;
+
+	/**
 	 * @param object|array|int $field
 	 * @param string           $type
 	 */
@@ -814,7 +819,7 @@ DEFAULT_HTML;
 	 * @return string
 	 */
 	public function prepare_field_html( $args ) {
-		if ( FrmField::get_option( $this->field, 'draft' ) ) {
+		if ( FrmField::get_option( $this->field, 'draft' ) && $this->should_hide_draft_field() ) {
 			// A draft field is never shown on the front-end.
 			return '';
 		}
@@ -837,6 +842,20 @@ DEFAULT_HTML;
 		}
 
 		return $html;
+	}
+
+	/**
+	 * A draft field can be previewed on the preview page for a user who can edit forms.
+	 *
+	 * @since x.x
+	 *
+	 * @return bool
+	 */
+	private function should_hide_draft_field() {
+		if ( ! isset( self::$should_hide_draft_fields ) ) {
+			self::$should_hide_draft_fields = ! FrmAppHelper::is_preview_page() || ! current_user_can( 'frm_edit_forms' );
+		}
+		return self::$should_hide_draft_fields;
 	}
 
 	/**

--- a/classes/views/frm-fields/back-end/settings.php
+++ b/classes/views/frm-fields/back-end/settings.php
@@ -5,7 +5,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div class="frm-single-settings frm_hidden frm-fields frm-type-<?php echo esc_attr( $field['type'] ); ?>" id="frm-single-settings-<?php echo esc_attr( $field['id'] ); ?>" data-fid="<?php echo esc_attr( $field['id'] ); ?>">
 	<input type="hidden" name="frm_fields_submitted[]" value="<?php echo esc_attr( $field['id'] ); ?>" />
-	<input type="hidden" name="field_options[field_order_<?php echo esc_attr( $field['id'] ); ?>]" value="<?php echo esc_attr( $field['field_order'] ); ?>"/>
+	<input type="hidden" name="field_options[field_order_<?php echo esc_attr( $field['id'] ); ?>]" value="<?php echo esc_attr( $field['field_order'] ); ?>" />
+
+	<?php // Always set 0 to unset draft on form update. ?>
+	<input type="hidden" name="field_options[draft_<?php echo esc_attr( $field['id'] ); ?>]" value="0" />
 
 	<h3 aria-expanded="true">
 		<?php

--- a/classes/views/frm-fields/back-end/settings.php
+++ b/classes/views/frm-fields/back-end/settings.php
@@ -7,9 +7,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<input type="hidden" name="frm_fields_submitted[]" value="<?php echo esc_attr( $field['id'] ); ?>" />
 	<input type="hidden" name="field_options[field_order_<?php echo esc_attr( $field['id'] ); ?>]" value="<?php echo esc_attr( $field['field_order'] ); ?>" />
 
-	<?php // Always set 0 to unset draft on form update. ?>
-	<input type="hidden" name="field_options[draft_<?php echo esc_attr( $field['id'] ); ?>]" value="0" />
-
 	<h3 aria-expanded="true">
 		<?php
 		printf(

--- a/classes/views/frm-forms/add_field.php
+++ b/classes/views/frm-forms/add_field.php
@@ -42,12 +42,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	</div>
 
-	<?php if ( ! empty( $field['draft'] ) ) { ?>
-		<div class="frm_note_style">
-			This field is unsaved and will not appear in the form builder until this builder is saved.
-		</div>
-	<?php } ?>
-
 	<label class="frm_primary_label" id="field_label_<?php echo esc_attr( $field['id'] ); ?>">
 		<?php echo FrmAppHelper::kses( force_balance_tags( $field['name'] ), 'all' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		<span class="frm_required <?php echo esc_attr( FrmField::is_required( $field ) ? '' : 'frm_hidden' ); ?>">

--- a/classes/views/frm-forms/add_field.php
+++ b/classes/views/frm-forms/add_field.php
@@ -42,6 +42,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	</div>
 
+	<?php if ( ! empty( $field['draft'] ) ) { ?>
+		<div class="frm_note_style">
+			This field is unsaved and will not appear in the form builder until this builder is saved.
+		</div>
+	<?php } ?>
+
 	<label class="frm_primary_label" id="field_label_<?php echo esc_attr( $field['id'] ); ?>">
 		<?php echo FrmAppHelper::kses( force_balance_tags( $field['name'] ), 'all' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		<span class="frm_required <?php echo esc_attr( FrmField::is_required( $field ) ? '' : 'frm_hidden' ); ?>">

--- a/classes/views/frm-forms/add_field_links.php
+++ b/classes/views/frm-forms/add_field_links.php
@@ -139,6 +139,7 @@ foreach ( $pro_fields as $field_key => $field_type ) {
 				<input type="hidden" name="frm_action" value="update" />
 				<input type="hidden" name="action" value="update" />
 				<input type="hidden" name="id" id="form_id" value="<?php echo esc_attr( $values['id'] ); ?>" />
+				<input type="hidden" name="draft_fields" id="draft_fields" value="<?php echo esc_attr( implode( ',', FrmFieldsHelper::get_all_draft_field_ids( $values['id'] ) ) ); ?>" />
 				<?php wp_nonce_field( 'frm_save_form_nonce', 'frm_save_form' ); ?>
 				<input type="hidden" id="frm-end-form-marker" name="frm_end" value="1" />
 

--- a/classes/views/frm-forms/edit.php
+++ b/classes/views/frm-forms/edit.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	?>
 
 	<div class="columns-2">
-	<?php require( FrmAppHelper::plugin_path() . '/classes/views/frm-forms/add_field_links.php' ); ?>
+	<?php require FrmAppHelper::plugin_path() . '/classes/views/frm-forms/add_field_links.php'; ?>
 	<div id="post-body-content">
 
 	<div class="frm_form_builder with_frm_style">
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</p>
 
 		<form method="post">
-			<?php require( FrmAppHelper::plugin_path() . '/classes/views/frm-forms/form.php' ); ?>
+			<?php require FrmAppHelper::plugin_path() . '/classes/views/frm-forms/form.php'; ?>
 		</form>
 
 	</div>

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2435,7 +2435,7 @@ function frmAdminBuildJS() {
 		addFieldIdToDraftFieldsInput( field );
 
 		let toggled = false;
-			
+
 		fieldUpdated();
 		setupSortable( section );
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2432,7 +2432,7 @@ function frmAdminBuildJS() {
 		const $thisSection = jQuery( section );
 		const type         = field.getAttribute( 'data-type' );
 
-		addFieldIdToDraftFieldsInput( field );
+		checkHtmlForNewFields( msg );
 
 		let toggled = false;
 
@@ -2503,6 +2503,18 @@ function frmAdminBuildJS() {
 	}
 
 	/**
+	 * Since multiple new fields may get added when a new field is inserted, check the HTML.
+	 *
+	 * @param {string} html
+	 * @returns {void}
+	 */
+	function checkHtmlForNewFields( html ) {
+		const element = div();
+		element.innerHTML = html;
+		element.querySelectorAll( '.form-field' ).forEach( addFieldIdToDraftFieldsInput );
+	}
+
+	/**
 	 * @param {HTMLElement} field
 	 * @returns {void}
 	 */
@@ -2519,7 +2531,10 @@ function frmAdminBuildJS() {
 		if ( '' === draftInput.value ) {
 			draftInput.value = field.dataset.fid;
 		} else {
-			draftInput.value += ',' + field.dataset.fid;
+			const split = draftInput.value.split( ',' );
+			if ( ! split.includes( field.dataset.fid ) ) {
+				draftInput.value += ',' + field.dataset.fid;
+			}
 		}
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2434,6 +2434,7 @@ function frmAdminBuildJS() {
 			toggled = false,
 			$parentSection;
 
+		fieldUpdated();
 		setupSortable( section );
 
 		if ( 'quantity' === type ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2425,15 +2425,15 @@ function frmAdminBuildJS() {
 	}
 
 	function afterAddField( msg, addFocus ) {
-		var regex = /id="(\S+)"/,
-			match = regex.exec( msg ),
-			field = document.getElementById( match[1]),
-			section = '#' + match[1] + '.edit_field_type_divider ul.frm_sorting.start_divider',
-			$thisSection = jQuery( section ),
-			type = field.getAttribute( 'data-type' ),
-			toggled = false,
-			$parentSection;
+		const regex        = /id="(\S+)"/;
+		const match        = regex.exec( msg );
+		const field        = document.getElementById( match[1]);
+		const section      = '#' + match[1] + '.edit_field_type_divider ul.frm_sorting.start_divider';
+		const $thisSection = jQuery( section );
+		const type         = field.getAttribute( 'data-type' );
 
+		let toggled = false;
+			
 		fieldUpdated();
 		setupSortable( section );
 
@@ -2451,7 +2451,7 @@ function frmAdminBuildJS() {
 		if ( $thisSection.length ) {
 			$thisSection.parent( '.frm_field_box' ).children( '.frm_no_section_fields' ).addClass( 'frm_block' );
 		} else {
-			$parentSection = jQuery( field ).closest( 'ul.frm_sorting.start_divider' );
+			const $parentSection = jQuery( field ).closest( 'ul.frm_sorting.start_divider' );
 			if ( $parentSection.length ) {
 				toggleOneSectionHolder( $parentSection );
 				toggled = true;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2432,6 +2432,8 @@ function frmAdminBuildJS() {
 		const $thisSection = jQuery( section );
 		const type         = field.getAttribute( 'data-type' );
 
+		addFieldIdToDraftFieldsInput( field );
+
 		let toggled = false;
 			
 		fieldUpdated();
@@ -2498,6 +2500,27 @@ function frmAdminBuildJS() {
 		addedEvent.frmType    = type;
 		addedEvent.frmToggles = toggled;
 		document.dispatchEvent( addedEvent );
+	}
+
+	/**
+	 * @param {HTMLElement} field
+	 * @returns {void}
+	 */
+	function addFieldIdToDraftFieldsInput( field ) {
+		if ( ! field.dataset.fid ) {
+			return;
+		}
+
+		const draftInput = document.getElementById( 'draft_fields' );
+		if ( ! draftInput ) {
+			return;
+		}
+
+		if ( '' === draftInput.value ) {
+			draftInput.value = field.dataset.fid;
+		} else {
+			draftInput.value += ',' + field.dataset.fid;
+		}
 	}
 
 	function clearSettingsBox( preventFieldGroups ) {

--- a/tests/fields/test_FrmFieldType.php
+++ b/tests/fields/test_FrmFieldType.php
@@ -315,10 +315,7 @@ class test_FrmFieldType extends FrmUnitTest {
 		$this->assertEquals( '', $html );
 
 		// Test a draft field on a preview page for a privileged user (the HTML should not be empty).
-		$reflectionClass = new ReflectionClass( 'FrmFieldType' );
-		$reflectionProperty = $reflectionClass->getProperty('should_hide_draft_fields');
-		$reflectionProperty->setAccessible( true );
-		$reflectionProperty->setValue( null, null );
+		$this->reset_should_hide_draft_fields_flag();
 
 		$this->use_frm_role( 'administrator' );
 		add_filter(
@@ -335,6 +332,19 @@ class test_FrmFieldType extends FrmUnitTest {
 
 		$html = $field_object->prepare_field_html( $args );
 		$this->make_text_field_html_assertions( $html, $field );
+	}
+
+	/**
+	 * This value is determined once per request and memoized.
+	 * This needs to be reset in test_prepare_field_html so the check can happen again.
+	 *
+	 * @return void
+	 */
+	private function reset_should_hide_draft_fields_flag() {
+		$reflection_class    = new ReflectionClass( 'FrmFieldType' );
+		$reflection_property = $reflection_class->getProperty( 'should_hide_draft_fields' );
+		$reflection_property->setAccessible( true );
+		$reflection_property->setValue( null, null );
 	}
 
 	/**

--- a/tests/fields/test_FrmFieldType.php
+++ b/tests/fields/test_FrmFieldType.php
@@ -277,4 +277,77 @@ class test_FrmFieldType extends FrmUnitTest {
 			$this->assertEquals( $expected, $actual );
 		}
 	}
+
+	/**
+	 * @covers FrmFieldType::prepare_field_html
+	 */
+	public function test_prepare_field_html() {
+		$form    = $this->factory->form->create_and_get();
+		$form_id = $form->id;
+
+		// Test a basic text field.
+		$field        = $this->factory->field->create_and_get(
+			array(
+				'type'    => 'text',
+				'form_id' => $form_id,
+			)
+		);
+		$field_array  = FrmFieldsHelper::setup_edit_vars( $field );
+		$field_object = FrmFieldFactory::get_field_type( 'text', $field_array );
+
+		$args = array(
+			'errors' => array(),
+			'form'   => FrmForm::getOne( $form_id ),
+		);
+		$html = $field_object->prepare_field_html( $args );
+
+		$this->make_text_field_html_assertions( $html, $field );
+
+		// Test a draft field (the HTML should be nothing).
+		$field->field_options['draft'] = 1;
+		FrmField::update( $field->id, array( 'field_options' => $field->field_options ) );
+
+		$field        = FrmField::getOne( $field->id );
+		$field_array  = FrmFieldsHelper::setup_edit_vars( $field );
+		$field_object = FrmFieldFactory::get_field_type( 'text', $field_array );
+
+		$html = $field_object->prepare_field_html( $args );
+		$this->assertEquals( '', $html );
+
+
+		$reflectionClass = new ReflectionClass( 'FrmFieldType' );
+		$reflectionProperty = $reflectionClass->getProperty('should_hide_draft_fields');
+		$reflectionProperty->setAccessible( true );
+		$reflectionProperty->setValue( null, null );
+
+		// Test a draft field on a preview page for a privileged user (the GTML should not be empty).
+		$this->use_frm_role( 'administrator' );
+		add_filter(
+			'user_has_cap',
+			function( $caps ) {
+				$caps['frm_edit_forms'] = true;
+				return $caps;
+			}
+		);
+
+		global $pagenow;
+		$pagenow = 'admin-ajax.php';
+		$_GET['action'] = 'frm_forms_preview';
+
+		$html = $field_object->prepare_field_html( $args );
+		$this->make_text_field_html_assertions( $html, $field );
+	}
+
+	/**
+	 * @param string   $html
+	 * @param stdClass $field
+	 * @return void
+	 */
+	private function make_text_field_html_assertions( $html, $field ) {
+		$this->assertStringContainsString( 'id="frm_field_' . $field->id . '_container"', $html );
+		$this->assertStringContainsString( 'class="frm_form_field form-field', $html );
+		$this->assertStringContainsString( '<input type="text"', $html );
+		$this->assertStringContainsString( 'name="item_meta[' . $field->id . ']"', $html );
+		$this->assertStringContainsString( 'id="field_' . $field->field_key . '"', $html );
+	}
 }

--- a/tests/fields/test_FrmFieldType.php
+++ b/tests/fields/test_FrmFieldType.php
@@ -327,7 +327,7 @@ class test_FrmFieldType extends FrmUnitTest {
 		);
 
 		global $pagenow;
-		$pagenow = 'admin-ajax.php';
+		$pagenow = 'admin-ajax.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$_GET['action'] = 'frm_forms_preview';
 
 		$html = $field_object->prepare_field_html( $args );

--- a/tests/fields/test_FrmFieldType.php
+++ b/tests/fields/test_FrmFieldType.php
@@ -314,7 +314,7 @@ class test_FrmFieldType extends FrmUnitTest {
 		$html = $field_object->prepare_field_html( $args );
 		$this->assertEquals( '', $html );
 
-		// Test a draft field on a preview page for a privileged user (the GTML should not be empty).
+		// Test a draft field on a preview page for a privileged user (the HTML should not be empty).
 		$reflectionClass = new ReflectionClass( 'FrmFieldType' );
 		$reflectionProperty = $reflectionClass->getProperty('should_hide_draft_fields');
 		$reflectionProperty->setAccessible( true );

--- a/tests/fields/test_FrmFieldType.php
+++ b/tests/fields/test_FrmFieldType.php
@@ -314,13 +314,12 @@ class test_FrmFieldType extends FrmUnitTest {
 		$html = $field_object->prepare_field_html( $args );
 		$this->assertEquals( '', $html );
 
-
+		// Test a draft field on a preview page for a privileged user (the GTML should not be empty).
 		$reflectionClass = new ReflectionClass( 'FrmFieldType' );
 		$reflectionProperty = $reflectionClass->getProperty('should_hide_draft_fields');
 		$reflectionProperty->setAccessible( true );
 		$reflectionProperty->setValue( null, null );
 
-		// Test a draft field on a preview page for a privileged user (the GTML should not be empty).
 		$this->use_frm_role( 'administrator' );
 		add_filter(
 			'user_has_cap',

--- a/tests/fields/test_FrmFieldsController.php
+++ b/tests/fields/test_FrmFieldsController.php
@@ -67,4 +67,23 @@ class test_FrmFieldsController extends FrmUnitTest {
 			$error_body
 		);
 	}
+
+	/**
+	 * @covers FrmFieldsController::include_new_field
+	 */
+	public function test_include_new_field() {
+		$form_id   = $this->factory->form->create();
+		$new_field = FrmFieldsController::include_new_field( 'text', $form_id );
+
+		// Confirm field is an array with type and form id keys.
+		$this->assertIsArray( $new_field );
+		$this->assertArrayHasKey( 'type', $new_field );
+		$this->assertEquals( 'text', $new_field['type'] ); 
+		$this->assertArrayHasKey( 'form_id', $new_field );
+		$this->assertEquals( $form_id, $new_field['form_id'] );
+
+		// Confirm new fields are flagged as "draft".
+		$this->assertArrayHasKey( 'draft', $new_field );
+		$this->assertEquals( 1, $new_field['draft'] );
+	}
 }

--- a/tests/fields/test_FrmFieldsController.php
+++ b/tests/fields/test_FrmFieldsController.php
@@ -78,7 +78,7 @@ class test_FrmFieldsController extends FrmUnitTest {
 		// Confirm field is an array with type and form id keys.
 		$this->assertIsArray( $new_field );
 		$this->assertArrayHasKey( 'type', $new_field );
-		$this->assertEquals( 'text', $new_field['type'] ); 
+		$this->assertEquals( 'text', $new_field['type'] );
 		$this->assertArrayHasKey( 'form_id', $new_field );
 		$this->assertEquals( $form_id, $new_field['form_id'] );
 

--- a/tests/fields/test_FrmFieldsHelper.php
+++ b/tests/fields/test_FrmFieldsHelper.php
@@ -193,4 +193,37 @@ class test_FrmFieldsHelper extends FrmUnitTest {
 			$this->assertEquals( $test['expected'], $result, $observed_value . ' ' . $test['condition'] . ' ' . $test['hide_opt'] . ' failed' );
 		}
 	}
+
+	/**
+	 * Covers FrmFieldsHelper::get_draft_field_results
+	 */
+	public function test_get_draft_field_results() {
+		$form_id = $this->factory->form->create();
+		$this->assertEquals( array(), FrmFieldsHelper::get_draft_field_results( $form_id ) );
+
+		$draft_field_options = array(
+			'form_id'       => $form_id,
+			'type'          => 'text',
+			'field_options' => array(
+				'draft' => 1,
+			),
+		);
+		$draft_field_id = $this->factory->field->create( $draft_field_options );
+
+		// Test a single draft field.
+		$results = FrmFieldsHelper::get_draft_field_results( $form_id );
+		$ids     = wp_list_pluck( $results, 'id' );
+		$this->assertEquals( array( $draft_field_id ), $ids );
+
+		// Test with two draft fields.
+		$draft_field_id2 = $this->factory->field->create( $draft_field_options );
+		$results = FrmFieldsHelper::get_draft_field_results( $form_id );
+		$ids     = wp_list_pluck( $results, 'id' );
+		$this->assertEquals( array( $draft_field_id, $draft_field_id2 ), $ids );
+
+		// Test the $field_ids parameter. If this is not empty, we only want o query for these IDs.
+		$results = FrmFieldsHelper::get_draft_field_results( $form_id, array( $draft_field_id2 ) );
+		$ids     = wp_list_pluck( $results, 'id' );
+		$this->assertEquals( array( $draft_field_id2 ), $ids );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4713

I cannot reliably delete the draft fields. The only event listener (that isn't deprecated) that gets triggered when leaving the page is `beforeunload` which is cancellable (with no way of knowing if it was cancelled or not) which doesn't make it a reliable event to try deleting drafts from as they would get deleted when you cancel because of unsaved changes.

And if we delete on form builder load there is a risk of deleting another user's draft fields that they are working on, so I'm not deleting fields due to the possible bugs that could occur from deleting fields that shouldn't be deleted.

This update adds a new `draft_fields` input to the page that stores a CSV of all draft field IDs. This allows us to cross-reference this before making a database check, and it guarantees that the draft fields getting marked as active are actually part of the form getting saved rather than part of another incomplete session.

This update also adds a `draft` flag to new fields. When a new field is added it will not appear in the front end until the save/update button is clicked. There is an exception though - a draft field is shown on the "preview" page for a user that can edit forms. If the user visiting the preview page cannot edit forms, or the form is embedded in a page, the draft fields will not be shown.

With this update, the unsaved changes pop up will trigger now whenever a new field is added.

**TODO**
- [x] Add unit tests.
- [x] Add additional unsaved changes messages.
- [x] Steph's comments https://github.com/Strategy11/formidable-pro/issues/4713#issuecomment-1889704905
