### PR TITLE
Remove title from bootstrap multiselect dropdown toggle button

### DIFF
--- a/js/admin/dom.js
+++ b/js/admin/dom.js
@@ -161,6 +161,9 @@
 				allSelectedText: '',
 				// This is 3 by default. We want to show more options before it starts showing a count.
 				numberDisplayed: 8,
+				onInitialized: function( _, $container ) {
+					$container.find( '.multiselect.dropdown-toggle' ).removeAttr( 'title' );
+				},
 				onDropdownShown: function( event ) {
 					const action = jQuery( event.currentTarget.closest( '.frm_form_action_settings, #frm-show-fields' ) );
 					if ( action.length ) {


### PR DESCRIPTION
Related comment https://github.com/Strategy11/formidable-pro/pull/4630#issuecomment-1952836137

> I don't see the tooltip issue when clicking the dropdown anymore, but if I hover the selected option then I can see it.

This update removes the title attribute from the bootstrap multiselect dropdown toggle buttons after it is initialized.