### PR TITLE
Use insertAdjacentHTML for 4796 fix

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7148,12 +7148,12 @@ function frmAdminBuildJS() {
 				nonce: frmGlobal.nonce
 			},
 			success: function( html ) {
-				jQuery( document.getElementById( 'logic_link_' + id ) ).fadeOut( 'slow', function() {
-					var $logicRow = jQuery( logicRowsContainer );
-					var tempDiv   = document.createElement( 'div' );
-					tempDiv.innerHTML = html;
-					logicRowsContainer.replaceChild( tempDiv.childNodes[0], placeholder );
-					$logicRow.parent( '.frm_logic_rows' ).fadeIn( 'slow' );
+				jQuery( document.getElementById( 'logic_link_' + id ) ).fadeOut( 'slow', () => {
+					placeholder.insertAdjacentHTML( 'beforebegin', html );
+					placeholder.remove();
+
+					// Show conditional logic options after "Add Conditional Logic" is clicked.
+					jQuery( logicRowsContainer ).parent( '.frm_logic_rows' ).fadeIn( 'slow' );
 				});
 			}
 		});


### PR DESCRIPTION
Related PR https://github.com/Strategy11/formidable-forms/pull/1533

This is just a small attempt to clean this part of this update up a bit. I don't think we need to create a temporary element and risk getting only a single child when the HTML returns multiple.