### PR TITLE
Add shortcodes popup to ai field

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6985,7 +6985,8 @@ function frmAdminBuildJS() {
 	}
 
 	function shouldAddShortcodesModalTriggerIcon( fieldType ) {
-		const fieldsWithShortcodesBox = [ 'html', 'ai' ];
+		const fieldsWithShortcodesBox = wp.hooks.applyFilters( 'frm_fields_with_shortcode_popup', [ 'html' ] );
+
 		return fieldsWithShortcodesBox.includes( fieldType );
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6985,7 +6985,7 @@ function frmAdminBuildJS() {
 	}
 
 	function shouldAddShortcodesModalTriggerIcon( fieldType ) {
-		const fieldsWithShortcodesBox = wp.hooks.applyFilters( 'frm_fields_with_shortcode_popup', [ 'html' ] );
+		const fieldsWithShortcodesBox = wp.hooks.applyFilters( 'frm_fields_with_shortcode_popup', [ 'html' ]);
 
 		return fieldsWithShortcodesBox.includes( fieldType );
 	}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6970,7 +6970,7 @@ function frmAdminBuildJS() {
 		singleField.querySelector( '.wp-editor-container' )?.classList.add( 'frm_has_shortcodes' );
 
 		const wrapTextareaWithIconContainer = () => {
-			const textarea = document.querySelector( fieldSettingsSelector + ' textarea' );
+			const textarea = document.querySelector( fieldSettingsSelector + ' .frm_has_shortcodes textarea' );
 			const wrapperSpan = span({ className: 'frm-with-right-icon' });
 			textarea.parentNode.insertBefore( wrapperSpan, textarea );
 			wrapperSpan.appendChild( createModalTriggerIcon() );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6967,7 +6967,7 @@ function frmAdminBuildJS() {
 		if ( document.querySelector( fieldSettingsSelector + ' .frm-show-box' ) ) {
 			return;
 		}
-		singleField.querySelector( '.wp-editor-container' ).classList.add( 'frm_has_shortcodes' );
+		singleField.querySelector( '.wp-editor-container' )?.classList.add( 'frm_has_shortcodes' );
 
 		const wrapTextareaWithIconContainer = () => {
 			const textarea = document.querySelector( fieldSettingsSelector + ' textarea' );
@@ -6985,7 +6985,7 @@ function frmAdminBuildJS() {
 	}
 
 	function shouldAddShortcodesModalTriggerIcon( fieldType ) {
-		const fieldsWithShortcodesBox = [ 'html' ];
+		const fieldsWithShortcodesBox = [ 'html', 'ai' ];
 		return fieldsWithShortcodesBox.includes( fieldType );
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-ai/issues/51
This update in lite is required to make shortcode popups work for an AI field in https://github.com/Strategy11/formidable-ai/pull/50 work