### PR TITLE
Return empty string instead of 'noform'

### DIFF
--- a/classes/widgets/FrmShowForm.php
+++ b/classes/widgets/FrmShowForm.php
@@ -92,6 +92,6 @@ class FrmShowForm extends WP_Widget {
 			</label>
 		</p>
 		<?php
-		return 'noform';
+		return '';
 	}
 }


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4314

### Test steps
1. Install and enable classic non-block themes like Twenty Twenty or something
2. Install "Classic Widgets" plugin for compatibility
3. Go to Appearance > Widgets and drag the 'Formidable Forms' widget to an active widget area.
4. Try changing the widget title and form selected
5. Confirm that the 'Save' button is visible and you can save it.
6. View a page on which this widget area is displayed and confirm everything is as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the form method to return an empty string for consistency, enhancing the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->