### PR TITLE
Filter import file options

### DIFF
--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -2063,5 +2063,22 @@ class FrmXMLHelper {
 	public static function check_if_libxml_disable_entity_loader_exists() {
 		return version_compare( phpversion(), '8.0', '<' ) && ! function_exists( 'libxml_disable_entity_loader' );
 	}
+
+	/**
+	 * Get the file types allowed for importing.
+	 * This is used in the "accept" attribute for the file upload input on the XML import page.
+	 *
+	 * @since x.x
+	 *
+	 * @return array
+	 */
+	public static function get_supported_upload_file_types() {
+		$file_types = array( '.xml' );
+		if ( FrmAppHelper::pro_is_installed() ) {
+			// CSV Importing is only available in Pro.
+			$file_types[] = '.csv';
+		}
+		return $file_types;
+	}
 }
 

--- a/classes/views/xml/import_form.php
+++ b/classes/views/xml/import_form.php
@@ -53,7 +53,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					?>)
 				</label>
 				<br/>
-				<input type="file" name="frm_import_file" size="25" />
+				<input type="file" name="frm_import_file" size="25" accept="<?php echo esc_attr( implode( ', ', FrmXMLHelper::get_supported_upload_file_types() ) ); ?>" />
 			</p>
 
 			<?php do_action( 'frm_csv_opts', $forms ); ?>


### PR DESCRIPTION
This update adds a `accept=".xml, .csv"` attribute when Pro is active, or a `accept=".xml"` attribute when only Lite is active.

I figure this is better for usability. It's more clear what can be uploaded since the wrong types are all faded out.

I got a little mixed up trying to upload a `.zip` of a `.xml` for a moment. This update helps make the types easier to tell apart, preventing a `.zip` upload from happening by accident.