### PR TITLE
Update `FrmAppHelper::sanitize_value` to support objects without a fatal error

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -646,17 +646,33 @@ class FrmAppHelper {
 		return $value;
 	}
 
+	/**
+	 * Sanitize a value in-place.
+	 * If $value is an array, the sanitize function will get called for each item.
+	 *
+	 * @param callable $sanitize
+	 * @param mixed    $value
+	 * @return void
+	 */
 	public static function sanitize_value( $sanitize, &$value ) {
-		if ( ! empty( $sanitize ) ) {
-			if ( is_array( $value ) ) {
-				$temp_values = $value;
-				foreach ( $temp_values as $k => $v ) {
-					self::sanitize_value( $sanitize, $value[ $k ] );
-				}
-			} else {
-				$value = call_user_func( $sanitize, $value );
-			}
+		if ( ! $sanitize ) {
+			return;
 		}
+
+		if ( is_object( $value ) ) {
+			$value = '';
+			return;
+		}
+
+		if ( is_array( $value ) ) {
+			$temp_values = $value;
+			foreach ( $temp_values as $k => $v ) {
+				self::sanitize_value( $sanitize, $value[ $k ] );
+			}
+			return;
+		}
+
+		$value = call_user_func( $sanitize, $value );
 	}
 
 	public static function sanitize_request( $sanitize_method, &$values ) {


### PR DESCRIPTION
I noticed this in an old ticket when searching for an error https://secure.helpscout.net/conversation/1902277510/100120

> Fatal error
> : Uncaught Error: Object of class WP_Post could not be converted to string in .../wp-includes/kses.php:1685 Stack trace: #0 .../wp-includes/kses.php(1685): preg_replace('/[x00-x08x0B...', '', Object(WP_Post)) #1 .../wp-includes/kses.php(717): wp_kses_no_null(Object(WP_Post), Array) #2 .../wp-includes/kses.php(2106): wp_kses(Object(WP_Post), 'post') #3 .../wp-content/plugins/formidable/classes/helpers/FrmAppHelper.php(548): wp_kses_post(Object(WP_Post)) #4 .../wp-content/plugins/formidable-stripe/models/FrmStrpAuth.php(261): FrmAppHelper::sanitize_value('wp_kses_post', Object(WP_Post)) #5 .../wp-content/plugins/formidable-stripe/models/FrmStrpAuth.php(230): FrmStrpAuth::generate_false_entry() #6 .../wp-content/plugi in
> .../wp-includes/kses.php

This comes from the Stripe add-on in code (that also exists now in Stripe Lite), where a value in `$_POST` is a `WP_Post` object. This must be caused by a plugin conflict of some sort.

This update sets `$value` to an empty string if it is an object, since we shouldn't accept an object.

I also updated the function a bit. I gave it comments, and I added some returns to reduce the indentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated input sanitization to handle object inputs more securely by converting them to an empty string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->