### PR TITLE
Add label to form list checkboxes

### DIFF
--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -231,10 +231,10 @@ class FrmFormsListHelper extends FrmListHelper {
 		$action_links = $this->row_actions( $actions );
 
 		// Set up the checkbox ( because the user is editable, otherwise its empty )
-		$checkbox        = '<input type="checkbox" name="item-action[]" id="cb-item-action-' . absint( $item->id ) . '" value="' . esc_attr( $item->id ) . '" />';
-		$checkbox_label  = __( 'Select ', 'formidable' );
-		$checkbox_label .= ! empty( $item->name ) ? $item->name : __( '(no title)', 'formidable' );
-		$checkbox       .= '<label for="cb-item-action-' . absint( $item->id ) . '"><span class="screen-reader-text">' . $checkbox_label . '</span></label>';
+		$checkbox             = '<input type="checkbox" name="item-action[]" id="cb-item-action-' . absint( $item->id ) . '" value="' . esc_attr( $item->id ) . '" />';
+		$checkbox_label_text  = __( 'Select ', 'formidable' );
+		$checkbox_label_text .= ! empty( $item->name ) ? $item->name : __( '(no title)', 'formidable' );
+		$checkbox            .= '<label for="cb-item-action-' . absint( $item->id ) . '"><span class="screen-reader-text">' . $checkbox_label_text . '</span></label>';
 
 		$r = '<tr id="item-action-' . absint( $item->id ) . '"' . $style . '>';
 

--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -231,7 +231,10 @@ class FrmFormsListHelper extends FrmListHelper {
 		$action_links = $this->row_actions( $actions );
 
 		// Set up the checkbox ( because the user is editable, otherwise its empty )
-		$checkbox = '<input type="checkbox" name="item-action[]" id="cb-item-action-' . absint( $item->id ) . '" value="' . esc_attr( $item->id ) . '" />';
+		$checkbox       = '<input type="checkbox" name="item-action[]" id="cb-item-action-' . absint( $item->id ) . '" value="' . esc_attr( $item->id ) . '" />';
+		$label_text     = __( 'Select ', 'formidable' );
+		$label_text    .= ! empty( $item->name ) ? $item->name : __( '(no title)', 'formidable' );
+		$checkbox_label = '<label for="cb-item-action-' . absint( $item->id ) . '"><span class="screen-reader-text">' . $label_text . '</span></label>';
 
 		$r = '<tr id="item-action-' . absint( $item->id ) . '"' . $style . '>';
 
@@ -260,7 +263,7 @@ class FrmFormsListHelper extends FrmListHelper {
 
 			switch ( $column_name ) {
 				case 'cb':
-					$r .= '<th scope="row" class="check-column">' . $checkbox . '</th>';
+					$r .= '<th scope="row" class="check-column">' . $checkbox . $checkbox_label . '</th>';
 					break;
 				case 'id':
 				case 'form_key':

--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -231,10 +231,14 @@ class FrmFormsListHelper extends FrmListHelper {
 		$action_links = $this->row_actions( $actions );
 
 		// Set up the checkbox ( because the user is editable, otherwise its empty )
-		$checkbox             = '<input type="checkbox" name="item-action[]" id="cb-item-action-' . absint( $item->id ) . '" value="' . esc_attr( $item->id ) . '" />';
-		$checkbox_label_text  = __( 'Select ', 'formidable' );
-		$checkbox_label_text .= ! empty( $item->name ) ? $item->name : __( '(no title)', 'formidable' );
-		$checkbox            .= '<label for="cb-item-action-' . absint( $item->id ) . '"><span class="screen-reader-text">' . $checkbox_label_text . '</span></label>';
+		$checkbox            = '<input type="checkbox" name="item-action[]" id="cb-item-action-' . absint( $item->id ) . '" value="' . esc_attr( $item->id ) . '" />';
+		$checkbox_label_text = sprintf(
+			// translators: Form title
+			__( 'Select %s', 'formidable' ),
+			! empty( $item->name ) ? $item->name : __( '(no title)', 'formidable' )
+		);
+
+		$checkbox .= '<label for="cb-item-action-' . absint( $item->id ) . '"><span class="screen-reader-text">' . $checkbox_label_text . '</span></label>';
 
 		$r = '<tr id="item-action-' . absint( $item->id ) . '"' . $style . '>';
 

--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -231,10 +231,10 @@ class FrmFormsListHelper extends FrmListHelper {
 		$action_links = $this->row_actions( $actions );
 
 		// Set up the checkbox ( because the user is editable, otherwise its empty )
-		$checkbox       = '<input type="checkbox" name="item-action[]" id="cb-item-action-' . absint( $item->id ) . '" value="' . esc_attr( $item->id ) . '" />';
-		$label_text     = __( 'Select ', 'formidable' );
-		$label_text    .= ! empty( $item->name ) ? $item->name : __( '(no title)', 'formidable' );
-		$checkbox_label = '<label for="cb-item-action-' . absint( $item->id ) . '"><span class="screen-reader-text">' . $label_text . '</span></label>';
+		$checkbox        = '<input type="checkbox" name="item-action[]" id="cb-item-action-' . absint( $item->id ) . '" value="' . esc_attr( $item->id ) . '" />';
+		$checkbox_label  = __( 'Select ', 'formidable' );
+		$checkbox_label .= ! empty( $item->name ) ? $item->name : __( '(no title)', 'formidable' );
+		$checkbox       .= '<label for="cb-item-action-' . absint( $item->id ) . '"><span class="screen-reader-text">' . $checkbox_label . '</span></label>';
 
 		$r = '<tr id="item-action-' . absint( $item->id ) . '"' . $style . '>';
 
@@ -263,7 +263,7 @@ class FrmFormsListHelper extends FrmListHelper {
 
 			switch ( $column_name ) {
 				case 'cb':
-					$r .= '<th scope="row" class="check-column">' . $checkbox . $checkbox_label . '</th>';
+					$r .= '<th scope="row" class="check-column">' . $checkbox . '</th>';
 					break;
 				case 'id':
 				case 'form_key':


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4577

Just adding a label to checkboxes in form list that would announce 'Select {form_name}" when checkboxes are selected.