### PR TITLE
improve table style for two cell rows

### DIFF
--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -275,6 +275,20 @@ class FrmTableHTMLGenerator {
 	}
 
 	/**
+	 * Appends inline css props to existing style string of style="prop:value" format
+	 *
+	 * @since x.x
+	 *
+	 * @param string $props
+	 * @param string $style
+	 *
+	 * @return string
+	 */
+	private function add_props_to_inline_style( $props, $style ) {
+		return rtrim( $style, '"' ) . $props . '"';
+	}
+
+	/**
 	 * Generate a two cell row for an HTML table
 	 *
 	 * @since 2.04
@@ -285,12 +299,12 @@ class FrmTableHTMLGenerator {
 	 * @return string
 	 */
 	public function generate_two_cell_table_row( $label, $value ) {
-		$row = '<tr' . $this->tr_style();
+		$row = '<tr ' . $this->add_props_to_inline_style( 'display:flex;', $this->tr_style() );
 		$row .= $this->add_row_class( $value === '' );
 		$row .= '>';
 
-		$label = '<th' . rtrim( $this->td_style, '"' ) . ' width: 50%;"' . '>' . wp_kses_post( $label ) . '</th>';
-		$value = '<td' . $this->td_style . '>' . wp_kses_post( $value ) . '</td>';
+		$label = '<th ' . $this->add_props_to_inline_style( 'min-width:50%;max-width: 50%;', $this->td_style ) . ' >' . wp_kses_post( $label ) . '</th>';
+		$value = '<td ' . $this->add_props_to_inline_style( 'width: 100%;', $this->td_style ) . ' >' . wp_kses_post( $value ) . '</td>';
 
 		if ( 'rtl' == $this->direction ) {
 			$row .= $value;

--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -299,12 +299,12 @@ class FrmTableHTMLGenerator {
 	 * @return string
 	 */
 	public function generate_two_cell_table_row( $label, $value ) {
-		$row = '<tr ' . $this->add_props_to_inline_style( 'display:flex;', $this->tr_style() );
+		$row = '<tr' . $this->add_props_to_inline_style( 'display:flex;', $this->tr_style() );
 		$row .= $this->add_row_class( $value === '' );
 		$row .= '>';
 
-		$label = '<th ' . $this->add_props_to_inline_style( 'min-width:50%;max-width: 50%;', $this->td_style ) . ' >' . wp_kses_post( $label ) . '</th>';
-		$value = '<td ' . $this->add_props_to_inline_style( 'width: 100%;', $this->td_style ) . ' >' . wp_kses_post( $value ) . '</td>';
+		$label = '<th' . $this->add_props_to_inline_style( 'min-width:50%;max-width: 50%;', $this->td_style ) . '>' . wp_kses_post( $label ) . '</th>';
+		$value = '<td' . $this->add_props_to_inline_style( 'width: 100%;', $this->td_style ) . '>' . wp_kses_post( $value ) . '</td>';
 
 		if ( 'rtl' == $this->direction ) {
 			$row .= $value;

--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -289,10 +289,8 @@ class FrmTableHTMLGenerator {
 		$row .= $this->add_row_class( $value === '' );
 		$row .= '>';
 
-		$td_style_with_limited_width = rtrim( $this->td_style, '"' ) . ' width: 50%;"';
-
-		$label = '<th' . $td_style_with_limited_width . '>' . wp_kses_post( $label ) . '</th>';
-		$value = '<td' . $td_style_with_limited_width . '>' . wp_kses_post( $value ) . '</td>';
+		$label = '<th' . rtrim( $this->td_style, '"' ) . ' width: 50%;"' . '>' . wp_kses_post( $label ) . '</th>';
+		$value = '<td' . $this->td_style . '>' . wp_kses_post( $value ) . '</td>';
 
 		if ( 'rtl' == $this->direction ) {
 			$row .= $value;

--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -285,6 +285,9 @@ class FrmTableHTMLGenerator {
 	 * @return string
 	 */
 	private function add_props_to_inline_style( $props, $style ) {
+		if ( empty( $style ) ) {
+			return 'style="' . $props . '"';
+		}
 		return rtrim( $style, '"' ) . $props . '"';
 	}
 

--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -289,8 +289,10 @@ class FrmTableHTMLGenerator {
 		$row .= $this->add_row_class( $value === '' );
 		$row .= '>';
 
-		$label = '<th' . $this->td_style . '>' . wp_kses_post( $label ) . '</th>';
-		$value = '<td' . $this->td_style . '>' . wp_kses_post( $value ) . '</td>';
+		$td_style_with_limited_width = rtrim( $this->td_style, '"' ) . ' width: 50%;"';
+
+		$label = '<th' . $td_style_with_limited_width . '>' . wp_kses_post( $label ) . '</th>';
+		$value = '<td' . $td_style_with_limited_width . '>' . wp_kses_post( $value ) . '</td>';
 
 		if ( 'rtl' == $this->direction ) {
 			$row .= $value;


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-quizzes/issues/189

When any of the first column cells have a long content, it pushes the second column far to the right and squashes it.

It looks max-width is not supported for non-replaced inline elements (See https://developer.mozilla.org/en-US/docs/Web/CSS/max-width#formal_definition). I just set the first cell's width to `50%` and believe it is just enough.

**Before**:
<img width="1435" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/617f2068-56cb-4ad6-8184-7d92f5283e1f">

**After**:
<img width="1435" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/e909fd7f-546b-49af-9c69-c19055a792f9">

### Test steps
1. Create a form and add some fields to it.
2. Edit one of the fields to make the label be a very long text.
3. Configure 'Send email' action to send the default message to your email.
4. Submit an entry populating the fields with values.
5. Check the table in the email sent out and confirm that the maximum width of the labels is 50% of the total row width