### PR TITLE
PHP CodeSniffer / Start checking for cognitive complexity

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -106,6 +106,28 @@
 	<!-- Add some rules from the Slevomat Coding Standard -->
 	<rule ref="SlevomatCodingStandard.PHP.UselessParentheses" />
 
+	<!-- Set rules for Cognitive Complexity -->
+	<rule ref="SlevomatCodingStandard.Complexity.Cognitive">
+		<properties>
+            <property name="warningThreshold" value="30" />
+			<property name="errorThreshold" value="10" />
+        </properties>
+	</rule>
+	<rule ref="SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh">
+		<exclude-pattern>classes/helpers/FrmFormsHelper.php</exclude-pattern>
+		<exclude-pattern>classes/helpers/FrmListHelper.php</exclude-pattern>
+		<exclude-pattern>classes/helpers/FrmXMLHelper.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmEntryMeta.php</exclude-pattern>
+		<exclude-pattern>classes/helpers/FrmCSVExportHelper.php</exclude-pattern>
+		<exclude-pattern>classes/helpers/FrmFieldsHelper.php</exclude-pattern>
+		<exclude-pattern>classes/controllers/FrmXMLController.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmEntryValidate.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmForm.php</exclude-pattern>
+		<exclude-pattern>classes/models/FrmStyle.php</exclude-pattern>
+		<exclude-pattern>classes/controllers/FrmFormActionsController.php</exclude-pattern>
+		<exclude-pattern>tests/base/FrmUnitTest.php</exclude-pattern>
+	</rule>
+
 	<!-- Treat these warnings as errors -->
 	<rule ref="Generic.Formatting.MultipleStatementAlignment.NotSameWarning">
 		<severity>8</severity>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -109,9 +109,9 @@
 	<!-- Set rules for Cognitive Complexity -->
 	<rule ref="SlevomatCodingStandard.Complexity.Cognitive">
 		<properties>
-            <property name="warningThreshold" value="30" />
+			<property name="warningThreshold" value="30" />
 			<property name="errorThreshold" value="10" />
-        </properties>
+		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh">
 		<exclude-pattern>classes/helpers/FrmFormsHelper.php</exclude-pattern>


### PR DESCRIPTION
The default benchmark for this is normally 6.

I went with 30 and still needed to exclude several files 😅.

This is a start. Hopefully this will stop any new files from hitting 30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved code quality by integrating Cognitive Complexity rules into our coding standards. Certain files have been excluded to manage complexity thresholds effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->