### PR TITLE
Add an is_array check in get_addon_for_license function fix

### DIFF
--- a/classes/models/FrmFormApi.php
+++ b/classes/models/FrmFormApi.php
@@ -158,7 +158,7 @@ class FrmFormApi {
 		$plugin      = array();
 		if ( empty( $download_id ) && ! empty( $addons ) ) {
 			foreach ( $addons as $addon ) {
-				if ( strtolower( $license_plugin->plugin_name ) == strtolower( $addon['title'] ) ) {
+				if ( is_array( $addon ) && strtolower( $license_plugin->plugin_name ) === strtolower( $addon['title'] ) ) {
 					return $addon;
 				}
 			}


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2517410674/190926

> An error of type E_ERROR was caused in line 161 of the file .../plugins/formidable/classes/models/FrmFormApi.php. Error message: Uncaught TypeError: Cannot access offset of type string on string in .../plugins/formidable/classes/models/FrmFormApi.php:161

The array of `$addons` includes non-array values `$addon` like `"active_sub" => "no"` and `"expires" => "1769903999"`.

This update makes sure that we only check array `$addon` values.

Pre-release,
[formidable-6.8.3b.zip](https://github.com/Strategy11/formidable-forms/files/14361728/formidable-6.8.3b.zip)
