### PR TITLE
Delete tooltip on action delete

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -622,6 +622,7 @@ function frmAdminBuildJS() {
 				const type = this.closest( '.frm_form_action_settings' ).querySelector( '.frm_action_name' ).value;
 				afterActionRemoved( type );
 			}
+			document.querySelector( '.tooltip' )?.remove();
 		});
 
 		if ( typeof removeMore !== 'undefined' ) {


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4934

Sharing Mike's screen record about the issue:
https://github.com/Strategy11/formidable-pro/assets/9134515/a136bf85-d72d-45b0-8e73-33999adc5ab6

Confirm that the tooltip doesn't get stuck anymore when deleting actions.