### PR TITLE
Pro issue 4776 / Add support for a new value arg in show search box f…

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1338,6 +1338,7 @@ class FrmAppHelper {
 			'tosearch'    => '',
 			'text'        => __( 'Search', 'formidable' ),
 			'input_id'    => '',
+			'value'       => false,
 		);
 		$atts = array_merge( $defaults, $atts );
 
@@ -1352,19 +1353,26 @@ class FrmAppHelper {
 
 		$input_id = $atts['input_id'] . '-search-input';
 
+		$input_atts = array(
+			'type'          => 'search',
+			'id'            => $input_id,
+			'name'          => 's',
+			'value'         => is_string( $atts['value'] ) ? $atts['value'] : ( isset( $_REQUEST['s'] ) ? wp_unslash( $_REQUEST['s'] ) : '' ),
+			'placeholder'   => $atts['placeholder'],
+			'class'         => $class,
+			'data-tosearch' => $atts['tosearch'],
+		);
+
+		if ( ! empty( $atts['tosearch'] ) ) {
+			$input_atts['autocomplete'] = 'off';
+		}
 		?>
 		<p class="frm-search">
 			<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>">
 				<?php echo esc_html( $atts['text'] ); ?>:
 			</label>
 			<span class="frmfont frm_search_icon"></span>
-			<input type="search" id="<?php echo esc_attr( $input_id ); ?>" name="s"
-				value="<?php _admin_search_query(); ?>" placeholder="<?php echo esc_attr( $atts['placeholder'] ); ?>"
-				class="<?php echo esc_attr( $class ); ?>" data-tosearch="<?php echo esc_attr( $atts['tosearch'] ); ?>"
-				<?php if ( ! empty( $atts['tosearch'] ) ) { ?>
-				autocomplete="off"
-				<?php } ?>
-				/>
+			<input <?php self::array_to_html_params( $input_atts, true ); ?> />
 			<?php
 			if ( empty( $atts['tosearch'] ) ) {
 				submit_button( $atts['text'], 'button-secondary', '', false, array( 'id' => 'search-submit' ) );

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1357,11 +1357,17 @@ class FrmAppHelper {
 			'type'          => 'search',
 			'id'            => $input_id,
 			'name'          => 's',
-			'value'         => is_string( $atts['value'] ) ? $atts['value'] : ( isset( $_REQUEST['s'] ) ? wp_unslash( $_REQUEST['s'] ) : '' ),
 			'placeholder'   => $atts['placeholder'],
 			'class'         => $class,
 			'data-tosearch' => $atts['tosearch'],
 		);
+
+		if ( is_string( $atts['value'] ) ) {
+			$input_atts['value'] = $atts['value'];
+		} elseif ( isset( $_REQUEST['s'] ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$input_atts['value'] = wp_unslash( $_REQUEST['s'] );
+		}
 
 		if ( ! empty( $atts['tosearch'] ) ) {
 			$input_atts['autocomplete'] = 'off';

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -153,6 +153,8 @@ class FrmFormsHelper {
 							'input_id'    => 'dropform',
 							'placeholder' => __( 'Search Forms', 'formidable' ),
 							'tosearch'    => 'frm-dropdown-form',
+							// Specify a value to avoid the $_REQUEST['s'] default value.
+							'value'       => '',
 						)
 					);
 					?>


### PR DESCRIPTION
…unction

Fixes https://github.com/Strategy11/formidable-pro/issues/4776

This update adds support for a `value` arg. If it is a string (rather than the `false` default value), it is used as the `value` param for the input.

Before it always used `_admin_search_query`.

The body of that function is simple:
```
echo isset( $_REQUEST['s'] ) ? esc_attr( wp_unslash( $_REQUEST['s'] ) ) : '';
```

I just copied that as the fallback value when there is no value arg set.

I changed this to use `FrmAppHelper::array_to_html_params` to echo out all of the input params as well.