### PR TITLE
Skip sending monthly summary email if there is no entries

### DIFF
--- a/classes/models/FrmEmailMonthly.php
+++ b/classes/models/FrmEmailMonthly.php
@@ -22,4 +22,16 @@ class FrmEmailMonthly extends FrmEmailStats {
 	protected function get_top_forms_label() {
 		return __( 'Top forms this month', 'formidable' );
 	}
+
+	/**
+	 * @since x.x
+	 */
+	protected function get_content_args() {
+		// Do not send monthly email if there is no entries this month.
+		if ( ! FrmEmailSummaryHelper::get_entries_count( $this->from_date, $this->to_date ) ) {
+			return false;
+		}
+
+		return parent::get_content_args();
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4881

We did the same thing for the yearly email before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced monthly email functionality to check for entries before sending, ensuring emails are only sent when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->