### PR TITLE
Try splitting PHPUnit workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -30,12 +30,12 @@ jobs:
           - php: 7.4
             wordpress: trunk
             multisite: 0
-            filter: '^(?!test_Frm[A-F]).*'
+            filter: '/^(?!test_Frm[A-F]).*/'
             group: 2
           - php: 8.0
             wordpress: trunk
             multisite: 0
-            filter: '^(?!test_Frm[A-F]).*'
+            filter: '/^(?!test_Frm[A-F]).*/'
             group: 2
 
     name: PHP ${{ matrix.php }} tests in WP ${{ matrix.wordpress }} (${{ matrix.group }}/2)

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,12 +20,12 @@ jobs:
           - php: 7.4
             wordpress: trunk
             multisite: 0
-            filter: '/^(test_Frm){1}[A-M]/'
+            filter: '/^(test_Frm){1}[A-F]/'
             group: 1
           - php: 8.0
             wordpress: trunk
             multisite: 0
-            filter: '/^(test_Frm){1}[A-M]/'
+            filter: '/^(test_Frm){1}[A-F]/'
             group: 1
           - php: 7.4
             wordpress: trunk

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,11 +20,25 @@ jobs:
           - php: 7.4
             wordpress: trunk
             multisite: 0
+            filter: '/^(test_Frm){1}[A-M]/'
+            group: 1
           - php: 8.0
             wordpress: trunk
             multisite: 0
+            filter: '/^(test_Frm){1}[A-M]/'
+            group: 1
+          - php: 7.4
+            wordpress: trunk
+            multisite: 0
+            filter: '^(?!test_Frm[A-F]).*'
+            group: 2
+          - php: 8.0
+            wordpress: trunk
+            multisite: 0
+            filter: '^(?!test_Frm[A-F]).*'
+            group: 2
 
-    name: PHP ${{ matrix.php }} tests in WP ${{ matrix.wordpress }}
+    name: PHP ${{ matrix.php }} tests in WP ${{ matrix.wordpress }} (${{ matrix.group }}/2)
     steps:
       - uses: actions/checkout@v3.5.0
 
@@ -54,7 +68,7 @@ jobs:
         run: |
           cd "/tmp/wordpress/src/wp-content/plugins/formidable"
           pwd
-          phpunit --coverage-clover=coverage.xml
+          phpunit --coverage-clover=coverage.xml --filter ${{ matrix.filter }}
       - name: Send code coverage report to Codecov.io
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           cd "/tmp/wordpress/src/wp-content/plugins/formidable"
           pwd
-          phpunit --coverage-clover=coverage.xml --filter ${{ matrix.filter }}
+          phpunit --coverage-clover=coverage.xml --filter '${{ matrix.filter }}'
       - name: Send code coverage report to Codecov.io
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,6 +17,8 @@ jobs:
     strategy:
       matrix:
         include:
+          # Run tests starting with test_FrmA through test_FrmF
+          # Tests are split into 2 groups to run in half the time.
           - php: 7.4
             wordpress: trunk
             multisite: 0
@@ -27,6 +29,8 @@ jobs:
             multisite: 0
             filter: '/^(test_Frm){1}[A-F]/'
             group: 1
+          # Run tests that do not start with test_FrmA through test_FrmF
+          # This includes the tests that do not start with test_Frm at all.
           - php: 7.4
             wordpress: trunk
             multisite: 0


### PR DESCRIPTION
This update splits our PHP Unit tests into two groups (prefixed with FrmA-FrmF and not prefixed with FrmA-FrmF).

This effectively halves the time it takes for unit tests to run by running them in parallel.

**But this also means that we can't send a complete report to Code Cov**

We could add another workflow like "Check code coverage"?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Enhanced PHPUnit test configurations to include filters and groups based on PHP and WordPress versions for more targeted test execution, impacting the test execution logic and grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->