### PR TITLE
Stop sanitizing on display if updated by user is privileged

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1395,7 +1395,7 @@ DEFAULT_HTML;
 	protected function should_strip_most_html( $entry ) {
 		if ( $entry->updated_by ) {
 			// Stop stripping HTML on display when the entry has been updated by a privileged user.
-			return ! $this->user_id_is_privileged( $entry->updated_by, 'frm_edit_entries' );
+			return ! $this->user_id_is_privileged( $entry->updated_by );
 		}
 		if ( ! $entry->user_id || ! $this->user_id_is_privileged( $entry->user_id ) ) {
 			return true;

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1387,20 +1387,21 @@ DEFAULT_HTML;
 	}
 
 	/**
+	 * Only allow medium-risk HTML tags like a and img when an entry is created by or edited by a privileged user.
+	 *
 	 * @since 6.7.1
 	 *
 	 * @param stdClass $entry
 	 * @return bool
 	 */
 	protected function should_strip_most_html( $entry ) {
-		if ( $entry->updated_by ) {
-			// Stop stripping HTML on display when the entry has been updated by a privileged user.
-			return ! $this->user_id_is_privileged( $entry->updated_by );
+		if ( $entry->updated_by && $this->user_id_is_privileged( $entry->updated_by ) ) {
+			return false;
 		}
-		if ( ! $entry->user_id || ! $this->user_id_is_privileged( $entry->user_id ) ) {
-			return true;
+		if ( $entry->user_id && $this->user_id_is_privileged( $entry->user_id ) ) {
+			return false;
 		}
-		return false;
+		return true;
 	}
 
 	/**

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1404,6 +1404,10 @@ DEFAULT_HTML;
 	}
 
 	/**
+	 * Check if a user is allowed to save additional HTML (like a and img tags).
+	 * HTML is stripped more strictly for users that are not logged in, or users that
+	 * do not have access to editing entries in the back end.
+	 *
 	 * @since x.x
 	 *
 	 * @param string|int $user_id

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1393,13 +1393,24 @@ DEFAULT_HTML;
 	 * @return bool
 	 */
 	protected function should_strip_most_html( $entry ) {
-		if ( ! $entry->user_id || ( ! user_can( $entry->user_id, 'frm_edit_entries' ) && ! user_can( $entry->user_id, 'administrator' ) ) ) {
+		if ( $entry->updated_by ) {
+			// Stop stripping HTML on display when the entry has been updated by a privileged user.
+			return ! $this->user_id_is_privileged( $entry->updated_by, 'frm_edit_entries' );
+		}
+		if ( ! $entry->user_id || ! $this->user_id_is_privileged( $entry->user_id ) ) {
 			return true;
 		}
-		if ( $entry->updated_by ) {
-			return ! user_can( $entry->updated_by, 'frm_edit_entries' ) && ! user_can( $entry->updated_by, 'administrator' );
-		}
 		return false;
+	}
+
+	/**
+	 * @since x.x
+	 *
+	 * @param string|int $user_id
+	 * @return bool
+	 */
+	private function user_id_is_privileged( $user_id ) {
+		return user_can( $user_id, 'administrator' ) || user_can( $user_id, 'frm_edit_entries' );
 	}
 
 	/**


### PR DESCRIPTION
Related comment https://github.com/Strategy11/formidable-pro/issues/4647#issuecomment-1892513008

I'm bumping up the `updated_by` check. If it's set, the permission check only checks the `updated_by` user's permissions.

This means that old entry data submitted by untrusted users that wasn't sanitized in the past (in older versions prior to v6.7.1) won't be sanitized with the additional strict filtering on display if the entry was updated by a privileged user that may not have noticed an unsafe anchor tag or img, but that's pretty low risk.