### PR TITLE
Fix pro issue 4717 / Check svg has a use child when cleaning HTML

### DIFF
--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -813,10 +813,14 @@
 		const tagType = node.tagName.toLowerCase();
 
 		if ( 'svg' === tagType ) {
-			return svg({
-				href: node.querySelector( 'use' ).getAttribute( 'xlink:href' ),
+			const svgArgs = {
 				classList: Array.from( node.classList )
-			});
+			};
+			const use = node.querySelector( 'use' );
+			if ( use ) {
+				svgArgs.href = use.getAttribute( 'xlink:href' );
+			}
+			return svg( svgArgs );
 		}
 
 		const newNode = document.createElement( tagType );

--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -819,6 +819,9 @@
 			const use = node.querySelector( 'use' );
 			if ( use ) {
 				svgArgs.href = use.getAttribute( 'xlink:href' );
+				if ( ! svgArgs.href ) {
+					svgArgs.href = use.getAttribute( 'href' );
+				}
 			}
 			return svg( svgArgs );
 		}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4717

I think this is because the cleaning happens now more than once, to clean nested HTML as well.

The error is because there are `svg` elements here with no `use` children. The svg has no child at all.

The cause is because the svg used on the option itself is getting sanitized multiple times and uses an inconsistent `xlink:href`/`href` value.

<img width="398" alt="Screen Shot 2024-01-12 at 4 17 14 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/db4e5ff7-e4f8-4549-bf45-c612ce77ee5d">

Now I check for both values just in case one fails.

This code worked on the assumption an `svg` always had this child. I've updated it to not break in that case either.