### PR TITLE
Use please select placeholder for bootstrap multiselect

### DIFF
--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -154,7 +154,7 @@
 					button: '<button type="button" class="multiselect dropdown-toggle btn" data-toggle="dropdown" ' + labelledBy + '><span class="multiselect-selected-text"></span> <b class="caret"></b></button>'
 				},
 				buttonContainer: '<div class="btn-group frm-btn-group dropdown" />',
-				nonSelectedText: '',
+				nonSelectedText: __( '— Please Select —', 'formidable' ),
 				onDropdownShown: function( event ) {
 					const action = jQuery( event.currentTarget.closest( '.frm_form_action_settings, #frm-show-fields' ) );
 					if ( action.length ) {

--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -154,7 +154,7 @@
 					button: '<button type="button" class="multiselect dropdown-toggle btn" data-toggle="dropdown" ' + labelledBy + '><span class="multiselect-selected-text"></span> <b class="caret"></b></button>'
 				},
 				buttonContainer: '<div class="btn-group frm-btn-group dropdown" />',
-				nonSelectedText: __( '— Please Select —', 'formidable' ),
+				nonSelectedText: __( '— Select —', 'formidable' ),
 				onDropdownShown: function( event ) {
 					const action = jQuery( event.currentTarget.closest( '.frm_form_action_settings, #frm-show-fields' ) );
 					if ( action.length ) {


### PR DESCRIPTION
Quoting Steph from https://github.com/Strategy11/formidable-pro/pull/4630#pullrequestreview-1883987426
> It would also help to show -- Select -- in the dropdown if nothing is selected.

Before this was always an empty string so there were no placeholders.

I figure this is fine to add to all multiselect dropdowns and not just the one in the linked PR.

<img width="1127" alt="Screen Shot 2024-02-16 at 2 11 10 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/183e3af0-0731-42e4-82b0-76bba8d52080">
