### PR TITLE
Fix undefined function in dashboard controller

### DIFF
--- a/classes/controllers/FrmDashboardController.php
+++ b/classes/controllers/FrmDashboardController.php
@@ -392,19 +392,10 @@ class FrmDashboardController {
 	 * @return array
 	 */
 	public static function entries_columns( $columns = array() ) {
-
-		$form_id = FrmForm::get_current_form_id();
-
-		if ( $form_id ) {
-			self::get_columns_for_form( $form_id, $columns );
-		} else {
-			$columns[ $form_id . '_form_id' ] = __( 'Form', 'formidable' );
-			$columns[ $form_id . '_name' ]    = __( 'Name', 'formidable' );
-			$columns[ $form_id . '_user_id' ] = __( 'Author', 'formidable' );
-		}
-
-		$columns[ $form_id . '_created_at' ] = __( 'Created on', 'formidable' );
-
+		$columns[ '0_form_id' ]    = esc_html__( 'Form', 'formidable' );
+		$columns[ '0_name' ]       = esc_html__( 'Name', 'formidable' );
+		$columns[ '0_user_id' ]    = esc_html__( 'Author', 'formidable' );
+		$columns[ '0_created_at' ] = esc_html__( 'Created on', 'formidable' );
 		return $columns;
 	}
 


### PR DESCRIPTION
I've been working on improving our static analysis in Lite.

I found this undefined function reference.

`self::get_columns_for_form` does not exist.

This is working fine since `$form_id` is also always 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the process of generating columns in the dashboard for a more streamlined experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->