### PR TITLE
Drop unused display type properties

### DIFF
--- a/classes/models/fields/FrmFieldEmail.php
+++ b/classes/models/fields/FrmFieldEmail.php
@@ -15,11 +15,6 @@ class FrmFieldEmail extends FrmFieldType {
 	protected $type = 'email';
 
 	/**
-	 * @var string
-	 */
-	protected $display_type = 'text';
-
-	/**
 	 * @var bool
 	 * @since 3.0
 	 */

--- a/classes/models/fields/FrmFieldNumber.php
+++ b/classes/models/fields/FrmFieldNumber.php
@@ -15,11 +15,6 @@ class FrmFieldNumber extends FrmFieldType {
 	protected $type = 'number';
 
 	/**
-	 * @var string
-	 */
-	protected $display_type = 'text';
-
-	/**
 	 * @var bool
 	 */
 	protected $array_allowed = false;

--- a/classes/models/fields/FrmFieldPhone.php
+++ b/classes/models/fields/FrmFieldPhone.php
@@ -15,11 +15,6 @@ class FrmFieldPhone extends FrmFieldType {
 	protected $type = 'phone';
 
 	/**
-	 * @var string
-	 */
-	protected $display_type = 'text';
-
-	/**
 	 * @var bool
 	 * @since 3.0
 	 */

--- a/classes/models/fields/FrmFieldUrl.php
+++ b/classes/models/fields/FrmFieldUrl.php
@@ -15,11 +15,6 @@ class FrmFieldUrl extends FrmFieldType {
 	protected $type = 'url';
 
 	/**
-	 * @var string
-	 */
-	protected $display_type = 'text';
-
-	/**
 	 * @var bool
 	 */
 	protected $array_allowed = false;


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/4166

I don't think there's any need to deprecate this since it isn't public. If it being used in a custom field, it would likely be defined in that class anyway, and I don't believe PHP will fatal if the property isn't set anyway.

Plus I'm not sure what use that check would be anyway since it's always `text`.

At worst it would trigger a `Undefined property` warning (or a notice in PHP 7.x).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the logic and structure related to the display types of email, number, phone, and URL fields for improved performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->