### PR TITLE
New function `FrmForm::prepare_form_row_data`

### DIFF
--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -817,17 +817,20 @@ class FrmForm {
 	 */
 	private static function prepare_form_row_data( $row ) {
 		$row = wp_unslash( $row );
-		if ( is_object( $row ) && ! is_array( $row->options ) ) {
+		if ( ! is_object( $row ) ) {
+			return $row;
+		}
+
+		if ( ! is_array( $row->options ) ) {
 			$row->options = FrmFormsHelper::get_default_opts();
 		}
-		if ( is_object( $row ) ) {
-			/**
-			 * @since 4.03.02
-			 *
-			 * @param stdClass $row
-			 */
-			$row = apply_filters( 'frm_form_object', $row );
-		}
+
+		/**
+		 * @since 4.03.02
+		 *
+		 * @param stdClass $row
+		 */
+		$row = apply_filters( 'frm_form_object', $row );
 		return $row;
 	}
 

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -818,7 +818,7 @@ class FrmForm {
 	private static function prepare_form_row_data( $row ) {
 		$row = wp_unslash( $row );
 		if ( is_object( $row ) && ! is_array( $row->options ) ) {
-			$row->options = array();
+			$row->options = FrmFormsHelper::get_default_opts();
 		}
 		return apply_filters( 'frm_form_object', $row );
 	}

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -787,8 +787,7 @@ class FrmForm {
 				if ( isset( $cache->options ) ) {
 					FrmAppHelper::unserialize_or_decode( $cache->options );
 				}
-
-				return apply_filters( 'frm_form_object', wp_unslash( $cache ) );
+				return self::prepare_form_row_data( $cache );
 			}
 		}
 
@@ -805,7 +804,23 @@ class FrmForm {
 			FrmAppHelper::unserialize_or_decode( $results->options );
 		}
 
-		return apply_filters( 'frm_form_object', wp_unslash( $results ) );
+		return self::prepare_form_row_data( $results );
+	}
+
+	/**
+	 * Make sure that if $row is an object, that $row->options is an array and not a string.
+	 *
+	 * @since x.x
+	 *
+	 * @param stdClass|null $row The database row for a target form.
+	 * @return stdClass|null
+	 */
+	private static function prepare_form_row_data( $row ) {
+		$row = wp_unslash( $row );
+		if ( is_object( $row ) && ! is_array( $row->options ) ) {
+			$row->options = array();
+		}
+		return apply_filters( 'frm_form_object', $row );
 	}
 
 	/**

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -820,7 +820,15 @@ class FrmForm {
 		if ( is_object( $row ) && ! is_array( $row->options ) ) {
 			$row->options = FrmFormsHelper::get_default_opts();
 		}
-		return apply_filters( 'frm_form_object', $row );
+		if ( is_object( $row ) ) {
+			/**
+			 * @since 4.03.02
+			 *
+			 * @param stdClass $row
+			 */
+			$row = apply_filters( 'frm_form_object', $row );
+		}
+		return $row;
 	}
 
 	/**

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -830,8 +830,7 @@ class FrmForm {
 		 *
 		 * @param stdClass $row
 		 */
-		$row = apply_filters( 'frm_form_object', $row );
-		return $row;
+		return apply_filters( 'frm_form_object', $row );
 	}
 
 	/**

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -217,7 +217,8 @@ class test_FrmForm extends FrmUnitTest {
 		// Test to make sure a form with no options column value still has an array $form->options value.
 		$form_id = $this->create_a_form_with_an_empty_options_column();
 		$form    = FrmForm::getOne( $form_id );
-		$this->assertEquals( array(), $form->options );
+		$this->assertIsArray( $form->options );
+		$this->assertArrayHasKey( 'custom_style', $form->options );
 
 		// Test a regular form. $form->options should be an array and it should not be empty.
 		$form = FrmForm::getOne( 'contact-with-email' );

--- a/tests/forms/test_FrmForm.php
+++ b/tests/forms/test_FrmForm.php
@@ -208,4 +208,41 @@ class test_FrmForm extends FrmUnitTest {
 		$name      = FrmForm::getName( (string) $form_id );
 		$this->assertEquals( $form_name, $name );
 	}
+
+	/**
+	 * @covers FrmForm::getOne
+	 * @covers FrmForm::prepare_form_row_data
+	 */
+	public function test_getOne() {
+		// Test to make sure a form with no options column value still has an array $form->options value.
+		$form_id = $this->create_a_form_with_an_empty_options_column();
+		$form    = FrmForm::getOne( $form_id );
+		$this->assertEquals( array(), $form->options );
+
+		// Test a regular form. $form->options should be an array and it should not be empty.
+		$form = FrmForm::getOne( 'contact-with-email' );
+		$this->assertIsArray( $form->options );
+		$this->assertNotEmpty( $form->options );
+	}
+
+	/**
+	 * Create a form with no options column value.
+	 *
+	 * @return int
+	 */
+	private function create_a_form_with_an_empty_options_column() {
+		global $wpdb;
+		$form_id = $this->factory->form->create();
+		$wpdb->update(
+			$wpdb->prefix . 'frm_forms',
+			array(
+				'options' => '',
+			),
+			array(
+				'id' => $form_id,
+			)
+		);
+		FrmForm::clear_form_cache();
+		return $form_id;
+	}
 }


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2518729092/191090/

A lot of code works on the assumption that `$form->options` is an array.

I tried adding some checks in some updates yesterday (in https://github.com/Strategy11/formidable-forms/pull/1543, https://github.com/Strategy11/formidable-pro/pull/4845 and https://github.com/Strategy11/formidable-pro/pull/4844) but I think we're better off just forcing `$form->options` as an array right away. Trying to fix this in every place where we assume `$form->options` is an array is turning into too much work and too many undetected bugs.

**This update now forces all results from `FrmForm::getOne` to have an array `$form->options` value when `$form` is not null. I used the lite form defaults so some basic keys are defined, to help fix an issue with a PHP warning.**

**Questions**
1. Would we want to try calling `FrmFormsHelper::get_default_opts()` as well to define some Pro defaults?
2. Would we want to start only filtering `frm_form_object` when it's an object and not null? That might help with stability as well.

> Fatal error: Uncaught TypeError: Cannot access offset of type string on string in .../wp-content/plugins/formidable/classes/models/FrmForm.php:605 Stack trace: #0 .../wp-content/plugins/formidable/classes/models/FrmForm.php(559): FrmForm::trash() #1 .../wp-content/plugins/formidable/classes/controllers/FrmFormsController.php(658): FrmForm::set_status() #2 .../wp-content/plugins/formidable/classes/controllers/FrmFormsController.php(626): FrmFormsController::change_form_status() #3 .../wp-content/plugins/formidable/classes/controllers/FrmFormsController.php(1754): FrmFormsController::trash() #4 .../wp-includes/class-wp-hook.php(324): FrmFormsController::route() #5 .../wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters() #6 .../wp-includes/plugin.php(517): WP_Hook->do_action() #7 .../wp-admin/admin.php(259): do_action() #8 {main} thrown in .../wp-content/plugins/formidable/classes/models/FrmForm.php on line 605

Coming from this line of code:
```
$options['trash_time'] = time();
```

Since `$options` is a string, trying to set `$options['trash_time']` triggers a fatal error.

