### PR TITLE
Add unit tests for color brightness and add support for hsl to hex

### DIFF
--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -225,6 +225,9 @@ class FrmStylesHelper {
 	 * @return string|null Null if it fails to parse the HSL string.
 	 */
 	private static function hsl_to_hex( $hsl ) {
+		// Convert hsla to hsl.
+		$hsl = preg_replace( '/hsla\((\d+),\s*([\d.]+)%,\s*([\d.]+)%,\s*([\d.]+)\)/', 'hsl($1, $2%, $3%)', $hsl );
+
 		// Extract HSL components from the color string.
 		preg_match( '/hsl\((\d+),\s*(\d+)%,\s*(\d+)%\)/', $hsl, $matches );
 

--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -219,6 +219,64 @@ class FrmStylesHelper {
 	}
 
 	/**
+	 * @since x.x
+	 *
+	 * @param string $hsl
+	 * @return string|null Null if it fails to parse the HSL string.
+	 */
+	private static function hsl_to_hex( $hsl ) {
+		// Extract HSL components from the color string.
+		preg_match( '/hsl\((\d+),\s*(\d+)%,\s*(\d+)%\)/', $hsl, $matches );
+
+		if ( count( $matches ) !== 4 ) {
+			// Invalid HSL string format.
+			return null;
+		}
+
+		// Extract HSL values.
+		$h = (int) $matches[1];
+		$s = (int) $matches[2] / 100;
+		$l = (int) $matches[3] / 100;
+
+		// Calculate RGB values.
+		$c = (1 - abs(2 * $l - 1)) * $s;
+		$x = $c * (1 - abs((($h / 60) % 2) - 1));
+		$m = $l - $c / 2;
+
+		$r = $g = $b = 0;
+
+		if ( $h >= 0 && $h < 60 ) {
+			$r = $c;
+			$g = $x;
+		} elseif ( $h >= 60 && $h < 120 ) {
+			$r = $x;
+			$g = $c;
+		} elseif ( $h >= 120 && $h < 180 ) {
+			$g = $c;
+			$b = $x;
+		} elseif ( $h >= 180 && $h < 240 ) {
+			$g = $x;
+			$b = $c;
+		} elseif ( $h >= 240 && $h < 300 ) {
+			$r = $x;
+			$b = $c;
+		} elseif ( $h >= 300 && $h < 360 ) {
+			$r = $c;
+			$b = $x;
+		}//end if
+
+		// Convert RGB to 8-bit values
+		$r = round( ( $r + $m ) * 255 );
+		$g = round( ( $g + $m ) * 255 );
+		$b = round( ( $b + $m ) * 255 );
+
+		// Convert RGB to hex
+		$hex = sprintf( "%02x%02x%02x", $r, $g, $b );
+
+		return $hex;
+	}
+
+	/**
 	 * @param string $hex   string  The original color in hex format #ffffff.
 	 * @param int    $steps integer Should be between -255 and 255. Negative = darker, positive = lighter.
 	 *
@@ -266,6 +324,15 @@ class FrmStylesHelper {
 	public static function get_color_brightness( $color ) {
 		if ( 0 === strpos( $color, 'rgb' ) ) {
 			$color = self::rgb_to_hex( $color );
+		}
+
+		if ( 0 === strpos( $color, 'hsl' ) ) {
+			$hsl_to_hex = self::hsl_to_hex( $color );
+			if ( is_null( $hsl_to_hex ) ) {
+				// Fallback if we cannot convert the HSL value.
+				return 0;
+			}
+			$color = $hsl_to_hex;
 		}
 
 		self::fill_hex( $color );

--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -240,7 +240,7 @@ class FrmStylesHelper {
 
 		// Calculate RGB values.
 		$c = ( 1 - abs( 2 * $l - 1 ) ) * $s;
-		$x = $c * ( 1 - abs( ( ( $h / 60 ) % 2 ) - 1 ) );
+		$x = $c * ( 1 - abs( ( (int) ( $h / 60 ) % 2 ) - 1 ) );
 		$m = $l - $c / 2;
 		$r = 0;
 		$g = 0;

--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -239,11 +239,12 @@ class FrmStylesHelper {
 		$l = (int) $matches[3] / 100;
 
 		// Calculate RGB values.
-		$c = (1 - abs(2 * $l - 1)) * $s;
-		$x = $c * (1 - abs((($h / 60) % 2) - 1));
+		$c = ( 1 - abs( 2 * $l - 1 ) ) * $s;
+		$x = $c * ( 1 - abs( ( ( $h / 60 ) % 2 ) - 1 ) );
 		$m = $l - $c / 2;
-
-		$r = $g = $b = 0;
+		$r = 0;
+		$g = 0;
+		$b = 0;
 
 		if ( $h >= 0 && $h < 60 ) {
 			$r = $c;
@@ -271,7 +272,7 @@ class FrmStylesHelper {
 		$b = round( ( $b + $m ) * 255 );
 
 		// Convert RGB to hex
-		$hex = sprintf( "%02x%02x%02x", $r, $g, $b );
+		$hex = sprintf( '%02x%02x%02x', $r, $g, $b );
 
 		return $hex;
 	}

--- a/tests/styles/test_FrmStylesHelper.php
+++ b/tests/styles/test_FrmStylesHelper.php
@@ -196,11 +196,18 @@ class test_FrmStylesHelper extends FrmUnitTest {
 		$this->assert_color_brightness( $blue_brightness, '0000ff' );
 
 		// Test rgb colors.
-		$this->assert_color_brightness( $white_brightness, 'rgb( 255, 255, 255 )' );
-		$this->assert_color_brightness( $black_brightness, 'rgb( 0, 0, 0 )' );
-		$this->assert_color_brightness( $red_brightness, 'rgb( 255, 0, 0 )' );
-		$this->assert_color_brightness( $green_brightness, 'rgb( 0, 255, 0 )' );
-		$this->assert_color_brightness( $blue_brightness, 'rgb( 0, 0, 255 )' );
+		$this->assert_color_brightness( $white_brightness, 'rgb(255, 255, 255)' );
+		$this->assert_color_brightness( $black_brightness, 'rgb(0, 0, 0)' );
+		$this->assert_color_brightness( $red_brightness, 'rgb(255, 0, 0)' );
+		$this->assert_color_brightness( $green_brightness, 'rgb(0, 255, 0)' );
+		$this->assert_color_brightness( $blue_brightness, 'rgb(0, 0, 255)' );
+
+		// Test rgba.
+		$this->assert_color_brightness( $white_brightness, 'rgba(255, 255, 255, 1)' );
+		$this->assert_color_brightness( $black_brightness, 'rgba(0, 0, 0, 1)' );
+		$this->assert_color_brightness( $red_brightness, 'rgba(255, 0, 0, 1)' );
+		$this->assert_color_brightness( $green_brightness, 'rgba(0, 255, 0,1 )' );
+		$this->assert_color_brightness( $blue_brightness, 'rgba(0, 0, 255, 1)' );
 
 		// Test hsl colors.
 		$this->assert_color_brightness( $white_brightness, 'hsl(0, 0%, 100%)' );
@@ -208,7 +215,13 @@ class test_FrmStylesHelper extends FrmUnitTest {
 		$this->assert_color_brightness( $red_brightness, 'hsl(0, 100%, 50%)' );
 		$this->assert_color_brightness( $green_brightness, 'hsl(120, 100%, 50%)' );
 		$this->assert_color_brightness( $blue_brightness, 'hsl(240, 100%, 50%)' );
-		
+
+		// Test hsla colors.
+		$this->assert_color_brightness( $white_brightness, 'hsla(0, 0%, 100%, 1)' );
+		$this->assert_color_brightness( $black_brightness, 'hsla(0, 0%, 0%, 1)' );
+		$this->assert_color_brightness( $red_brightness, 'hsla(0, 100%, 50%, 1)' );
+		$this->assert_color_brightness( $green_brightness, 'hsla(120, 100%, 50%, 1)' );
+		$this->assert_color_brightness( $blue_brightness, 'hsla(240, 100%, 50%, 1)' );
 	}
 
 	/**

--- a/tests/styles/test_FrmStylesHelper.php
+++ b/tests/styles/test_FrmStylesHelper.php
@@ -177,4 +177,45 @@ class test_FrmStylesHelper extends FrmUnitTest {
 		$this->assertEquals( 1, FrmStylesHelper::get_form_count_for_style( $conversational_style_id, false ) );
 		$this->assertEquals( 2, FrmStylesHelper::get_form_count_for_style( $conversational_style_id, true ) );
 	}
+
+	/**
+	 * @covers FrmStylesHelper::get_color_brightness
+	 */
+	public function test_get_color_brightness() {
+		$white_brightness = 255;
+		$black_brightness = 0;
+		$red_brightness   = 76.245;
+		$green_brightness = 149.685;
+		$blue_brightness  = 29.07;
+
+		// Test hex colors.
+		$this->assert_color_brightness( $white_brightness, 'ffffff' );
+		$this->assert_color_brightness( $black_brightness, '000000' );
+		$this->assert_color_brightness( $red_brightness, 'ff0000' );
+		$this->assert_color_brightness( $green_brightness, '00ff00' );
+		$this->assert_color_brightness( $blue_brightness, '0000ff' );
+
+		// Test rgb colors.
+		$this->assert_color_brightness( $white_brightness, 'rgb(255,255,255)' );
+		$this->assert_color_brightness( $black_brightness, 'rgb(0,0,0)' );
+		$this->assert_color_brightness( $red_brightness, 'rgb(255,0,0)' );
+		$this->assert_color_brightness( $green_brightness, 'rgb(0,255,0)' );
+		$this->assert_color_brightness( $blue_brightness, 'rgb(0,0,255)' );
+
+		// Test hsl colors.
+		$this->assert_color_brightness( $white_brightness, 'hsl(0, 0%, 100%)' );
+		$this->assert_color_brightness( $black_brightness, 'hsl(0, 0%, 0%)' );
+		$this->assert_color_brightness( $red_brightness, 'hsl(0, 100%, 50%)' );
+		$this->assert_color_brightness( $green_brightness, 'hsl(120, 100%, 50%)' );
+		$this->assert_color_brightness( $blue_brightness, 'hsl(240, 100%, 50%)' );
+	}
+
+	/**
+	 * @param float  $expected
+	 * @param string $color
+	 * @return void
+	 */
+	private function assert_color_brightness( $expected, $color ) {	
+		$this->assertEquals( $expected, FrmStylesHelper::get_color_brightness( $color ) );
+	}
 }

--- a/tests/styles/test_FrmStylesHelper.php
+++ b/tests/styles/test_FrmStylesHelper.php
@@ -196,11 +196,11 @@ class test_FrmStylesHelper extends FrmUnitTest {
 		$this->assert_color_brightness( $blue_brightness, '0000ff' );
 
 		// Test rgb colors.
-		$this->assert_color_brightness( $white_brightness, 'rgb(255,255,255)' );
-		$this->assert_color_brightness( $black_brightness, 'rgb(0,0,0)' );
-		$this->assert_color_brightness( $red_brightness, 'rgb(255,0,0)' );
-		$this->assert_color_brightness( $green_brightness, 'rgb(0,255,0)' );
-		$this->assert_color_brightness( $blue_brightness, 'rgb(0,0,255)' );
+		$this->assert_color_brightness( $white_brightness, 'rgb( 255, 255, 255 )' );
+		$this->assert_color_brightness( $black_brightness, 'rgb( 0, 0, 0 )' );
+		$this->assert_color_brightness( $red_brightness, 'rgb( 255, 0, 0 )' );
+		$this->assert_color_brightness( $green_brightness, 'rgb( 0, 255, 0 )' );
+		$this->assert_color_brightness( $blue_brightness, 'rgb( 0, 0, 255 )' );
 
 		// Test hsl colors.
 		$this->assert_color_brightness( $white_brightness, 'hsl(0, 0%, 100%)' );
@@ -208,6 +208,7 @@ class test_FrmStylesHelper extends FrmUnitTest {
 		$this->assert_color_brightness( $red_brightness, 'hsl(0, 100%, 50%)' );
 		$this->assert_color_brightness( $green_brightness, 'hsl(120, 100%, 50%)' );
 		$this->assert_color_brightness( $blue_brightness, 'hsl(240, 100%, 50%)' );
+		
 	}
 
 	/**

--- a/tests/styles/test_FrmStylesHelper.php
+++ b/tests/styles/test_FrmStylesHelper.php
@@ -215,7 +215,7 @@ class test_FrmStylesHelper extends FrmUnitTest {
 	 * @param string $color
 	 * @return void
 	 */
-	private function assert_color_brightness( $expected, $color ) {	
+	private function assert_color_brightness( $expected, $color ) {
 		$this->assertEquals( $expected, FrmStylesHelper::get_color_brightness( $color ) );
 	}
 }


### PR DESCRIPTION
Following up from https://github.com/Strategy11/formidable-forms/pull/1472

I was seeing this error when I tried to use an HSL color

> PHP Deprecated:  Invalid characters passed for attempted conversion, these have been ignored in /var/www/src/wp-content/plugins/formidable/classes/helpers/FrmStylesHelper.php on line 275
