### PR TITLE
Stop triggering drop field functions multiple times

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -317,6 +317,10 @@ function frmAdminBuildJS() {
 	const { __, sprintf } = wp.i18n;
 	let debouncedSyncAfterDragAndDrop, postBodyContent, $postBodyContent;
 
+	const dragState = {
+		dragging: false
+	};
+
 	if ( thisForm !== null ) {
 		thisFormId = thisForm.value;
 	}
@@ -956,6 +960,8 @@ function frmAdminBuildJS() {
 	}
 
 	function handleDragStart( event, ui ) {
+		dragState.dragging = true;
+
 		const container = postBodyContent;
 		container.classList.add( 'frm-dragging-field' );
 
@@ -1058,6 +1064,14 @@ function frmAdminBuildJS() {
 	}
 
 	function handleFieldDrop( _, ui ) {
+		if ( ! dragState.dragging ) {
+			// dragState.dragging is set to true on drag start.
+			// The deactivate event gets called for every droppable. This check to make sure it happens once.
+			return;
+		}
+
+		dragState.dragging = false;
+
 		const draggable = ui.draggable[0];
 		const placeholder = document.getElementById( 'frm_drag_placeholder' );
 


### PR DESCRIPTION
I noticed this while working on fixing https://github.com/Strategy11/formidable-pro/issues/1644

Too many calls to `handleFieldDrop` were causing issues.

I believe this has some impact on performance on a large form.

I merged this branch with https://github.com/Strategy11/formidable-forms/pull/1467 in another branch (https://github.com/Strategy11/formidable-forms/compare/combined_performance_updates?expand=1).

My update may not make a large difference, but it may be worth trying to test these together using the `combined_performance_updates` branch to see if this update helps make https://github.com/Strategy11/formidable-forms/pull/1467 feel any more snappy.