### PR TITLE
Show/hide bulk edit when interacting with 'Use images in buttons' checkbox

### DIFF
--- a/classes/views/frm-fields/back-end/field-options.php
+++ b/classes/views/frm-fields/back-end/field-options.php
@@ -3,10 +3,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
 
-$field_option_count = is_array( $args['field']['options'] ) ? count( $args['field']['options'] ) : 0;
-$display_format     = FrmField::get_option( $args['field'], 'image_options' );
+$field_option_count    = is_array( $args['field']['options'] ) ? count( $args['field']['options'] ) : 0;
+$display_format        = FrmField::get_option( $args['field'], 'image_options' );
+if ( $display_format === 'buttons' ) {
+	$should_hide_bulk_edit = FrmField::get_option( $args['field'], 'use_images_in_buttons' ) === '1';
+} else {
+	$should_hide_bulk_edit = $display_format === '1';
+}
 ?>
-<span class="frm-bulk-edit-link <?php echo $display_format === '1' ? 'frm_hidden' : ''; // Hide bulk edit for image buttons ?>">
+<span class="frm-bulk-edit-link <?php echo $should_hide_bulk_edit ? 'frm_hidden' : ''; ?>">
 	<a href="#" title="<?php echo esc_attr( $option_title ); ?>" class="frm-bulk-edit-link">
 		<?php echo esc_html( $this->get_bulk_edit_string() ); ?>
 	</a>


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-surveys/issues/211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logic to selectively hide the bulk edit option for fields with image button display formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->