### PR TITLE
Only make frm_has_shortcodes children spans display block fix

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -985,7 +985,7 @@ p.frm_has_shortcodes {
 }
 
 .frm_form_settings span.frm-with-right-icon,
-#frm_builder_page .wp-editor-container span.frm-with-right-icon:not(.frm_hidden) {
+#frm_builder_page .frm_has_shortcodes span.frm-with-right-icon:not(.frm_hidden) {
 	display: block;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -984,7 +984,8 @@ p.frm_has_shortcodes {
 	margin: 0 -4px;
 }
 
-.frm_form_settings span.frm-with-right-icon, #frm_builder_page span.frm-with-right-icon:not(.frm_hidden) {
+.frm_form_settings span.frm-with-right-icon,
+#frm_builder_page .wp-editor-container span.frm-with-right-icon:not(.frm_hidden) {
 	display: block;
 }
 


### PR DESCRIPTION
Following up from https://github.com/Strategy11/formidable-forms/pull/1549

The CSS added in https://github.com/Strategy11/formidable-forms/pull/1442 is causing other issues too.

I'm changing this to only happen for `frm_has_shortcodes` children to cut back on styling conflicts.

`display: block` is causing these icons to look off.
<img width="372" alt="Screen Shot 2024-02-29 at 12 08 48 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/fd0354ab-aa76-442c-8c62-1bed66a5fcb1">

They should look like this
<img width="377" alt="Screen Shot 2024-02-29 at 12 08 57 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/8fd6b356-3004-4d39-9e7b-c0bf96841493">
