### PR TITLE
Add checks if set time limit function exists before calling it

### DIFF
--- a/classes/controllers/FrmXMLController.php
+++ b/classes/controllers/FrmXMLController.php
@@ -664,7 +664,9 @@ class FrmXMLController {
 		}
 
 		// Remove time limit to execute this function.
-		set_time_limit( 0 );
+		if ( function_exists( 'set_time_limit' ) ) {
+			set_time_limit( 0 );
+		}
 		$mem_limit = str_replace( 'M', '', ini_get( 'memory_limit' ) );
 		if ( (int) $mem_limit < 256 ) {
 			wp_raise_memory_limit();

--- a/stripe/helpers/FrmStrpLiteConnectHelper.php
+++ b/stripe/helpers/FrmStrpLiteConnectHelper.php
@@ -186,7 +186,7 @@ class FrmStrpLiteConnectHelper {
 	 * @return void
 	 */
 	private static function try_to_extend_server_timeout( $timeout ) {
-		if ( ! ini_get( 'safe_mode' ) ) {
+		if ( ! ini_get( 'safe_mode' ) && function_exists( 'set_time_limit' ) ) {
 			set_time_limit( $timeout + 10 );
 		}
 	}

--- a/stripe/helpers/FrmStrpLiteConnectHelper.php
+++ b/stripe/helpers/FrmStrpLiteConnectHelper.php
@@ -186,7 +186,7 @@ class FrmStrpLiteConnectHelper {
 	 * @return void
 	 */
 	private static function try_to_extend_server_timeout( $timeout ) {
-		if ( ! ini_get( 'safe_mode' ) && function_exists( 'set_time_limit' ) ) {
+		if ( function_exists( 'set_time_limit' ) ) {
 			set_time_limit( $timeout + 10 );
 		}
 	}


### PR DESCRIPTION
Related ticket https://wordpress.org/support/topic/call-to-undefined-function-set_time_limit-in-frmproreportshelper-php79/

> Uncaught Error: Call to undefined function set_time_limit()

Since this function could be disabled, I'm adding checks everywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved server request handling by adding checks before modifying server time limits, ensuring compatibility across different server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->