### PR TITLE
Stop showing "All Selected" text in Bootstrap multiselect dropdowns

### DIFF
--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -157,6 +157,8 @@
 				nonSelectedText: '',
 				// Prevent the dropdown from showing "All Selected" when every option is checked.
 				allSelectedText: '',
+				// This is 3 by default. We want to show more options before it starts showing a count.
+				numberDisplayed: 8,
 				onDropdownShown: function( event ) {
 					const action = jQuery( event.currentTarget.closest( '.frm_form_action_settings, #frm-show-fields' ) );
 					if ( action.length ) {

--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -155,6 +155,8 @@
 				},
 				buttonContainer: '<div class="btn-group frm-btn-group dropdown" />',
 				nonSelectedText: '',
+				// Prevent the dropdown from showing "All Selected" when every option is checked.
+				allSelectedText: '',
 				onDropdownShown: function( event ) {
 					const action = jQuery( event.currentTarget.closest( '.frm_form_action_settings, #frm-show-fields' ) );
 					if ( action.length ) {


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4810

Bootstrap multiselect by default shows "All selected" when all items are selected.

This isn't very useful when there are only a couple options. With this update, I'm removing the "All selected text", so it never shows.

**Before**
<img width="739" alt="Screen Shot 2024-02-16 at 9 40 01 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/efd826d0-2315-4217-b4f7-334a30613474">

**After**
<img width="760" alt="Screen Shot 2024-02-16 at 9 39 41 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/d219ec32-69b2-4605-840d-a341985e853b">

If you select a lot of options, it starts to count them. IF you select all of them, after this update, instead of "All selected", it will just continue to show a count.
<img width="613" alt="Screen Shot 2024-02-16 at 9 41 47 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/9cfcdcc7-b65e-4a53-b8f4-2b2b5b72c8ca">

**I'm not sure if we want to make this more dynamic?**

It starts to count items elected when the number of options selected exceeds `numberDisplayed`. The default value for `numberDisplayed` is 3.

We could consider bumping this number as well. For example, if I bump it to 10, it looks like this,
<img width="1125" alt="Screen Shot 2024-02-16 at 9 44 23 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/d7b84a16-e1aa-46e1-bf74-35f669150548">

It might be that we want to still show "All selected" if there are more than 3 options, since "All selected" may be nicer than "11 selected".