### PR TITLE
Php cs fixer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,8 @@
 .jshintignore export-ignore
 .wordpress-org export-ignore
 .phpunit.result.cache export-ignore
+.php-cs-fixer.php
+.php-cs-fixer.cache
 /bin/ export-ignore
 changelog.txt export-ignore
 codesniffer.xml export-ignore

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,0 +1,22 @@
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [ opened, labeled, synchronize ]
+
+name: Inspections
+jobs:
+  runPHPCSFixerInspection:
+    if: contains(github.event.pull_request.labels.*.name, 'run analysis')
+    name: Run PHPCS inspection
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Install dependencies
+        run: composer install --dev --prefer-dist --no-progress --no-suggest
+
+      - name: PHPCS check
+        run: . vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --verbose

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -19,4 +19,4 @@ jobs:
         run: composer install --dev --prefer-dist --no-progress --no-suggest
 
       - name: PHPCS check
-        run: . vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --verbose
+        run: ./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --verbose

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -11,12 +11,12 @@ name: Inspections
 jobs:
   runPHPCSFixerInspection:
     if: contains(github.event.pull_request.labels.*.name, 'run analysis')
-    name: Run PHPCS inspection
+    name: Run PHP CS Fixer inspection
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Install dependencies
         run: composer install --dev --prefer-dist --no-progress --no-suggest
 
-      - name: PHPCS check
+      - name: PHPCSFixer check
         run: ./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ composer.lock
 
 # PHPUnit
 .phpunit.result.cache
+
+# PHP CS Fixer
+.php-cs-fixer.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -3,12 +3,17 @@
 $finder = ( new PhpCsFixer\Finder() )->in( __DIR__ );
 $rules  = array(
 	// Keep these rules for sure.
-	// 'phpdoc_order'            => true,
-	// 'phpdoc_scalar'           => true,
-	// 'phpdoc_trim'             => true,
-	// 'phpdoc_var_without_name' => true,
-	// 'phpdoc_indent'           => true,
-	// 'align_multiline_comment' => true,
+	// 'phpdoc_order'                => true,
+	// 'phpdoc_scalar'               => true,
+	// 'phpdoc_trim'                 => true,
+	// 'phpdoc_var_without_name'     => true,
+	// 'phpdoc_indent'               => true,
+	// 'align_multiline_comment'     => true,
+	// 'short_scalar_cast'           => true,
+	// 'standardize_not_equals'      => true,
+	// 'echo_tag_syntax'             => true,
+	// 'semicolon_after_instruction' => true,
+	'string_length_to_empty' => true,
 );
 
 $config = new PhpCsFixer\Config();
@@ -18,8 +23,14 @@ return $config->setFinder( $finder );
 
 // Probably include these (but not right away).
 // 'phpdoc_types_order' => true,
+// 'no_superfluous_elseif' => true,
+// 'no_useless_else' => true,
+// 'static_lambda' => true,
+// 'return_assignment' => true,
 
 // Maybe include these.
 // 'phpdoc_separation' => true,
 // 'phpdoc_summary' => true,
 // 'phpdoc_align' => true,
+// 'visibility_required' => true,
+// 'multiline_comment_opening_closing' => true,

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,11 @@
+<?php
+
+$finder = ( new PhpCsFixer\Finder() )->in( __DIR__ );
+$rules  = array(
+	'phpdoc_order' => true,
+);
+
+$config = new PhpCsFixer\Config();
+$config->setRules( $rules );
+
+return $config->setFinder( $finder );

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -3,17 +3,16 @@
 $finder = ( new PhpCsFixer\Finder() )->in( __DIR__ );
 $rules  = array(
 	// Keep these rules for sure.
-	// 'phpdoc_order'                => true,
-	// 'phpdoc_scalar'               => true,
-	// 'phpdoc_trim'                 => true,
-	// 'phpdoc_var_without_name'     => true,
-	// 'phpdoc_indent'               => true,
-	// 'align_multiline_comment'     => true,
-	// 'short_scalar_cast'           => true,
-	// 'standardize_not_equals'      => true,
-	// 'echo_tag_syntax'             => true,
-	// 'semicolon_after_instruction' => true,
-	'string_length_to_empty' => true,
+	'phpdoc_order'                => true,
+	'phpdoc_scalar'               => true,
+	'phpdoc_trim'                 => true,
+	'phpdoc_var_without_name'     => true,
+	'phpdoc_indent'               => true,
+	'align_multiline_comment'     => true,
+	'short_scalar_cast'           => true,
+	'standardize_not_equals'      => true,
+	'echo_tag_syntax'             => true,
+	'semicolon_after_instruction' => true,
 );
 
 $config = new PhpCsFixer\Config();

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -2,7 +2,8 @@
 
 $finder = ( new PhpCsFixer\Finder() )->in( __DIR__ );
 $rules  = array(
-	'phpdoc_order' => true,
+	'phpdoc_order'  => true,
+	'phpdoc_scalar' => true,
 );
 
 $config = new PhpCsFixer\Config();

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -15,6 +15,7 @@ $rules  = array(
 	'semicolon_after_instruction' => true,
 	'no_useless_else'             => true,
 	'no_superfluous_elseif'       => true,
+	'phpdoc_separation'           => true,
 );
 
 $config = new PhpCsFixer\Config();

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -13,9 +13,8 @@ $rules  = array(
 	'standardize_not_equals'      => true,
 	'echo_tag_syntax'             => true,
 	'semicolon_after_instruction' => true,
-
-	'no_useless_else' => true,
-	
+	'no_useless_else'             => true,
+	'no_superfluous_elseif'       => true,
 );
 
 $config = new PhpCsFixer\Config();
@@ -23,16 +22,12 @@ $config->setRules( $rules );
 
 return $config->setFinder( $finder );
 
-// Probably include these (but not right away).
-// 'phpdoc_types_order' => true,
-// 'no_superfluous_elseif' => true,
-// 'no_useless_else' => true,
-// 'static_lambda' => true,
-// 'return_assignment' => true,
-
 // Maybe include these.
 // 'phpdoc_separation' => true,
 // 'phpdoc_summary' => true,
 // 'phpdoc_align' => true,
 // 'visibility_required' => true,
 // 'multiline_comment_opening_closing' => true,
+// 'phpdoc_types_order' => true,
+// 'return_assignment' => true,
+// 'static_lambda' => true,

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -15,7 +15,6 @@ $rules  = array(
 	'semicolon_after_instruction' => true,
 	'no_useless_else'             => true,
 	'no_superfluous_elseif'       => true,
-	'phpdoc_separation'           => true,
 );
 
 $config = new PhpCsFixer\Config();

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -13,6 +13,9 @@ $rules  = array(
 	'standardize_not_equals'      => true,
 	'echo_tag_syntax'             => true,
 	'semicolon_after_instruction' => true,
+
+	'no_useless_else' => true,
+	
 );
 
 $config = new PhpCsFixer\Config();

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -2,11 +2,20 @@
 
 $finder = ( new PhpCsFixer\Finder() )->in( __DIR__ );
 $rules  = array(
-	'phpdoc_order'  => true,
-	'phpdoc_scalar' => true,
+	// Keep these rules for sure.
+	// 'phpdoc_order'  => true,
+	// 'phpdoc_scalar' => true,
+	// 'phpdoc_trim'   => true,
 );
 
 $config = new PhpCsFixer\Config();
 $config->setRules( $rules );
 
 return $config->setFinder( $finder );
+
+// Probably include these (but not right away).
+// 'phpdoc_types_order' => true,
+
+// Maybe include these.
+// 'phpdoc_separation' => true,
+// 'phpdoc_summary' => true,

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -3,9 +3,12 @@
 $finder = ( new PhpCsFixer\Finder() )->in( __DIR__ );
 $rules  = array(
 	// Keep these rules for sure.
-	// 'phpdoc_order'  => true,
-	// 'phpdoc_scalar' => true,
-	// 'phpdoc_trim'   => true,
+	// 'phpdoc_order'            => true,
+	// 'phpdoc_scalar'           => true,
+	// 'phpdoc_trim'             => true,
+	// 'phpdoc_var_without_name' => true,
+	// 'phpdoc_indent'           => true,
+	// 'align_multiline_comment' => true,
 );
 
 $config = new PhpCsFixer\Config();
@@ -19,3 +22,4 @@ return $config->setFinder( $finder );
 // Maybe include these.
 // 'phpdoc_separation' => true,
 // 'phpdoc_summary' => true,
+// 'phpdoc_align' => true,

--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -37,6 +37,8 @@ zip -r $zipname $destination \
 	-x "*/.git/*" \
 	-x "*/.github/*" \
 	-x "*/.phpunit.result.cache" \
+	-x "*/.php-cs-fixer.yml" \
+	-x "*/.php-cs-fixer.cache" \
 	-x "*/bin/*" \
 	-x "*/scss/*" \
 	-x "*/css/*.css.map" \

--- a/classes/models/fields/FrmFieldCaptcha.php
+++ b/classes/models/fields/FrmFieldCaptcha.php
@@ -394,9 +394,8 @@ class FrmFieldCaptcha extends FrmFieldType {
 	}
 
 	/**
-	 * @return string
-	 *
 	 * @param FrmSettings $frm_settings
+	 * @return string
 	 */
 	protected function captcha_size( $frm_settings ) {
 		_deprecated_function( __METHOD__, '6.8.4' );

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
 		"squizlabs/php_codesniffer": "^3.9",
 		"phpstan/phpstan": "^1.4",
 		"phpstan/phpstan-strict-rules": "^1.5",
-		"phpstan/extension-installer": "^1.3"
+		"phpstan/extension-installer": "^1.3",
+		"slevomat/coding-standard": "~8.0",
+		"friendsofphp/php-cs-fixer": "^3.54"
 	},
 	"config": {
 		"allow-plugins": {

--- a/tests/misc/test_FrmDirectFileAccess.php
+++ b/tests/misc/test_FrmDirectFileAccess.php
@@ -13,16 +13,18 @@ class test_FrmDirectFileAccess extends FrmUnitTest {
 			$dir = FrmAppHelper::plugin_path();
 		}
 
-		$files = scandir( $dir );
+		$files             = scandir( $dir );
+		$files_to_ignore   = array( 'set-php-version.php', 'stubs.php', '.php-cs-fixer.php' );
+		$folders_to_ignore = array( 'tests', 'vendor', 'languages', 'node_modules', 'js' );
 
 		foreach ( $files as $key => $value ) {
 			$path = realpath( $dir . DIRECTORY_SEPARATOR . $value );
 			if ( ! is_dir( $path ) ) {
-				if ( substr( $value, strlen( $value ) - 4 ) === '.php' && ! in_array( $value, array( 'set-php-version.php', 'stubs.php' ), true ) ) {
+				if ( substr( $value, strlen( $value ) - 4 ) === '.php' && ! in_array( $value, $files_to_ignore, true ) ) {
 					$results[] = $path;
 				}
 			} elseif ( $value !== '.' && $value !== '..' ) {
-				if ( in_array( $value, array( 'tests', 'vendor', 'languages', 'node_modules', 'js' ), true ) ) {
+				if ( in_array( $value, $folders_to_ignore, true ) ) {
 					continue;
 				}
 


### PR DESCRIPTION
I'm adding a new workflow, and a new config, for a new dev dependency to improve our code quality more and automate common code review issues.

🚀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Excluded additional files from the zip archive creation process in the `zip-plugin.sh` script.
	- Updated export settings to exclude specific cache and configuration files.

- **New Features**
	- Implemented code style and formatting checks using PHP CS Fixer in the GitHub Actions workflow named "Inspections."

- **Documentation**
	- Defined coding standards and rules using PHP CS Fixer in the configuration file.
  
- **Refactor**
	- Enhanced the functionality of the `all_php_file_paths` method in `test_FrmDirectFileAccess.php` to ignore certain files and folders while scanning for PHP files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->