### PR TITLE
Add an isset check to FrmFormApi::get_addon_for_license

### DIFF
--- a/classes/models/FrmFormApi.php
+++ b/classes/models/FrmFormApi.php
@@ -158,7 +158,7 @@ class FrmFormApi {
 		$plugin      = array();
 		if ( empty( $download_id ) && ! empty( $addons ) ) {
 			foreach ( $addons as $addon ) {
-				if ( is_array( $addon ) && strtolower( $license_plugin->plugin_name ) === strtolower( $addon['title'] ) ) {
+				if ( is_array( $addon ) && ! empty( $addon['title'] ) && strtolower( $license_plugin->plugin_name ) === strtolower( $addon['title'] ) ) {
 					return $addon;
 				}
 			}


### PR DESCRIPTION
Following up from an update from yesterday (https://github.com/Strategy11/formidable-forms/pull/1524).

I'm testing with errors, and there are still PHP warnings coming from this line still because errors are arrays but do not include the `title` key.

> PHP Warning:  Undefined array key "title" in /var/www/src/wp-content/plugins/formidable/classes/models/FrmFormApi.php on line 161

>  PHP Deprecated:  strtolower(): Passing null to parameter #1 ($string) of type string is deprecated