### PR TITLE
Define new FrmAddon property

### DIFF
--- a/classes/models/FrmAddon.php
+++ b/classes/models/FrmAddon.php
@@ -19,6 +19,7 @@ class FrmAddon {
 	private $is_expired_addon = false;
 	public $license;
 	protected $get_beta = false;
+	protected $save_status;
 
 	/**
 	 * This is used to decide whether the license checks should continue.


### PR DESCRIPTION
This was introduced in https://github.com/Strategy11/formidable-forms/pull/1517

> PHP Deprecated:  Creation of dynamic property FrmProEddController::$save_status is deprecated in /var/www/src/wp-content/plugins/formidable/classes/models/FrmAddon.php on line 802

I'm just defining the property so it isn't dynamic.