### PR TITLE
Fix deprecated messaged when running Stripe unit tests

### DIFF
--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -652,6 +652,11 @@ class FrmUnitTest extends WP_UnitTestCase {
 
 	protected function set_private_property( $object, $property, $value ) {
 		$p = $this->get_accessible_property( $object, $property );
+		if ( ! is_object( $object ) && ! is_null( $object ) ) {
+			// Avoid passing a non-object, non-null value to setValue.
+			// Otherwise a ReflectionProperty::setValue() with a 1st argument which is not null or an object message will get logged.
+			$object = null;
+		}
 		$p->setValue( $object, $value );
 	}
 


### PR DESCRIPTION
I saw this message a lot when running Stripe unit tests.

This is just a small update to not pass a string as the 1st argument to `setValue`. I'm passing null instead of the param is the unexpected type.

> PHP Deprecated:  Calling ReflectionProperty::setValue() with a 1st argument which is not null or an object is deprecated in .../formidable/tests/base/FrmUnitTest.php on line 655