### PR TITLE
Add a new filter that allows updating bulk edit button status

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -427,6 +427,19 @@ DEFAULT_HTML;
 		/* translators: %s: Field name */
 		$option_title = sprintf( __( '%s Options', 'formidable' ), $short_name );
 
+		$display_format = FrmField::get_option( $args['field'], 'image_options' );
+
+		/**
+		 * Allows updating a flag that determines whether Bulk edit option should be visible on page load.
+		 *
+		 * @since x.x
+		 *
+		 * @param bool   $should_hide_bulk_edit
+		 * @param string $display_format
+		 * @param array  $args
+		 */
+		$should_hide_bulk_edit = apply_filters( 'frm_should_hide_bulk_edit', $display_format === '1', $display_format, $args );
+
 		include( FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/field-options.php' );
 	}
 

--- a/classes/views/frm-fields/back-end/field-options.php
+++ b/classes/views/frm-fields/back-end/field-options.php
@@ -5,8 +5,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $field_option_count = is_array( $args['field']['options'] ) ? count( $args['field']['options'] ) : 0;
 $display_format     = FrmField::get_option( $args['field'], 'image_options' );
+
+/**
+ * Allows updating a flag that determines whether Bulk edit option should be visible on page load.
+ *
+ * @since x.x
+ *
+ * @param bool   $should_hide_bulk_edit
+ * @param string $display_format
+ * @param array  $args
+ */
+$should_hide_bulk_edit = apply_filters( 'frm_should_hide_bulk_edit', $display_format === '1', $display_format, $args );
 ?>
-<span class="frm-bulk-edit-link <?php echo $display_format === '1' ? 'frm_hidden' : ''; // Hide bulk edit for image buttons ?>">
+<span class="frm-bulk-edit-link <?php echo $should_hide_bulk_edit ? 'frm_hidden' : ''; ?>">
 	<a href="#" title="<?php echo esc_attr( $option_title ); ?>" class="frm-bulk-edit-link">
 		<?php echo esc_html( $this->get_bulk_edit_string() ); ?>
 	</a>

--- a/classes/views/frm-fields/back-end/field-options.php
+++ b/classes/views/frm-fields/back-end/field-options.php
@@ -4,18 +4,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $field_option_count = is_array( $args['field']['options'] ) ? count( $args['field']['options'] ) : 0;
-$display_format     = FrmField::get_option( $args['field'], 'image_options' );
-
-/**
- * Allows updating a flag that determines whether Bulk edit option should be visible on page load.
- *
- * @since x.x
- *
- * @param bool   $should_hide_bulk_edit
- * @param string $display_format
- * @param array  $args
- */
-$should_hide_bulk_edit = apply_filters( 'frm_should_hide_bulk_edit', $display_format === '1', $display_format, $args );
 ?>
 <span class="frm-bulk-edit-link <?php echo $should_hide_bulk_edit ? 'frm_hidden' : ''; ?>">
 	<a href="#" title="<?php echo esc_attr( $option_title ); ?>" class="frm-bulk-edit-link">


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-surveys/issues/211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Refactored the logic for determining the visibility of the Bulk edit link in form fields to use a new filter `frm_should_hide_bulk_edit`, providing more flexibility for customization.
- **New Features**
	- Added a new variable `$should_hide_bulk_edit` in the `FrmFieldType` class, controlled by the filter `frm_should_hide_bulk_edit` based on `image_options`, enhancing the visibility control of Bulk edit option on page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->