### PR TITLE
Fix pro issue 4852 / Hide dismiss button in inbox banner

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -9240,6 +9240,10 @@ Responsive Design
 	text-decoration: underline !important;
 }
 
+#frm_banner .frm-banner-cta a.frm_inbox_dismiss {
+	display: none;
+}
+
 .frm-banner-dismiss {
 	cursor: pointer;
 	position: absolute;


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4854

The dismiss button isn't necessary here. There's already a dismiss button that is always shown.

When this was implemented, the `cta` for the active inbox items must not have included dismiss buttons.

It isn't too easy too straight-forward the button out with PHP so I'm just hiding it with CSS to keep it simple.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the admin interface to hide a specific UI element for a cleaner look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->