### PR TITLE
Fix broken pro tests alternative fix

### DIFF
--- a/tests/forms/test_FrmFormsController.php
+++ b/tests/forms/test_FrmFormsController.php
@@ -43,6 +43,9 @@ class test_FrmFormsController extends FrmUnitTest {
 			$this->markTestSkipped( 'Run with --filter test_form_update_no_ajax' );
 		}
 
+		// Allow for Pro hooks to load.
+		FrmHooksController::trigger_load_form_hooks();
+
 		$form_id = $this->factory->form->get_id_by_key( $this->contact_form_key );
 		$this->set_current_user_to_1();
 		self::_setup_post_values( $form_id );


### PR DESCRIPTION
I don't think we need to fix this in the code, just in the tests.

I tested manually, and the filter does exist in the form builder.

This replaces https://github.com/Strategy11/formidable-forms/pull/1606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved form update tests to ensure Pro hooks load correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->