### PR TITLE
Fix truncate on int

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2508,13 +2508,20 @@ class FrmAppHelper {
 		return $custom_style;
 	}
 
+	/**
+	 * @param mixed      $original_string
+	 * @param string|int $length
+	 * @param int        $minword
+	 * @param string     $continue
+	 * @return string
+	 */
 	public static function truncate( $original_string, $length, $minword = 3, $continue = '...' ) {
-		if ( ! is_string( $original_string ) ) {
+		if ( ! is_string( $original_string ) && ! is_int( $original_string ) ) {
 			return '';
 		}
 
 		$length       = (int) $length;
-		$str          = wp_strip_all_tags( $original_string );
+		$str          = wp_strip_all_tags( (string) $original_string );
 		$original_len = self::mb_function( array( 'mb_strlen', 'strlen' ), array( $str ) );
 
 		if ( $length == 0 ) {


### PR DESCRIPTION
This change is breaking Pro unit tests https://github.com/Strategy11/formidable-forms/pull/1631/commits/62327f70c8f3f36be9b2d1f7052c043545d9965d

I'm adding an int check to fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the `truncate` method to support more parameter types, improving flexibility and robustness in text handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->