### PR TITLE
Apply more phpcs fixer changes

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -253,27 +253,27 @@ class FrmFormsController {
 
 		if ( count( $errors ) > 0 ) {
 			return self::get_edit_vars( $id, $errors );
-		} else {
-			self::maybe_remove_draft_option_from_fields( $id );
+		}
 
-			FrmForm::update( $id, $values );
-			$message = __( 'Form was successfully updated.', 'formidable' );
+		self::maybe_remove_draft_option_from_fields( $id );
 
-			if ( self::is_too_long( $values ) ) {
-				$message .= '<br/> ' . sprintf(
-					/* translators: %1$s: Start link HTML, %2$s: end link HTML */
-					__( 'However, your form is very long and may be %1$sreaching server limits%2$s.', 'formidable' ),
-					'<a href="https://formidableforms.com/knowledgebase/i-have-a-long-form-why-did-the-options-at-the-end-of-the-form-stop-saving/?utm_source=WordPress&utm_medium=builder&utm_campaign=liteplugin" target="_blank" rel="noopener">',
-					'</a>'
-				);
-			}
+		FrmForm::update( $id, $values );
+		$message = __( 'Form was successfully updated.', 'formidable' );
 
-			if ( defined( 'DOING_AJAX' ) ) {
-				wp_die( FrmAppHelper::kses( $message, array( 'a' ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			}
+		if ( self::is_too_long( $values ) ) {
+			$message .= '<br/> ' . sprintf(
+				/* translators: %1$s: Start link HTML, %2$s: end link HTML */
+				__( 'However, your form is very long and may be %1$sreaching server limits%2$s.', 'formidable' ),
+				'<a href="https://formidableforms.com/knowledgebase/i-have-a-long-form-why-did-the-options-at-the-end-of-the-form-stop-saving/?utm_source=WordPress&utm_medium=builder&utm_campaign=liteplugin" target="_blank" rel="noopener">',
+				'</a>'
+			);
+		}
 
-			return self::get_edit_vars( $id, array(), $message );
-		}//end if
+		if ( defined( 'DOING_AJAX' ) ) {
+			wp_die( FrmAppHelper::kses( $message, array( 'a' ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+
+		return self::get_edit_vars( $id, array(), $message );
 	}
 
 	/**

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2820,9 +2820,8 @@ class FrmAppHelper {
 	public static function get_first_record_num( $r_count, $current_p, $p_size ) {
 		if ( $current_p == 1 ) {
 			return 1;
-		} else {
-			return ( self::get_last_record_num( $r_count, ( $current_p - 1 ), $p_size ) + 1 );
 		}
+		return ( self::get_last_record_num( $r_count, ( $current_p - 1 ), $p_size ) + 1 );
 	}
 
 	/**

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -838,9 +838,8 @@ BEFORE_HTML;
 		if ( empty( $style ) ) {
 			if ( FrmAppHelper::is_admin_page( 'formidable-entries' ) ) {
 				return $class;
-			} else {
-				return;
 			}
+			return;
 		}
 
 		// If submit button needs to be inline or centered.

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -514,9 +514,8 @@ class FrmEmail {
 	private function has_recipients() {
 		if ( empty( $this->to ) && empty( $this->cc ) && empty( $this->bcc ) ) {
 			return false;
-		} else {
-			return true;
 		}
+		return true;
 	}
 
 	/**
@@ -693,18 +692,18 @@ class FrmEmail {
 			if ( is_email( $val ) ) {
 				// If a plain email is used, no formatting is needed
 				continue;
-			} else {
-				$parts = explode( ' ', $val );
-				$email = end( $parts );
+			}
 
-				if ( is_email( $email ) ) {
-					// If user enters a name and email
-					$name = trim( str_replace( $email, '', $val ) );
-				} else {
-					// If user enters a name without an email
-					unset( $recipients[ $key ] );
-					continue;
-				}
+			$parts = explode( ' ', $val );
+			$email = end( $parts );
+
+			if ( is_email( $email ) ) {
+				// If user enters a name and email
+				$name = trim( str_replace( $email, '', $val ) );
+			} else {
+				// If user enters a name without an email
+				unset( $recipients[ $key ] );
+				continue;
 			}
 
 			$recipients[ $key ] = $this->format_from_email( $name, $email );

--- a/classes/models/FrmEntryMeta.php
+++ b/classes/models/FrmEntryMeta.php
@@ -211,9 +211,8 @@ class FrmEntryMeta {
 	public static function get_meta_value( $entry, $field_id ) {
 		if ( isset( $entry->metas ) ) {
 			return isset( $entry->metas[ $field_id ] ) ? $entry->metas[ $field_id ] : false;
-		} else {
-			return self::get_entry_meta_by_field( $entry->id, $field_id );
 		}
+		return self::get_entry_meta_by_field( $entry->id, $field_id );
 	}
 
 	public static function get_entry_meta_by_field( $entry_id, $field_id ) {

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -1112,50 +1112,84 @@ class FrmField {
 
 	/**
 	 * @since 2.0.9
+	 *
+	 * @param array $field
+	 * @return bool
 	 */
 	public static function is_required( $field ) {
-		$required = ( $field['required'] != '0' );
-		$required = apply_filters( 'frm_is_field_required', $required, $field );
+		$required = $field['required'] != '0';
+
+		/**
+		 * @param bool  $required
+		 * @param array $field
+		 */
+		$required = (bool) apply_filters( 'frm_is_field_required', $required, $field );
 
 		return $required;
 	}
 
 	/**
 	 * @since 2.0.9
+	 *
+	 * @param array|object $field
+	 * @param string       $option
+	 * @return bool
 	 */
 	public static function is_option_true( $field, $option ) {
 		if ( is_array( $field ) ) {
 			return self::is_option_true_in_array( $field, $option );
-		} else {
-			return self::is_option_true_in_object( $field, $option );
 		}
+		return self::is_option_true_in_object( $field, $option );
 	}
 
 	/**
 	 * @since 2.0.9
+	 *
+	 * @param array|object $field
+	 * @param string       $option
+	 * @return bool
 	 */
 	public static function is_option_empty( $field, $option ) {
 		if ( is_array( $field ) ) {
 			return self::is_option_empty_in_array( $field, $option );
-		} else {
-			return self::is_option_empty_in_object( $field, $option );
 		}
+		return self::is_option_empty_in_object( $field, $option );
 	}
 
+	/**
+	 * @param array  $field
+	 * @param string $option
+	 * @return bool
+	 */
 	public static function is_option_true_in_array( $field, $option ) {
-		return isset( $field[ $option ] ) && $field[ $option ];
+		return ! empty( $field[ $option ] );
 	}
 
+	/**
+	 * @param object $field
+	 * @param string $option
+	 * @return bool
+	 */
 	public static function is_option_true_in_object( $field, $option ) {
 		return isset( $field->field_options[ $option ] ) && $field->field_options[ $option ];
 	}
 
+	/**
+	 * @param array  $field
+	 * @param string $option
+	 * @return bool
+	 */
 	public static function is_option_empty_in_array( $field, $option ) {
-		return ! isset( $field[ $option ] ) || empty( $field[ $option ] );
+		return empty( $field[ $option ] );
 	}
 
+	/**
+	 * @param object $field
+	 * @param string $option
+	 * @return bool
+	 */
 	public static function is_option_empty_in_object( $field, $option ) {
-		return ! isset( $field->field_options[ $option ] ) || empty( $field->field_options[ $option ] );
+		return empty( $field->field_options[ $option ] );
 	}
 
 	/**
@@ -1169,6 +1203,10 @@ class FrmField {
 
 	/**
 	 * @since 2.0.18
+	 *
+	 * @param object|array $field
+	 * @param string       $option
+	 * @return mixed
 	 */
 	public static function get_option( $field, $option ) {
 		if ( is_array( $field ) ) {
@@ -1180,8 +1218,12 @@ class FrmField {
 		return $option;
 	}
 
+	/**
+	 * @param array  $field
+	 * @param string $option
+	 * @return mixed
+	 */
 	public static function get_option_in_array( $field, $option ) {
-
 		if ( isset( $field[ $option ] ) ) {
 			$this_option = $field[ $option ];
 		} elseif ( isset( $field['field_options'] ) && is_array( $field['field_options'] ) && isset( $field['field_options'][ $option ] ) ) {
@@ -1199,15 +1241,18 @@ class FrmField {
 
 	/**
 	 * @since 2.0.09
+	 *
+	 * @param array|object $field
+	 * @return bool
 	 */
 	public static function is_repeating_field( $field ) {
 		if ( is_array( $field ) ) {
-			$is_repeating_field = ( 'divider' == $field['type'] );
+			$is_repeating_field = ( 'divider' === $field['type'] );
 		} else {
-			$is_repeating_field = ( 'divider' == $field->type );
+			$is_repeating_field = ( 'divider' === $field->type );
 		}
 
-		return ( $is_repeating_field && self::is_option_true( $field, 'repeat' ) );
+		return $is_repeating_field && self::is_option_true( $field, 'repeat' );
 	}
 
 	/**


### PR DESCRIPTION
Following up from https://github.com/Strategy11/formidable-forms/pull/1634

This update fixes one rule so far: `no_useless_else`. Basically, if there's a `return`in the `if`, we should not use `else`.

I also manually added some type comments in `FrmField.php`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved form update process and error message handling in form management.
  - Streamlined calculation for the first record number in listings.
  - Optimized style class retrieval for forms, enhancing performance.
  - Enhanced email recipient handling to support edge cases more effectively.

- **Bug Fixes**
  - Unified meta value retrieval logic in entry management, ensuring consistency.

- **Refactor**
  - Updated several form field evaluation methods to increase reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->