### PR TITLE
Add aria-expanded to accordion h3 elements

### DIFF
--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1249,7 +1249,7 @@
 			el.setAttribute( 'role', 'button' );
 			el.addEventListener( 'click', ( event ) => {
 				event.stopPropagation();
-				frmAdminBuild.maybeCollapseSettings.call( el, 'open', true );
+				frmAdminBuild.maybeCollapseSettings.call( el, event, 'open', true );
 			});
 		});
 	}

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1248,21 +1248,23 @@
 			el.setAttribute( 'aria-expanded', el.parentElement.classList.contains( 'open' ) );
 			el.setAttribute( 'role', 'button' );
 			el.addEventListener( 'click', event => {
-				event.stopPropagation();
-				maybeCollapseSettings( el );
+				// event.stopPropagation();
+				updateAriaExpandedAtt( el );
 			});
 			el.addEventListener( 'keydown', event => {
 				if ( event.key === ' ' ) {
 					event.preventDefault();
-					maybeCollapseSettings( el );
+					updateAriaExpandedAtt( el );
 				}
 			});
 		});
 	}
 
-	function maybeCollapseSettings( target ) {
-		const expanded = target.parentElement.classList.toggle( 'open' );
-		target.setAttribute( 'aria-expanded', expanded );
+	/**
+	 * @param {HTMLElement} target
+	 */
+	function updateAriaExpandedAtt( target ) {
+		target.setAttribute( 'aria-expanded', target.parentElement.classList.contains( 'open' ) );
 	}
 
 	/**

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1260,7 +1260,7 @@
 	}
 
 	/**
-	 * @param {HTMLElement} target
+	 * @param {Event} event
 	 */
 	function maybeCollapseSettings( event ) {
 		let expanded;

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1248,13 +1248,12 @@
 			el.setAttribute( 'aria-expanded', el.parentElement.classList.contains( 'open' ) );
 			el.setAttribute( 'role', 'button' );
 			el.addEventListener( 'click', event => {
-				// event.stopPropagation();
-				updateAriaExpandedAtt( el );
+				maybeCollapseSettings( event );
 			});
 			el.addEventListener( 'keydown', event => {
 				if ( event.key === ' ' ) {
 					event.preventDefault();
-					updateAriaExpandedAtt( el );
+					maybeCollapseSettings( event );
 				}
 			});
 		});
@@ -1263,8 +1262,16 @@
 	/**
 	 * @param {HTMLElement} target
 	 */
-	function updateAriaExpandedAtt( target ) {
-		target.setAttribute( 'aria-expanded', target.parentElement.classList.contains( 'open' ) );
+	function maybeCollapseSettings( event ) {
+		let expanded;
+		if ( event.type === 'keydown' ) {
+			expanded = event.target.parentElement.classList.toggle( 'open' );
+			event.target.parentElement.querySelector( '.accordion-section-content' ).style.display = expanded ? 'block' : 'none';
+		} else {
+			expanded = event.target.parentElement.classList.contains( 'open' );
+		}
+
+		event.target.setAttribute( 'aria-expanded', expanded );
 	}
 
 	/**

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1247,9 +1247,15 @@
 		document.querySelectorAll( '.styling_settings h3.accordion-section-title' ).forEach( el => {
 			el.setAttribute( 'aria-expanded', el.parentElement.classList.contains( 'open' ) );
 			el.setAttribute( 'role', 'button' );
-			el.addEventListener( 'click', ( event ) => {
+			el.addEventListener( 'click', event => {
 				event.stopPropagation();
 				frmAdminBuild.maybeCollapseSettings.call( el, event, 'open', true );
+			});
+			el.addEventListener( 'keydown', event => {
+				if ( event.key === ' ' ) {
+					event.preventDefault();
+					frmAdminBuild.maybeCollapseSettings.call( el, event, 'open', true );
+				}
 			});
 		});
 	}

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1249,15 +1249,20 @@
 			el.setAttribute( 'role', 'button' );
 			el.addEventListener( 'click', event => {
 				event.stopPropagation();
-				frmAdminBuild.maybeCollapseSettings.call( el, event, 'open', true );
+				maybeCollapseSettings( el );
 			});
 			el.addEventListener( 'keydown', event => {
 				if ( event.key === ' ' ) {
 					event.preventDefault();
-					frmAdminBuild.maybeCollapseSettings.call( el, event, 'open', true );
+					maybeCollapseSettings( el );
 				}
 			});
 		});
+	}
+
+	function maybeCollapseSettings( target ) {
+		const expanded = target.parentElement.classList.toggle( 'open' );
+		target.setAttribute( 'aria-expanded', expanded );
 	}
 
 	/**

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1267,7 +1267,7 @@
 		const sectionParent = event.target.parentElement;
 		if ( event.type === 'keydown' ) {
 			expanded = sectionParent.classList.toggle( 'open' );
-			sectionParent.querySelector( '.accordion-section-content' ).style.display = expanded ? 'block' : 'none';
+			jQuery( sectionParent.querySelector( '.accordion-section-content' ) ).toggle( ! expanded ).slideToggle( 150 ); // Animate toggle to keep consistency with click
 		} else {
 			expanded = sectionParent.classList.contains( 'open' );
 		}

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1243,6 +1243,14 @@
 
 			radio.closest( '.dropdown-item' ).classList.add( 'active' );
 		});
+
+		document.querySelectorAll( '.styling_settings h3.accordion-section-title' ).forEach( el => {
+			el.setAttribute( 'aria-expanded', el.parentElement.classList.contains( 'open' ) );
+			el.setAttribute( 'role', 'button' );
+			el.addEventListener( 'click', ( event ) => {
+				el.setAttribute( 'aria-expanded', event.target.parentElement.classList.contains( 'open' ) );
+			});
+		});
 	}
 
 	/**

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1248,7 +1248,8 @@
 			el.setAttribute( 'aria-expanded', el.parentElement.classList.contains( 'open' ) );
 			el.setAttribute( 'role', 'button' );
 			el.addEventListener( 'click', ( event ) => {
-				el.setAttribute( 'aria-expanded', event.target.parentElement.classList.contains( 'open' ) );
+				event.stopPropagation();
+				frmAdminBuild.maybeCollapseSettings.call( el, 'open' );
 			});
 		});
 	}

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1264,11 +1264,12 @@
 	 */
 	function maybeCollapseSettings( event ) {
 		let expanded;
+		const sectionParent = event.target.parentElement;
 		if ( event.type === 'keydown' ) {
-			expanded = event.target.parentElement.classList.toggle( 'open' );
-			event.target.parentElement.querySelector( '.accordion-section-content' ).style.display = expanded ? 'block' : 'none';
+			expanded = sectionParent.classList.toggle( 'open' );
+			sectionParent.querySelector( '.accordion-section-content' ).style.display = expanded ? 'block' : 'none';
 		} else {
-			expanded = event.target.parentElement.classList.contains( 'open' );
+			expanded = sectionParent.classList.contains( 'open' );
 		}
 
 		event.target.setAttribute( 'aria-expanded', expanded );

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1249,7 +1249,7 @@
 			el.setAttribute( 'role', 'button' );
 			el.addEventListener( 'click', ( event ) => {
 				event.stopPropagation();
-				frmAdminBuild.maybeCollapseSettings.call( el, 'open' );
+				frmAdminBuild.maybeCollapseSettings.call( el, 'open', true );
 			});
 		});
 	}

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1267,7 +1267,7 @@
 		const sectionParent = event.target.parentElement;
 		if ( event.type === 'keydown' ) {
 			expanded = sectionParent.classList.toggle( 'open' );
-			jQuery( sectionParent.querySelector( '.accordion-section-content' ) ).toggle( ! expanded ).slideToggle( 150 ); // Animate toggle to keep consistency with click
+			jQuery( sectionParent.querySelector( '.accordion-section-content' ) ).toggle( ! expanded ).slideToggle( 150 ); // Animate toggle as in click/enter.
 		} else {
 			expanded = sectionParent.classList.contains( 'open' );
 		}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5238,9 +5238,9 @@ function frmAdminBuildJS() {
 		parentCont.classList.toggle( 'frm-section-collapsed' );
 	}
 
-	function maybeCollapseSettings() {
+	function maybeCollapseSettings( toggleClass = 'frm-collapsed' ) {
 		/*jshint validthis:true */
-		this.classList.toggle( 'frm-collapsed' );
+		this.parentElement.classList.toggle( toggleClass );
 
 		// Toggles the "aria-expanded" attribute
 		let expanded = this.getAttribute( 'aria-expanded' ) === 'true' || false;
@@ -10511,7 +10511,8 @@ function frmAdminBuildJS() {
 		addRadioCheckboxOpt,
 		installNewForm,
 		toggleAddonState,
-		purifyHtml
+		purifyHtml,
+		maybeCollapseSettings
 	};
 }
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10346,6 +10346,13 @@ function frmAdminBuildJS() {
 			$previewWrapper.on( 'click', '.frm_remove_image_option', removeImageFromOption );
 
 			wp.hooks.doAction( 'frm_style_editor_init' );
+
+			document.querySelectorAll( '.styling_settings h3.accordion-section-title' ).forEach( el => {
+				el.setAttribute( 'aria-expanded', el.parentElement.classList.contains( 'open' ) );
+				el.addEventListener( 'click', ( event ) => {
+					el.setAttribute( 'aria-expanded', event.target.parentElement.classList.contains( 'open' ) );
+				});
+			});
 		},
 
 		customCSSInit: function() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5238,7 +5238,7 @@ function frmAdminBuildJS() {
 		parentCont.classList.toggle( 'frm-section-collapsed' );
 	}
 
-	function maybeCollapseSettings( toggleClass = 'frm-collapsed', toggleParentClass = false ) {
+	function maybeCollapseSettings( event, toggleClass = 'frm-collapsed', toggleParentClass = false ) {
 		const toggleElement = toggleParentClass ? this.parentElement : this;
 		/*jshint validthis:true */
 		toggleElement.classList.toggle( toggleClass );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5238,9 +5238,10 @@ function frmAdminBuildJS() {
 		parentCont.classList.toggle( 'frm-section-collapsed' );
 	}
 
-	function maybeCollapseSettings( toggleClass = 'frm-collapsed' ) {
+	function maybeCollapseSettings( toggleClass = 'frm-collapsed', toggleParentClass = false ) {
+		const toggleElement = toggleParentClass ? this.parentElement : this;
 		/*jshint validthis:true */
-		this.parentElement.classList.toggle( toggleClass );
+		toggleElement.classList.toggle( toggleClass );
 
 		// Toggles the "aria-expanded" attribute
 		let expanded = this.getAttribute( 'aria-expanded' ) === 'true' || false;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10346,14 +10346,6 @@ function frmAdminBuildJS() {
 			$previewWrapper.on( 'click', '.frm_remove_image_option', removeImageFromOption );
 
 			wp.hooks.doAction( 'frm_style_editor_init' );
-
-			document.querySelectorAll( '.styling_settings h3.accordion-section-title' ).forEach( el => {
-				el.setAttribute( 'aria-expanded', el.parentElement.classList.contains( 'open' ) );
-				el.setAttribute( 'role', 'button' );
-				el.addEventListener( 'click', ( event ) => {
-					el.setAttribute( 'aria-expanded', event.target.parentElement.classList.contains( 'open' ) );
-				});
-			});
 		},
 
 		customCSSInit: function() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5241,7 +5241,11 @@ function frmAdminBuildJS() {
 	function maybeCollapseSettings( event, toggleClass = 'frm-collapsed', toggleParentClass = false ) {
 		const toggleElement = toggleParentClass ? this.parentElement : this;
 		/*jshint validthis:true */
-		const expanded = toggleElement.classList.toggle( toggleClass );
+		let expanded = toggleElement.classList.toggle( toggleClass );
+
+		if ( toggleClass === 'open' ) {
+			expanded = ! expanded;
+		}
 
 		// Toggles the "aria-expanded" attribute
 		this.setAttribute( 'aria-expanded', ! expanded );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10349,6 +10349,7 @@ function frmAdminBuildJS() {
 
 			document.querySelectorAll( '.styling_settings h3.accordion-section-title' ).forEach( el => {
 				el.setAttribute( 'aria-expanded', el.parentElement.classList.contains( 'open' ) );
+				el.setAttribute( 'role', 'button' );
 				el.addEventListener( 'click', ( event ) => {
 					el.setAttribute( 'aria-expanded', event.target.parentElement.classList.contains( 'open' ) );
 				});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5241,10 +5241,9 @@ function frmAdminBuildJS() {
 	function maybeCollapseSettings( event, toggleClass = 'frm-collapsed', toggleParentClass = false ) {
 		const toggleElement = toggleParentClass ? this.parentElement : this;
 		/*jshint validthis:true */
-		toggleElement.classList.toggle( toggleClass );
+		const expanded = toggleElement.classList.toggle( toggleClass );
 
 		// Toggles the "aria-expanded" attribute
-		let expanded = this.getAttribute( 'aria-expanded' ) === 'true' || false;
 		this.setAttribute( 'aria-expanded', ! expanded );
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5241,14 +5241,10 @@ function frmAdminBuildJS() {
 	function maybeCollapseSettings( event, toggleClass = 'frm-collapsed', toggleParentClass = false ) {
 		const toggleElement = toggleParentClass ? this.parentElement : this;
 		/*jshint validthis:true */
-		let expanded = toggleElement.classList.toggle( toggleClass );
-
-		if ( toggleClass === 'open' ) {
-			expanded = ! expanded;
-		}
+		const expanded = toggleElement.classList.toggle( toggleClass );
 
 		// Toggles the "aria-expanded" attribute
-		this.setAttribute( 'aria-expanded', ! expanded );
+		this.setAttribute( 'aria-expanded', toggleClass === 'open' ? expanded : ! expanded );
 	}
 
 	function clickLabel() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5238,13 +5238,13 @@ function frmAdminBuildJS() {
 		parentCont.classList.toggle( 'frm-section-collapsed' );
 	}
 
-	function maybeCollapseSettings( event, toggleClass = 'frm-collapsed', toggleParentClass = false ) {
-		const toggleElement = toggleParentClass ? this.parentElement : this;
+	function maybeCollapseSettings() {
 		/*jshint validthis:true */
-		const expanded = toggleElement.classList.toggle( toggleClass );
+		this.classList.toggle( 'frm-collapsed' );
 
 		// Toggles the "aria-expanded" attribute
-		this.setAttribute( 'aria-expanded', toggleClass === 'open' ? expanded : ! expanded );
+		let expanded = this.getAttribute( 'aria-expanded' ) === 'true' || false;
+		this.setAttribute( 'aria-expanded', ! expanded );
 	}
 
 	function clickLabel() {
@@ -10511,8 +10511,7 @@ function frmAdminBuildJS() {
 		addRadioCheckboxOpt,
 		installNewForm,
 		toggleAddonState,
-		purifyHtml,
-		maybeCollapseSettings
+		purifyHtml
 	};
 }
 


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4611

### Test steps
1. Go to Visual Styler page and turn on your Assistive software.
2. Try tabbing through the accordion headers and confirm that the state of the currently tabbed accordion element is announced as you do so.