### PR TITLE
Add field name shortcode for error messages

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3152,7 +3152,6 @@ class FrmAppHelper {
 		}
 
 		if ( $location === 'admin' ) {
-			$frm_settings         = self::get_settings();
 			$admin_script_strings = array(
 				'desc'               => __( '(Click to add description)', 'formidable' ),
 				'blank'              => __( '(Blank)', 'formidable' ),
@@ -3168,7 +3167,7 @@ class FrmAppHelper {
 				'conf_delete'        => __( 'Are you sure you want to delete this field and all data associated with it?', 'formidable' ),
 				'conf_delete_sec'    => __( 'All fields inside this Section will be deleted along with their data. Are you sure you want to delete this group of fields?', 'formidable' ),
 				'conf_no_repeat'     => __( 'Warning: If you have entries with multiple rows, all but the first row will be lost.', 'formidable' ),
-				'default_unique'     => $frm_settings->unique_msg,
+				'default_unique'     => FrmFieldsHelper::default_unique_msg(),
 				'default_conf'       => __( 'The entered values do not match', 'formidable' ),
 				'enter_email'        => __( 'Enter Email', 'formidable' ),
 				'confirm_email'      => __( 'Confirm Email', 'formidable' ),

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -352,32 +352,34 @@ class FrmFieldsHelper {
 		$msg = empty( $msg ) ? $defaults[ $error ]['part'] : $msg;
 		$msg = do_shortcode( $msg );
 
-		$substrings_to_replace_with_field_name = array(
-			'[field_name]',
-			'This value',
-			'This field',
-		);
-		/**
-		 * @since x.x
-		 *
-		 * @param array<string> $substrings_to_replace_with_field_name
-		 * @param array         $args {
-		 *     @type string       $msg   The current error message before the substrings are replaced.
-		 *     @type string       $error A key including 'unique_msg', 'invalid', 'blank', or 'conf_msg'.
-		 *     @type array|object $field The field with the error.
-		 * }
-		 */
-		$filtered_substrings = apply_filters( 'frm_error_substrings_to_replace_with_field_name', $substrings_to_replace_with_field_name, compact( 'msg', 'error', 'field' ) );
+		if ( trim( $field_name ) ) {
+			$substrings_to_replace_with_field_name = array(
+				'[field_name]',
+				'This value',
+				'This field',
+			);
+			/**
+			 * @since x.x
+			 *
+			 * @param array<string> $substrings_to_replace_with_field_name
+			 * @param array         $args {
+			 *     @type string       $msg   The current error message before the substrings are replaced.
+			 *     @type string       $error A key including 'unique_msg', 'invalid', 'blank', or 'conf_msg'.
+			 *     @type array|object $field The field with the error.
+			 * }
+			 */
+			$filtered_substrings = apply_filters( 'frm_error_substrings_to_replace_with_field_name', $substrings_to_replace_with_field_name, compact( 'msg', 'error', 'field' ) );
 
-		if ( is_array( $filtered_substrings ) ) {
-			$substrings_to_replace_with_field_name = $filtered_substrings;
-		} else {
-			_doing_it_wrong( __FUNCTION__, 'Only arrays should be returned when using the frm_error_substrings_to_replace_with_field_name filter.', 'x.x' );
-		}
+			if ( is_array( $filtered_substrings ) ) {
+				$substrings_to_replace_with_field_name = $filtered_substrings;
+			} else {
+				_doing_it_wrong( __FUNCTION__, 'Only arrays should be returned when using the frm_error_substrings_to_replace_with_field_name filter.', 'x.x' );
+			}
 
-		foreach ( $substrings_to_replace_with_field_name as $substring ) {
-			if ( false !== strpos( $msg, $substring ) ) {
-				$msg = str_replace( $substring, FrmAppHelper::maybe_kses( $field_name ), $msg );
+			foreach ( $substrings_to_replace_with_field_name as $substring ) {
+				if ( false !== strpos( $msg, $substring ) ) {
+					$msg = str_replace( $substring, FrmAppHelper::maybe_kses( $field_name ), $msg );
+				}
 			}
 		}
 

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -362,11 +362,12 @@ class FrmFieldsHelper {
 		 *
 		 * @param array<string> $substrings_to_replace_with_field_name
 		 * @param array         $args {
-		 *     @type string $msg   The current error message before the substrings are replaced.
-		 *     @type string $error A key including 'unique_msg', 'invalid', 'blank', or 'conf_msg'.
+		 *     @type string       $msg   The current error message before the substrings are replaced.
+		 *     @type string       $error A key including 'unique_msg', 'invalid', 'blank', or 'conf_msg'.
+		 *     @type array|object $field The field with the error.
 		 * }
 		 */
-		$filtered_substrings = apply_filters( 'frm_error_substrings_to_replace_with_field_name', $substrings_to_replace_with_field_name, compact( 'msg', 'error' ) );
+		$filtered_substrings = apply_filters( 'frm_error_substrings_to_replace_with_field_name', $substrings_to_replace_with_field_name, compact( 'msg', 'error', 'field' ) );
 
 		if ( is_array( $filtered_substrings ) ) {
 			$substrings_to_replace_with_field_name = $filtered_substrings;

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -352,34 +352,45 @@ class FrmFieldsHelper {
 		$msg = empty( $msg ) ? $defaults[ $error ]['part'] : $msg;
 		$msg = do_shortcode( $msg );
 
-		if ( trim( $field_name ) ) {
+		$substrings_to_replace_with_field_name = array(
+			'[field_name]',
+		);
+
+		$use_name_value = FrmAppHelper::maybe_kses( $field_name );
+		if ( $use_name_value ) {
+			array_push(
+				$substrings_to_replace_with_field_name,
+				'This value',
+				'This field'
+			);
+		} else {
+			$use_name_value                        = __( 'This field', 'formidable' );
 			$substrings_to_replace_with_field_name = array(
 				'[field_name]',
-				'This value',
-				'This field',
 			);
-			/**
-			 * @since x.x
-			 *
-			 * @param array<string> $substrings_to_replace_with_field_name
-			 * @param array         $args {
-			 *     @type string       $msg   The current error message before the substrings are replaced.
-			 *     @type string       $error A key including 'unique_msg', 'invalid', 'blank', or 'conf_msg'.
-			 *     @type array|object $field The field with the error.
-			 * }
-			 */
-			$filtered_substrings = apply_filters( 'frm_error_substrings_to_replace_with_field_name', $substrings_to_replace_with_field_name, compact( 'msg', 'error', 'field' ) );
+		}
 
-			if ( is_array( $filtered_substrings ) ) {
-				$substrings_to_replace_with_field_name = $filtered_substrings;
-			} else {
-				_doing_it_wrong( __FUNCTION__, 'Only arrays should be returned when using the frm_error_substrings_to_replace_with_field_name filter.', 'x.x' );
-			}
+		/**
+		 * @since x.x
+		 *
+		 * @param array<string> $substrings_to_replace_with_field_name
+		 * @param array         $args {
+		 *     @type string       $msg   The current error message before the substrings are replaced.
+		 *     @type string       $error A key including 'unique_msg', 'invalid', 'blank', or 'conf_msg'.
+		 *     @type array|object $field The field with the error.
+		 * }
+		 */
+		$filtered_substrings = apply_filters( 'frm_error_substrings_to_replace_with_field_name', $substrings_to_replace_with_field_name, compact( 'msg', 'error', 'field' ) );
 
-			foreach ( $substrings_to_replace_with_field_name as $substring ) {
-				if ( false !== strpos( $msg, $substring ) ) {
-					$msg = str_replace( $substring, FrmAppHelper::maybe_kses( $field_name ), $msg );
-				}
+		if ( is_array( $filtered_substrings ) ) {
+			$substrings_to_replace_with_field_name = $filtered_substrings;
+		} else {
+			_doing_it_wrong( __FUNCTION__, 'Only arrays should be returned when using the frm_error_substrings_to_replace_with_field_name filter.', 'x.x' );
+		}
+
+		foreach ( $substrings_to_replace_with_field_name as $substring ) {
+			if ( false !== strpos( $msg, $substring ) ) {
+				$msg = str_replace( $substring, $use_name_value, $msg );
 			}
 		}
 

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -364,13 +364,11 @@ class FrmFieldsHelper {
 	 * @param array|object $field
 	 */
 	private static function maybe_replace_substrings_with_field_name( $msg, $error, $field ) {
-		$field_name            = is_array( $field ) ? $field['name'] : $field->name;
-		$field_name            = FrmAppHelper::maybe_kses( $field_name );
-		$substrings_to_replace = array( '[field_name]' );
+		$field_name = is_array( $field ) ? $field['name'] : $field->name;
+		$field_name = FrmAppHelper::maybe_kses( $field_name );
+		$substrings = self::get_substrings_to_replace_with_field_name( $field_name, compact( 'msg', 'error', 'field' ) );
 
-		if ( $field_name ) {
-			array_push( $substrings_to_replace, 'This value', 'This field' );
-		} else {
+		if ( ! $field_name ) {
 			if ( 'unique_msg' === $error ) {
 				$field_name = __( 'This value', 'formidable' );
 			} else {
@@ -378,25 +376,7 @@ class FrmFieldsHelper {
 			}
 		}
 
-		/**
-		 * @since x.x
-		 *
-		 * @param array<string> $substrings_to_replace
-		 * @param array         $args {
-		 *     @type string       $msg   The current error message before the substrings are replaced.
-		 *     @type string       $error A key including 'unique_msg', 'invalid', 'blank', or 'conf_msg'.
-		 *     @type array|object $field The field with the error.
-		 * }
-		 */
-		$filtered_substrings = apply_filters( 'frm_error_substrings_to_replace_with_field_name', $substrings_to_replace, compact( 'msg', 'error', 'field' ) );
-
-		if ( is_array( $filtered_substrings ) ) {
-			$substrings_to_replace = $filtered_substrings;
-		} else {
-			_doing_it_wrong( __FUNCTION__, 'Only arrays should be returned when using the frm_error_substrings_to_replace_with_field_name filter.', 'x.x' );
-		}
-
-		foreach ( $substrings_to_replace as $substring ) {
+		foreach ( $substrings as $substring ) {
 			if ( false !== strpos( $msg, $substring ) ) {
 				$msg = str_replace( $substring, $field_name, $msg );
 			}
@@ -406,10 +386,37 @@ class FrmFieldsHelper {
 	}
 
 	/**
+	 * @since x.x
+	 *
+	 * @param string $field_name
+	 * @param array  $filter_args {
+	 *     @type string       $msg   The current error message before the substrings are replaced.
+	 *     @type string       $error A key including 'unique_msg', 'invalid', 'blank', or 'conf_msg'.
+	 *     @type array|object $field The field with the error.
+	 * }
 	 * @return array
 	 */
-	private static function get_substrings_to_replace_with_field_name() {
+	private static function get_substrings_to_replace_with_field_name( $field_name, $filter_args ) {
+		$substrings = array( '[field_name]' );
+		if ( $field_name ) {
+			array_push( $substrings, 'This value', 'This field' );
+		}
 
+		/**
+		 * @since x.x
+		 *
+		 * @param array<string> $substrings
+		 * @param array         $filter_args
+		 */
+		$filtered_substrings = apply_filters( 'frm_error_substrings_to_replace_with_field_name', $substrings, $filter_args );
+
+		if ( is_array( $filtered_substrings ) ) {
+			$substrings = $filtered_substrings;
+		} else {
+			_doing_it_wrong( __FUNCTION__, 'Only arrays should be returned when using the frm_error_substrings_to_replace_with_field_name filter.', 'x.x' );
+		}
+
+		return $substrings;
 	}
 
 	public static function get_form_fields( $form_id, $error = array() ) {

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -383,9 +383,6 @@ class FrmFieldsHelper {
 			} else {
 				$field_name = __( 'This field', 'formidable' );
 			}
-			$substrings_to_replace_with_field_name = array(
-				'[field_name]',
-			);
 		}
 
 		/**

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -364,7 +364,11 @@ class FrmFieldsHelper {
 				'This field'
 			);
 		} else {
-			$use_name_value                        = __( 'This field', 'formidable' );
+			if ( 'unique_msg' === $error ) {
+				$use_name_value = __( 'This value', 'formidable' );
+			} else {
+				$use_name_value = __( 'This field', 'formidable' );
+			}
 			$substrings_to_replace_with_field_name = array(
 				'[field_name]',
 			);

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -364,19 +364,12 @@ class FrmFieldsHelper {
 	 * @param array|object $field
 	 */
 	private static function maybe_replace_substrings_with_field_name( $msg, $error, $field ) {
-		$field_name = is_array( $field ) ? $field['name'] : $field->name;
-		$field_name = FrmAppHelper::maybe_kses( $field_name );
-
-		$substrings_to_replace_with_field_name = array(
-			'[field_name]',
-		);
+		$field_name            = is_array( $field ) ? $field['name'] : $field->name;
+		$field_name            = FrmAppHelper::maybe_kses( $field_name );
+		$substrings_to_replace = array( '[field_name]' );
 
 		if ( $field_name ) {
-			array_push(
-				$substrings_to_replace_with_field_name,
-				'This value',
-				'This field'
-			);
+			array_push( $substrings_to_replace, 'This value', 'This field' );
 		} else {
 			if ( 'unique_msg' === $error ) {
 				$field_name = __( 'This value', 'formidable' );
@@ -388,22 +381,22 @@ class FrmFieldsHelper {
 		/**
 		 * @since x.x
 		 *
-		 * @param array<string> $substrings_to_replace_with_field_name
+		 * @param array<string> $substrings_to_replace
 		 * @param array         $args {
 		 *     @type string       $msg   The current error message before the substrings are replaced.
 		 *     @type string       $error A key including 'unique_msg', 'invalid', 'blank', or 'conf_msg'.
 		 *     @type array|object $field The field with the error.
 		 * }
 		 */
-		$filtered_substrings = apply_filters( 'frm_error_substrings_to_replace_with_field_name', $substrings_to_replace_with_field_name, compact( 'msg', 'error', 'field' ) );
+		$filtered_substrings = apply_filters( 'frm_error_substrings_to_replace_with_field_name', $substrings_to_replace, compact( 'msg', 'error', 'field' ) );
 
 		if ( is_array( $filtered_substrings ) ) {
-			$substrings_to_replace_with_field_name = $filtered_substrings;
+			$substrings_to_replace = $filtered_substrings;
 		} else {
 			_doing_it_wrong( __FUNCTION__, 'Only arrays should be returned when using the frm_error_substrings_to_replace_with_field_name filter.', 'x.x' );
 		}
 
-		foreach ( $substrings_to_replace_with_field_name as $substring ) {
+		foreach ( $substrings_to_replace as $substring ) {
 			if ( false !== strpos( $msg, $substring ) ) {
 				$msg = str_replace( $substring, $field_name, $msg );
 			}

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -194,11 +194,7 @@ class FrmFieldsHelper {
 	public static function default_unique_msg() {
 		$frm_settings   = FrmAppHelper::get_settings();
 		$unique_message = $frm_settings->unique_msg;
-
-		if ( false !== strpos( $unique_message, 'This value' ) ) {
-			$unique_message = str_replace( 'This value', '[field_name]', $unique_message );
-		}
-
+		$unique_message = str_replace( 'This value', '[field_name]', $unique_message );
 		return $unique_message;
 	}
 
@@ -210,11 +206,7 @@ class FrmFieldsHelper {
 	public static function default_blank_msg() {
 		$frm_settings  = FrmAppHelper::get_settings();
 		$blank_message = $frm_settings->blank_msg;
-
-		if ( false !== strpos( $blank_message, 'This field' ) ) {
-			$blank_message = str_replace( 'This field', '[field_name]', $blank_message );
-		}
-
+		$blank_message = str_replace( 'This field', '[field_name]', $blank_message );
 		return $blank_message;
 	}
 
@@ -377,12 +369,7 @@ class FrmFieldsHelper {
 			}
 		}
 
-		foreach ( $substrings as $substring ) {
-			if ( false !== strpos( $msg, $substring ) ) {
-				$msg = str_replace( $substring, $field_name, $msg );
-			}
-		}
-
+		$msg = str_replace( $substrings, $field_name, $msg );
 		return $msg;
 	}
 

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -368,6 +368,7 @@ class FrmFieldsHelper {
 		$field_name = FrmAppHelper::maybe_kses( $field_name );
 		$substrings = self::get_substrings_to_replace_with_field_name( $field_name, compact( 'msg', 'error', 'field' ) );
 
+		// Use the "This value"/"This field" placeholder strings if field name is empty.
 		if ( ! $field_name ) {
 			if ( 'unique_msg' === $error ) {
 				$field_name = __( 'This value', 'formidable' );

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -378,6 +378,8 @@ class FrmFieldsHelper {
 	 *
 	 * @param string $field_name
 	 * @param array  $filter_args {
+	 *     Filter arguments.
+	 *
 	 *     @type string       $msg   The current error message before the substrings are replaced.
 	 *     @type string       $error A key including 'unique_msg', 'invalid', 'blank', or 'conf_msg'.
 	 *     @type array|object $field The field with the error.

--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -106,7 +106,8 @@ class FrmSettings {
 			're_multi' => 1,
 
 			'success_msg'      => __( 'Your responses were successfully submitted. Thank you!', 'formidable' ),
-			'blank_msg'        => __( 'This field cannot be blank.', 'formidable' ),
+			// translators: %s: [field_name] shortcode.
+			'blank_msg'        => sprintf( __( '%s cannot be blank.', 'formidable' ), '[field_name]' ),
 			'unique_msg'       => __( 'This value must be unique.', 'formidable' ),
 			'invalid_msg'      => __( 'There was a problem with your submission. Errors are marked below.', 'formidable' ),
 			'failed_msg'       => __( 'We\'re sorry. It looks like you\'ve already submitted that.', 'formidable' ),

--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -108,7 +108,8 @@ class FrmSettings {
 			'success_msg'      => __( 'Your responses were successfully submitted. Thank you!', 'formidable' ),
 			// translators: %s: [field_name] shortcode.
 			'blank_msg'        => sprintf( __( '%s cannot be blank.', 'formidable' ), '[field_name]' ),
-			'unique_msg'       => __( 'This value must be unique.', 'formidable' ),
+			// translators: %s: [field_name] shortcode.
+			'unique_msg'       => sprintf( __( '%s must be unique.', 'formidable' ), '[field_name]' ),
 			'invalid_msg'      => __( 'There was a problem with your submission. Errors are marked below.', 'formidable' ),
 			'failed_msg'       => __( 'We\'re sorry. It looks like you\'ve already submitted that.', 'formidable' ),
 			'submit_value'     => __( 'Submit', 'formidable' ),

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -648,17 +648,6 @@ DEFAULT_HTML;
 		return array_merge( $field, $field_options );
 	}
 
-	protected function default_unique_msg() {
-		if ( is_object( $this->field ) && ! FrmField::is_option_true( $this->field, 'unique' ) ) {
-			$message = '';
-		} else {
-			$frm_settings = FrmAppHelper::get_settings();
-			$message      = $frm_settings->unique_msg;
-		}
-
-		return $message;
-	}
-
 	/**
 	 * @return string
 	 */
@@ -708,7 +697,7 @@ DEFAULT_HTML;
 			'blank'              => FrmFieldsHelper::default_blank_msg(),
 			'required_indicator' => '*',
 			'invalid'            => $this->default_invalid_msg(),
-			'unique_msg'         => $this->default_unique_msg(),
+			'unique_msg'         => '',
 			'separate_value'     => 0,
 			'clear_on_focus'     => 0,
 			'classes'            => '',
@@ -1584,5 +1573,15 @@ DEFAULT_HTML;
 			FrmAppHelper::unserialize_or_decode( $value );
 		}
 		return $value;
+	}
+
+	/**
+	 * @deprecated x.x
+	 */
+	protected function default_unique_msg() {
+		_deprecated_function( __METHOD__, 'x.x' );
+		$frm_settings = FrmAppHelper::get_settings();
+		$message      = $frm_settings->unique_msg;
+		return $message;
 	}
 }

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -640,9 +640,6 @@ DEFAULT_HTML;
 			'options'       => '',
 			'default_value' => '',
 			'required'      => false,
-			'blank'         => $frm_settings->blank_msg,
-			'unique_msg'    => $this->default_unique_msg(),
-			'invalid'       => $this->default_invalid_msg(),
 			'field_options' => $this->get_default_field_options(),
 		);
 
@@ -662,16 +659,11 @@ DEFAULT_HTML;
 		return $message;
 	}
 
+	/**
+	 * @return string
+	 */
 	protected function default_invalid_msg() {
-		$field_name = $this->get_field_column( 'name' );
-		if ( $field_name == '' ) {
-			$invalid = __( 'This field is invalid', 'formidable' );
-		} else {
-			/* translators: %s: The field name. */
-			$invalid = sprintf( __( '%s is invalid', 'formidable' ), $field_name );
-		}
-
-		return $invalid;
+		return FrmFieldsHelper::default_invalid_msg();
 	}
 
 	/**
@@ -708,13 +700,15 @@ DEFAULT_HTML;
 	 * @return array
 	 */
 	public function get_default_field_options() {
-		$opts       = array(
+		$frm_settings = FrmAppHelper::get_settings();
+		$opts         = array(
 			'size'               => '',
 			'max'                => '',
 			'label'              => '',
-			'blank'              => '',
+			'blank'              => FrmFieldsHelper::default_blank_msg(),
 			'required_indicator' => '*',
-			'invalid'            => '',
+			'invalid'            => $this->default_invalid_msg(),
+			'unique_msg'         => $this->default_unique_msg(),
 			'separate_value'     => 0,
 			'clear_on_focus'     => 0,
 			'classes'            => '',
@@ -726,10 +720,9 @@ DEFAULT_HTML;
 			'placeholder'        => '',
 			'draft'              => 0,
 		);
-		$field_opts = $this->extra_field_opts();
-		$opts       = array_merge( $opts, $field_opts );
-
-		$filter_args = array(
+		$field_opts   = $this->extra_field_opts();
+		$opts         = array_merge( $opts, $field_opts );
+		$filter_args  = array(
 			'field' => $this->field,
 			'type'  => $this->type,
 		);

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -649,13 +649,6 @@ DEFAULT_HTML;
 	}
 
 	/**
-	 * @return string
-	 */
-	protected function default_invalid_msg() {
-		return FrmFieldsHelper::default_invalid_msg();
-	}
-
-	/**
 	 * Get the default field name when a field is inserted into a form.
 	 *
 	 * @return string
@@ -696,7 +689,7 @@ DEFAULT_HTML;
 			'label'              => '',
 			'blank'              => FrmFieldsHelper::default_blank_msg(),
 			'required_indicator' => '*',
-			'invalid'            => $this->default_invalid_msg(),
+			'invalid'            => '',
 			'unique_msg'         => '',
 			'separate_value'     => 0,
 			'clear_on_focus'     => 0,
@@ -1577,11 +1570,23 @@ DEFAULT_HTML;
 
 	/**
 	 * @deprecated x.x
+	 *
+	 * @return string
 	 */
 	protected function default_unique_msg() {
-		_deprecated_function( __METHOD__, 'x.x' );
+		_deprecated_function( __METHOD__, 'x.x', 'FrmFieldsHelper::default_unique_msg' );
 		$frm_settings = FrmAppHelper::get_settings();
 		$message      = $frm_settings->unique_msg;
 		return $message;
+	}
+
+	/**
+	 * @deprecated x.x
+	 *
+	 * @return string
+	 */
+	protected function default_invalid_msg() {
+		_deprecated_function( __METHOD__, 'x.x', 'FrmFieldsHelper::default_invalid_msg' );
+		return FrmFieldsHelper::default_invalid_msg();
 	}
 }

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -682,8 +682,7 @@ DEFAULT_HTML;
 	 * @return array
 	 */
 	public function get_default_field_options() {
-		$frm_settings = FrmAppHelper::get_settings();
-		$opts         = array(
+		$opts        = array(
 			'size'               => '',
 			'max'                => '',
 			'label'              => '',
@@ -702,9 +701,9 @@ DEFAULT_HTML;
 			'placeholder'        => '',
 			'draft'              => 0,
 		);
-		$field_opts   = $this->extra_field_opts();
-		$opts         = array_merge( $opts, $field_opts );
-		$filter_args  = array(
+		$field_opts  = $this->extra_field_opts();
+		$opts        = array_merge( $opts, $field_opts );
+		$filter_args = array(
 			'field' => $this->field,
 			'type'  => $this->type,
 		);

--- a/tests/fields/test_FrmFieldsHelper.php
+++ b/tests/fields/test_FrmFieldsHelper.php
@@ -269,7 +269,6 @@ class test_FrmFieldsHelper extends FrmUnitTest {
 
 	/**
 	 * @covers FrmFieldsHelper::get_error_msg
-	 * @group mike
 	 */
 	public function test_get_error_msg() {
 		$form_id = $this->factory->form->create();

--- a/tests/fields/test_FrmFieldsHelper.php
+++ b/tests/fields/test_FrmFieldsHelper.php
@@ -266,4 +266,40 @@ class test_FrmFieldsHelper extends FrmUnitTest {
 			FrmFieldsHelper::replace_content_shortcodes( $shortcode, $entry, $shortcodes )
 		);
 	}
+
+	/**
+	 * @covers FrmFieldsHelper::get_error_msg
+	 */
+	public function test_get_error_msg() {
+		$form_id = $this->factory->form->create();
+
+		// Test a field with no name. We should see "This field" (or "This value" for unique validation).
+		$field = $this->factory->field->create_and_get(
+			array(
+				'name'          => '',
+				'form_id'       => $form_id,
+				'type'          => 'text',
+				'field_options' => array(
+					'blank'      => '[field_name] cannot be blank',
+					'unique_msg' => '[field_name] must be unique',
+				),
+			)
+		);
+
+		$error_message = FrmFieldsHelper::get_error_msg( $field, 'blank' );
+		$this->assertEquals( 'This field cannot be blank', $error_message );
+
+		$error_message = FrmFieldsHelper::get_error_msg( $field, 'unique_msg' );
+		$this->assertEquals( 'This value must be unique', $error_message );
+
+		// Test with a field name.
+		$field->name = 'My example field';
+
+		$error_message = FrmFieldsHelper::get_error_msg( $field, 'blank' );
+		$this->assertEquals( 'My example field cannot be blank', $error_message );
+
+		$error_message = FrmFieldsHelper::get_error_msg( $field, 'unique_msg' );
+		$this->assertEquals( 'My example field must be unique', $error_message );
+
+	}
 }

--- a/tests/fields/test_FrmFieldsHelper.php
+++ b/tests/fields/test_FrmFieldsHelper.php
@@ -301,5 +301,14 @@ class test_FrmFieldsHelper extends FrmUnitTest {
 		$error_message = FrmFieldsHelper::get_error_msg( $field, 'unique_msg' );
 		$this->assertEquals( 'My example field must be unique', $error_message );
 
+		// Test that "This field" and "This value" are automatically replaced.
+		$field->field_options['blank']      = 'This field cannot be blank';
+		$field->field_options['unique_msg'] = 'This value must be unique';
+
+		$error_message = FrmFieldsHelper::get_error_msg( $field, 'blank' );
+		$this->assertEquals( 'My example field cannot be blank', $error_message );
+
+		$error_message = FrmFieldsHelper::get_error_msg( $field, 'unique_msg' );
+		$this->assertEquals( 'My example field must be unique', $error_message );
 	}
 }

--- a/tests/fields/test_FrmFieldsHelper.php
+++ b/tests/fields/test_FrmFieldsHelper.php
@@ -269,6 +269,7 @@ class test_FrmFieldsHelper extends FrmUnitTest {
 
 	/**
 	 * @covers FrmFieldsHelper::get_error_msg
+	 * @group mike
 	 */
 	public function test_get_error_msg() {
 		$form_id = $this->factory->form->create();


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2505693625/189582/

> if a field is left blank, the error message needs to include what field , such as "The name field cannot be left blank", "the message field cannot be left blank", etc.

I initially brought this up in Slack (https://strategy11.slack.com/archives/G01KDLFJTJS/p1707484587610489).

Quoting Steph's reply,
> We could use "[label] cannot be blank", but I think it's fine if we replace "this field" so we don't have to add extra support, and fix this for existing forms.

I'm using `[field_name]` (rather than `[label]`) which is already a supported in a few places. I believe it works with JavaScript validation without making further changes because it gets replaced in field HTML already.

**Some issues with blank error messages require https://github.com/Strategy11/formidable-pro/pull/4822 or the "This field"/ text will still be used when Pro is active.**

### General Description
- Some substrings are now replaced in error messages.
    - "This field" and "This value" will be replaced by a field name dynamically. This is for backward compatibility so old fields are also supported. This can be disabled using a new `frm_error_substrings_to_replace_with_field_name` filter.
    -  On settings pages, "This field" and "This value" will be changed to `[field_name]` automatically in the builder.
- I try to use `[field_name]` everywhere as much as possible. **This works better with translations** than trying to only use the "This field"/"This value" substrings.

I left some comments in the PR with more details as to why certain changes were made.

I added a new `frm_error_substrings_to_replace_with_field_name` filter so this can be tweaked. If someone wants to keep their "This field" or "This value" substrings from getting converted to `[field_name]` then they can use those filters to remove the strings from the array.

**The hook can also be used to add additional translated strings, if you wanted to convert more substrings universally in a single place.**

Example usage to only replace `[field_name]` shortcodes,
```
add_filter( 'frm_error_substrings_to_replace_with_field_name', function() {
	return array( '[field_name]' );
} );
```

There is however no way to avoid the `str_replace` happening when a new field loads its default value from the global settings. I always replace "This field" and "This value" from the global setting to `[field_name]` when a new field is inserted.
