### PR TITLE
Set fields updated to 0 on global settings form submit

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10361,6 +10361,9 @@ function frmAdminBuildJS() {
 				const showNote           = event.target.value !== captchaValueOnLoad;
 				document.querySelector( '.captcha_settings .frm_note_style' ).classList.toggle( 'frm_hidden', ! showNote );
 			});
+
+			// Set fieldsUpdated to 0 to avoid the unsaved changes pop up.
+			frmDom.util.documentOn( 'submit', '.frm_settings_form', () => fieldsUpdated = 0 );
 		},
 
 		exportInit: function() {


### PR DESCRIPTION
Related PR https://github.com/Strategy11/formidable-quizzes/pull/194

This helps to avoid the unsaved changes pop up after removing a scored quiz row.

This is because we call `fieldUpdated()` when the row is removed without checking the page first.

We'll likely want to add the unsaved changes pop up in global settings in the future. This update just makes sure that the pop up does not appear when the update button is clicked.