### PR TITLE
Do js validation for confirmation field even if its empty

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -492,7 +492,11 @@ function frmFrontFormJS() {
 			confirmValue = confirmField.value;
 		}
 
-		if ( ! ( value === '' && confirmValue === ''  ) && value !== confirmValue ) {
+		if ( value === '' && confirmValue === '' ) {
+			return;
+		}
+
+		if ( value !== confirmValue ) {
 			errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( confirmField, 'data-confmsg' );
 			return
 		}

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -488,7 +488,7 @@ function frmFrontFormJS() {
 			firstField = document.getElementById( strippedId );
 			value = firstField.value;
 			confirmValue = confirmField.value;
-			if ( value !== confirmValue ) {
+			if ( ! ( value === '' && confirmValue === '' ) && value !== confirmValue ) {
 				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( confirmField, 'data-confmsg' );
 			}
 		} else {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -492,7 +492,7 @@ function frmFrontFormJS() {
 			confirmValue = confirmField.value;
 		}
 
-		if ( value !== confirmValue ) {
+		if ( ! ( value === '' && confirmValue === ''  ) && value !== confirmValue ) {
 			errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( confirmField, 'data-confmsg' );
 			return
 		}

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -483,17 +483,25 @@ function frmFrontFormJS() {
 		if ( confirmField === null || typeof errors[ 'conf_' + strippedFieldID ] !== 'undefined' ) {
 			return;
 		}
-
 		if ( fieldID !== strippedFieldID ) {
 			firstField = document.getElementById( strippedId );
 			value = firstField.value;
 			confirmValue = confirmField.value;
-			if ( '' !== value && '' !== confirmValue && value !== confirmValue ) {
-				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( confirmField, 'data-confmsg' );
-			}
 		} else {
-			validateField( confirmField );
+			value        = field.value;
+			confirmValue = confirmField.value;
 		}
+
+		if ( value !== confirmValue ) {
+			errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( confirmField, 'data-confmsg' );
+			return
+		}
+
+		if ( fieldID !== strippedFieldID ) {
+			return;
+		}
+
+		validateField( confirmField );
 	}
 
 	function checkNumberField( field, errors ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -488,7 +488,7 @@ function frmFrontFormJS() {
 			firstField = document.getElementById( strippedId );
 			value = firstField.value;
 			confirmValue = confirmField.value;
-			if ( ! ( value === '' && confirmValue === '' ) && value !== confirmValue ) {
+			if ( value !== confirmValue ) {
 				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( confirmField, 'data-confmsg' );
 			}
 		} else {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -483,29 +483,17 @@ function frmFrontFormJS() {
 		if ( confirmField === null || typeof errors[ 'conf_' + strippedFieldID ] !== 'undefined' ) {
 			return;
 		}
+
 		if ( fieldID !== strippedFieldID ) {
 			firstField = document.getElementById( strippedId );
 			value = firstField.value;
 			confirmValue = confirmField.value;
+			if ( value !== confirmValue ) {
+				errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( confirmField, 'data-confmsg' );
+			}
 		} else {
-			value        = field.value;
-			confirmValue = confirmField.value;
+			validateField( confirmField );
 		}
-
-		if ( value === '' && confirmValue === '' ) {
-			return;
-		}
-
-		if ( value !== confirmValue ) {
-			errors[ 'conf_' + strippedFieldID ] = getFieldValidationMessage( confirmField, 'data-confmsg' );
-			return
-		}
-
-		if ( fieldID !== strippedFieldID ) {
-			return;
-		}
-
-		validateField( confirmField );
 	}
 
 	function checkNumberField( field, errors ) {


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4882

### Test steps
1. Create a form and add fields that support confirmation like email and password field to it.
2. Enable JS validation in the form
3. Preview the form and fill only the first fields and leaving confirmation fields empty
4. Confirm that a JS validation error is triggered and you cannot submit the form.

<img width="1175" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/83ae6023-11f9-41e3-837e-46d576f2be6c">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved form field validation to handle conditions and error messages more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->