### PR TITLE
Fix too many arguments psalm rule

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -179,9 +179,7 @@
 		</MissingPropertyType>
 		<TooManyArguments>
 			<errorLevel type="suppress">
-				<directory name="classes" />
-				<directory name="stripe" />
-				<directory name="deprecated" />
+				<referencedFunction name="apply_filters" />
 			</errorLevel>
 		</TooManyArguments>
 		<PossiblyNullPropertyFetch>


### PR DESCRIPTION
There were no conflicts for this rule other than `apply_filters`.

🥳