### PR TITLE
Pro issue 4777 / Add more css to hide search buttons

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1296,6 +1296,11 @@ body.frm-hidden-overflow {
 	display: inline-block;
 }
 
+.no-js.wp-core-ui .frm-search .button.hide-if-no-js,
+.js.wp-core-ui .frm-search .button.hide-if-js {
+	display: none;
+}
+
 .frm-button-tertiary {
 	border-color: transparent;
 	color: var(--primary-500);


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4777

I tested this on our staging site where it has the same issue as formidableforms.com.

I think the issue is just the order that the CSS loads. It must be loading in a different order on these sites where the WordPress styles get less priority.

I took the style suggestion from the issue, which did the trick. I also tested with JavaScript disabled, which had the same issue with displaying both buttons, so I added a `no-js` rule as well.