### PR TITLE
Update Psalm

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v4.1.1
 
       - name: Psalm
-        uses: docker://vimeo/psalm-github-actions:4.30.0
+        uses: docker://vimeo/psalm-github-actions
         with:
           composer_require_dev: true

--- a/classes/controllers/FrmDashboardController.php
+++ b/classes/controllers/FrmDashboardController.php
@@ -392,19 +392,10 @@ class FrmDashboardController {
 	 * @return array
 	 */
 	public static function entries_columns( $columns = array() ) {
-
-		$form_id = FrmForm::get_current_form_id();
-
-		if ( $form_id ) {
-			self::get_columns_for_form( $form_id, $columns );
-		} else {
-			$columns[ $form_id . '_form_id' ] = __( 'Form', 'formidable' );
-			$columns[ $form_id . '_name' ]    = __( 'Name', 'formidable' );
-			$columns[ $form_id . '_user_id' ] = __( 'Author', 'formidable' );
-		}
-
-		$columns[ $form_id . '_created_at' ] = __( 'Created on', 'formidable' );
-
+		$columns[ '0_form_id' ]    = __( 'Form', 'formidable' );
+		$columns[ '0_name' ]       = __( 'Name', 'formidable' );
+		$columns[ '0_user_id' ]    = __( 'Author', 'formidable' );
+		$columns[ '0_created_at' ] = __( 'Created on', 'formidable' );
 		return $columns;
 	}
 

--- a/classes/controllers/FrmDashboardController.php
+++ b/classes/controllers/FrmDashboardController.php
@@ -392,10 +392,19 @@ class FrmDashboardController {
 	 * @return array
 	 */
 	public static function entries_columns( $columns = array() ) {
-		$columns[ '0_form_id' ]    = __( 'Form', 'formidable' );
-		$columns[ '0_name' ]       = __( 'Name', 'formidable' );
-		$columns[ '0_user_id' ]    = __( 'Author', 'formidable' );
-		$columns[ '0_created_at' ] = __( 'Created on', 'formidable' );
+
+		$form_id = FrmForm::get_current_form_id();
+
+		if ( $form_id ) {
+			self::get_columns_for_form( $form_id, $columns );
+		} else {
+			$columns[ $form_id . '_form_id' ] = __( 'Form', 'formidable' );
+			$columns[ $form_id . '_name' ]    = __( 'Name', 'formidable' );
+			$columns[ $form_id . '_user_id' ] = __( 'Author', 'formidable' );
+		}
+
+		$columns[ $form_id . '_created_at' ] = __( 'Created on', 'formidable' );
+
 		return $columns;
 	}
 

--- a/classes/factories/FrmFieldFactory.php
+++ b/classes/factories/FrmFieldFactory.php
@@ -52,7 +52,7 @@ class FrmFieldFactory {
 	/**
 	 * @param int|string|object $field
 	 *
-	 * @return stdClass
+	 * @return FrmFieldType
 	 */
 	public static function get_field_object( $field ) {
 		if ( ! is_object( $field ) ) {
@@ -68,7 +68,7 @@ class FrmFieldFactory {
 	 * @param string           $field_type
 	 * @param int|array|object $field
 	 *
-	 * @return stdClass
+	 * @return FrmFieldType
 	 */
 	public static function get_field_type( $field_type, $field = 0 ) {
 		$class = self::get_field_type_class( $field_type );

--- a/classes/helpers/FrmStylesCardHelper.php
+++ b/classes/helpers/FrmStylesCardHelper.php
@@ -396,7 +396,7 @@ class FrmStylesCardHelper {
 			 * @param int          $count Used for pagination.
 			 * @return void
 			 */
-			function( $style, $key ) use ( &$count ) {
+			function( $style, $key ) {
 				if ( ! is_numeric( $key ) ) {
 					// Skip active_sub/expires keys.
 					return;

--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -416,9 +416,8 @@ class FrmEntryValidate {
 	private static function check_disallowed_words( $author, $email, $url, $content, $ip, $user_agent ) {
 		if ( function_exists( 'wp_check_comment_disallowed_list' ) ) {
 			return wp_check_comment_disallowed_list( $author, $email, $url, $content, $ip, $user_agent );
-		} else {
-			return wp_blacklist_check( $author, $email, $url, $content, $ip, $user_agent );
 		}
+		return wp_blacklist_check( $author, $email, $url, $content, $ip, $user_agent );
 	}
 
 	/**

--- a/classes/views/frm-fields/front-end/dropdown-field.php
+++ b/classes/views/frm-fields/front-end/dropdown-field.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
 
-if ( isset( $field['post_field'] ) && $field['post_field'] == 'post_category' && FrmAppHelper::pro_is_installed() ) {
+if ( isset( $field['post_field'] ) && $field['post_field'] === 'post_category' && FrmAppHelper::pro_is_installed() ) {
 	echo FrmProPost::get_category_dropdown( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		$field,
 		array(

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -64,3 +64,4 @@ parameters:
 		- '#callback of function spl_autoload_register expects#'
 		- '#customer_id_error_message#'
 		- "#Offset 'custom_style' on#"
+		- '#Call to an undefined method FrmFieldType::get\_file\_id#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <psalm
-	errorLevel="7"
+	errorLevel="2"
+	findUnusedCode="false"
+	findUnusedBaselineEntry="true"
 	resolveFromConfigFile="true"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="https://getpsalm.org/schema/config"
@@ -105,6 +107,7 @@
 		<ParamNameMismatch>
 			<errorLevel type="suppress">
 				<file name="classes/views/frm-form-actions/email_action.php" />
+				<file name="classes/models/FrmInstallerSkin.php" />
 			</errorLevel>
 		</ParamNameMismatch>
 		<UndefinedAttributeClass>
@@ -112,5 +115,375 @@
 				<referencedClass name="AllowDynamicProperties" />
 			</errorLevel>
 		</UndefinedAttributeClass>
+		<MissingParamType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+				<directory name="deprecated" />
+				<file name="formidable.php" />
+			</errorLevel>
+		</MissingParamType>
+		<PropertyNotSetInConstructor>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PropertyNotSetInConstructor>
+		<UnresolvableInclude>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+				<file name="formidable.php" />
+			</errorLevel>
+		</UnresolvableInclude>
+		<RiskyTruthyFalsyComparison>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+				<directory name="deprecated" />
+				<file name="formidable.php" />
+			</errorLevel>
+		</RiskyTruthyFalsyComparison>
+		<MissingReturnType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+				<directory name="deprecated" />
+			</errorLevel>
+		</MissingReturnType>
+		<InvalidArgument>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</InvalidArgument>
+		<PossiblyUndefinedVariable>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyUndefinedVariable>
+		<MissingClosureParamType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</MissingClosureParamType>
+		<NullableReturnStatement>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</NullableReturnStatement>
+		<TypeDoesNotContainType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</TypeDoesNotContainType>
+		<InvalidReturnStatement>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</InvalidReturnStatement>
+		<InvalidArrayOffset>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</InvalidArrayOffset>
+		<PossiblyNullPropertyAssignment>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyNullPropertyAssignment>
+		<MissingPropertyType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+				<directory name="deprecated" />
+			</errorLevel>
+		</MissingPropertyType>
+		<TooManyArguments>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+				<directory name="deprecated" />
+			</errorLevel>
+		</TooManyArguments>
+		<PossiblyNullPropertyFetch>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyNullPropertyFetch>
+		<InvalidScalarArgument>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</InvalidScalarArgument>
+		<InvalidNullableReturnType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</InvalidNullableReturnType>
+		<PossiblyInvalidOperand>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyInvalidOperand>
+		<PossiblyInvalidIterator>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyInvalidIterator>
+		<ArgumentTypeCoercion>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</ArgumentTypeCoercion>
+		<PossiblyUndefinedArrayOffset>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyUndefinedArrayOffset>
+		<InvalidOperand>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</InvalidOperand>
+		<InvalidFalsableReturnType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</InvalidFalsableReturnType>
+		<PossiblyInvalidPropertyFetch>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyInvalidPropertyFetch>
+		<FalsableReturnStatement>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</FalsableReturnStatement>
+		<DocblockTypeContradiction>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</DocblockTypeContradiction>
+		<RedundantConditionGivenDocblockType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+				<directory name="deprecated" />
+				<file name="formidable.php" />
+			</errorLevel>
+		</RedundantConditionGivenDocblockType>
+		<InvalidReturnType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</InvalidReturnType>
+		<LessSpecificReturnStatement>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</LessSpecificReturnStatement>
+		<PossiblyInvalidPropertyAssignmentValue>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyInvalidPropertyAssignmentValue>
+		<ReferenceConstraintViolation>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</ReferenceConstraintViolation>
+		<InvalidPropertyFetch>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+				<directory name="deprecated" />
+			</errorLevel>
+		</InvalidPropertyFetch>
+		<InvalidStringClass>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</InvalidStringClass>
+		<RedundantCondition>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+				<file name="formidable.php" />
+			</errorLevel>
+		</RedundantCondition>
+		<PossiblyNullIterator>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyNullIterator>
+		<MoreSpecificImplementedParamType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</MoreSpecificImplementedParamType>
+		<MissingClosureReturnType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</MissingClosureReturnType>
+		<PossiblyInvalidArrayAssignment>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyInvalidArrayAssignment>
+		<PossiblyInvalidArrayAccess>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyInvalidArrayAccess>
+		<ImplementedReturnTypeMismatch>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</ImplementedReturnTypeMismatch>
+		<NonInvariantDocblockPropertyType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</NonInvariantDocblockPropertyType>
+		<RedundantCastGivenDocblockType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</RedundantCastGivenDocblockType>
+		<UndefinedPropertyFetch>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</UndefinedPropertyFetch>
+		<RiskyCast>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</RiskyCast>
+		<PossiblyInvalidPropertyAssignment>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyInvalidPropertyAssignment>
+		<PossiblyInvalidArgument>
+			<errorLevel type="suppress">
+				<directory name="deprecated" />
+			</errorLevel>
+		</PossiblyInvalidArgument>
+		<PossiblyFalsePropertyAssignmentValue>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyFalsePropertyAssignmentValue>
+		<InvalidPropertyAssignmentValue>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</InvalidPropertyAssignmentValue>
+		<RedundantCast>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</RedundantCast>
+		<InvalidCast>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</InvalidCast>
+		<PropertyTypeCoercion>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PropertyTypeCoercion>
+		<DirectConstructorCall>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</DirectConstructorCall>
+		<NoValue>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</NoValue>
+		<UnsafeInstantiation>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</UnsafeInstantiation>
+		<InvalidMethodCall>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</InvalidMethodCall>
+		<InvalidArrayAccess>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</InvalidArrayAccess>
+		<PossiblyFalseReference>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyFalseReference>
+		<LessSpecificImplementedReturnType>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</LessSpecificImplementedReturnType>
+		<DeprecatedMethod>
+			<errorLevel type="suppress">
+				<directory name="deprecated" />
+			</errorLevel>
+		</DeprecatedMethod>
 	</issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -46,21 +46,11 @@
 				<referencedFunction name="__autoload" />
 			</errorLevel>
 		</UndefinedFunction>
-		<MissingFile>
-			<errorLevel type="suppress">
-				<file name="formidable.php" />
-			</errorLevel>
-		</MissingFile>
 		<InvalidParamDefault>
 			<errorLevel type="suppress">
 				<directory name="deprecated" />
 			</errorLevel>
 		</InvalidParamDefault>
-		<MethodSignatureMustProvideReturnType>
-			<errorLevel type="suppress">
-				<file name="classes/widgets/FrmShowForm.php" />
-			</errorLevel>
-		</MethodSignatureMustProvideReturnType>
 		<!-- Add exceptions for classes/views files. -->
 		<UndefinedGlobalVariable>
 			<errorLevel type="suppress">
@@ -78,11 +68,6 @@
 				<directory name="classes/views" />
 			</errorLevel>
 		</UndefinedVariable>
-		<NonStaticSelfCall>
-			<errorLevel type="suppress">
-				<directory name="classes/views" />
-			</errorLevel>
-		</NonStaticSelfCall>
 		<NullReference>
 			<errorLevel type="suppress">
 				<directory name="classes/views" />
@@ -110,11 +95,6 @@
 				<file name="classes/models/FrmInstallerSkin.php" />
 			</errorLevel>
 		</ParamNameMismatch>
-		<UndefinedAttributeClass>
-			<errorLevel type="suppress">
-				<referencedClass name="AllowDynamicProperties" />
-			</errorLevel>
-		</UndefinedAttributeClass>
 		<MissingParamType>
 			<errorLevel type="suppress">
 				<directory name="classes" />
@@ -225,12 +205,6 @@
 				<directory name="stripe" />
 			</errorLevel>
 		</InvalidScalarArgument>
-		<InvalidNullableReturnType>
-			<errorLevel type="suppress">
-				<directory name="classes" />
-				<directory name="stripe" />
-			</errorLevel>
-		</InvalidNullableReturnType>
 		<PossiblyInvalidOperand>
 			<errorLevel type="suppress">
 				<directory name="classes" />
@@ -261,12 +235,6 @@
 				<directory name="stripe" />
 			</errorLevel>
 		</InvalidOperand>
-		<InvalidFalsableReturnType>
-			<errorLevel type="suppress">
-				<directory name="classes" />
-				<directory name="stripe" />
-			</errorLevel>
-		</InvalidFalsableReturnType>
 		<PossiblyInvalidPropertyFetch>
 			<errorLevel type="suppress">
 				<directory name="classes" />
@@ -497,6 +465,7 @@
 				<file name="classes/controllers/FrmFormsController.php" />
 				<file name="classes/controllers/FrmFieldsController.php" />
 				<file name="classes/controllers/FrmAppController.php" />
+				<file name="classes/helpers/FrmAppHelper.php" />
 			</errorLevel>
 		</DeprecatedMethod>
 		<DeprecatedFunction>

--- a/psalm.xml
+++ b/psalm.xml
@@ -480,10 +480,36 @@
 				<directory name="stripe" />
 			</errorLevel>
 		</LessSpecificImplementedReturnType>
+		<PossiblyNullReference>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</PossiblyNullReference>
 		<DeprecatedMethod>
 			<errorLevel type="suppress">
 				<directory name="deprecated" />
+				<file name="classes/helpers/FrmFieldsHelper.php" />
+				<file name="classes/helpers/FrmStylesHelper.php" />
+				<file name="classes/helpers/FrmFormsHelper.php" />
+				<file name="classes/controllers/FrmAddonsController.php" />
+				<file name="classes/models/FrmFormAction.php" />
+				<file name="classes/controllers/FrmFormsController.php" />
+				<file name="classes/controllers/FrmFieldsController.php" />
+				<file name="classes/controllers/FrmAppController.php" />
 			</errorLevel>
 		</DeprecatedMethod>
+		<DeprecatedFunction>
+			<errorLevel type="suppress">
+				<directory name="deprecated" />
+				<file name="classes/models/FrmEntryValidate.php" />
+			</errorLevel>
+		</DeprecatedFunction>
+		<UndefinedThisPropertyAssignment>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="stripe" />
+			</errorLevel>
+		</UndefinedThisPropertyAssignment>
 	</issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,6 +4,7 @@
 	findUnusedCode="false"
 	findUnusedBaselineEntry="true"
 	resolveFromConfigFile="true"
+	findUnusedIssueHandlerSuppression="false"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="https://getpsalm.org/schema/config"
 	xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/psalm.xml
+++ b/psalm.xml
@@ -58,21 +58,11 @@
 				<directory name="stripe" />
 			</errorLevel>
 		</UndefinedGlobalVariable>
-		<UndefinedAttributeClass>
-			<errorLevel type="suppress">
-				<referencedClass name="AllowDynamicProperties"/>
-			</errorLevel>
-		</UndefinedAttributeClass>
 		<UndefinedVariable>
 			<errorLevel type="suppress">
 				<directory name="classes/views" />
 			</errorLevel>
 		</UndefinedVariable>
-		<NullReference>
-			<errorLevel type="suppress">
-				<directory name="classes/views" />
-			</errorLevel>
-		</NullReference>
 		<InvalidScope>
 			<errorLevel type="suppress">
 				<directory name="classes/views" />
@@ -466,6 +456,7 @@
 				<file name="classes/controllers/FrmFieldsController.php" />
 				<file name="classes/controllers/FrmAppController.php" />
 				<file name="classes/helpers/FrmAppHelper.php" />
+				<file name="classes/models/FrmEntryValidate.php" />
 			</errorLevel>
 		</DeprecatedMethod>
 		<DeprecatedFunction>
@@ -480,5 +471,13 @@
 				<directory name="stripe" />
 			</errorLevel>
 		</UndefinedThisPropertyAssignment>
+		<UndefinedMethod>
+			<errorLevel type="suppress">
+				<directory name="deprecated" />
+				<file name="classes/models/FrmFieldValueSelector.php" />
+				<file name="classes/controllers/FrmDashboardController.php" />
+
+			</errorLevel>
+		</UndefinedMethod>
 	</issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -444,6 +444,11 @@
 				<directory name="stripe" />
 			</errorLevel>
 		</PossiblyNullReference>
+		<PossiblyFalseIterator>
+			<errorLevel type="suppress">
+				<file name="classes/helpers/FrmXMLHelper.php" />
+			</errorLevel>
+		</PossiblyFalseIterator>
 		<DeprecatedMethod>
 			<errorLevel type="suppress">
 				<directory name="deprecated" />
@@ -476,7 +481,8 @@
 				<directory name="deprecated" />
 				<file name="classes/models/FrmFieldValueSelector.php" />
 				<file name="classes/controllers/FrmDashboardController.php" />
-
+				<file name="classes/helpers/FrmXMLHelper.php" />
+				<file name="classes/models/FrmFormTemplateApi.php" />
 			</errorLevel>
 		</UndefinedMethod>
 	</issueHandlers>

--- a/psalm.xml
+++ b/psalm.xml
@@ -480,7 +480,6 @@
 			<errorLevel type="suppress">
 				<directory name="deprecated" />
 				<file name="classes/models/FrmFieldValueSelector.php" />
-				<file name="classes/controllers/FrmDashboardController.php" />
 				<file name="classes/helpers/FrmXMLHelper.php" />
 				<file name="classes/models/FrmFormTemplateApi.php" />
 			</errorLevel>

--- a/stubs.php
+++ b/stubs.php
@@ -56,6 +56,13 @@ namespace {
 	class FrmProStylesController extends FrmStylesController {
 	}
 	class FrmProPost {
+		/**
+		 * @param array $field
+		 * @param array $args
+		 * @return string
+		 */
+		public static function get_category_dropdown( $field, $args ) {
+		}
 	}
 	class FrmProEntriesController {
 		public static function show_entry_shortcode( $atts ) {

--- a/stubs.php
+++ b/stubs.php
@@ -35,9 +35,21 @@ namespace {
 	class FrmProAppHelper {
 		public static function get_settings() {
 		}
+		public static function convert_date( $date_str, $from_format, $to_format ) {
+		}
 	}
 	class FrmProEntryMetaHelper {
 		public static function get_post_or_meta_value( $entry, $field, $atts = array() ) {
+		}
+		/**
+		 * @param object|string|int $field_id
+		 * @param array|string      $value
+		 * @param string|int|false  $entry_id
+		 * @return array|null|string|object
+		 */
+		public static function &value_exists( $field_id, $value, $entry_id = false ) {
+		}
+		public static function get_post_value( $post_id, $post_field, $custom_field, $atts ) {
 		}
 	}
 	class FrmProFormActionsController {
@@ -66,6 +78,12 @@ namespace {
 	}
 	class FrmProEntriesController {
 		public static function show_entry_shortcode( $atts ) {
+		}
+		/**
+		 * @param array $atts
+		 * @return string
+		 */
+		public static function entry_delete_link( $atts ) {
 		}
 	}
 	class FrmProFormsHelper {
@@ -107,6 +125,16 @@ namespace {
 		}
 	}
 	class Akismet {
+		/**
+		 * @param string $request
+		 * @param string $path
+		 * @param string $ip
+		 * @return array
+		 */
+		public static function http_post( $request, $path, $ip = null ) {
+		}
+		public static function get_user_roles( $user_id ) {
+		}
 	}
 	class PHPMailer {
 		public function __construct( $exceptions = null ) {

--- a/stubs.php
+++ b/stubs.php
@@ -114,6 +114,14 @@ namespace {
 	class FrmProEntriesHelper {
 		public static function get_search_str( $where_clause, $search_str, $form_id = 0, $fid = '' ) {
 		}
+		/**
+		 * @param object           $field
+		 * @param object           $entry
+		 * @param string|array|int $field_value
+		 * @return void
+		 */
+		public static function get_dynamic_list_values( $field, $entry, &$field_value ) {
+		}
 	}
 	class FrmProFieldsHelper {
 		/**
@@ -122,6 +130,12 @@ namespace {
 		 * @return void
 		 */
 		public static function replace_non_standard_formidable_shortcodes( $args, &$value ) {
+		}
+		/**
+		 * @param object|array $field
+		 * @return bool
+		 */
+		public static function &is_field_visible_to_user( $field ) {
 		}
 	}
 	class FrmViewsAppHelper {
@@ -206,6 +220,14 @@ namespace WPMailSMTP {
 		*/
 	   public static function init() {
 	   }
+	   /**
+		 * @param string $group
+		 * @param string $key
+		 * @param bool   $strip_slashes
+		 * @return mixed|null
+		 */
+		public function get( $group, $key, $strip_slashes = true ) {
+		}
 	}
 	class Core {
 		/**

--- a/stubs.php
+++ b/stubs.php
@@ -37,6 +37,11 @@ namespace {
 		}
 		public static function convert_date( $date_str, $from_format, $to_format ) {
 		}
+		/**
+		 * @return bool
+		 */
+		public static function views_is_installed() {
+		}
 	}
 	class FrmProEntryMetaHelper {
 		public static function get_post_or_meta_value( $entry, $field, $atts = array() ) {
@@ -95,6 +100,8 @@ namespace {
 	class FrmProEntryFormatter extends FrmEntryFormatter {
 	}
 	class FrmProEntriesHelper {
+		public static function get_search_str( $where_clause, $search_str, $form_id = 0, $fid = '' ) {
+		}
 	}
 	class FrmProFieldsHelper {
 		/**

--- a/stubs.php
+++ b/stubs.php
@@ -42,6 +42,11 @@ namespace {
 		 */
 		public static function views_is_installed() {
 		}
+		/**
+		 * @return string
+		 */
+		public static function plugin_path() {
+		}
 	}
 	class FrmProEntryMetaHelper {
 		public static function get_post_or_meta_value( $entry, $field, $atts = array() ) {
@@ -96,6 +101,13 @@ namespace {
 		}
 	}
 	class FrmProEntry {
+		/**
+		 * @param array|false $values
+		 * @param string      $location
+		 * @return array
+		 */
+		public static function mod_other_vals( $values = false, $location = 'front' ) {
+		}
 	}
 	class FrmProEntryFormatter extends FrmEntryFormatter {
 	}
@@ -179,11 +191,21 @@ namespace Elementor {
 	}
 
 	class Plugin {
+		/**
+		 * @return Plugin
+		 */
+		public static function instance() {
+		}
 	}
 }
 
 namespace WPMailSMTP {
 	class Options {
+	   /**
+		* @return Options
+		*/
+	   public static function init() {
+	   }
 	}
 	class Core {
 		/**


### PR DESCRIPTION
This updates Psalm to level 2 from level 7.

Most rules are still in as exceptions.

But I left the undefined function/method rules and deprecated rules mostly alone.

Stubs are added to fill in those gaps where required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated return type declarations in `FrmFieldFactory` class for enhanced type safety.
	- Modified method in `FrmEntryValidate` class for improved content filtering.
	- Updated comparison operator in dropdown field template for increased accuracy in comparisons.
- **Bug Fixes**
	- Removed unnecessary variable reference in `FrmStylesCardHelper` class to avoid potential errors.
- **New Features**
	- Expanded functionality with new methods in multiple classes.
- **Chores**
	- Updated GitHub Actions workflow for improved CI process.
	- Introduced new error message in `phpstan.neon` for better error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->