### PR TITLE
Fix issue 4944 / Drag to index 0 when there are no fields

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1145,6 +1145,11 @@ function frmAdminBuildJS() {
 
 		let index, item, itemTop, returnIndex;
 
+		if ( ! document.querySelector( '.frm-has-fields .frm_no_fields' ) ) {
+			// Always return 0 when there are no fields.
+			return 0;
+		}
+
 		returnIndex = 0;
 		for ( index = length - 1; index >= 0; --index ) {
 			item    = $items.get( index );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4944

This makes it work more like it did in v6.8.4. When there are no fields, the index is always 0, so the drag marker always shows at the top, above the no fields element.

<img width="494" alt="Screen Shot 2024-04-11 at 2 51 09 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/71e6c43e-d799-4644-a023-c9fdfcf2f337">

**Pre-release,**
[formidable-6.9b.zip](https://github.com/Strategy11/formidable-forms/files/14949646/formidable-6.9b.zip)
