### PR TITLE
Clear the running transient too when resetting cache

### DIFF
--- a/classes/models/FrmFormApi.php
+++ b/classes/models/FrmFormApi.php
@@ -353,6 +353,7 @@ class FrmFormApi {
 		} else {
 			delete_option( $this->cache_key );
 		}
+		$this->done_running();
 	}
 
 	/**


### PR DESCRIPTION
We ran into a site that had a Cloudflare browser integrity check. Then the transient wasn't getting cleared so the plugin thought is was in Lite mode.

This update clears the running transient too when the api cache is cleared.

See https://secure.helpscout.net/conversation/2565742705/195727