### PR TITLE
Add message with Email summary settings

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -174,18 +174,16 @@ class FrmAppHelper {
 
 	/**
 	 * Determine if the current branding is set to 'formidable'.
-	 *
-	 * Checks the menu title, retrieved through get_menu_name,
-	 * and verifies if it matches the 'formidable' branding.
+	 * Checks the menu icon, and verifies if it matches the formidable branding.
 	 *
 	 * @since 6.4.2
 	 *
-	 * @return bool True if the menu title is 'formidable', false otherwise.
+	 * @return bool True if the menu icon is the logo, false otherwise.
 	 */
 	public static function is_formidable_branding() {
-		$menu_title = self::get_menu_name();
+		$menu_icon = self::get_menu_icon_class();
 
-		return 'formidable' === strtolower( trim( $menu_title ) );
+		return strpos( $menu_icon, 'frm_logo_icon' ) !== false;
 	}
 
 	/**

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -181,8 +181,11 @@ class FrmAppHelper {
 	 * @return bool True if the menu icon is the logo, false otherwise.
 	 */
 	public static function is_formidable_branding() {
-		$menu_icon = self::get_menu_icon_class();
+		if ( ! self::pro_is_installed() ) {
+			return true;
+		}
 
+		$menu_icon = self::get_menu_icon_class();
 		return strpos( $menu_icon, 'frm_logo_icon' ) !== false;
 	}
 

--- a/classes/helpers/FrmEmailSummaryHelper.php
+++ b/classes/helpers/FrmEmailSummaryHelper.php
@@ -531,28 +531,14 @@ class FrmEmailSummaryHelper {
 	 * @param array $recipients Recipients.
 	 */
 	public static function maybe_remove_recipients_from_api( &$recipients ) {
-		$skip_emails = self::api_emails_to_skip();
-		if ( empty( $skip_emails ) ) {
-			return;
-		}
-		$recipients = array_diff( $recipients, $skip_emails );
-	}
-
-	/**
-	 * Checks if API email summary is on.
-	 *
-	 * @since x.x
-	 *
-	 * @return array
-	 */
-	private static function api_emails_to_skip() {
 		$api    = new FrmFormApi();
 		$addons = $api->get_api_info();
 		if ( empty( $addons['no_emails'] ) ) {
-			return false;
+			return;
 		}
 
-		return is_string( $addons['no_emails'] ) ? explode( ',', $addons['no_emails'] ) : (array) $addons['no_emails'];
+		$skip_emails = is_string( $addons['no_emails'] ) ? explode( ',', $addons['no_emails'] ) : (array) $addons['no_emails'];
+		$recipients  = array_diff( $recipients, $skip_emails );
 	}
 
 	/**

--- a/classes/helpers/FrmEmailSummaryHelper.php
+++ b/classes/helpers/FrmEmailSummaryHelper.php
@@ -545,7 +545,7 @@ class FrmEmailSummaryHelper {
 	 *
 	 * @return array
 	 */
-	public static function api_emails_to_skip() {
+	private static function api_emails_to_skip() {
 		$api    = new FrmFormApi();
 		$addons = $api->get_api_info();
 		if ( empty( $addons['no_emails'] ) ) {

--- a/classes/helpers/FrmEmailSummaryHelper.php
+++ b/classes/helpers/FrmEmailSummaryHelper.php
@@ -531,14 +531,28 @@ class FrmEmailSummaryHelper {
 	 * @param array $recipients Recipients.
 	 */
 	public static function maybe_remove_recipients_from_api( &$recipients ) {
+		$skip_emails = self::api_emails_to_skip();
+		if ( empty( $skip_emails ) ) {
+			return;
+		}
+		$recipients = array_diff( $recipients, $skip_emails );
+	}
+
+	/**
+	 * Checks if API email summary is on.
+	 *
+	 * @since x.x
+	 *
+	 * @return array
+	 */
+	public static function api_emails_to_skip() {
 		$api    = new FrmFormApi();
 		$addons = $api->get_api_info();
 		if ( empty( $addons['no_emails'] ) ) {
-			return;
+			return false;
 		}
 
-		$skip_emails = is_string( $addons['no_emails'] ) ? explode( ',', $addons['no_emails'] ) : (array) $addons['no_emails'];
-		$recipients  = array_diff( $recipients, $skip_emails );
+		return is_string( $addons['no_emails'] ) ? explode( ',', $addons['no_emails'] ) : (array) $addons['no_emails'];
 	}
 
 	/**

--- a/classes/views/frm-settings/misc.php
+++ b/classes/views/frm-settings/misc.php
@@ -24,9 +24,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</label>
 </p>
 
-<p class="frm_summary_emails_recipients_wrapper <?php echo ! $frm_settings->summary_emails ? 'frm_hidden' : ''; ?>">
-	<label for="frm_summary_emails_recipients"><?php esc_html_e( 'Recipients', 'formidable' ); ?></label>
+<p class="frm_summary_emails_recipients_wrapper frm_indent_opt <?php echo ! $frm_settings->summary_emails ? 'frm_hidden' : ''; ?>">
+	<label for="frm_summary_emails_recipients"><?php esc_html_e( 'Summary email recipients', 'formidable' ); ?></label>
 	<input type="text" name="frm_summary_emails_recipients" id="frm_summary_emails_recipients" value="<?php echo esc_attr( $frm_settings->summary_emails_recipients ); ?>" />
+	<?php if ( FrmAppHelper::is_formidable_branding() && in_array( FrmAddonsController::license_type(), array( 'elite', 'business' ), true ) ) { ?>
+		<span>
+			<?php
+			printf(
+				/* translators: %1$s the opening link tag, %2$s the closing link tag */
+				esc_html__( 'Summary emails can be disabled across multiple sites from %1$sFormidableForms.com%2$s.', 'formidable' ),
+				'<a href="' . esc_url( FrmAppHelper::admin_upgrade_link( 'misc-settings', 'account/profile/' ) ) . '" target="_blank" rel="noopener">',
+				'</a>'
+			);
+			?>
+		</span>
+	<?php } ?>
 </p>
 
 <!-- Deprecated settings can only be switched away from the default -->


### PR DESCRIPTION
- Show a message with link to disable summary emails in profile for Elite and Business users (licenses that could have lots of sites)
- Changed setting name from "Recipients" to "Summary email recipients" for clarity
- Check white labeling based on icon instead of name. For a while, the menu default was "Forms" so this is excluding too many sites. Also, don't check if pro is inactive (Part of https://github.com/Strategy11/formidable-pro/issues/4687 )

<img width="961" alt="Screenshot 2024-01-31 at 2 06 30 PM" src="https://github.com/Strategy11/formidable-forms/assets/1116876/f3721208-21c9-4f9f-839a-7e61e1b1e458">
