### PR TITLE
Load 15 fields at a time in builder fix

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1932,9 +1932,12 @@ function frmAdminBuildJS() {
 
 		let nextElement = thisField;
 		addHtmlToField( nextElement );
-		while ( nextElement.nextElementSibling && field.length < 15 ) {
-			addHtmlToField( nextElement.nextElementSibling );
-			nextElement = nextElement.nextElementSibling;
+
+		let nextField = getNextField( nextElement );
+		while ( nextField && field.length < 15 ) {
+			addHtmlToField( nextField );
+			nextElement = nextField;
+			nextField = getNextField( nextField );
 		}
 
 		jQuery.ajax({
@@ -1948,6 +1951,20 @@ function frmAdminBuildJS() {
 			},
 			success: html => handleAjaxLoadFieldSuccess( html, $thisField, field )
 		});
+	}
+
+	function getNextField( field ) {
+		if ( field.nextElementSibling ) {
+			return field.nextElementSibling;
+		}
+		if ( ! field.parentNode ) {
+			return false;
+		}
+		const fieldBox = field.parentNode.closest( '.frm_field_box' );
+		if ( ! fieldBox || ! fieldBox.nextElementSibling ) {
+			return false;
+		}
+		return fieldBox.nextElementSibling.querySelector( '.form-field' );
 	}
 
 	function handleAjaxLoadFieldSuccess( html, $thisField, field ) {


### PR DESCRIPTION
I noticed that all of my `frm_load_field` calls were for 1 or 2 fields at a time.

This code here is capped at 15.

But because of my side-by-side fields update, the `nextElementSibling` isn't always the next field.

I missed this until now.