### PR TITLE
Fix some HTML is printed in unit tests

### DIFF
--- a/tests/fields/test_FrmFieldsController.php
+++ b/tests/fields/test_FrmFieldsController.php
@@ -73,7 +73,11 @@ class test_FrmFieldsController extends FrmUnitTest {
 	 */
 	public function test_include_new_field() {
 		$form_id   = $this->factory->form->create();
+		ob_start();
 		$new_field = FrmFieldsController::include_new_field( 'text', $form_id );
+		$field_output = ob_get_clean();
+
+		$this->assertEquals( 0, strpos( trim( $field_output ), '<li id="frm_field_id_' . $new_field['id'] . '"' ) );
 
 		// Confirm field is an array with type and form id keys.
 		$this->assertIsArray( $new_field );


### PR DESCRIPTION
When running unit tests, I found some HTML is printed:

<img width="570" alt="Screenshot 2024-03-20 at 13 25 57" src="https://github.com/Strategy11/formidable-forms/assets/19748318/60088872-2cb7-4e50-84b8-6b245e7dffc2">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved testing for field output by implementing output buffering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->