### PR TITLE
Remove a lot of old CSS rules that are no longer required

### DIFF
--- a/classes/controllers/FrmSMTPController.php
+++ b/classes/controllers/FrmSMTPController.php
@@ -452,8 +452,6 @@ class FrmSMTPController {
 		?>
 <style>
 #frm-admin-smtp *, #frm-admin-smtp *::before, #frm-admin-smtpp *::after {
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
 #frm-admin-smtp{
@@ -514,8 +512,6 @@ class FrmSMTPController {
 }
 #frm-admin-smtp .step,
 #frm-admin-smtp .screenshot .cont {
-	-webkit-box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.05);
-	-moz-box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.05);
 	box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.05);
 }
 #frm-admin-smtp .step {

--- a/classes/models/FrmSolution.php
+++ b/classes/models/FrmSolution.php
@@ -786,8 +786,6 @@ class FrmSolution {
 		?>
 <style>
 #frm-welcome *, #frm-welcome *::before, #frm-welcome  *::after {
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
 #frm-welcome{
@@ -848,8 +846,6 @@ class FrmSolution {
 }
 #frm-welcome .step,
 #frm-welcome .screenshot .cont {
-	-webkit-box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.05);
-	-moz-box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.05);
 	box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.05);
 }
 #frm-welcome .step {

--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -265,8 +265,6 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 	color:<?php echo esc_html( $submit_text_color . $important ); ?>;
 	cursor:pointer;
 	font-weight:<?php echo esc_html( $submit_weight . $important ); ?>;
-	-moz-border-radius:<?php echo esc_html( $submit_border_radius . $important ); ?>;
-	-webkit-border-radius:<?php echo esc_html( $submit_border_radius . $important ); ?>;
 	border-radius:<?php echo esc_html( $submit_border_radius . $important ); ?>;
 	text-shadow:none;
 	padding:<?php echo esc_html( $submit_padding . $important ); ?>;
@@ -274,8 +272,6 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 	box-sizing:border-box;
 	-ms-box-sizing:border-box;
 	<?php if ( ! empty( $submit_shadow_color ) ) { ?>
-	-moz-box-shadow:0 1px 1px <?php echo esc_html( $submit_shadow_color ); ?>;
-	-webkit-box-shadow:0 1px 1px <?php echo esc_html( $submit_shadow_color ); ?>;
 	box-shadow:0 1px 1px <?php echo esc_html( $submit_shadow_color ); ?>;
 	<?php } ?>
 	margin:<?php echo esc_html( $submit_margin ); ?>;

--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -195,10 +195,6 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 <?php echo esc_html( $style_class ); ?> textarea:-ms-input-placeholder{
 	color: <?php echo esc_html( $text_color_disabled . $important ); ?>;
 }
-.<?php echo esc_html( $style_class ); ?> input:-moz-placeholder,
-.<?php echo esc_html( $style_class ); ?> textarea:-moz-placeholder{
-	color: <?php echo esc_html( $text_color_disabled . $important ); ?>;
-}
 
 .<?php echo esc_html( $style_class ); ?> .frm_default,
 .<?php echo esc_html( $style_class ); ?> input.frm_default,
@@ -268,7 +264,6 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 	border-radius:<?php echo esc_html( $submit_border_radius . $important ); ?>;
 	text-shadow:none;
 	padding:<?php echo esc_html( $submit_padding . $important ); ?>;
-	-moz-box-sizing:border-box;
 	box-sizing:border-box;
 	-ms-box-sizing:border-box;
 	<?php if ( ! empty( $submit_shadow_color ) ) { ?>

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -41,6 +41,7 @@ $important     = empty( $defaults['important_style'] ) ? '' : ' !important';
 	text-align:var(--form-align)<?php echo esc_html( $important ); ?>;
 }
 
+/* Keep this. This is used for Honeypot */
 input:-webkit-autofill {
 	-webkit-box-shadow: 0 0 0 30px white inset;
 }
@@ -245,8 +246,6 @@ legend.frm_hidden{
 	border-width:var(--field-border-width)<?php echo esc_html( $important ); ?>;
 	border-style:<?php echo esc_html( $defaults['field_border_style'] ); ?>;
 	border-style:var(--field-border-style)<?php echo esc_html( $important ); ?>;
-	-moz-border-radius:<?php echo esc_html( $defaults['border_radius'] . $important ); ?>;
-	-webkit-border-radius:<?php echo esc_html( $defaults['border_radius'] . $important ); ?>;
 	border-radius:<?php echo esc_html( $defaults['border_radius'] ); ?>;
 	border-radius:var(--border-radius)<?php echo esc_html( $important ); ?>;
 	width:<?php echo esc_html( $defaults['field_width'] ); ?>;
@@ -256,8 +255,6 @@ legend.frm_hidden{
 	font-size:var(--field-font-size)<?php echo esc_html( $important ); ?>;
 	padding:<?php echo esc_html( $defaults['field_pad'] ); ?>;
 	padding:var(--field-pad)<?php echo esc_html( $important ); ?>;
-	-webkit-box-sizing:border-box;
-	-moz-box-sizing:border-box;
 	box-sizing:border-box;
 	outline:none<?php echo esc_html( $important ); ?>;
 	font-weight:<?php echo esc_html( $defaults['field_weight'] ); ?>;
@@ -619,8 +616,6 @@ legend.frm_hidden{
 	padding:5px;
 <?php } ?>
 <?php if ( ! empty( $defaults['border_radius'] ) ) { ?>
-	-moz-border-radius:<?php echo esc_html( $defaults['border_radius'] . $important ); ?>;
-	-webkit-border-radius:<?php echo esc_html( $defaults['border_radius'] . $important ); ?>;
 	border-radius:<?php echo esc_html( $defaults['border_radius'] . $important ); ?>;
 	border-radius:var(--border-radius)<?php echo esc_html( $important ); ?>;
 <?php } ?>
@@ -773,10 +768,7 @@ legend.frm_hidden{
 	margin-left: -<?php echo absint( $loader_size / 2 ); ?>px;
 	width: <?php echo absint( $loader_size ); ?>px;
 	height: <?php echo absint( $loader_size ); ?>px;
-	-webkit-animation: spin 2s linear infinite;
-	-moz-animation:    spin 2s linear infinite;
-	-o-animation:      spin 2s linear infinite;
-	animation:         spin 2s linear infinite;
+	animation: spin 2s linear infinite;
 }
 
 .with_frm_style .frm_submit.frm_flex {
@@ -927,7 +919,6 @@ a.frm_save_draft{
 .with_frm_style .frm_scale input[type=radio],
 <?php endif; ?>
 .with_frm_style .frm_checkbox input[type=checkbox]{
-	-webkit-appearance: none;
 	appearance: none;
 	background-color: var(--bg-color);
 	flex: none;
@@ -989,8 +980,6 @@ a.frm_save_draft{
 .with_frm_style .frm_error_style,
 .with_frm_style .frm_message,
 .frm_success_style{
-	-moz-border-radius:4px;
-	-webkit-border-radius:4px;
 	border-radius:4px;
 	padding:15px;
 }
@@ -1254,8 +1243,6 @@ select.frm_loading_lookup{
 .wp-editor-wrap *,
 .wp-editor-wrap *:after,
 .wp-editor-wrap *:before{
-	-webkit-box-sizing:content-box;
-	-moz-box-sizing:content-box;
 	box-sizing:content-box;
 }
 
@@ -1537,8 +1524,6 @@ select.frm_loading_lookup{
 	border-width:var(--field-border-width);
 	border-style:<?php echo esc_html( $defaults['field_border_style'] ); ?>;
 	border-style:var(--field-border-style);
-	-moz-border-radius:<?php echo esc_html( $defaults['border_radius'] ); ?>;
-	-webkit-border-radius:<?php echo esc_html( $defaults['border_radius'] ); ?>;
 	border-radius:<?php echo esc_html( $defaults['border_radius'] ); ?>;
 	border-radius:var(--border-radius);
 	width:<?php echo esc_html( $defaults['field_width'] ); ?>;
@@ -1548,8 +1533,6 @@ select.frm_loading_lookup{
 	font-size:var(--field-font-size);
 	padding:<?php echo esc_html( $defaults['field_pad'] ); ?>;
 	padding:var(--field-pad);
-	-webkit-box-sizing:border-box;
-	-moz-box-sizing:border-box;
 	box-sizing:border-box;
 	outline:none<?php echo esc_html( $important ); ?>;
 	font-weight:normal;
@@ -1564,8 +1547,6 @@ select.frm_loading_lookup{
 	background-color:transparent !important;
 	border:none !important;
 	font-weight:bold;
-	-moz-box-shadow:none;
-	-webkit-box-shadow:none;
 	width:auto !important;
 	height:auto !important;
 	box-shadow:none !important;
@@ -1587,8 +1568,6 @@ select.frm_loading_lookup{
 .frm_form_field.frm_total textarea:focus{
 	background-color:transparent;
 	border:none;
-	-moz-box-shadow:none;
-	-webkit-box-shadow:none;
 	box-shadow:none;
 }
 

--- a/css/font_icons.css
+++ b/css/font_icons.css
@@ -64,7 +64,6 @@ a.frm_icon_font:hover{
 .frm_icon_font:focus,
 .frm_dashicon_font:focus{
 	box-shadow:none;
-	-webkit-box-shadow:none;
 }
 
 .frmfont:active,

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -561,7 +561,6 @@ ul.frm_form_nav > li {
 .frm_form_nav a:active,
 .frm_form_nav a:focus {
 	outline: none;
-	-webkit-box-shadow: none;
 	box-shadow: none;
 }
 
@@ -4021,8 +4020,6 @@ label input[type="checkbox"], label input[type="radio"] {
 	line-height: var(--leading);
 	border: 0 none;
 	outline: none;
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
 }
 
@@ -4257,11 +4254,7 @@ label input[type="checkbox"], label input[type="radio"] {
 	line-height: inherit;
 	width: auto;
 	height: auto !important;
-	-moz-border-radius: 0;
-	-webkit-border-radius: 0;
 	border-radius: 0;
-	-webkit-box-sizing: content-box;
-	-moz-box-sizing: content-box;
 	box-sizing: content-box;
 }
 
@@ -4281,8 +4274,6 @@ label input[type="checkbox"], label input[type="radio"] {
 	margin: 1px 0 0;
 	border: 1px solid #dfdfdf;
 	border-top: none;
-	-moz-border-radius: 0;
-	-webkit-border-radius: 0;
 	border-radius: 0;
 	float: none !important;
 }

--- a/css/frm_grids.css
+++ b/css/frm_grids.css
@@ -322,11 +322,8 @@
 /* End RTL Grids */
 
 .frm-fade-in {
-	-webkit-animation-name: fadeIn;
 	animation-name: fadeIn;
-	-webkit-animation-duration: 1s;
 	animation-duration: 1s;
-	-webkit-animation-fill-mode: both;
 	animation-fill-mode: both;
 }
 


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2518544642/191058/

This update removes a lot of the prefixed `-webkit-` and `-moz-` CSS rules. These are legacy from back when CSS3 was really new and are no longer required. Many of these now throw warnings when validating site CSS (like using https://jigsaw.w3.org/).

Many of these at least no longer work in Firefox, and documentation is fully removed.

I didn't fix everything. This is more of a phase 1 update. It helps drop a lot of errors from the CSS validation list so the remaining pieces are easier to digest. So far I was able to drop about 50 lines of CSS across various files.

I mostly target a few rules in this update including `-webkit-box-sizing`, `-moz-border-radius`, `-webkit-box-shadow`, and `animation` rules.

Once this is approved, I'll start working on a Pro update as well. For now, I haven't started working on reducing CSS in Pro.