### PR TITLE
Check if id is defined before invoking a method on it

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -707,7 +707,7 @@ function frmAdminBuildJS() {
 				show = '';
 				hide = '';
 			}
-		} else if ( id.indexOf( 'frm_postmeta_' ) === 0 ) {
+		} else if ( id && id.indexOf( 'frm_postmeta_' ) === 0 ) {
 			if ( jQuery( '#frm_postmeta_rows .frm_postmeta_row' ).length < 2 ) {
 				show = '.frm_add_postmeta_row.button';
 			}


### PR DESCRIPTION
I updated Quiz score global settings page to use frm_font_icon instead of the +/- <i> tags in https://github.com/Strategy11/formidable-quizzes/pull/194 and this error came up when clicking the delete row icon.

<img width="958" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/0d2927fc-ab1c-4afc-845f-93dfcc0b8ad9">

