### PR TITLE
Run some php cs fixer fixes

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -1623,8 +1623,8 @@ class FrmAddonsController {
 	 * @deprecated 3.04.03
 	 * @codeCoverageIgnore
 	 *
-	 * @param bool $return
-	 * @param string  $package
+	 * @param bool   $return
+	 * @param string $package
 	 *
 	 * @return bool
 	 */

--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmAddonsController {
 
 	/**
-	 * @var string $plugin
+	 * @var string
 	 */
 	protected static $plugin;
 
@@ -315,7 +315,7 @@ class FrmAddonsController {
 	/**
 	 * @since 4.08
 	 *
-	 * @return boolean|int false or the number of days until expiration.
+	 * @return bool|int false or the number of days until expiration.
 	 */
 	public static function is_license_expiring() {
 		if ( is_callable( 'FrmProAddonsController::is_license_expiring' ) ) {
@@ -1623,10 +1623,10 @@ class FrmAddonsController {
 	 * @deprecated 3.04.03
 	 * @codeCoverageIgnore
 	 *
-	 * @param boolean $return
+	 * @param bool $return
 	 * @param string  $package
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function add_shorten_edd_filename_filter( $return, $package ) {
 		return FrmDeprecated::add_shorten_edd_filename_filter( $return, $package );

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -490,7 +490,7 @@ class FrmAppController {
 	 * Check if the database is outdated
 	 *
 	 * @since 2.0.1
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function needs_update() {
 		$needs_upgrade = self::compare_for_update(

--- a/classes/controllers/FrmDashboardController.php
+++ b/classes/controllers/FrmDashboardController.php
@@ -190,9 +190,9 @@ class FrmDashboardController {
 	/**
 	 * Build view args for cta.
 	 *
-	 * @param string  $title
-	 * @param string  $link
-	 * @param bool $display
+	 * @param string $title
+	 * @param string $link
+	 * @param bool   $display
 	 *
 	 * @return array
 	 */

--- a/classes/controllers/FrmDashboardController.php
+++ b/classes/controllers/FrmDashboardController.php
@@ -192,7 +192,7 @@ class FrmDashboardController {
 	 *
 	 * @param string  $title
 	 * @param string  $link
-	 * @param boolean $display
+	 * @param bool $display
 	 *
 	 * @return array
 	 */
@@ -341,7 +341,7 @@ class FrmDashboardController {
 	/**
 	 * Check if user has closed the welcome banner. The status of banner is saved in db options.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function welcome_banner_has_closed() {
 		$user_id                = get_current_user_id();
@@ -356,7 +356,7 @@ class FrmDashboardController {
 	/**
 	 * Check if is dashboard page.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function is_dashboard_page() {
 		return FrmAppHelper::is_admin_page( 'formidable-dashboard' );
@@ -366,7 +366,7 @@ class FrmDashboardController {
 	 * Detect if the logged user's email is subscribed. Used for inbox email subscribe.
 	 *
 	 * @param string $email The logged user's email.
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function email_is_subscribed( $email ) {
 		$subscribed_emails = self::get_subscribed_emails();

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -73,8 +73,8 @@ class FrmFieldsController {
 	/**
 	 * Set up and create a new field
 	 *
-	 * @param string  $field_type
-	 * @param int $form_id
+	 * @param string $field_type
+	 * @param int    $form_id
 	 *
 	 * @return array|bool
 	 */

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -74,7 +74,7 @@ class FrmFieldsController {
 	 * Set up and create a new field
 	 *
 	 * @param string  $field_type
-	 * @param integer $form_id
+	 * @param int $form_id
 	 *
 	 * @return array|bool
 	 */

--- a/classes/controllers/FrmFormTemplatesController.php
+++ b/classes/controllers/FrmFormTemplatesController.php
@@ -58,77 +58,77 @@ class FrmFormTemplatesController {
 	/**
 	 * Instance of the Form Template API handler.
 	 *
-	 * @var FrmFormTemplateApi $form_template_api Form Template API handler.
+	 * @var FrmFormTemplateApi Form Template API handler.
 	 */
 	private static $form_template_api;
 
 	/**
 	 * Templates fetched from the API.
 	 *
-	 * @var array $templates Templates information from API.
+	 * @var array Templates information from API.
 	 */
 	private static $templates = array();
 
 	/**
 	 * Featured templates.
 	 *
-	 * @var array $featured_templates Associative array with the featured templates' information.
+	 * @var array Associative array with the featured templates' information.
 	 */
 	private static $featured_templates = array();
 
 	/**
 	 * List of user favorite templates.
 	 *
-	 * @var array $favorite_templates List of templates that the user has marked as favorites.
+	 * @var array List of templates that the user has marked as favorites.
 	 */
 	private static $favorite_templates = array();
 
 	/**
 	 * Templates fetched from the published form by user.
 	 *
-	 * @var array $custom_templates Templates information from published form.
+	 * @var array Templates information from published form.
 	 */
 	private static $custom_templates = array();
 
 	/**
 	 * Categories for organizing templates.
 	 *
-	 * @var array $categories Categories for organizing templates.
+	 * @var array Categories for organizing templates.
 	 */
 	private static $categories = array();
 
 	/**
 	 * Status of API request, true if expired.
 	 *
-	 * @var bool $is_expired Whether the API request is expired or not.
+	 * @var bool Whether the API request is expired or not.
 	 */
 	private static $is_expired = false;
 
 	/**
 	 * The type of license received from the API.
 	 *
-	 * @var string $license_type License type received from the API.
+	 * @var string License type received from the API.
 	 */
 	private static $license_type = '';
 
 	/**
 	 * Path to views.
 	 *
-	 * @var string $view_path Path to form templates views.
+	 * @var string Path to form templates views.
 	 */
 	private static $view_path = '';
 
 	/**
 	 * Upgrade URL.
 	 *
-	 * @var string $upgrade_link URL for upgrading accounts.
+	 * @var string URL for upgrading accounts.
 	 */
 	private static $upgrade_link = '';
 
 	/**
 	 * Renew URL.
 	 *
-	 * @var string $renew_link URL for renewing accounts.
+	 * @var string URL for renewing accounts.
 	 */
 	private static $renew_link = '';
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1398,7 +1398,7 @@ class FrmFormsController {
 	 *
 	 * @since 2.03.08
 	 *
-	 * @param array|boolean $values
+	 * @param array|bool $values
 	 */
 	private static function clean_submit_html( &$values ) {
 		if ( is_array( $values ) && isset( $values['submit_html'] ) ) {
@@ -3028,7 +3028,7 @@ class FrmFormsController {
 
 	/**
 	 * @since 2.0.8
-	 * @return boolean
+	 * @return bool
 	 */
 	private static function is_minification_on( $atts ) {
 		return isset( $atts['minimize'] ) && ! empty( $atts['minimize'] );

--- a/classes/controllers/FrmOverlayController.php
+++ b/classes/controllers/FrmOverlayController.php
@@ -22,7 +22,7 @@ class FrmOverlayController {
 	/**
 	 * The controller configs passed through construct. If empty the overlay will run normaly, it will open every time when open_overlay is called.
 	 *
-	 * @var array {
+	 * @var array Config {
 	 *
 	 *     @type string $execution-frequency Example values: '1 day', '10 days', '1 week', etc.
 	 *     @type string $config-option-name A handle name that will be used to store the controller options_data.
@@ -41,7 +41,7 @@ class FrmOverlayController {
 	/**
 	 * The controller data. It will handle the options from multiple instances of the controller
 	 *
-	 * @var array {
+	 * @var array Option data {
 	 *     @type array $options_data[ '[instance1-option_name_provided_via-->config-option-name]' ] {
 	 *       @type string $execution-frequency Values example: '1 day' | '10 days' | '1 week' | '10 weeks' | '1 month' | '10 months' | '1 year' | '10 years'
 	 *     }

--- a/classes/controllers/FrmOverlayController.php
+++ b/classes/controllers/FrmOverlayController.php
@@ -15,14 +15,14 @@ class FrmOverlayController {
 	/**
 	 * Check if the overlay will run again periodically.
 	 *
-	 * @var boolean If the condition is true, the overlay will execute only following a specified time interval.
+	 * @var bool If the condition is true, the overlay will execute only following a specified time interval.
 	 */
 	private $recurring_execution = false;
 
 	/**
 	 * The controller configs passed through construct. If empty the overlay will run normaly, it will open every time when open_overlay is called.
 	 *
-	 * @var array $config {
+	 * @var array {
 	 *
 	 *     @type string $execution-frequency Example values: '1 day', '10 days', '1 week', etc.
 	 *     @type string $config-option-name A handle name that will be used to store the controller options_data.
@@ -41,7 +41,7 @@ class FrmOverlayController {
 	/**
 	 * The controller data. It will handle the options from multiple instances of the controller
 	 *
-	 * @var array $options_data {
+	 * @var array {
 	 *     @type array $options_data[ '[instance1-option_name_provided_via-->config-option-name]' ] {
 	 *       @type string $execution-frequency Values example: '1 day' | '10 days' | '1 week' | '10 weeks' | '1 month' | '10 months' | '1 year' | '10 years'
 	 *     }
@@ -101,7 +101,7 @@ class FrmOverlayController {
 	/**
 	 * Ascertain whether the overlay needs to be executed or not.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	private function is_time_to_execute() {
 		if ( ! isset( $this->options_data[ $this->config['config-option-name'] ] ) ) {
@@ -145,7 +145,7 @@ class FrmOverlayController {
 	 *       @type string $buttons[]['target'] Target attribute for the button link.
 	 *       @type string $buttons[]['label'] Label/text of the button.
 	 * }
-	 * @return boolean
+	 * @return bool
 	 */
 	public function open_overlay( $data = array() ) {
 		if ( true === $this->recurring_execution ) {

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -6,17 +6,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmStylesController {
 
 	/**
-	 * @var string $post_type
+	 * @var string
 	 */
 	public static $post_type = 'frm_styles';
 
 	/**
-	 * @var string $screen
+	 * @var string
 	 */
 	public static $screen = 'formidable_page_formidable-styles';
 
 	/**
-	 * @var string|null $message
+	 * @var string|null
 	 */
 	private static $message;
 
@@ -1107,7 +1107,7 @@ class FrmStylesController {
 	/**
 	 * Get the style post object for a target form.
 	 *
-	 * @param object|string|boolean $form
+	 * @param object|string|bool $form
 	 * @return WP_Post|null
 	 */
 	public static function get_form_style( $form = 'default' ) {

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1580,9 +1580,9 @@ class FrmAppHelper {
 	}
 
 	/**
-	 * @param array   $args
-	 * @param string  $page_id Deprecated.
-	 * @param bool $truncate Deprecated.
+	 * @param array  $args
+	 * @param string $page_id Deprecated.
+	 * @param bool   $truncate Deprecated.
 	 */
 	public static function wp_pages_dropdown( $args = array(), $page_id = '', $truncate = false ) {
 		self::prep_page_dropdown_params( $page_id, $truncate, $args );

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -24,7 +24,7 @@ class FrmAppHelper {
 	public static $font_version = 7;
 
 	/**
-	 * @var bool $added_gmt_offset_filter
+	 * @var bool
 	 */
 	private static $added_gmt_offset_filter = false;
 
@@ -297,7 +297,7 @@ class FrmAppHelper {
 	 *
 	 * @param string $page The name of the page to check.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function is_admin_page( $page = 'formidable' ) {
 		global $pagenow;
@@ -342,7 +342,7 @@ class FrmAppHelper {
 	 *
 	 * @since 2.0
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function is_preview_page() {
 		global $pagenow;
@@ -356,7 +356,7 @@ class FrmAppHelper {
 	 *
 	 * @since 2.0
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function doing_ajax() {
 		return wp_doing_ajax() && ! self::is_preview_page();
@@ -400,7 +400,7 @@ class FrmAppHelper {
 	 * @param mixed  $value Value to check.
 	 * @param string $empty
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function is_empty_value( $value, $empty = '' ) {
 		return ( is_array( $value ) && empty( $value ) ) || $value === $empty;
@@ -1491,7 +1491,7 @@ class FrmAppHelper {
 	 *
 	 * @param string $value The value to compare.
 	 *
-	 * @return boolean True or False
+	 * @return bool True or False
 	 */
 	public static function is_true( $value ) {
 		return ( true === $value || 1 == $value || 'true' == $value || 'yes' == $value );
@@ -1582,7 +1582,7 @@ class FrmAppHelper {
 	/**
 	 * @param array   $args
 	 * @param string  $page_id Deprecated.
-	 * @param boolean $truncate Deprecated.
+	 * @param bool $truncate Deprecated.
 	 */
 	public static function wp_pages_dropdown( $args = array(), $page_id = '', $truncate = false ) {
 		self::prep_page_dropdown_params( $page_id, $truncate, $args );
@@ -2495,7 +2495,7 @@ class FrmAppHelper {
 	 *
 	 * @param array $post_values
 	 *
-	 * @return boolean|int
+	 * @return bool|int
 	 */
 	public static function custom_style_value( $post_values ) {
 		if ( ! empty( $post_values ) && isset( $post_values['options']['custom_style'] ) ) {
@@ -2802,9 +2802,9 @@ class FrmAppHelper {
 	// Pagination Methods.
 
 	/**
-	 * @param integer $r_count
-	 * @param integer $current_p
-	 * @param integer $p_size
+	 * @param int $r_count
+	 * @param int $current_p
+	 * @param int $p_size
 	 * @return int
 	 */
 	public static function get_last_record_num( $r_count, $current_p, $p_size ) {
@@ -2812,9 +2812,9 @@ class FrmAppHelper {
 	}
 
 	/**
-	 * @param integer $r_count
-	 * @param integer $current_p
-	 * @param integer $p_size
+	 * @param int $r_count
+	 * @param int $current_p
+	 * @param int $p_size
 	 * @return int
 	 */
 	public static function get_first_record_num( $r_count, $current_p, $p_size ) {

--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -6,87 +6,87 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmCSVExportHelper {
 
 	/**
-	 * @var string $separator
+	 * @var string
 	 */
 	protected static $separator = ', ';
 
 	/**
-	 * @var string $column_separator
+	 * @var string
 	 */
 	protected static $column_separator = ',';
 
 	/**
-	 * @var string $line_break
+	 * @var string
 	 */
 	protected static $line_break = 'return';
 
 	/**
-	 * @var string $charset
+	 * @var string
 	 */
 	protected static $charset = 'UTF-8';
 
 	/**
-	 * @var string $to_encoding
+	 * @var string
 	 */
 	protected static $to_encoding = 'UTF-8';
 
 	/**
-	 * @var string $wp_date_format
+	 * @var string
 	 */
 	protected static $wp_date_format = 'Y-m-d H:i:s';
 
 	/**
-	 * @var int $comment_count
+	 * @var int
 	 */
 	protected static $comment_count = 0;
 
 	/**
-	 * @var int $form_id
+	 * @var int
 	 */
 	protected static $form_id = 0;
 
 	/**
-	 * @var array $headings
+	 * @var array
 	 */
 	protected static $headings = array();
 
 	/**
-	 * @var array $fields
+	 * @var array
 	 */
 	protected static $fields = array();
 
 	/**
-	 * @var stdClass|null $entry
+	 * @var stdClass|null
 	 */
 	protected static $entry;
 
 	/**
-	 * @var bool|null $has_parent_id
+	 * @var bool|null
 	 */
 	protected static $has_parent_id;
 
 	/**
-	 * @var array|null $fields_by_repeater_id
+	 * @var array|null
 	 */
 	protected static $fields_by_repeater_id;
 
 	/**
-	 * @var string $mode either 'echo' or 'file' are supported.
+	 * @var string either 'echo' or 'file' are supported.
 	 */
 	protected static $mode = 'echo';
 
 	/**
-	 * @var resource|null $fp used to write a CSV file in file mode.
+	 * @var resource|null used to write a CSV file in file mode.
 	 */
 	protected static $fp;
 
 	/**
-	 * @var string $context the context of the CSV being generated. Possible values include 'email' when used as an email attachment, or 'default'.
+	 * @var string the context of the CSV being generated. Possible values include 'email' when used as an email attachment, or 'default'.
 	 */
 	protected static $context = 'default';
 
 	/**
-	 * @var array $meta
+	 * @var array
 	 */
 	protected static $meta = array();
 

--- a/classes/helpers/FrmDashboardHelper.php
+++ b/classes/helpers/FrmDashboardHelper.php
@@ -25,7 +25,7 @@ class FrmDashboardHelper {
 	 *        @type array  $counters['counters'][]['cta']
 	 *            @type string  $counters['counters'][]['cta']['title']
 	 *            @type string  $counters['counters'][]['cta']['link']
-	 *            @type boolean $counters['counters'][]['cta']['display'] If true a CTA will be displayed instead of the counter.
+	 *            @type bool $counters['counters'][]['cta']['display'] If true a CTA will be displayed instead of the counter.
 	 *    @type array $license Array of license args
 	 *        @type string $license['heading']
 	 *        @type string $license['copy']
@@ -68,7 +68,7 @@ class FrmDashboardHelper {
 	 *                @type string $entries['placeholder']['button']['label']
 	 *                @type string $entries['placeholder']['button']['link']
 	 *    @type array $payments Array of payments args
-	 *        @type boolean $payments['show-placeholder']
+	 *        @type bool $payments['show-placeholder']
 	 *        @type array   $payments['placeholder']
 	 *            @type string $payments['placeholder']['copy']
 	 *            @type array  $payments['placeholder']['cta']

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -103,7 +103,7 @@ class FrmEntriesHelper {
 	 * @since 2.0.13
 	 *
 	 * @param object  $field - this is passed by reference since it is an object.
-	 * @param boolean $reset
+	 * @param bool $reset
 	 * @param array   $args
 	 *
 	 * @return string|array $new_value
@@ -130,7 +130,7 @@ class FrmEntriesHelper {
 	 * @param object $field
 	 * @param array  $args
 	 *
-	 * @return boolean $value_is_posted
+	 * @return bool $value_is_posted
 	 */
 	public static function value_is_posted( $field, $args ) {
 		$value_is_posted = false;

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -102,9 +102,9 @@ class FrmEntriesHelper {
 	 *
 	 * @since 2.0.13
 	 *
-	 * @param object  $field - this is passed by reference since it is an object.
-	 * @param bool $reset
-	 * @param array   $args
+	 * @param object $field - this is passed by reference since it is an object.
+	 * @param bool   $reset
+	 * @param array  $args
 	 *
 	 * @return string|array $new_value
 	 */

--- a/classes/helpers/FrmFieldGridHelper.php
+++ b/classes/helpers/FrmFieldGridHelper.php
@@ -28,7 +28,7 @@ class FrmFieldGridHelper {
 	private $active_field_size;
 
 	/**
-	 * @var bool $is_frm_first flagged while calling get_field_layout_class, true if classes contain frm_first class.
+	 * @var bool flagged while calling get_field_layout_class, true if classes contain frm_first class.
 	 */
 	private $is_frm_first;
 
@@ -38,17 +38,17 @@ class FrmFieldGridHelper {
 	private $field;
 
 	/**
-	 * @var FrmFieldGridHelper $section_helper
+	 * @var FrmFieldGridHelper
 	 */
 	private $section_helper;
 
 	/**
-	 * @var bool $nested
+	 * @var bool
 	 */
 	private $nested;
 
 	/**
-	 * @var int $section_size
+	 * @var int
 	 */
 	private $section_size;
 

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1215,7 +1215,7 @@ class FrmFieldsHelper {
 	 *
 	 * @param string $opt_key
 	 *
-	 * @return boolean Returns true if current field option is an "Other" option
+	 * @return bool Returns true if current field option is an "Other" option
 	 */
 	public static function is_other_opt( $opt_key ) {
 		return $opt_key && strpos( $opt_key, 'other_' ) === 0;
@@ -1318,7 +1318,7 @@ class FrmFieldsHelper {
 	 * @since 2.0.6
 	 *
 	 * @param array   $args Should include field, opt_key and field name.
-	 * @param boolean $other_opt
+	 * @param bool $other_opt
 	 * @param string  $checked
 	 *
 	 * @return array $other_args
@@ -1449,7 +1449,7 @@ class FrmFieldsHelper {
 	 *
 	 * @param string         $type    Field type.
 	 * @param string         $html_id
-	 * @param string|boolean $opt_key
+	 * @param string|bool $opt_key
 	 *
 	 * @return string $other_id
 	 */

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1317,9 +1317,9 @@ class FrmFieldsHelper {
 	 *
 	 * @since 2.0.6
 	 *
-	 * @param array   $args Should include field, opt_key and field name.
-	 * @param bool $other_opt
-	 * @param string  $checked
+	 * @param array  $args Should include field, opt_key and field name.
+	 * @param bool   $other_opt
+	 * @param string $checked
 	 *
 	 * @return array $other_args
 	 */
@@ -1447,8 +1447,8 @@ class FrmFieldsHelper {
 	 *
 	 * @since 2.0.08
 	 *
-	 * @param string         $type    Field type.
-	 * @param string         $html_id
+	 * @param string      $type    Field type.
+	 * @param string      $html_id
 	 * @param string|bool $opt_key
 	 *
 	 * @return string $other_id

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -675,9 +675,9 @@ BEFORE_HTML;
 	 *
 	 * @since 2.0
 	 *
-	 * @param object  $form
-	 * @param array   $fields
-	 * @param bool $reset_fields
+	 * @param object $form
+	 * @param array  $fields
+	 * @param bool   $reset_fields
 	 */
 	public static function auto_add_end_section_fields( $form, $fields, &$reset_fields ) {
 		if ( empty( $fields ) ) {

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -677,7 +677,7 @@ BEFORE_HTML;
 	 *
 	 * @param object  $form
 	 * @param array   $fields
-	 * @param boolean $reset_fields
+	 * @param bool $reset_fields
 	 */
 	public static function auto_add_end_section_fields( $form, $fields, &$reset_fields ) {
 		if ( empty( $fields ) ) {
@@ -940,7 +940,7 @@ BEFORE_HTML;
 	}
 
 	/**
-	 * @param object|array|string|boolean $form
+	 * @param object|array|string|bool $form
 	 * @return string
 	 */
 	public static function get_form_style( $form ) {
@@ -1315,7 +1315,7 @@ BEFORE_HTML;
 	 * @param array $atts {
 	 *     Optional. An array of attributes for rendering.
 	 *     @type string  $html 'span' or 'div'. Default 'span'.
-	 *     @type boolean $bg   Whether to add a background color or not. Default false.
+	 *     @type bool $bg   Whether to add a background color or not. Default false.
 	 * }
 	 *
 	 * @return void

--- a/classes/helpers/FrmListHelper.php
+++ b/classes/helpers/FrmListHelper.php
@@ -67,7 +67,6 @@ class FrmListHelper {
 	protected $modes = array();
 
 	/**
-	 *
 	 * @var array
 	 */
 	protected $params;

--- a/classes/helpers/FrmStylesCardHelper.php
+++ b/classes/helpers/FrmStylesCardHelper.php
@@ -417,12 +417,12 @@ class FrmStylesCardHelper {
 		array_walk(
 			$styles,
 			/**
-			* Echo a style card for a single style in the $styles array.
-			*
-			* @param WP_Post $style
-			* @param int     $count Used for pagination.
-			* @return void
-			*/
+			 * Echo a style card for a single style in the $styles array.
+			 *
+			 * @param WP_Post $style
+			 * @param int     $count Used for pagination.
+			 * @return void
+			 */
 			function ( $style ) use ( &$count ) {
 				$hidden = $count > ( self::PAGE_SIZE - 1 );
 				$this->echo_style_card( $style, $hidden );

--- a/classes/helpers/FrmStylesPreviewHelper.php
+++ b/classes/helpers/FrmStylesPreviewHelper.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmStylesPreviewHelper {
 
 	/**
-	 * @var int $form_id
+	 * @var int
 	 */
 	private $form_id;
 

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmXMLHelper {
 
 	/**
-	 * @var bool $installing_template true if importing an XML from API, false if importing an XML file manually.
+	 * @var bool true if importing an XML from API, false if importing an XML file manually.
 	 */
 	private static $installing_template = false;
 
@@ -2089,9 +2089,9 @@ class FrmXMLHelper {
 	/**
 	 * PHP 8 backward compatibility for the libxml_disable_entity_loader function
 	 *
-	 * @param boolean $loader
+	 * @param bool $loader
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function maybe_libxml_disable_entity_loader( $loader ) {
 		if ( version_compare( phpversion(), '8.0', '<' ) && function_exists( 'libxml_disable_entity_loader' ) ) {

--- a/classes/models/FrmApplicationApi.php
+++ b/classes/models/FrmApplicationApi.php
@@ -9,17 +9,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmApplicationApi extends FrmFormApi {
 
 	/**
-	 * @var string $base_api_url
+	 * @var string
 	 */
 	private static $base_api_url = 'https://formidableforms.com/wp-json/view-templates/v1/list';
 
 	/**
-	 * @var int $new_days
+	 * @var int
 	 */
 	protected $new_days = 60;
 
 	/**
-	 * @var string $cache_timeout
+	 * @var string
 	 */
 	protected $cache_timeout = '+12 hours';
 

--- a/classes/models/FrmApplicationTemplate.php
+++ b/classes/models/FrmApplicationTemplate.php
@@ -9,22 +9,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmApplicationTemplate {
 
 	/**
-	 * @var array<string>|null $keys
+	 * @var array<string>|null
 	 */
 	private static $keys;
 
 	/**
-	 * @var array<string>|null $keys_with_images
+	 * @var array<string>|null
 	 */
 	private static $keys_with_images;
 
 	/**
-	 * @var array<string>|null $categories
+	 * @var array<string>|null
 	 */
 	private static $categories;
 
 	/**
-	 * @var array $api_data
+	 * @var array
 	 */
 	private $api_data;
 

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -9,92 +9,92 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmEmail {
 
 	/**
-	 * @var string $email_key
+	 * @var string
 	 */
 	private $email_key = '';
 
 	/**
-	 * @var array $to
+	 * @var array
 	 */
 	private $to = array();
 
 	/**
-	 * @var array $cc
+	 * @var array
 	 */
 	private $cc = array();
 
 	/**
-	 * @var array $bcc
+	 * @var array
 	 */
 	private $bcc = array();
 
 	/**
-	 * @var string $from
+	 * @var string
 	 */
 	private $from = '';
 
 	/**
-	 * @var string $reply_to
+	 * @var string
 	 */
 	private $reply_to = '';
 
 	/**
-	 * @var string $subject
+	 * @var string
 	 */
 	private $subject = '';
 
 	/**
-	 * @var string $message
+	 * @var string
 	 */
 	private $message = '';
 
 	/**
-	 * @var array $attachments
+	 * @var array
 	 */
 	private $attachments = array();
 
 	/**
-	 * @var bool $is_plain_text
+	 * @var bool
 	 */
 	private $is_plain_text = false;
 
 	/**
-	 * @var bool $is_single_recipient
+	 * @var bool
 	 */
 	private $is_single_recipient = false;
 
 	/**
-	 * @var bool $include_user_info
+	 * @var bool
 	 */
 	private $include_user_info = false;
 
 	/**
-	 * @var string $charset
+	 * @var string
 	 */
 	private $charset = '';
 
 	/**
-	 * @var string $content_type
+	 * @var string
 	 */
 	private $content_type = 'text/html';
 
 	/**
-	 * @var array $settings
+	 * @var array
 	 */
 	private $settings = array();
 
 	/**
-	 * @var stdClass $entry
+	 * @var stdClass
 	 */
 	private $entry;
 
 	/**
-	 * @var stdClass $form
+	 * @var stdClass
 	 */
 	private $form;
 
 	/**
-	 * @var int $action_id
+	 * @var int
 	 */
 	private $action_id = 0;
 

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -1027,9 +1027,9 @@ class FrmEntry {
 	 * @since 2.0.16
 	 *
 	 * @param bool|int $query_results
-	 * @param int         $id
-	 * @param array       $values
-	 * @param array       $new_values
+	 * @param int      $id
+	 * @param array    $values
+	 * @param array    $new_values
 	 */
 	private static function after_update_entry( $query_results, $id, $values, $new_values ) {
 		if ( $query_results ) {

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -10,7 +10,7 @@ class FrmEntry {
 	 *
 	 * @param array $values
 	 *
-	 * @return int | boolean $entry_id
+	 * @return int|bool $entry_id
 	 */
 	public static function create( $values ) {
 		$entry_id = self::create_entry( $values, 'standard' );
@@ -24,7 +24,7 @@ class FrmEntry {
 	 * @param array  $values
 	 * @param string $type
 	 *
-	 * @return int | boolean $entry_id
+	 * @return int|bool $entry_id
 	 */
 	private static function create_entry( $values, $type ) {
 		$new_values = self::before_insert_entry_in_database( $values, $type );
@@ -42,7 +42,7 @@ class FrmEntry {
 	/**
 	 * Check for duplicate entries created in the last minute
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function is_duplicate( $new_values, $values ) {
 		$duplicate_entry_time = apply_filters( 'frm_time_to_check_duplicates', 60, $new_values );
@@ -216,7 +216,7 @@ class FrmEntry {
 	 * @param int   $id
 	 * @param array $values
 	 *
-	 * @return boolean|int $update_results
+	 * @return bool|int $update_results
 	 */
 	public static function update( $id, $values ) {
 		$update_results = self::update_entry( $id, $values, 'standard' );
@@ -232,7 +232,7 @@ class FrmEntry {
 	 * @param int   $id
 	 * @param array $values
 	 *
-	 * @return boolean|int $query_results
+	 * @return bool|int $query_results
 	 */
 	private static function update_entry( $id, $values, $update_type ) {
 		global $wpdb;
@@ -650,7 +650,7 @@ class FrmEntry {
 	 * @param array $values
 	 * @param array $new_values
 	 *
-	 * @return boolean|int $entry_id
+	 * @return bool|int $entry_id
 	 */
 	private static function continue_to_create_entry( $values, $new_values ) {
 		$entry_id = self::insert_entry_into_database( $new_values );
@@ -851,7 +851,7 @@ class FrmEntry {
 	 *
 	 * @param array $new_values
 	 *
-	 * @return int | boolean $entry_id
+	 * @return int|bool $entry_id
 	 */
 	private static function insert_entry_into_database( $new_values ) {
 		global $wpdb;
@@ -961,7 +961,7 @@ class FrmEntry {
 	 * @param array  $values
 	 * @param string $update_type
 	 *
-	 * @return boolean $update
+	 * @return bool $update
 	 */
 	private static function before_update_entry( $id, &$values, $update_type ) {
 		$update = true;
@@ -1026,7 +1026,7 @@ class FrmEntry {
 	 *
 	 * @since 2.0.16
 	 *
-	 * @param boolean|int $query_results
+	 * @param bool|int $query_results
 	 * @param int         $id
 	 * @param array       $values
 	 * @param array       $new_values
@@ -1059,7 +1059,7 @@ class FrmEntry {
 	 *
 	 * @param array $values
 	 *
-	 * @return int | boolean $entry_id
+	 * @return int|bool $entry_id
 	 */
 	public static function create_entry_from_xml( $values ) {
 		$entry_id = self::create_entry( $values, 'xml' );
@@ -1076,7 +1076,7 @@ class FrmEntry {
 	 * @param int   $id
 	 * @param array $values
 	 *
-	 * @return int | boolean $updated
+	 * @return int|bool $updated
 	 */
 	public static function update_entry_from_xml( $id, $values ) {
 		$updated = self::update_entry( $id, $values, 'xml' );

--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -298,9 +298,9 @@ class FrmEntryValidate {
 	/**
 	 * Check for spam
 	 *
-	 * @param bool $exclude
-	 * @param array   $values
-	 * @param array   $errors By reference.
+	 * @param bool  $exclude
+	 * @param array $values
+	 * @param array $errors By reference.
 	 */
 	public static function spam_check( $exclude, $values, &$errors ) {
 		if ( ! empty( $exclude ) || ! isset( $values['item_meta'] ) || empty( $values['item_meta'] ) || ! empty( $errors ) ) {

--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -298,7 +298,7 @@ class FrmEntryValidate {
 	/**
 	 * Check for spam
 	 *
-	 * @param boolean $exclude
+	 * @param bool $exclude
 	 * @param array   $values
 	 * @param array   $errors By reference.
 	 */
@@ -352,7 +352,7 @@ class FrmEntryValidate {
 
 	/**
 	 * @param array $values
-	 * @return boolean
+	 * @return bool
 	 */
 	private static function is_honeypot_spam( $values ) {
 		$honeypot = new FrmHoneypot( $values['form_id'] );
@@ -360,7 +360,7 @@ class FrmEntryValidate {
 	}
 
 	/**
-	 * @return boolean
+	 * @return bool
 	 */
 	private static function is_spam_bot() {
 		$ip = FrmAppHelper::get_ip_address();
@@ -370,7 +370,7 @@ class FrmEntryValidate {
 
 	/**
 	 * @param array $values
-	 * @return boolean
+	 * @return bool
 	 */
 	private static function is_akismet_spam( $values ) {
 		global $wpcom_api_key;
@@ -439,7 +439,7 @@ class FrmEntryValidate {
 	/**
 	 * Check entries for Akismet spam
 	 *
-	 * @return boolean true if is spam
+	 * @return bool true if is spam
 	 */
 	public static function akismet( $values ) {
 		if ( empty( $values['item_meta'] ) ) {

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -1043,7 +1043,7 @@ class FrmField {
 	 *
 	 * @param array|object $field
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function is_field_with_multiple_values( $field ) {
 		if ( ! $field ) {
@@ -1089,7 +1089,7 @@ class FrmField {
 	 * Check if this is a multiselect dropdown field
 	 *
 	 * @since 2.0.9
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function is_multiple_select( $field ) {
 		$field_type  = self::get_field_type( $field );
@@ -1243,7 +1243,7 @@ class FrmField {
 	 *
 	 * @param array|object $field
 	 *
-	 * @return boolean true if field type is radio or Dynamic radio
+	 * @return bool true if field type is radio or Dynamic radio
 	 */
 	public static function is_radio( $field ) {
 		return self::is_field_type( $field, 'radio' );
@@ -1256,7 +1256,7 @@ class FrmField {
 	 *
 	 * @param array|object $field
 	 *
-	 * @return boolean true if field type is checkbox or Dynamic checkbox
+	 * @return bool true if field type is checkbox or Dynamic checkbox
 	 */
 	public static function is_checkbox( $field ) {
 		return self::is_field_type( $field, 'checkbox' );
@@ -1270,7 +1270,7 @@ class FrmField {
 	 * @param array|object $field
 	 * @param string       $is_type Options include radio, checkbox, text.
 	 *
-	 * @return boolean true if field type is checkbox or Dynamic checkbox
+	 * @return bool true if field type is checkbox or Dynamic checkbox
 	 */
 	public static function is_field_type( $field, $is_type ) {
 		$field_type = self::get_original_field_type( $field );

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -70,7 +70,7 @@ class FrmForm {
 	}
 
 	/**
-	 * @return int|boolean ID on success or false on failure
+	 * @return int|bool ID on success or false on failure
 	 */
 	public static function duplicate( $id, $template = false, $copy_keys = false, $blog_id = false ) {
 		global $wpdb;
@@ -219,7 +219,7 @@ class FrmForm {
 	}
 
 	/**
-	 * @return int|boolean
+	 * @return int|bool
 	 */
 	public static function update( $id, $values, $create_link = false ) {
 		global $wpdb;
@@ -552,7 +552,7 @@ class FrmForm {
 	 * @param int    $id
 	 * @param string $status
 	 *
-	 * @return int|boolean
+	 * @return int|bool
 	 */
 	public static function set_status( $id, $status ) {
 		if ( 'trash' == $status ) {
@@ -589,7 +589,7 @@ class FrmForm {
 	}
 
 	/**
-	 * @return int|boolean
+	 * @return int|bool
 	 */
 	public static function trash( $id ) {
 		if ( ! EMPTY_TRASH_DAYS ) {
@@ -635,7 +635,7 @@ class FrmForm {
 	}
 
 	/**
-	 * @return int|boolean
+	 * @return int|bool
 	 */
 	public static function destroy( $id ) {
 		global $wpdb;

--- a/classes/models/FrmFormAction.php
+++ b/classes/models/FrmFormAction.php
@@ -330,7 +330,7 @@ class FrmFormAction {
 	 * @since 2.0
 	 *
 	 * @param array $action
-	 * @return integer $post_id
+	 * @return int $post_id
 	 */
 	public function maybe_create_action( $action, $forms ) {
 		if ( isset( $action['ID'] ) && is_numeric( $action['ID'] ) && isset( $forms[ $action['menu_order'] ] ) && $forms[ $action['menu_order'] ] == 'updated' ) {

--- a/classes/models/FrmFormApi.php
+++ b/classes/models/FrmFormApi.php
@@ -23,7 +23,7 @@ class FrmFormApi {
 	/**
 	 * The number of days an add-on is new.
 	 *
-	 * @var int $new_days
+	 * @var int
 	 */
 	protected $new_days = 90;
 

--- a/classes/models/FrmFormState.php
+++ b/classes/models/FrmFormState.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmFormState {
 
 	/**
-	 * @var FrmFormState $instance
+	 * @var FrmFormState
 	 */
 	private static $instance;
 

--- a/classes/models/FrmFormTemplateApi.php
+++ b/classes/models/FrmFormTemplateApi.php
@@ -12,12 +12,12 @@ class FrmFormTemplateApi extends FrmFormApi {
 	protected static $free_license;
 
 	/**
-	 * @var int $new_days
+	 * @var int
 	 */
 	protected $new_days = 30;
 
 	/**
-	 * @var string $cache_timeout
+	 * @var string
 	 */
 	protected $cache_timeout = '+12 hours';
 

--- a/classes/models/FrmHoneypot.php
+++ b/classes/models/FrmHoneypot.php
@@ -24,7 +24,7 @@ class FrmHoneypot extends FrmValidate {
 	}
 
 	/**
-	 * @return boolean
+	 * @return bool
 	 */
 	private function is_honeypot_spam() {
 		$is_honeypot_spam = $this->is_legacy_honeypot_spam();

--- a/classes/models/FrmStyleApi.php
+++ b/classes/models/FrmStyleApi.php
@@ -9,17 +9,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmStyleApi extends FrmFormApi {
 
 	/**
-	 * @var string $base_api_url
+	 * @var string
 	 */
 	private static $base_api_url = 'https://formidableforms.com/wp-json/style-templates/v1/list';
 
 	/**
-	 * @var int $new_days
+	 * @var int
 	 */
 	protected $new_days = 30;
 
 	/**
-	 * @var string $cache_timeout
+	 * @var string
 	 */
 	protected $cache_timeout = '+12 hours';
 

--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -180,7 +180,7 @@ class FrmTableHTMLGenerator {
 	 *
 	 * @since 2.05
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	private function is_color_setting( $setting_key ) {
 		return strpos( $setting_key, 'color' ) !== false;

--- a/classes/models/FrmValidate.php
+++ b/classes/models/FrmValidate.php
@@ -6,12 +6,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 abstract class FrmValidate {
 
 	/**
-	 * @var int $form_id
+	 * @var int
 	 */
 	protected $form_id;
 
 	/**
-	 * @var object $form
+	 * @var object
 	 */
 	protected $form;
 

--- a/classes/models/fields/FrmFieldCombo.php
+++ b/classes/models/fields/FrmFieldCombo.php
@@ -446,7 +446,6 @@ class FrmFieldCombo extends FrmFieldType {
 	}
 
 	/**
-	 *
 	 * Get a list of all field settings that should be translated
 	 * on a multilingual site.
 	 *

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1370,7 +1370,7 @@ DEFAULT_HTML;
 	 *
 	 * @param string|array $value
 	 *
-	 * @return string|array|float|integer
+	 * @return string|array|float|int
 	 */
 	public function set_value_before_save( $value ) {
 		return $value;
@@ -1379,7 +1379,6 @@ DEFAULT_HTML;
 	/** Prepare value for display **/
 
 	/**
-	 *
 	 * @param string|array $value
 	 * @param array        $atts
 	 *

--- a/classes/views/form-templates/template.php
+++ b/classes/views/form-templates/template.php
@@ -51,7 +51,7 @@ FrmFormTemplatesHelper::prepare_template_details( $template, $pricing, $license_
 			<div class="frm-flex-box frm-gap-xs frm-items-center frm-ml-auto">
 				<?php
 				if ( $template['is_custom'] ) {
-					$trash_links = FrmFormsHelper::delete_trash_links( $template['id'] )
+					$trash_links = FrmFormsHelper::delete_trash_links( $template['id'] );
 					?>
 					<a href="<?php echo esc_url( $trash_links['trash']['url'] ); ?>" class="frm-form-templates-custom-item-trash-button frm-flex-center frm-fadein" data-frmverify="<?php esc_attr_e( 'Do you want to move this form template to the trash?', 'formidable' ); ?>" data-frmverify-btn="frm-button-red" role="button" aria-label="<?php esc_attr_e( 'Move to the trash button', 'formidable' ); ?>">
 						<?php FrmAppHelper::icon_by_class( 'frmfont frm_delete_icon', array( 'aria-label' => __( 'Move to Trash', 'formidable' ) ) ); ?>

--- a/classes/views/summary-emails/stats.php
+++ b/classes/views/summary-emails/stats.php
@@ -107,7 +107,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					// translators: the list of out-of-date plugins.
 					esc_html__( 'The following plugins are out of date: %s', 'formidable' ),
 					'<span style="font-style: italic;">' . esc_html( implode( ', ', $args['out_of_date_plugins'] ) ) . '</span>'
-				)
+				);
 				?>
 			</p>
 

--- a/deprecated/FrmDeprecated.php
+++ b/deprecated/FrmDeprecated.php
@@ -228,10 +228,10 @@ class FrmDeprecated {
 	 * @since 2.03.08
 	 * @deprecated 3.04.03
 	 *
-	 * @param boolean $return
+	 * @param bool $return
 	 * @param string $package
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function add_shorten_edd_filename_filter( $return, $package ) {
 		_deprecated_function( __FUNCTION__, '3.04.03' );
@@ -459,9 +459,9 @@ class FrmDeprecated {
 		return FrmStylesHelper::get_single_label_positions();
 	}
 
-	/**
-	 * @deprecated 3.02.03
-	 */
+    /**
+     * @deprecated 3.02.03
+     */
     public static function jquery_themes() {
 		_deprecated_function( __FUNCTION__, '3.02.03', 'FrmProStylesController::jquery_themes' );
 
@@ -496,9 +496,9 @@ class FrmDeprecated {
         return $themes;
     }
 
-	/**
-	 * @deprecated 3.02.03
-	 */
+    /**
+     * @deprecated 3.02.03
+     */
     public static function enqueue_jquery_css() {
 		_deprecated_function( __FUNCTION__, '3.02.03', 'FrmProStylesController::enqueue_jquery_css' );
 

--- a/stripe/helpers/FrmTransLiteListHelper.php
+++ b/stripe/helpers/FrmTransLiteListHelper.php
@@ -16,7 +16,7 @@ class FrmTransLiteListHelper extends FrmListHelper {
 	 * This is used to determine if a specific entry is deleted.
 	 * When an entry is deleted, there is no link to the deleted entry.
 	 *
-	 * @var int[] $valid_entry_ids
+	 * @var int[]
 	 */
 	private $valid_entry_ids = array();
 

--- a/stubs.php
+++ b/stubs.php
@@ -216,11 +216,11 @@ namespace Elementor {
 namespace WPMailSMTP {
 	class Options {
 	   /**
-		* @return Options
-		*/
+	    * @return Options
+	    */
 	   public static function init() {
 	   }
-	   /**
+		/**
 		 * @param string $group
 		 * @param string $key
 		 * @param bool   $strip_slashes

--- a/tests/base/FrmUnitTest.php
+++ b/tests/base/FrmUnitTest.php
@@ -23,7 +23,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 	protected $is_pro_active = false;
 
 	/**
-	 * @var FrmUnitTest $instance
+	 * @var FrmUnitTest
 	 */
 	protected static $instance;
 

--- a/tests/emails/test_FrmEmail.php
+++ b/tests/emails/test_FrmEmail.php
@@ -401,7 +401,6 @@ class test_FrmEmail extends FrmUnitTest {
 	}
 
 	/**
-	 *
 	 * Reply_to:
 	 * From: [x] [y]
 	 *

--- a/tests/forms/test_FrmFormsHelper.php
+++ b/tests/forms/test_FrmFormsHelper.php
@@ -6,7 +6,7 @@
 class test_FrmFormsHelper extends FrmUnitTest {
 
 	/**
-	 * @var stdClass|null $form
+	 * @var stdClass|null
 	 */
 	private $form;
 

--- a/tests/test_wordpress_plugin_tests.php
+++ b/tests/test_wordpress_plugin_tests.php
@@ -16,10 +16,9 @@ class WP_Test_WordPress_Plugin_Tests extends FrmUnitTest {
 }
 
 /**
-*
-* Namespacing allows more flexibility
-*   - Mock objects without real data
-* Check out PHPUnit test doubles, PHPunit data providers, Test-driven development (TDD)
-* qunit/phantomjs for js unit testing
-* See: "Browser Eyeballing != Javascript testing" by Jordna Kaspar
-*/
+ * Namespacing allows more flexibility
+ *   - Mock objects without real data
+ * Check out PHPUnit test doubles, PHPunit data providers, Test-driven development (TDD)
+ * qunit/phantomjs for js unit testing
+ * See: "Browser Eyeballing != Javascript testing" by Jordna Kaspar
+ */


### PR DESCRIPTION
I started experimenting with another PHP tool, https://github.com/PHP-CS-Fixer/PHP-CS-Fixer

I went through the rules and found a few rules that play well with our other rules,

This isn't everything. This is really just the first phase,
```
'phpdoc_order'                => true,
'phpdoc_scalar'               => true,
'phpdoc_trim'                 => true,
'phpdoc_var_without_name'     => true,
'phpdoc_indent'               => true,
'align_multiline_comment'     => true,
'short_scalar_cast'           => true,
'standardize_not_equals'      => true,
'echo_tag_syntax'             => true,
'semicolon_after_instruction' => true,
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Standardized boolean type declarations across various classes and methods for consistency.
  - Updated integer type declarations to use `int` for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->