### PR TITLE
Fix field shortcode items long text style

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7486,7 +7486,6 @@ ul.frm_two_col {
 
 .frm_code_list.frm-full-hover a span {
 	max-width: 83px;
-	text-align: left;
 	margin-right: var(--gap-xs);
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7490,10 +7490,13 @@ ul.frm_two_col {
 	margin-left: auto;
 }
 
+.frm_code_list.frm-full-hover a {
+	overflow: hidden;
+}
+
 .frm_code_list.frm-full-hover a,
 .frm_code_list.frm-full-hover a span {
 	white-space: nowrap;
-	overflow: hidden;
 	text-overflow: ellipsis;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8492,6 +8492,10 @@ button.frm_choose_image_box,
 	background-position: left 11px top 55%;
 }
 
+.rtl .frm_code_list.frm-full-hover a span {
+	margin-left: var(--gap-xs);
+}
+
 /* ---------------------------------------------------------------
 Clearfix
 --------------------------------------------------------------- */

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7491,7 +7491,6 @@ ul.frm_two_col {
 }
 
 .frm_code_list.frm-full-hover a {
-	max-width: 95%;
     display: block;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7492,7 +7492,7 @@ ul.frm_two_col {
 
 .frm_code_list.frm-full-hover a {
 	max-width: 95%;
-    display: inline-block;
+    display: block;
 }
 
 .frm_code_list.frm-full-hover a,

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7486,17 +7486,19 @@ ul.frm_two_col {
 
 .frm_code_list.frm-full-hover a span {
 	max-width: 83px;
-	text-align: right;
-	margin-left: auto;
+	text-align: left;
+	margin-right: var(--gap-xs);
 }
 
 .frm_code_list.frm-full-hover a {
-	overflow: hidden;
+	max-width: 95%;
+    display: inline-block;
 }
 
 .frm_code_list.frm-full-hover a,
 .frm_code_list.frm-full-hover a span {
 	white-space: nowrap;
+	overflow: hidden;
 	text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4659
### Test steps

1. Create a form with 2 fields, make the first field's label very long.
2. In the other field, switch Default value to calculation. Confirm that the `[field_id]` shortcode text is visible for the first field despite the long label it has.

### Screenshots
**Before**:
<img width="536" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/e7df5cab-16ac-4fd6-9792-eacb2f955b14">

**After:**
<img width="528" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/e5c96e6f-3b85-4a6b-b9b6-90b6dc41140a">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
	- Adjusted text alignment to left and margin properties for improved layout in the admin form.
	- Updated max-width and display properties for enhanced styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->