### PR TITLE
Stop running unit test for every commit

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
+    types: [ opened, labeled, synchronize ]
 
 name: PHPUnit
 jobs:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,6 +11,7 @@ on:
 name: PHPUnit
 jobs:
   build-test:
+    if: contains(github.event.pull_request.labels.*.name, 'run tests')
     runs-on: ubuntu-20.04
     env:
       WP_MULTISITE: ${{ matrix.multisite }}


### PR DESCRIPTION
Our unit tests are running too often and pinging our sites a lot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Modified conditions to run tests only for pull requests with a specific label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->