### PR TITLE
Make form API error handling support string errors

### DIFF
--- a/classes/models/FrmAddon.php
+++ b/classes/models/FrmAddon.php
@@ -230,10 +230,10 @@ class FrmAddon {
 	/**
 	 * @since 3.04.03
 	 *
-	 * @param array $error
+	 * @param array|string $error
 	 */
 	public function maybe_clear_license( $error ) {
-		if ( $error['code'] === 'disabled' && $error['license'] === $this->license ) {
+		if ( is_array( $error ) && $error['code'] === 'disabled' && $error['license'] === $this->license ) {
 			$this->clear_license();
 		}
 	}

--- a/classes/models/FrmFormApi.php
+++ b/classes/models/FrmFormApi.php
@@ -258,7 +258,12 @@ class FrmFormApi {
 		}
 		$errors = array();
 		if ( isset( $addons['error'] ) ) {
-			$errors[] = $addons['error']['message'];
+			if ( is_string( $addons['error'] ) ) {
+				$errors[] = $addons['error'];
+			} elseif ( ! empty( $addons['error']['message'] ) ) {
+				$errors[] = $addons['error']['message'];
+			}
+
 			do_action( 'frm_license_error', $addons['error'] );
 		}
 

--- a/tests/misc/test_FrmFormApi.php
+++ b/tests/misc/test_FrmFormApi.php
@@ -1,0 +1,32 @@
+<?php
+
+class test_FrmFormApi extends FrmUnitTest {
+
+	/**
+	 * @covers FrmFormApi::get_error_from_response
+	 */
+	public function test_get_error_from_response() {
+		$api     = new FrmFormApi();
+
+		// Test an array error.
+		$message = 'Your license has expired.';
+		$addons  = array(
+			'error' => array(
+				'license' => 'license_123',
+				'code'    => 'expired',
+				'message' => $message,
+			)
+		);
+		$error   = $api->get_error_from_response( $addons );
+		$this->assertEquals( array( $message ), $error );
+
+		// Test a string error.
+		$message = 'Your site has been blocked!';
+		$addons  = array(
+			'error' => $message,
+		);
+		$error   = $api->get_error_from_response( $addons );
+
+		$this->assertEquals( array( $message ), $error );
+	}
+}


### PR DESCRIPTION
**Related tickets**
https://secure.helpscout.net/conversation/2506175920/189635
https://secure.helpscout.net/conversation/2506108172/189628/

It looks like an error for a nulled license works differently.

Instead of the expected `$addons['error']` array, it's a string like "Your license has been blocked!".

The "Y" shows up in PHP 7.4.
![image](https://github.com/Strategy11/formidable-forms/assets/9134515/5e85a514-9435-4d16-9f1c-37594250049d)

<img width="889" alt="Add more power to your forms, and bring" src="https://github.com/Strategy11/formidable-forms/assets/9134515/fb25b258-54e7-4b2b-ab2f-d85955050b1f">

In PHP 8 it throws a fatal error instead,
> Uncaught TypeError: Cannot access offset of type string on string in .../formidable/classes/models/FrmFormApi.php:261
> Stack trace:
> #0 .../formidable/classes/models/FrmFormApi.php(245): FrmFormApi->get_error_from_response()
> #1 .../formidable/classes/models/FrmAddon.php(327): FrmFormApi->error_for_license()
> #2 .../formidable/classes/models/FrmAddon.php(317): FrmAddon->show_license_message()
> #3 .../class-wp-hook.php(326): FrmAddon->maybe_show_license_message()

The error seems to be causing issues with disconnecting a nulled license. I couldn't figure out where this is being defined though. When I searched the error message, I couldn't find where this message was actually coming from.

Pre-release,
[formidable-6.8.1b.zip](https://github.com/Strategy11/formidable-forms/files/14225789/formidable-6.8.1b.zip)