### PR TITLE
Fix incorrect covers comment in unit test

### DIFF
--- a/tests/fields/test_FrmFieldsHelper.php
+++ b/tests/fields/test_FrmFieldsHelper.php
@@ -230,7 +230,7 @@ class test_FrmFieldsHelper extends FrmUnitTest {
 	/**
 	 * Test the "sep" option for checkbox field shortcodes.
 	 *
-	 * @covers FrmFormsHelper::replace_content_shortcodes
+	 * @covers FrmFieldsHelper::replace_content_shortcodes
 	 */
 	public function test_sep_option() {
 		$form           = $this->factory->form->create_and_get();


### PR DESCRIPTION
This is just a small fix for a PHPUnit warning I was seeing,

<img width="542" alt="Screen Shot 2024-02-21 at 11 48 19 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/cbbed4bd-0f11-44f3-94c0-63770f9ffb34">
