### PR TITLE
Resolve Overlapping Search Boxes Issue

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7188,9 +7188,9 @@ i.frm-show-inline-modal {
 	padding-top: 10px;
 }
 
-#wpwrap .frm-search .frm_search_icon {
-	padding-left: 18px;
-	padding-right: 12px;
+.frm-search .frm_search_icon {
+	padding-left: 18px !important;
+	padding-right: 12px !important;
 }
 
 .frm-search input[name="s"],
@@ -7208,8 +7208,8 @@ i.frm-show-inline-modal {
 	padding: var(--gap-xs);
 }
 
-#wpwrap .frm-search input[type="search"],
-#wpwrap .frm-search input[type="text"] {
+.frm-search input[type="search"],
+.frm-search input[type="text"] {
 	padding-left: var(--gap-xl) !important;
 }
 


### PR DESCRIPTION
This PR rectifies the overlapping issue in search boxes across various places

## Related Issue:
[Some search boxes are overlapping #4693](https://github.com/Strategy11/formidable-pro/issues/4693)

## Testing Instructions:
To ensure the overlapping issue is resolved, please follow these steps:

1. **Application Item Search:**
   - Go to an existing Application.
   - Click on the "Add Item" button.
   - Select "Existing forms/views/pages".
   - Observe the "Search Items" search box.

2. **View Name Search:**
   - Navigate to any View.
   - Click on the name of the View.
   - Check the "Search views" search box.

3. **Advanced Tab Search in View Editor:**
   - Open any View and click on a column in the editor.
   - In the sidebar, go to the "Advanced" tab.
   - Look for the search box here.

## QA URL:
https://qa.formidableforms.com/sherv3/wp-admin/term.php?taxonomy=frm_application&tag_ID=2
https://qa.formidableforms.com/sherv3/wp-admin/?page=formidable-views-editor&view=15

## Output:
### Application Item Search
**Before**
![Overlapping issue in Application Item Search](https://github.com/Strategy11/formidable-forms/assets/69119241/075a1a0c-3a68-4e2f-aeb9-8fff7e53c56a)

**After**
![Resolved in Application Item Search](https://github.com/Strategy11/formidable-forms/assets/69119241/b3661a34-cf36-4f28-93f5-31e9a55ccfbf)

### View Name Search
**Before**
![Overlapping issue in View Name Search](https://github.com/Strategy11/formidable-forms/assets/69119241/0d687a4d-e3ae-4a75-9c35-dfd88790225e)

**After**
![Resolved in View Name Search](https://github.com/Strategy11/formidable-forms/assets/69119241/a2bc98a7-ce8f-48d2-923c-9b06fd80252d)

### Advanced Tab Search in View Editor
**Before**
![Overlapping issue in Advanced Tab Search](https://github.com/Strategy11/formidable-forms/assets/69119241/13873cee-97f9-4f94-b688-b1c62c97a5bf)

**After**
![Resolved in Advanced Tab Search](https://github.com/Strategy11/formidable-forms/assets/69119241/783a3d63-f70c-4d28-b3b8-bcd78a9c2694)