### PR TITLE
Hide bulk edit only for image buttons

### DIFF
--- a/classes/views/frm-fields/back-end/field-options.php
+++ b/classes/views/frm-fields/back-end/field-options.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $field_option_count = is_array( $args['field']['options'] ) ? count( $args['field']['options'] ) : 0;
 $display_format     = FrmField::get_option( $args['field'], 'image_options' );
 ?>
-<span class="frm-bulk-edit-link <?php echo $display_format === '1' ? 'frm_hidden' : ''; ?> ">
+<span class="frm-bulk-edit-link <?php echo $display_format === '1' ? 'frm_hidden' : ''; // Hide bulk edit for image buttons ?> ">
 	<a href="#" title="<?php echo esc_attr( $option_title ); ?>" class="frm-bulk-edit-link">
 		<?php echo esc_html( $this->get_bulk_edit_string() ); ?>
 	</a>

--- a/classes/views/frm-fields/back-end/field-options.php
+++ b/classes/views/frm-fields/back-end/field-options.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $field_option_count = is_array( $args['field']['options'] ) ? count( $args['field']['options'] ) : 0;
 $display_format     = FrmField::get_option( $args['field'], 'image_options' );
 ?>
-<span class="frm-bulk-edit-link <?php echo $display_format === '1' ? 'frm_hidden' : ''; // Hide bulk edit for image buttons ?> ">
+<span class="frm-bulk-edit-link <?php echo $display_format === '1' ? 'frm_hidden' : ''; // Hide bulk edit for image buttons ?>">
 	<a href="#" title="<?php echo esc_attr( $option_title ); ?>" class="frm-bulk-edit-link">
 		<?php echo esc_html( $this->get_bulk_edit_string() ); ?>
 	</a>

--- a/classes/views/frm-fields/back-end/field-options.php
+++ b/classes/views/frm-fields/back-end/field-options.php
@@ -4,8 +4,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $field_option_count = is_array( $args['field']['options'] ) ? count( $args['field']['options'] ) : 0;
+$display_format     = FrmField::get_option( $args['field'], 'image_options' );
 ?>
-<span class="frm-bulk-edit-link <?php echo empty( FrmField::get_option( $args['field'], 'image_options' ) ) ? '' : 'frm_hidden'; ?> ">
+<span class="frm-bulk-edit-link <?php echo $display_format === '1' ? 'frm_hidden' : ''; ?> ">
 	<a href="#" title="<?php echo esc_attr( $option_title ); ?>" class="frm-bulk-edit-link">
 		<?php echo esc_html( $this->get_bulk_edit_string() ); ?>
 	</a>


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-surveys/issues/211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced readability of displaying the bulk edit link in image options settings by refactoring the logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->