### PR TITLE
Set empty option title attributes for bootstrap multiselect

### DIFF
--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -147,6 +147,8 @@
 			let labelledBy = id ? jQuery( '#for_' + id ) : false;
 			labelledBy     = id && labelledBy.length ? 'aria-labelledby="' + labelledBy.attr( 'id' ) + '"' : '';
 
+			// Set empty title attributes so that none of the dropdown options include title attributes.
+			$select.find( 'option' ).attr( 'title', ' ' );
 			$select.multiselect({
 				templates: {
 					popupContainer: '<div class="multiselect-container frm-dropdown-menu"></div>',


### PR DESCRIPTION
Related comment https://github.com/Strategy11/formidable-forms/pull/1515#issuecomment-1949084973

By defining a `" "` title value on my option elements, bootstrap-multiselect uses that as the `title` attribute for the options. When it's just a space character, the title never shows (tested in Firefox and Chrome).