### PR TITLE
Hide notices in plugin cards

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2384,6 +2384,11 @@ h2.frm-h2 + .howto {
 	opacity: 0.8;
 }
 
+.frm-addons .plugin-card-top > :not(p):not(h2) {
+	/* Hide notices from third party plugins */
+	display: none;
+}
+
 .frm-addons .plugin-card-bottom {
 	padding: 5px 20px 20px;
 	text-align: center;


### PR DESCRIPTION
I noticed this annoying notice on our add-ons page.

I'm adding some CSS to hide this.

<img width="405" alt="Formidable Forms Pro" src="https://github.com/Strategy11/formidable-forms/assets/9134515/b32ae5cf-7ff6-4ea4-b6bd-ece3fe00cfc2">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Style**
	- Improved user interface by hiding notices from third-party plugins to maintain a clean admin area.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->