### PR TITLE
Fix submit button PR breaks Pro unit tests

### DIFF
--- a/classes/helpers/FrmSubmitHelper.php
+++ b/classes/helpers/FrmSubmitHelper.php
@@ -142,6 +142,10 @@ class FrmSubmitHelper {
 			return;
 		}
 
+		if ( FrmAppHelper::pro_is_installed() && ! has_filter( 'frm_default_field_options', 'FrmProFieldsHelper::add_default_field_settings' ) ) {
+			add_filter( 'frm_default_field_options', 'FrmProFieldsHelper::add_default_field_settings', 10, 2 );
+		}
+
 		$field_data = FrmFieldsHelper::setup_new_vars( self::FIELD_TYPE, $form->id );
 
 		$submit_settings             = self::get_submit_settings_from_form( $form );

--- a/stubs.php
+++ b/stubs.php
@@ -137,6 +137,8 @@ namespace {
 		 */
 		public static function &is_field_visible_to_user( $field ) {
 		}
+		public static function add_default_field_settings( $settings, $atts ) {
+		}
 	}
 	class FrmViewsAppHelper {
 	}


### PR DESCRIPTION
This gets the Pro unit tests passing.

It fixes this error.
![image](https://github.com/Strategy11/formidable-forms/assets/9134515/c996576b-5c7f-4d0c-9e55-8b935f631ad5)

The hook gets loaded in `load_form_hooks` but that isn't triggered when the submit button is getting generated.

This fixes the issue, but I don't love it.

Maybe there's a better option?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved form submission behavior by adding conditional checks before setting up field data.
- **New Features**
	- Added a new public static function to the `FrmField` class for setting default field settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->