### PR TITLE
Stop prepending # in front of hsla hwb

### DIFF
--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -446,8 +446,23 @@ class FrmStylesHelper {
 			$color = str_replace( ')', ',1)', $color );
 		} elseif ( strpos( $color, '#' ) === false ) {
 			// If a color looks like a hex code without the #, prepend the #.
-			// A color looks like a hex code if it does not contain the substrings "rgb", "rgba", or "hsl".
-			$is_hex = false === strpos( $color, 'rgba(' ) && false === strpos( $color, 'hsl(' );
+			// A color looks like a hex code if it does not contain the substrings "rgb", "rgba", "hsl", "hsla", or "hwb".
+
+			$non_hex_substrings = array(
+				'rgba(',
+				'hsl(',
+				'hsla(',
+				'hwb(',
+			);
+
+			$is_hex = true;
+			foreach ( $non_hex_substrings as $substring ) {
+				if ( false !== strpos( $color, $substring ) ) {
+					$is_hex = false;
+					break;
+				}
+			}
+
 			if ( $is_hex ) {
 				$color = '#' . $color;
 			}


### PR DESCRIPTION
Following up from https://github.com/Strategy11/formidable-forms/pull/1472

There are other types of colors too.

This adds checks for `hsla` and `hwb` as well.

https://developer.mozilla.org/en-US/docs/Web/CSS/color
