### PR TITLE
Add div with site-branding class when twenty nineteen is active

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2820,20 +2820,6 @@ class FrmFormsController {
 	}
 
 	/**
-	 * Returns true if the current theme name matches $theme_name.
-	 *
-	 * @since x.x
-	 *
-	 * @param string $theme_name
-	 *
-	 * @return bool
-	 */
-	public static function current_theme_is( $theme_name ) {
-		$current_theme = wp_get_theme();
-		return  $current_theme->get( 'Name' ) === $theme_name;
-	}
-
-	/**
 	 * @return string - 'before', 'after', or 'submit'
 	 *
 	 * @since 4.05.02

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2820,6 +2820,20 @@ class FrmFormsController {
 	}
 
 	/**
+	 * Returns true if the current theme name matches $theme_name.
+	 *
+	 * @since x.x
+	 *
+	 * @param string $theme_name
+	 *
+	 * @return bool
+	 */
+	public static function current_theme_is( $theme_name ) {
+		$current_theme = wp_get_theme();
+		return  $current_theme->get( 'Name' ) === $theme_name;
+	}
+
+	/**
 	 * @return string - 'before', 'after', or 'submit'
 	 *
 	 * @since 4.05.02

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -603,6 +603,9 @@ class FrmFormsController {
 	private static function load_direct_preview() {
 		header( 'Content-Type: text/html; charset=' . get_option( 'blog_charset' ) );
 
+		// print_emoji_styles is deprecated.
+		remove_action( 'wp_print_styles', 'print_emoji_styles' );
+
 		$key = FrmAppHelper::simple_get( 'form', 'sanitize_title' );
 		if ( $key == '' ) {
 			$key = FrmAppHelper::get_post_param( 'form', '', 'sanitize_title' );

--- a/classes/views/frm-entries/direct.php
+++ b/classes/views/frm-entries/direct.php
@@ -13,7 +13,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php FrmFormsController::maybe_load_css( $form, 1, false ); ?>
 </head>
 <body class="frm_preview_page">
-	<?php echo FrmFormsController::show_form( $form->id, '', 'auto', 'auto' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+	<?php
+	if ( is_callable( 'twentynineteen_setup' ) ) {
+		?>
+	<div class="site-branding frm_hidden"></div>
+		<?php
+	}
+	echo FrmFormsController::show_form( $form->id, '', 'auto', 'auto' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	?>
 	<?php wp_footer(); ?>
 </body>
 </html>

--- a/classes/views/frm-entries/form.php
+++ b/classes/views/frm-entries/form.php
@@ -27,6 +27,7 @@ FrmFormsController::maybe_load_css( $form, $values['custom_style'], $frm_vars['l
 
 // Get conditionally hidden fields
 $frm_hide_fields = FrmAppHelper::get_post_param( 'frm_hide_fields_' . $form->id, '', 'sanitize_text_field' );
+
 ?>
 <div class="frm_form_fields <?php echo esc_attr( apply_filters( 'frm_form_fields_class', '', $values ) ); ?>">
 <fieldset>

--- a/classes/views/frm-entries/form.php
+++ b/classes/views/frm-entries/form.php
@@ -28,6 +28,11 @@ FrmFormsController::maybe_load_css( $form, $values['custom_style'], $frm_vars['l
 // Get conditionally hidden fields
 $frm_hide_fields = FrmAppHelper::get_post_param( 'frm_hide_fields_' . $form->id, '', 'sanitize_text_field' );
 
+if ( FrmFormsController::current_theme_is( 'Twenty Nineteen' ) ) {
+	?>
+<div class="site-branding frm_hidden"></div>
+	<?php
+}
 ?>
 <div class="frm_form_fields <?php echo esc_attr( apply_filters( 'frm_form_fields_class', '', $values ) ); ?>">
 <fieldset>

--- a/classes/views/frm-entries/form.php
+++ b/classes/views/frm-entries/form.php
@@ -27,12 +27,6 @@ FrmFormsController::maybe_load_css( $form, $values['custom_style'], $frm_vars['l
 
 // Get conditionally hidden fields
 $frm_hide_fields = FrmAppHelper::get_post_param( 'frm_hide_fields_' . $form->id, '', 'sanitize_text_field' );
-
-if ( is_callable( 'twentynineteen_setup' ) ) {
-	?>
-<div class="site-branding frm_hidden"></div>
-	<?php
-}
 ?>
 <div class="frm_form_fields <?php echo esc_attr( apply_filters( 'frm_form_fields_class', '', $values ) ); ?>">
 <fieldset>

--- a/classes/views/frm-entries/form.php
+++ b/classes/views/frm-entries/form.php
@@ -28,7 +28,7 @@ FrmFormsController::maybe_load_css( $form, $values['custom_style'], $frm_vars['l
 // Get conditionally hidden fields
 $frm_hide_fields = FrmAppHelper::get_post_param( 'frm_hide_fields_' . $form->id, '', 'sanitize_text_field' );
 
-if ( FrmFormsController::current_theme_is( 'Twenty Nineteen' ) ) {
+if ( is_callable( 'twentynineteen_setup' ) ) {
 	?>
 <div class="site-branding frm_hidden"></div>
 	<?php


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-landing/issues/11

<img width="833" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/39535bfa-bb35-4860-8fb5-6ca55f89d8a4">

### Test steps
1. Install and activate Twenty Nineteen theme.
2. Create a menu and assign it to Primary menu (so that the js script being tested loads on the page)
3. Preview the form **On Blank page** and confirm that there is no JS error in the console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved compatibility with the `twentynineteen` theme by conditionally adding specific HTML elements to ensure proper layout.
	- Enhanced conditional check for the existence of the function `twentynineteen_setup` in `form.php` and `direct.php` files.
	- Added a `<div>` with the class `site-branding frm_hidden` before displaying the form if the function is callable.
	- Deprecated the usage of `print_emoji_styles` by adding a `remove_action` call in the `load_direct_preview` method of `FrmFormsController.php`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->