### PR TITLE
Make hex to rgb function work with rgb values

### DIFF
--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -185,7 +185,23 @@ class FrmStylesHelper {
 		<?php
 	}
 
+	/**
+	 * Convert a hex color to RGB.
+	 *
+	 * @param string $hex Hex color value.
+	 * @return string RGB value without the rgb() wrapper.
+	 */
 	public static function hex2rgb( $hex ) {
+		if ( 0 === strpos( $hex, 'rgb' ) ) {
+			$rgb = str_replace( array( 'rgb(', 'rgba(', ')' ), '', $hex );
+			$rgb = explode( ',', $rgb );
+			if ( 4 === count( $rgb ) ) {
+				// Drop the alpha. The function is expected to only return r,g,b as a CSV.
+				array_pop( $rgb );
+			}
+			return implode( ',', $rgb );
+		}
+
 		$hex = str_replace( '#', '', $hex );
 
 		list( $r, $g, $b ) = sscanf( $hex, '%02x%02x%02x' );

--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -186,7 +186,7 @@ class FrmStylesHelper {
 	}
 
 	/**
-	 * Convert a hex color to a RGB CSV (without the rgb()/rgba() wrapper).
+	 * Convert a color setting to a RGB CSV (without the rgb()/rgba() wrapper).
 	 *
 	 * @since 2.0
 	 *

--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -186,29 +186,52 @@ class FrmStylesHelper {
 	}
 
 	/**
-	 * Convert a hex color to RGB.
+	 * Convert a hex color to a RGB CSV (without the rgb()/rgba() wrapper).
 	 *
-	 * @param string $hex Hex color value.
+	 * @since 2.0
+	 *
+	 * @param string $color Color setting value. This could be hex or rgb.
 	 * @return string RGB value without the rgb() wrapper.
 	 */
-	public static function hex2rgb( $hex ) {
-		if ( 0 === strpos( $hex, 'rgb' ) ) {
-			$rgb = str_replace( array( 'rgb(', 'rgba(', ')' ), '', $hex );
-			$rgb = explode( ',', $rgb );
-			if ( 4 === count( $rgb ) ) {
-				// Drop the alpha. The function is expected to only return r,g,b as a CSV.
-				array_pop( $rgb );
-			}
-			return implode( ',', $rgb );
+	public static function hex2rgb( $color ) {
+		if ( 0 === strpos( $color, 'rgb' ) ) {
+			$rgb = self::get_rgb_array_from_rgb( $color );
+		} else {
+			$rgb = self::get_rgb_array_from_hex( $color );
 		}
-
-		$hex = str_replace( '#', '', $hex );
-
-		list( $r, $g, $b ) = sscanf( $hex, '%02x%02x%02x' );
-
-		$rgb = array( $r, $g, $b );
-
 		return implode( ',', $rgb );
+	}
+
+	/**
+	 * Remove the rgb()/rgba() wrapper from a RGB color and return its R, G and B values as an array.
+	 *
+	 * @since x.x
+	 *
+	 * @param string $rgb    RGB value including the rgb() or rgba() wrapper.
+	 * @return array<string> including three numeric values for R, G, and B.
+	 */
+	private static function get_rgb_array_from_rgb( $rgb ) {
+		$rgb = str_replace( array( 'rgb(', 'rgba(', ')' ), '', $rgb );
+		$rgb = explode( ',', $rgb );
+		if ( 4 === count( $rgb ) ) {
+			// Drop the alpha. The function is expected to only return r,g,b as a CSV.
+			array_pop( $rgb );
+		}
+		return $rgb;
+	}
+
+	/**
+	 * Get the R, G, and B array values from a Hex color code.
+	 *
+	 * @since x.x
+	 *
+	 * @param string $hex    A hex color string.
+	 * @return array<string> Including three numeric values for R, G, and B.
+	 */
+	private static function get_rgb_array_from_hex( $hex ) {
+		$hex               = str_replace( '#', '', $hex );
+		list( $r, $g, $b ) = sscanf( $hex, '%02x%02x%02x' );
+		return array( $r, $g, $b );
 	}
 
 	/**
@@ -223,11 +246,12 @@ class FrmStylesHelper {
 	/**
 	 * @since 6.0
 	 *
-	 * @param string $rgba
-	 * @return string
+	 * @param string $rgba Color setting value. This could be hex or rgb.
+	 * @return string Hex color value.
 	 */
 	private static function rgb_to_hex( $rgba ) {
 		if ( strpos( $rgba, '#' ) === 0 ) {
+			// Color is already hex.
 			return $rgba;
 		}
 		preg_match( '/^rgba?[\s+]?\([\s+]?(\d+)[\s+]?,[\s+]?(\d+)[\s+]?,[\s+]?(\d+)[\s+]?/i', $rgba, $by_color );

--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -214,7 +214,7 @@ class FrmStylesHelper {
 		$rgb = str_replace( array( 'rgb(', 'rgba(', ')' ), '', $rgb );
 		$rgb = explode( ',', $rgb );
 		if ( 4 === count( $rgb ) ) {
-			// Drop the alpha. The function is expected to only return r,g,b as a CSV.
+			// Drop the alpha. The function is expected to only return r,g,b with no alpha.
 			array_pop( $rgb );
 		}
 		return $rgb;

--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -259,7 +259,9 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 	echo esc_html( $important );
 	?>
 	;
+	<?php if ( '' !== $submit_border_width ) : ?>
 	border-width:<?php echo esc_html( $submit_border_width ); ?>;
+	<?php endif; ?>
 	border-color: <?php echo esc_html( $submit_border_color . $important ); ?>;
 	border-style:solid;
 	color:<?php echo esc_html( $submit_text_color . $important ); ?>;

--- a/tests/styles/test_FrmStylesHelper.php
+++ b/tests/styles/test_FrmStylesHelper.php
@@ -65,7 +65,7 @@ class test_FrmStylesHelper extends FrmUnitTest {
 			'#ffffff'           => '255,255,255',
 			'262626'            => '38,38,38',
 			'rgb(255,255,255)'  => '255,255,255',
-			'rgba(211,77,40,1)' => '211,77,40'
+			'rgba(211,77,40,1)' => '211,77,40',
 		);
 
 		foreach ( $colors as $hex => $rgb ) {

--- a/tests/styles/test_FrmStylesHelper.php
+++ b/tests/styles/test_FrmStylesHelper.php
@@ -61,9 +61,11 @@ class test_FrmStylesHelper extends FrmUnitTest {
 	 */
 	public function test_hex2rgb() {
 		$colors = array(
-			'ffffff'  => '255,255,255',
-			'#ffffff' => '255,255,255',
-			'262626'  => '38,38,38',
+			'ffffff'            => '255,255,255',
+			'#ffffff'           => '255,255,255',
+			'262626'            => '38,38,38',
+			'rgb(255,255,255)'  => '255,255,255',
+			'rgba(211,77,40,1)' => '211,77,40'
 		);
 
 		foreach ( $colors as $hex => $rgb ) {


### PR DESCRIPTION
I noticed some issues when testing my Formidable CSS against https://jigsaw.w3.org/css-validator/

Colour values when using RGB values are coming through wrong as `background: rgba(, , , 0.15) !important;`.

The problem is that `hex2rgb` is called unconditionally and doesn't work with rgb values.

<img width="583" alt="frm_style_formidable-style-5 with frm style td ui-datepicker-current-day," src="https://github.com/Strategy11/formidable-forms/assets/9134515/cbca6aaf-33a8-4f7c-b374-6cc735468aa4">

I also added a check if `$border_width` is empty to avoid a parsing error,
<img width="296" alt="height auto;" src="https://github.com/Strategy11/formidable-forms/assets/9134515/c45817cc-efe8-42d5-8184-460134441b15">

Really, we should be checking if every setting is empty, but each check makes this look more messy.