### PR TITLE
Undo changes to modal in views editor

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7504,7 +7504,11 @@ ul.frm_two_col {
 	margin-right: var(--gap-xs);
 }
 
-.frm_code_list.frm-full-hover a {
+.frm-views-editor-body .frm_code_list.frm-full-hover a span {
+	margin-left: auto;
+}
+
+.frm-single-settings .frm_code_list.frm-full-hover a {
     display: block;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7502,9 +7502,6 @@ ul.frm_two_col {
 .frm_code_list.frm-full-hover a span {
 	max-width: 83px;
 	margin-right: var(--gap-xs);
-}
-
-.frm-views-editor-body .frm_code_list.frm-full-hover a span {
 	margin-left: auto;
 }
 


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4659

Just reverting fields modal style in views editor.
**Before:**
![image](https://github.com/Strategy11/formidable-forms/assets/41271840/3255cd68-1349-47bc-a150-a6dc6f199f73)

![image](https://github.com/Strategy11/formidable-forms/assets/41271840/618a5bda-3544-452a-a23a-b3bc49c10a65)
