### PR TITLE
Fix: Hide 'Entries' for XML Export in Lite Mode (#4709)

### DIFF
--- a/classes/views/xml/import_form.php
+++ b/classes/views/xml/import_form.php
@@ -109,7 +109,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<p id="frm_csv_data_export" class="xml_opts">
 				<label><?php esc_html_e( 'Include the following in the export file', 'formidable' ); ?></label>
 				<?php foreach ( $export_types as $t => $type ) { ?>
-					<label class="frm_inline_label frm-<?php echo esc_attr( sanitize_title( $type ) ); ?>">
+					<label class="frm_inline_label frm-<?php echo esc_attr( sanitize_title( $t ) ); ?>">
 						<input type="checkbox" name="type[]" value="<?php echo esc_attr( $t ); ?>"/>
 						<?php echo esc_html( $type ); ?>
 					</label> &nbsp;

--- a/classes/views/xml/import_form.php
+++ b/classes/views/xml/import_form.php
@@ -109,7 +109,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<p id="frm_csv_data_export" class="xml_opts">
 				<label><?php esc_html_e( 'Include the following in the export file', 'formidable' ); ?></label>
 				<?php foreach ( $export_types as $t => $type ) { ?>
-					<label class="frm_inline_label frm-<?php echo esc_attr( sanitize_title( $t ) ); ?>">
+					<label class="frm_inline_label frm-<?php echo esc_attr( $t ); ?>">
 						<input type="checkbox" name="type[]" value="<?php echo esc_attr( $t ); ?>"/>
 						<?php echo esc_html( $type ); ?>
 					</label> &nbsp;

--- a/classes/views/xml/import_form.php
+++ b/classes/views/xml/import_form.php
@@ -109,7 +109,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<p id="frm_csv_data_export" class="xml_opts">
 				<label><?php esc_html_e( 'Include the following in the export file', 'formidable' ); ?></label>
 				<?php foreach ( $export_types as $t => $type ) { ?>
-					<label class="frm_inline_label frm-<?php echo esc_attr( $t ); ?>">
+					<label class="frm_inline_label frm-export-xml-<?php echo esc_attr( $t ); ?>">
 						<input type="checkbox" name="type[]" value="<?php echo esc_attr( $t ); ?>"/>
 						<?php echo esc_html( $type ); ?>
 					</label> &nbsp;

--- a/classes/views/xml/import_form.php
+++ b/classes/views/xml/import_form.php
@@ -109,7 +109,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<p id="frm_csv_data_export" class="xml_opts">
 				<label><?php esc_html_e( 'Include the following in the export file', 'formidable' ); ?></label>
 				<?php foreach ( $export_types as $t => $type ) { ?>
-					<label class="frm_inline_label">
+					<label class="frm_inline_label frm-<?php echo esc_attr( sanitize_title( $type ) ); ?>">
 						<input type="checkbox" name="type[]" value="<?php echo esc_attr( $t ); ?>"/>
 						<?php echo esc_html( $type ); ?>
 					</label> &nbsp;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5223,6 +5223,10 @@ label.frm-example-icon {
 }
 
 /* Import/Export */
+.frm-lite .xml_opts .frm-entries {
+	display: none;
+}
+
 .csv_opts #frm_csv_col_sep {
 	width: 45px;
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5223,7 +5223,7 @@ label.frm-example-icon {
 }
 
 /* Import/Export */
-.frm-lite .xml_opts .frm-items {
+.frm-lite .xml_opts .frm-export-xml-items {
 	display: none;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5223,7 +5223,7 @@ label.frm-example-icon {
 }
 
 /* Import/Export */
-.frm-lite .xml_opts .frm-entries {
+.frm-lite .xml_opts .frm-items {
 	display: none;
 }
 


### PR DESCRIPTION
This PR resolves the issue where the 'Entries' checkbox appeared for XML exports in Formidable Lite, despite being non-functional. Now, the 'Entries' option is hidden when XML is selected in Lite mode, aligning with the expected behavior.

## QA URL:
https://qa.formidableforms.com/sherv2/wp-admin/admin.php?page=formidable-import

## Related Issue:
[#4709 - Stop showing "Entries" as an XML export option when Pro is inactive](https://github.com/Strategy11/formidable-pro/issues/4709)

## Testing Instructions:
1. Disable Pro.
2. Go to `WP Admin > Formidable > Import/Export`.
3. Verify that the 'Entries' checkbox is not visible for XML export.

## Output:
### Before
<img width="1659" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/6436cbaf-c0b2-43d5-a9ce-23f74c190533">

### After
<img width="1659" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/69119241/f0949888-9ae3-4d47-beb5-f4ade037c9cc">
