### PR TITLE
Fix fatal error when styles API request fails

### DIFF
--- a/classes/models/FrmAddon.php
+++ b/classes/models/FrmAddon.php
@@ -799,7 +799,6 @@ class FrmAddon {
 			$arg_array
 		);
 		$body = wp_remote_retrieve_body( $resp );
-
 		$this->save_status = array( 'response_code' => wp_remote_retrieve_response_code( $resp ) );
 
 		$message = __( 'Your License Key was invalid', 'formidable' );

--- a/classes/views/styles/_styles-list.php
+++ b/classes/views/styles/_styles-list.php
@@ -84,8 +84,11 @@ if ( $globally_disabled ) {
 		<?php $card_helper->echo_card_wrapper( 'frm_custom_style_cards_wrapper', $custom_styles ); ?>
 	<?php } ?>
 
-	<div class="frm_form_settings">
-		<h2><?php esc_html_e( 'Formidable Styles', 'formidable' ); ?></h2>
-	</div>
-	<?php $card_helper->echo_card_wrapper( 'frm_template_style_cards_wrapper', $card_helper->get_template_info() ); ?>
+	<?php $style_templates = array_filter( $card_helper->get_template_info(), 'is_array' ); ?>
+	<?php if ( $style_templates ) { ?>
+		<div class="frm_form_settings">
+			<h2><?php esc_html_e( 'Formidable Styles', 'formidable' ); ?></h2>
+		</div>
+		<?php $card_helper->echo_card_wrapper( 'frm_template_style_cards_wrapper', $style_templates ); ?>
+	<?php } ?>
 </div>


### PR DESCRIPTION
I noticed this on the site where every API request is resulting in a 520 error.

<img width="417" alt="Formidable Styles" src="https://github.com/Strategy11/formidable-forms/assets/9134515/2f1a89ee-2345-4275-8c56-e9f3a49f8d52">

> Fatal error: Uncaught Error: Attempt to modify property "post_content" on null
in /var/www/src/wp-content/plugins/formidable/classes/helpers/FrmStylesCardHelper.php on line 265

This update just adds a check to make sure the styles are actually arrays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Minor code cleanup in `FrmAddon.php` without affecting functionality.
- **New Features**
	- Enhanced the display logic for Formidable Styles, allowing styles to be filtered and shown based on specific criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->