### PR TITLE
Pro issue 4725 / Delay adding hamburger menus by 1ms

### DIFF
--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -76,7 +76,9 @@
 	 */
 	function initListPage() {
 		document.addEventListener( 'click', handleClickEventsForListPage );
-		setTimeout( addHamburgerMenusToCards, 0 ); // Add a timeout so Pro has a chance to add a filter first.
+		// Add a timeout so Pro has a chance to add a filter first.
+		// 0 does not always work in Google Chrome, so use 1.
+		setTimeout( addHamburgerMenusToCards, 1 );
 		initDatepickerSample();
 
 		const enableToggle              = document.getElementById( 'frm_enable_styling' );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4725

I can only replicate this in Chrome on Toyin's account.

The Lite placeholder options is added because Pro isn't hooking into the `frm_style_card_dropdown_options` filter yet.

It needs a little bit more time. Changing this from `0` to `1` seems to fix the issue. It's tough to actually try waiting for Pro as well since Pro may not exist at all either.