### PR TITLE
Separate value input is visible when disabled fix

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -984,7 +984,7 @@ p.frm_has_shortcodes {
 	margin: 0 -4px;
 }
 
-.frm_form_settings span.frm-with-right-icon, #frm_builder_page span.frm-with-right-icon {
+.frm_form_settings span.frm-with-right-icon, #frm_builder_page span.frm-with-right-icon:not(.frm_hidden) {
 	display: block;
 }
 

--- a/tests/emails/test_FrmEmailSummaryHelper.php
+++ b/tests/emails/test_FrmEmailSummaryHelper.php
@@ -155,7 +155,10 @@ class test_FrmEmailSummaryHelper extends FrmUnitTest {
 				}
 
 				return array(
-					'response' => array( 'code' => 200, 'message' => 'Fake response' ),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'Fake response',
+					),
 					'body'     => json_encode( array( 'no_emails' => 'test@example.com' ) ),
 				);
 			},


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4749

This issue is not specific to Product fields but any field with options and separate values settings.

The issue is that this `display: block` rule is overwriting the `display: none` rule from `frm_hidden`.

**This is not a live bug yet.** It's just a bug in master. This is introduced in https://github.com/Strategy11/formidable-forms/pull/1442