### PR TITLE
Stop stripping list tags from form input HTML

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -686,6 +686,9 @@ class FrmAppHelper {
 			'strong' => array(),
 			'p'      => array(),
 			'i'      => array(),
+			'ul'     => array(),
+			'ol'     => array(),
+			'li'     => array(),
 		);
 
 		/**


### PR DESCRIPTION
Related Slack conversation https://strategy11.slack.com/archives/CJFQ599V5/p1705053738151109

There isn't really any harm in allowing list tags: `ul`, `ol,` and `li`.

So I'm adding those to the list of tags that are allowed by default.