### PR TITLE
Stop stripping most HTML from HTML field display value fix

### DIFF
--- a/classes/models/fields/FrmFieldHTML.php
+++ b/classes/models/fields/FrmFieldHTML.php
@@ -70,17 +70,16 @@ class FrmFieldHTML extends FrmFieldType {
 	}
 
 	/**
-	 * Overwrite FrmFieldType::get_display_value.
+	 * Overwrite FrmFieldType::should_strip_most_html_before_preparing_display_value.
 	 * An HTML field is not populated from user input.
 	 * It does not need to be passed through FrmAppHelper::strip_most_html.
 	 *
 	 * @since x.x
 	 *
-	 * @param string|array $value
-	 * @param array        $atts
-	 * @return string
+	 * @param array $atts
+	 * @return bool
 	 */
-	public function get_display_value( $value, $atts = array() ) {
-		return $value;
+	protected function should_strip_most_html_before_preparing_display_value( $atts ) {
+		return false;
 	}
 }

--- a/classes/models/fields/FrmFieldHTML.php
+++ b/classes/models/fields/FrmFieldHTML.php
@@ -68,4 +68,19 @@ class FrmFieldHTML extends FrmFieldType {
 	protected function include_form_builder_file() {
 		return FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/field-html.php';
 	}
+
+	/**
+	 * Overwrite FrmFieldType::get_display_value.
+	 * An HTML field is not populated from user input.
+	 * It does not need to be passed through FrmAppHelper::strip_most_html.
+	 *
+	 * @since x.x
+	 *
+	 * @param string|array $value
+	 * @param array        $atts
+	 * @return string
+	 */
+	public function get_display_value( $value, $atts = array() ) {
+		return $value;
+	}
 }


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2511714226/190280/

When showing a quiz score's correct answers, `FrmProEntriesController::show_entry_shortcode` is called.

When a user is not logged in, `FrmAppHelper::strip_most_html` is removing `img` tags from HTML field display.

This was introduced with https://github.com/Strategy11/formidable-forms/pull/1439

An HTML field doesn't really need any of the logic from `FrmFieldType::get_display_value`.

This skips some code, so `fill_default_atts`, `FrmAppHelper::strip_most_html`, `prepare_display_value`, and some checks for if `$value` is an array with checks for `$atts['show']`, are all skipped entirely.

HTML fields really don't need any of that. They should just display as is, since there isn't any user content directly defining its output.