### PR TITLE
Set form options to array if string when setting on submit migrated f…

### DIFF
--- a/classes/helpers/FrmOnSubmitHelper.php
+++ b/classes/helpers/FrmOnSubmitHelper.php
@@ -395,8 +395,13 @@ class FrmOnSubmitHelper {
 	 * @since 6.1.1
 	 *
 	 * @param object $form Limited form object.
+	 * @return void
 	 */
 	private static function save_migrated_success_actions( $form ) {
+		// Options may be an empty string.
+		if ( ! is_array( $form->options ) ) {
+			$forn->options = array();
+		}
 		$form->options['on_submit_migrated'] = 1;
 		FrmForm::update( $form->id, array( 'options' => $form->options ) );
 	}

--- a/classes/helpers/FrmOnSubmitHelper.php
+++ b/classes/helpers/FrmOnSubmitHelper.php
@@ -400,7 +400,7 @@ class FrmOnSubmitHelper {
 	private static function save_migrated_success_actions( $form ) {
 		// Options may be an empty string.
 		if ( ! is_array( $form->options ) ) {
-			$forn->options = array();
+			$form->options = array();
 		}
 		$form->options['on_submit_migrated'] = 1;
 		FrmForm::update( $form->id, array( 'options' => $form->options ) );

--- a/classes/helpers/FrmStylesPreviewHelper.php
+++ b/classes/helpers/FrmStylesPreviewHelper.php
@@ -141,8 +141,15 @@ class FrmStylesPreviewHelper {
 	private function disable_javascript_validation() {
 		add_filter(
 			'frm_form_object',
+			/**
+			 * @param stdClass|null $form
+			 * @param int           $form_id
+			 * @return stdClass|null
+			 */
 			function( $form ) {
-				$form->options['js_validate'] = false;
+				if ( is_object( $form ) && is_array( $form->options ) ) {
+					$form->options['js_validate'] = false;
+				}
 				return $form;
 			}
 		);

--- a/classes/views/styles/_styles-list.php
+++ b/classes/views/styles/_styles-list.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $frm_settings      = FrmAppHelper::get_settings();
 $globally_disabled = 'none' === $frm_settings->load_style;
-$enabled           = 0 !== (int) $form->options['custom_style'] && ! $globally_disabled;
+$enabled           = ( ! is_array( $form->options ) || 0 !== (int) $form->options['custom_style'] ) && ! $globally_disabled;
 $card_helper       = new FrmStylesCardHelper( $active_style, $default_style, $form->id, $enabled );
 $styles            = $card_helper->get_styles();
 $custom_styles     = $card_helper->filter_custom_styles( $styles );


### PR DESCRIPTION
…lag fix

Related ticket https://secure.helpscout.net/conversation/2518729092/191090/

> Fatal error: Uncaught TypeError: Cannot access offset of type string on string in .../formidable/classes/helpers/FrmOnSubmitHelper.php:400 Stack trace: #0 .../formidable/classes/helpers/FrmOnSubmitHelper.php(305): FrmOnSubmitHelper::save_migrated_success_actions() #1 .../formidable/classes/controllers/FrmFormsController.php(153): FrmOnSubmitHelper::maybe_migrate_submit_settings_to_action() #2 .../formidable/classes/controllers/FrmFormsController.php(1754): FrmFormsController::settings() #3 .../wp-includes/class-wp-hook.php(324): FrmFormsController::route() #4 .../wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters() #5 .../wp-includes/plugin.php(517): WP_Hook->do_action() #6 .../wp-admin/admin.php(259): do_action() #7 {main} thrown in .../formidable/classes/helpers/FrmOnSubmitHelper.php on line 400

Pre-release,
[formidable-6.8.3b.zip](https://github.com/Strategy11/formidable-forms/files/14438017/formidable-6.8.3b.zip)

@truongwp I requested your review since I'm updating `save_migrated_success_actions`. Do you think this fix makes sense?