### PR TITLE
Add new filter for validation messages

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -689,27 +689,15 @@ class FrmFieldsController {
 	}
 
 	private static function add_validation_messages( $field, array &$add_html ) {
-		if ( $field['type'] === 'hidden' ) {
-			$field_messages_status = array(
-				'data-invmsg' => false,
-				'data-reqmsg' => false,
-			);
-		} else {
-			$field_messages_status = array(
-				'data-invmsg' => true,
-				'data-reqmsg' => true,
-			);
-		}
+		$field_validation_messages = self::get_field_validation_messages_status( $field );
 
-		$field_messages_status = apply_filters( 'frm_field_messages_status', $field_messages_status, $field );
-
-		if ( FrmField::is_required( $field ) && $field_messages_status['data-reqmsg'] ) {
+		if ( FrmField::is_required( $field ) && ! empty( $field_validation_messages['data-reqmsg'] ) ) {
 			$required_message        = FrmFieldsHelper::get_error_msg( $field, 'blank' );
 			$add_html['data-reqmsg'] = 'data-reqmsg="' . esc_attr( $required_message ) . '"';
 			self::maybe_add_html_required( $field, $add_html );
 		}
 
-		if ( ! FrmField::is_option_empty( $field, 'invalid' ) && $field_messages_status['data-invmsg'] ) {
+		if ( ! FrmField::is_option_empty( $field, 'invalid' ) && ! empty( $field_validation_messages['data-invmsg'] ) ) {
 			$invalid_message         = FrmFieldsHelper::get_error_msg( $field, 'invalid' );
 			$add_html['data-invmsg'] = 'data-invmsg="' . esc_attr( $invalid_message ) . '"';
 		}
@@ -717,6 +705,38 @@ class FrmFieldsController {
 		if ( ! empty( $add_html['data-reqmsg'] ) || ! empty( $add_html['data-invmsg'] ) ) {
 			self::maybe_add_error_html_for_js_validation( $field, $add_html );
 		}
+	}
+
+	/**
+	 * Returns an array that contains field validation messages status.
+	 *
+	 * @since x.x
+	 *
+	 * @param array $field_array
+	 * @return array
+	 */
+	private static function get_field_validation_messages_status( $field_array ) {
+		if ( $field_array['type'] === 'hidden' ) {
+			$field_validation_messages_status = array(
+				'data-invmsg' => false,
+				'data-reqmsg' => false,
+			);
+		} else {
+			$field_validation_messages_status = array(
+				'data-invmsg' => true,
+				'data-reqmsg' => true,
+			);
+		}
+
+		/**
+		 * Allows controlling which field validation messages would be included in the field html.
+		 *
+		 * @since x.x
+		 *
+		 * @param array $field_validation_messages_status
+		 * @param array $field_array
+		 */
+		return apply_filters( 'frm_field_validation_messages_status', $field_validation_messages_status, $field_array );
 	}
 
 	/**

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -689,15 +689,15 @@ class FrmFieldsController {
 	}
 
 	private static function add_validation_messages( $field, array &$add_html ) {
-		$field_validation_messages = self::get_field_validation_messages_status( $field );
+		$field_validation_messages_status = self::get_field_validation_messages_status( $field );
 
-		if ( FrmField::is_required( $field ) && ! empty( $field_validation_messages['data-reqmsg'] ) ) {
+		if ( FrmField::is_required( $field ) && ! empty( $field_validation_messages_status['data-reqmsg'] ) ) {
 			$required_message        = FrmFieldsHelper::get_error_msg( $field, 'blank' );
 			$add_html['data-reqmsg'] = 'data-reqmsg="' . esc_attr( $required_message ) . '"';
 			self::maybe_add_html_required( $field, $add_html );
 		}
 
-		if ( ! FrmField::is_option_empty( $field, 'invalid' ) && ! empty( $field_validation_messages['data-invmsg'] ) ) {
+		if ( ! FrmField::is_option_empty( $field, 'invalid' ) && ! empty( $field_validation_messages_status['data-invmsg'] ) ) {
 			$invalid_message         = FrmFieldsHelper::get_error_msg( $field, 'invalid' );
 			$add_html['data-invmsg'] = 'data-invmsg="' . esc_attr( $invalid_message ) . '"';
 		}

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -715,7 +715,7 @@ class FrmFieldsController {
 	 * @param array|object $field
 	 * @return array
 	 */
-	private static function get_field_validation_messages_status( $field) {
+	private static function get_field_validation_messages_status( $field ) {
 		if ( FrmField::get_field_type( $field ) === 'hidden' ) {
 			$field_validation_messages_status = array(
 				'data-invmsg' => false,
@@ -734,9 +734,9 @@ class FrmFieldsController {
 		 * @since x.x
 		 *
 		 * @param array $field_validation_messages_status
-		 * @param array $field_array
+		 * @param array $field
 		 */
-		return apply_filters( 'frm_field_validation_messages_status', $field_validation_messages_status, $field_array );
+		return apply_filters( 'frm_field_validation_messages_status', $field_validation_messages_status, $field );
 	}
 
 	/**

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -689,7 +689,7 @@ class FrmFieldsController {
 	}
 
 	private static function add_validation_messages( $field, array &$add_html ) {
-		$field_validation_messages_status = self::get_field_validation_messages_status( $field );
+		$field_validation_messages_status = self::get_validation_data_attribute_visibility_info( $field );
 
 		if ( FrmField::is_required( $field ) && ! empty( $field_validation_messages_status['data-reqmsg'] ) ) {
 			$required_message        = FrmFieldsHelper::get_error_msg( $field, 'blank' );
@@ -715,14 +715,14 @@ class FrmFieldsController {
 	 * @param array|object $field
 	 * @return array
 	 */
-	private static function get_field_validation_messages_status( $field ) {
+	private static function get_validation_data_attribute_visibility_info( $field ) {
 		if ( FrmField::get_field_type( $field ) === 'hidden' ) {
-			$field_validation_messages_status = array(
+			$field_validation_data_attributes = array(
 				'data-invmsg' => false,
 				'data-reqmsg' => false,
 			);
 		} else {
-			$field_validation_messages_status = array(
+			$field_validation_data_attributes = array(
 				'data-invmsg' => true,
 				'data-reqmsg' => true,
 			);
@@ -736,7 +736,7 @@ class FrmFieldsController {
 		 * @param array $field_validation_messages_status
 		 * @param array|object $field
 		 */
-		return apply_filters( 'frm_field_validation_messages_status', $field_validation_messages_status, $field );
+		return apply_filters( 'frm_field_validation_include_data_attributes', $field_validation_data_attributes, $field );
 	}
 
 	/**

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -689,13 +689,27 @@ class FrmFieldsController {
 	}
 
 	private static function add_validation_messages( $field, array &$add_html ) {
-		if ( FrmField::is_required( $field ) ) {
+		if ( $field['type'] === 'hidden' ) {
+			$field_messages_status = array(
+				'data-invmsg' => false,
+				'data-reqmsg' => false,
+			);
+		} else {
+			$field_messages_status = array(
+				'data-invmsg' => true,
+				'data-reqmsg' => true,
+			);
+		}
+
+		$field_messages_status = apply_filters( 'frm_field_messages_status', $field_messages_status, $field );
+
+		if ( FrmField::is_required( $field ) && $field_messages_status['data-reqmsg'] ) {
 			$required_message        = FrmFieldsHelper::get_error_msg( $field, 'blank' );
 			$add_html['data-reqmsg'] = 'data-reqmsg="' . esc_attr( $required_message ) . '"';
 			self::maybe_add_html_required( $field, $add_html );
 		}
 
-		if ( ! FrmField::is_option_empty( $field, 'invalid' ) ) {
+		if ( ! FrmField::is_option_empty( $field, 'invalid' ) && $field_messages_status['data-invmsg'] ) {
 			$invalid_message         = FrmFieldsHelper::get_error_msg( $field, 'invalid' );
 			$add_html['data-invmsg'] = 'data-invmsg="' . esc_attr( $invalid_message ) . '"';
 		}

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -734,7 +734,7 @@ class FrmFieldsController {
 		 * @since x.x
 		 *
 		 * @param array $field_validation_messages_status
-		 * @param array $field
+		 * @param array|object $field
 		 */
 		return apply_filters( 'frm_field_validation_messages_status', $field_validation_messages_status, $field );
 	}

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -712,11 +712,11 @@ class FrmFieldsController {
 	 *
 	 * @since x.x
 	 *
-	 * @param array $field_array
+	 * @param array|object $field
 	 * @return array
 	 */
-	private static function get_field_validation_messages_status( $field_array ) {
-		if ( $field_array['type'] === 'hidden' ) {
+	private static function get_field_validation_messages_status( $field) {
+		if ( FrmField::get_field_type( $field ) === 'hidden' ) {
 			$field_validation_messages_status = array(
 				'data-invmsg' => false,
 				'data-reqmsg' => false,

--- a/tests/fields/test_FrmFieldsController.php
+++ b/tests/fields/test_FrmFieldsController.php
@@ -90,4 +90,34 @@ class test_FrmFieldsController extends FrmUnitTest {
 		$this->assertArrayHasKey( 'draft', $new_field );
 		$this->assertEquals( 1, $new_field['draft'] );
 	}
+
+	/**
+	 * @covers FrmFieldsController::add_validation_messages
+	 */
+	public function test_add_validation_messages() {
+		$form_id   = $this->factory->form->create();
+		$field     = $this->factory->field->create_and_get(
+			array(
+				'form_id' => $form_id,
+				'type'    => 'email',
+			)
+		);
+		$field = FrmFieldsHelper::setup_edit_vars( $field );
+
+		$add_html  = array();
+		$this->run_private_method( array( 'FrmFieldsController', 'add_validation_messages' ), array( $field, &$add_html ) );
+		$this->assertArrayHasKey( 'data-invmsg', $add_html );
+		$this->assertArrayNotHasKey( 'data-reqmsg', $add_html );
+
+		$field['required'] = '1';
+		$add_html = array();
+		$this->run_private_method( array( 'FrmFieldsController', 'add_validation_messages' ), array( $field, &$add_html ) );
+		$this->assertArrayHasKey( 'data-reqmsg', $add_html );
+
+		$field['type'] = 'hidden';
+		$add_html = array();
+		$this->run_private_method( array( 'FrmFieldsController', 'add_validation_messages' ), array( $field, &$add_html ) );
+		$this->assertArrayNotHasKey( 'data-invmsg', $add_html );
+		$this->assertArrayNotHasKey( 'data-reqmsg', $add_html );
+	}
 }


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4819

### Test steps
1. Create a multi-page form.
2. Add fields with "Required" turned on different pages to make sure `data-reqmsg` is included for JS validation purpose.
3. Preview the form and inspect the HTML for fields NOT included on the current page.
4. Confirm that `data-invmsg` and `data-reqmsg` are not there.
5. Inspect the HTML for fields on the current page.
6. Confirm that both data attributes are there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Enhancements**
	- Improved field validation by selectively including specific messages based on field type and conditions, enhancing user feedback during form submissions.
	- Added a new test method to ensure the `add_validation_messages` method functions correctly for different field configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->