### PR TITLE
Pro issue 4842 / Convert string recipients to array fix

### DIFF
--- a/classes/helpers/FrmEmailSummaryHelper.php
+++ b/classes/helpers/FrmEmailSummaryHelper.php
@@ -528,7 +528,8 @@ class FrmEmailSummaryHelper {
 	 *
 	 * @since 6.8
 	 *
-	 * @param array $recipients Recipients.
+	 * @param string $recipients Recipients.
+	 * @return void
 	 */
 	public static function maybe_remove_recipients_from_api( &$recipients ) {
 		$api    = new FrmFormApi();
@@ -538,7 +539,10 @@ class FrmEmailSummaryHelper {
 		}
 
 		$skip_emails = is_string( $addons['no_emails'] ) ? explode( ',', $addons['no_emails'] ) : (array) $addons['no_emails'];
-		$recipients  = array_diff( $recipients, $skip_emails );
+
+		$recipients = array_map( 'trim', explode( ',', $recipients ) );
+		$recipients = array_diff( $recipients, $skip_emails );
+		$recipients = implode( ',', $recipients );
 	}
 
 	/**

--- a/tests/emails/test_FrmEmailSummaryHelper.php
+++ b/tests/emails/test_FrmEmailSummaryHelper.php
@@ -138,4 +138,33 @@ class test_FrmEmailSummaryHelper extends FrmUnitTest {
 			array( $options )
 		);
 	}
+
+	/**
+	 * @covers FrmEmailSummaryHelper::maybe_remove_recipients_from_api
+	 */
+	public function test_maybe_remove_recipients_from_api() {
+		add_filter(
+			'pre_http_request',
+			function( $pre, $parsed_args, $url ) {
+				if ( strpos( $url, 'formidableforms.com' ) === false ) {
+					return $pre;
+				}
+		
+				return array(
+					'response' => array( 'code' => 200, 'message' => 'Fake response' ),
+					'body'     => json_encode( array( 'no_emails' => 'test@example.com' ) ),
+				);
+			},
+			10,
+			3
+		);
+
+		$recipients = 'test@example.com';
+		FrmEmailSummaryHelper::maybe_remove_recipients_from_api( $recipients );
+		$this->assertEquals( '', $recipients );
+
+		$recipients = 'test@example.com,recipient2@example.com';
+		FrmEmailSummaryHelper::maybe_remove_recipients_from_api( $recipients );
+		$this->assertEquals( 'recipient2@example.com', $recipients );
+	}
 }

--- a/tests/emails/test_FrmEmailSummaryHelper.php
+++ b/tests/emails/test_FrmEmailSummaryHelper.php
@@ -143,13 +143,17 @@ class test_FrmEmailSummaryHelper extends FrmUnitTest {
 	 * @covers FrmEmailSummaryHelper::maybe_remove_recipients_from_api
 	 */
 	public function test_maybe_remove_recipients_from_api() {
+		// Clear the cache so our fake response gets used.
+		$api = new FrmFormApi();
+		delete_option( $api->get_cache_key() );
+
 		add_filter(
 			'pre_http_request',
 			function( $pre, $parsed_args, $url ) {
 				if ( strpos( $url, 'formidableforms.com' ) === false ) {
 					return $pre;
 				}
-		
+
 				return array(
 					'response' => array( 'code' => 200, 'message' => 'Fake response' ),
 					'body'     => json_encode( array( 'no_emails' => 'test@example.com' ) ),


### PR DESCRIPTION
With https://github.com/Strategy11/formidable-forms/pull/1457/ the function `maybe_remove_recipients_from_api` was introduced.

The problem is that `$recipients` is a string, not an array, so the function doesn't really work as expected.