### PR TITLE
Also check for entry user id in should strip most html

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1420,11 +1420,12 @@ DEFAULT_HTML;
 	 * @return bool
 	 */
 	protected function should_strip_most_html( $entry ) {
-		// $entry->updated_by may not always be set.
+		// In old versions of Pro, updated_by and user_id may both be missing.
+		// This is because $entry may be an stdClass created in FrmProSummaryValues::base_entry.
 		if ( ! empty( $entry->updated_by ) && $this->user_id_is_privileged( $entry->updated_by ) ) {
 			return false;
 		}
-		if ( $entry->user_id && $this->user_id_is_privileged( $entry->user_id ) ) {
+		if ( ! empty( $entry->user_id ) && $this->user_id_is_privileged( $entry->user_id ) ) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Related comment https://github.com/Strategy11/formidable-forms/pull/1501#discussion_r1483226320

Related PR https://github.com/Strategy11/formidable-pro/pull/4789

This update adds another check for `user_id` so old versions of Pro don't trigger this warning.

The issue is that `FrmProSummaryValues::base_entry` creates an `stdClass` with no `user_id` or `updated_by` values. In https://github.com/Strategy11/formidable-pro/pull/4789 I define these keys now.