### PR TITLE
Stop prepending # in front of HSL colors

### DIFF
--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -444,8 +444,13 @@ class FrmStylesHelper {
 		} elseif ( false !== strpos( $color, 'rgb(' ) ) {
 			$color = str_replace( 'rgb(', 'rgba(', $color );
 			$color = str_replace( ')', ',1)', $color );
-		} elseif ( strpos( $color, '#' ) === false && false === strpos( $color, 'rgba(' ) ) {
-			$color = '#' . $color;
+		} elseif ( strpos( $color, '#' ) === false ) {
+			// If a color looks like a hex code without the #, prepend the #.
+			// A color looks like a hex code if it does not contain the substrings "rgb", "rgba", or "hsl".
+			$is_hex = false === strpos( $color, 'rgba(' ) && false === strpos( $color, 'hsl(' );
+			if ( $is_hex ) {
+				$color = '#' . $color;
+			}
 		}
 	}
 


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2474621653/185651/

This update stops prepending a `#` in front of an HSL color.

Trying to get an HSL colour to work with `wpColorPicker` however doesn't appear to be supported. It looks like it's supported by the underlying iris library (https://automattic.github.io/Iris/) but when I tried changing to iris I wasn't having much luck with HSL colours either.