### PR TITLE
Fix Alignment and Button Styles on Add-Ons Page

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -1306,11 +1306,25 @@ body.frm-hidden-overflow {
 	color: var(--primary-500);
 }
 
+.frm-button-tertiary:focus {
+	outline: none;
+}
+
+.frm-button-tertiary.frm_loading_button::before {
+	border-right-color: var(--grey);
+	border-bottom-color: var(--grey);
+}
+
 .frm-button-red,
 .frm-button-red:focus {
-	color: #fff !important;
+	--primary-color: var(--error-500);
 	--primary-500: var(--error-500);
 	--primary-700: var(--error-700);
+}
+
+.frm-button-red:not(.frm-button-tertiary),
+.frm-button-red:not(.frm-button-tertiary):focus {
+	color: #fff !important;
 }
 
 .frm-white-body h2 .button,
@@ -2361,7 +2375,8 @@ h2.frm-h2 + .howto {
 	font-size: 15px;
 }
 
-.frm-addons .button {
+.frm-addons .button,
+.frm-addons .frm-button-tertiary {
 	float: right;
 }
 
@@ -2378,7 +2393,8 @@ h2.frm-h2 + .howto {
 .frm-addon-active  .frm-activate-addon,
 .frm-addon-active  .frm-install-addon,
 .frm-addon-active .frm-uninstall-addon,
-.plugin-card-pro.frm-addon-active .button {
+.plugin-card-pro.frm-addon-active .button,
+.plugin-card-pro.frm-addon-active .frm-button-tertiary {
 	display: none !important;
 }
 


### PR DESCRIPTION
This PR resolves the UI inconsistencies reported in [Issue #4832](https://github.com/Strategy11/formidable-pro/issues/4832), focusing on the add-ons page when the pro version is installed but not authorized. Changes include altering button styles from primary to tertiary, ensuring that activate/deactivate/uninstall options do not coexist with the upgrade button, and improving the vertical alignment of text and buttons.

## Related Issue:
[Messed up add-ons page with lots of buttons #4832](https://github.com/Strategy11/formidable-pro/issues/4832)

## Formidable PRO Plugin PR:
https://github.com/Strategy11/formidable-pro/pull/4857

## Testing Instructions:
1. Install the Formidable Pro plugin but leave it unauthorized.
2. Navigate to the Add-Ons page (`WP Admin > Formidable > Add-Ons`).
3. Observe the button styles and alignment, comparing them to the provided screenshots for reference.
4. Confirm that the "Upgrade" button and activate/deactivate/uninstall options do not appear.
5. Test the functionality of the deactivate and uninstall links to ensure they perform as expected without any issues.

## Visual References:
![2024-03-05 22 07 41](https://github.com/Strategy11/formidable-forms/assets/69119241/86d4ede9-6720-4099-b376-af4af7d136ac)

![image](https://github.com/Strategy11/formidable-forms/assets/69119241/bb3d17c4-272a-4b2f-b27a-6fc6094a9ef5)
