### PR TITLE
Add an action hook that fires after csv is generated

### DIFF
--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -115,7 +115,6 @@ class FrmCSVExportHelper {
 		self::set_has_parent_id( $atts['form'] );
 
 		$filename = self::generate_csv_filename( $atts['form'] );
-		unset( $atts['form'], $atts['form_cols'] );
 
 		if ( 'file' === self::$mode ) {
 			$filepath = get_temp_dir() . $filename;
@@ -151,10 +150,33 @@ class FrmCSVExportHelper {
 			self::prepare_next_csv_rows( $next_set );
 		}
 
+		self::do_frm_after_generate_csv_action( $atts );
+
+		unset( $atts['form'], $atts['form_cols'] );
+
 		if ( 'file' === self::$mode ) {
 			fclose( self::$fp );
 			return $filepath;
 		}
+	}
+
+	/**
+	 * @since x.x
+	 *
+	 * @param array $atts
+	 * @return void
+	 */
+	private static function do_frm_after_generate_csv_action( $atts ) {
+		/**
+		 * @since x.x
+		 *
+		 * @param array $atts {
+		 *   @type object $form
+		 *   @type array  $entry_ids
+		 *   @type array  $form_cols
+		 * }
+		 */
+		do_action( 'frm_after_generate_csv', $atts );
 	}
 
 	/**

--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -150,7 +150,7 @@ class FrmCSVExportHelper {
 			self::prepare_next_csv_rows( $next_set );
 		}
 
-		self::after_generate_csv_action( $atts );
+		self::after_generate_csv( $atts );
 
 		unset( $atts['form'], $atts['form_cols'] );
 
@@ -166,7 +166,7 @@ class FrmCSVExportHelper {
 	 * @param array $atts
 	 * @return void
 	 */
-	private static function after_generate_csv_action( $atts ) {
+	private static function after_generate_csv( $atts ) {
 		/**
 		 * @since x.x
 		 *

--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -150,7 +150,7 @@ class FrmCSVExportHelper {
 			self::prepare_next_csv_rows( $next_set );
 		}
 
-		self::do_frm_after_generate_csv_action( $atts );
+		self::after_generate_csv_action( $atts );
 
 		unset( $atts['form'], $atts['form_cols'] );
 
@@ -166,7 +166,7 @@ class FrmCSVExportHelper {
 	 * @param array $atts
 	 * @return void
 	 */
-	private static function do_frm_after_generate_csv_action( $atts ) {
+	private static function after_generate_csv_action( $atts ) {
 		/**
 		 * @since x.x
 		 *


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4820

I have added a new action `frm_after_generate_csv` that fires after CSV is generated.

### Test steps
Try hooking into the action with something like `add_action( 'frm_after_generate_csv', yourcallback )`;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Introduced an action hook after CSV generation for enhanced extensibility.
- **Refactor**
	- Optimized the order of operations in CSV generation for better performance and maintainability.
- **Chores**
	- Rearranged unset operations in CSV generation for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->