### PR TITLE
Prevent null from being passed to string functions

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1948,7 +1948,24 @@ class FrmAppHelper {
 				}
 			}
 		} else {
+			$value = self::maybe_update_value_if_null( $value, $function );
 			$value = call_user_func( $function, $value );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Updates value to empty string if it is null and being passed to a string function.
+	 *
+	 * @since x.x
+	 * @param mixed $value
+	 * @param string $function
+	 * @return mixed
+	 */
+	private static function maybe_update_value_if_null( $value, $function ) {
+		if ( null === $value && in_array( $function, array( 'trim', 'strlen' ), true ) ) {
+			$value = '';
 		}
 
 		return $value;

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1959,7 +1959,7 @@ class FrmAppHelper {
 	 * Updates value to empty string if it is null and being passed to a string function.
 	 *
 	 * @since x.x
-	 * @param mixed $value
+	 * @param mixed  $value
 	 * @param string $function
 	 * @return mixed
 	 */

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -753,4 +753,31 @@ class test_FrmAppHelper extends FrmUnitTest {
 			$this->assertEquals( $assertion['expected'], $result );
 		}
 	}
+
+	/**
+	 * @covers FrmAppHelper::recursive_function_map
+	 */
+	public function test_recursive_function_map() {
+		$test_cases = array(
+			array(
+				'input'    => array( 'Apple', 'Banana', '', null ),
+				'function' => 'strlen',
+				'expected' => array( 5, 6, 0, 0 ),
+			),
+			array(
+				'input'    => array( '  Apple', '  Banana  ', '   ', null ),
+				'function' => 'trim',
+				'expected' => array( 'Apple', 'Banana', '', '' ),
+			),
+			array(
+				'input'    => array( '&gt;', '&amp;' ),
+				'function' => 'htmlspecialchars_decode',
+				'expected' => array( '>', '&' ),
+			)
+		);
+		foreach ( $test_cases as $test_case ) {
+			$result = FrmAppHelper::recursive_function_map( $test_case['input'], $test_case['function'] );
+			$this->assertEquals( $test_case['expected'], $result );
+		}
+	}
 }

--- a/tests/misc/test_FrmAppHelper.php
+++ b/tests/misc/test_FrmAppHelper.php
@@ -773,7 +773,7 @@ class test_FrmAppHelper extends FrmUnitTest {
 				'input'    => array( '&gt;', '&amp;' ),
 				'function' => 'htmlspecialchars_decode',
 				'expected' => array( '>', '&' ),
-			)
+			),
 		);
 		foreach ( $test_cases as $test_case ) {
 			$result = FrmAppHelper::recursive_function_map( $test_case['input'], $test_case['function'] );


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/3453

This update adds a check for a variable value against null and then convert it to empty string before passing it to string manipulation functions.

### Test steps
1. Make sure your PHP version is `>=8.1`
2. There could be different methods to test this but I just used `FrmAppHelper::recursive_function_map( array(), 'trim' );` in a code snippet.