### PR TITLE
Support multiple shortcode popups per field

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6958,7 +6958,7 @@ function frmAdminBuildJS() {
 				textarea.parentNode.insertBefore( wrapperSpan, textarea );
 				wrapperSpan.appendChild( createModalTriggerIcon() );
 				wrapperSpan.appendChild( textarea );
-			})
+			});
 		};
 
 		const createModalTriggerIcon = () => {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6952,11 +6952,13 @@ function frmAdminBuildJS() {
 		singleField.querySelector( '.wp-editor-container' )?.classList.add( 'frm_has_shortcodes' );
 
 		const wrapTextareaWithIconContainer = () => {
-			const textarea = document.querySelector( fieldSettingsSelector + ' .frm_has_shortcodes textarea' );
-			const wrapperSpan = span({ className: 'frm-with-right-icon' });
-			textarea.parentNode.insertBefore( wrapperSpan, textarea );
-			wrapperSpan.appendChild( createModalTriggerIcon() );
-			wrapperSpan.appendChild( textarea );
+			const textareas = document.querySelectorAll( fieldSettingsSelector + ' .frm_has_shortcodes textarea' );
+			textareas.forEach( textarea => {
+				const wrapperSpan = span({ className: 'frm-with-right-icon' });
+				textarea.parentNode.insertBefore( wrapperSpan, textarea );
+				wrapperSpan.appendChild( createModalTriggerIcon() );
+				wrapperSpan.appendChild( textarea );
+			})
 		};
 
 		const createModalTriggerIcon = () => {


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-ai/pull/50

We want to support multiple shortcodes popups per field as per Mike's comment in Guide prompt for AI field here: https://github.com/Strategy11/formidable-ai/pull/50#issuecomment-1969627465