### PR TITLE
Optimize the serialized string parser

### DIFF
--- a/classes/helpers/FrmSerializedStringParserHelper.php
+++ b/classes/helpers/FrmSerializedStringParserHelper.php
@@ -54,59 +54,77 @@ class FrmSerializedStringParserHelper {
 		$val = null;
 
 		// May be : or ; as a terminator, depending on what the data type is.
-		$type = substr( $string->read( 2 ), 0, 1 );
+		$type = $string->read( 1 );
+		$string->increment_position( 1 );
 
 		switch ( $type ) {
 			case 'a':
-				// Associative array: a:length:{[index][value]...}
-				$count = (int) $string->read_until( ':' );
-
-				// Eat the opening "{" of the array.
-				$string->read( 1 );
-
-				$val = array();
-				for ( $i = 0; $i < $count; $i++ ) {
-					$array_key   = $this->do_parse( $string );
-					$array_value = $this->do_parse( $string );
-
-					if ( ! is_array( $array_key ) ) {
-						$val[ $array_key ] = $array_value;
-					}
-				}
-
-				// Eat "}" terminating the array.
-				$string->read( 1 );
-				break;
+				return $this->parse_array( $string );
 
 			case 's':
-				$len = (int) $string->read_until( ':' );
-				$val = $string->read( $len + 2 );
-
-				// Eat the separator.
-				$string->read( 1 );
-				break;
+				return $this->parse_string( $string );
 
 			case 'i':
-				$val = (int) $string->read_until( ';' );
-				break;
+				return $this->parse_int( $string );
 
 			case 'd':
-				$val = (float) $string->read_until( ';' );
-				break;
+				return $this->parse_float( $string );
 
 			case 'b':
-				// Boolean is 0 or 1.
-				$bool = $string->read( 2 );
-				$val  = substr( $bool, 0, 1 ) == '1';
-				break;
+				return $this->parse_bool( $string );
+		}
 
-			default:
-				// Includes case 'N' and case 'O'.
-				// Treat a serialized object or anything unexpected as Null.
-				$val = null;
-				break;
-		}//end switch
+		// Includes case 'N' and case 'O'.
+		// Treat a serialized object or anything unexpected as Null.
+		return null;
+	}
+
+	private function parse_array( $string ) {
+		// Associative array: a:length:{[index][value]...}
+		$count = (int) $string->read_until( ':' );
+
+		// Eat the opening "{" of the array.
+		$string->increment_position( 1 );
+
+		$val = array();
+		for ( $i = 0; $i < $count; $i++ ) {
+			$array_key   = $this->do_parse( $string );
+			$array_value = $this->do_parse( $string );
+
+			if ( ! is_array( $array_key ) ) {
+				$val[ $array_key ] = $array_value;
+			}
+		}
+
+		// Eat "}" terminating the array.
+		$string->increment_position( 1 );
 
 		return $val;
 	}
+
+	private function parse_string( $string ) {
+		$len = (int) $string->read_until( ':' );
+		$val = $string->read( $len + 2 );
+
+		// Eat the separator.
+		$string->increment_position( 1 );
+
+		return $val;
+	}
+
+	private function parse_int( $string ) {
+		return (int) $string->read_until( ';' );
+	}
+
+	private function parse_float( $string ) {
+		return (float) $string->read_until( ';' );
+	}
+
+	private function parse_bool( $string ) {
+		// Boolean is 0 or 1.
+		$val = $string->read( 1 ) === '1';
+		$string->increment_position( 1 );
+		return $val;
+	}
+
 }

--- a/classes/helpers/FrmSerializedStringParserHelper.php
+++ b/classes/helpers/FrmSerializedStringParserHelper.php
@@ -53,7 +53,7 @@ class FrmSerializedStringParserHelper {
 	private function do_parse( $string ) {
 		// May be : or ; as a terminator, depending on what the data type is.
 		$type = $string->read( 1 );
-		$string->increment_position( 1 );
+		$string->skip_next_character();
 
 		switch ( $type ) {
 			case 'a':
@@ -86,7 +86,7 @@ class FrmSerializedStringParserHelper {
 		$count = (int) $string->read_until( ':' );
 
 		// Eat the opening "{" of the array.
-		$string->increment_position( 1 );
+		$string->skip_next_character();
 
 		$val = array();
 		for ( $i = 0; $i < $count; $i++ ) {
@@ -99,7 +99,7 @@ class FrmSerializedStringParserHelper {
 		}
 
 		// Eat "}" terminating the array.
-		$string->increment_position( 1 );
+		$string->skip_next_character();
 
 		return $val;
 	}
@@ -113,7 +113,7 @@ class FrmSerializedStringParserHelper {
 		$val = $string->read( $len + 2 );
 
 		// Eat the separator.
-		$string->increment_position( 1 );
+		$string->skip_next_character();
 
 		return $val;
 	}
@@ -141,7 +141,7 @@ class FrmSerializedStringParserHelper {
 	private function parse_bool( $string ) {
 		// Boolean is 0 or 1.
 		$val = $string->read( 1 ) === '1';
-		$string->increment_position( 1 );
+		$string->skip_next_character();
 		return $val;
 	}
 

--- a/classes/helpers/FrmSerializedStringParserHelper.php
+++ b/classes/helpers/FrmSerializedStringParserHelper.php
@@ -144,5 +144,4 @@ class FrmSerializedStringParserHelper {
 		$string->skip_next_character();
 		return $val;
 	}
-
 }

--- a/classes/helpers/FrmSerializedStringParserHelper.php
+++ b/classes/helpers/FrmSerializedStringParserHelper.php
@@ -48,11 +48,9 @@ class FrmSerializedStringParserHelper {
 	 * This is the recursive parser.
 	 *
 	 * @param FrmStringReaderHelper $string
-	 * @return mixed
+	 * @return array|bool|float|int|string|null
 	 */
 	private function do_parse( $string ) {
-		$val = null;
-
 		// May be : or ; as a terminator, depending on what the data type is.
 		$type = $string->read( 1 );
 		$string->increment_position( 1 );
@@ -79,6 +77,10 @@ class FrmSerializedStringParserHelper {
 		return null;
 	}
 
+	/**
+	 * @param FrmStringReaderHelper $string
+	 * @return array
+	 */
 	private function parse_array( $string ) {
 		// Associative array: a:length:{[index][value]...}
 		$count = (int) $string->read_until( ':' );
@@ -102,6 +104,10 @@ class FrmSerializedStringParserHelper {
 		return $val;
 	}
 
+	/**
+	 * @param FrmStringReaderHelper $string
+	 * @return string
+	 */
 	private function parse_string( $string ) {
 		$len = (int) $string->read_until( ':' );
 		$val = $string->read( $len + 2 );
@@ -112,14 +118,26 @@ class FrmSerializedStringParserHelper {
 		return $val;
 	}
 
+	/**
+	 * @param FrmStringReaderHelper $string
+	 * @return int
+	 */
 	private function parse_int( $string ) {
 		return (int) $string->read_until( ';' );
 	}
 
+	/**
+	 * @param FrmStringReaderHelper $string
+	 * @return float
+	 */
 	private function parse_float( $string ) {
 		return (float) $string->read_until( ';' );
 	}
 
+	/**
+	 * @param FrmStringReaderHelper $string
+	 * @return bool
+	 */
 	private function parse_bool( $string ) {
 		// Boolean is 0 or 1.
 		$val = $string->read( 1 ) === '1';

--- a/classes/helpers/FrmStringReaderHelper.php
+++ b/classes/helpers/FrmStringReaderHelper.php
@@ -53,13 +53,13 @@ class FrmStringReaderHelper {
 		$value = '';
 
 		if ( $discard_char ) {
-			while ( $this->pos <= $this->max && ( $one = $this->string[$this->pos++] ) !== $char ) {
+			while ( $this->pos <= $this->max && ! is_null( $one = $this->string[$this->pos++] ) && $one !== $char ) {
 				$value .= $one;
 			}
 			return $value;
 		}
 
-		while ( $this->pos <= $this->max && ( $one = $this->string[ $this->pos++ ] ) ) {
+		while ( $this->pos <= $this->max && ! is_null( $one = $this->string[ $this->pos++ ] ) ) {
 			$value .= $one;
 			if ( $one === $char ) {
 				break;

--- a/classes/helpers/FrmStringReaderHelper.php
+++ b/classes/helpers/FrmStringReaderHelper.php
@@ -52,14 +52,22 @@ class FrmStringReaderHelper {
 	public function read_until( $char, $discard_char = true ) {
 		$value = '';
 
-		while ( null !== ( $one = $this->read_one() ) ) {
-			if ( $one !== $char || ! $discard_char ) {
+		if ( ! $discard_char ) {
+			while ( null !== ( $one = $this->read_one() ) ) {
 				$value .= $one;
+				if ( $one === $char ) {
+					break;
+				}
 			}
+			return $value;
+		}
 
-			if ( $one === $char ) {
-				break;
+		while ( null !== ( $one = $this->read_one() ) ) {
+			if ( $one !== $char ) {
+				$value .= $one;
+				continue;
 			}
+			break;
 		}
 
 		return $value;
@@ -82,6 +90,13 @@ class FrmStringReaderHelper {
 		}
 
 		return $this->strip_quotes( $value );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function increment_position( $count = 0 ) {
+		$this->pos += 1;
 	}
 
 	/**

--- a/classes/helpers/FrmStringReaderHelper.php
+++ b/classes/helpers/FrmStringReaderHelper.php
@@ -68,14 +68,15 @@ class FrmStringReaderHelper {
 		$value = '';
 
 		while ( $count > 0 && $this->pos <= $this->max && ( ( $one = $this->string[ $this->pos ] ) || '0' === $one ) ) {
-			$value .= $one;
+			$value     .= $one;
 			$this->pos += 1;
 			--$count;
-		}		
+		}
 
 		/**
 		 * Remove a single set of double-quotes from around a string.
 		 *
+		 * Examples:
 		 * abc => abc
 		 * "abc" => abc
 		 * ""abc"" => "abc"

--- a/classes/helpers/FrmStringReaderHelper.php
+++ b/classes/helpers/FrmStringReaderHelper.php
@@ -53,18 +53,19 @@ class FrmStringReaderHelper {
 		$value = '';
 
 		if ( $discard_char ) {
-			while ( ! is_null( $one = $this->read_one() ) && $one !== $char ) {
+			while ( $this->pos <= $this->max && ( $one = $this->string[$this->pos++] ) !== $char ) {
 				$value .= $one;
 			}
 			return $value;
 		}
 
-		while ( ! is_null( $one = $this->read_one() ) ) {
+		while ( $this->pos <= $this->max && ( $one = $this->string[ $this->pos++ ] ) ) {
 			$value .= $one;
 			if ( $one === $char ) {
 				break;
 			}
 		}
+
 		return $value;
 	}
 
@@ -79,10 +80,11 @@ class FrmStringReaderHelper {
 	public function read( $count ) {
 		$value = '';
 
-		while ( $count > 0 && ! is_null( $one = $this->read_one() ) ) {
+		while ($count > 0 && $this->pos <= $this->max && ($one = $this->string[$this->pos]) !== null) {
 			$value .= $one;
+			$this->pos += 1;
 			--$count;
-		}
+		}		
 
 		/**
 		 * Remove a single set of double-quotes from around a string.
@@ -111,20 +113,5 @@ class FrmStringReaderHelper {
 	 */
 	public function increment_position( $count = 0 ) {
 		$this->pos += $count;
-	}
-
-	/**
-	 * Read the next character from the supplied string.
-	 * Return null when we have run out of characters.
-	 *
-	 * @return string|null
-	 */
-	private function read_one() {
-		if ( $this->pos <= $this->max ) {
-			$value      = $this->string[ $this->pos ];
-			$this->pos += 1;
-			return $value;
-		}
-		return null;
 	}
 }

--- a/classes/helpers/FrmStringReaderHelper.php
+++ b/classes/helpers/FrmStringReaderHelper.php
@@ -89,14 +89,33 @@ class FrmStringReaderHelper {
 			--$count;
 		}
 
-		return $this->strip_quotes( $value );
+		/**
+		 * Remove a single set of double-quotes from around a string.
+		 *
+		 * abc => abc
+		 * "abc" => abc
+		 * ""abc"" => "abc"
+		 */
+		if ( strlen( $value ) < 2 || substr( $value, 0, 1 ) !== '"' || substr( $value, -1, 1 ) !== '"' ) {
+			// Only remove exactly one quote from the start and the end and then only if there is one at each end.
+			// Too short, or does not start or end with a quote.
+			return $value;
+		}
+
+		// Return the middle of the string, from the second character to the second-but-last.
+		return substr( $value, 1, -1 );
 	}
 
 	/**
+	 * Shift the position. This is used to skip characters that we don't need to read.
+	 *
+	 * @since x.x This was added as an optimization.
+	 *
+	 * @param int $count
 	 * @return void
 	 */
 	public function increment_position( $count = 0 ) {
-		$this->pos += 1;
+		$this->pos += $count;
 	}
 
 	/**
@@ -109,30 +128,8 @@ class FrmStringReaderHelper {
 		if ( $this->pos <= $this->max ) {
 			$value      = $this->string[ $this->pos ];
 			$this->pos += 1;
-		} else {
-			$value = null;
+			return $value;
 		}
-		return $value;
-	}
-
-	/**
-	 * Remove a single set of double-quotes from around a string.
-	 *  abc => abc
-	 *  "abc" => abc
-	 *  ""abc"" => "abc"
-	 *
-	 * @param string $string
-	 * @return string
-	 */
-	private function strip_quotes( $string ) {
-		// Only remove exactly one quote from the start and the end and then only if there is one at each end.
-
-		if ( strlen( $string ) < 2 || substr( $string, 0, 1 ) !== '"' || substr( $string, -1, 1 ) !== '"' ) {
-			// Too short, or does not start or end with a quote.
-			return $string;
-		}
-
-		// Return the middle of the string, from the second character to the second-but-last.
-		return substr( $string, 1, -1 );
+		return null;
 	}
 }

--- a/classes/helpers/FrmStringReaderHelper.php
+++ b/classes/helpers/FrmStringReaderHelper.php
@@ -52,24 +52,19 @@ class FrmStringReaderHelper {
 	public function read_until( $char, $discard_char = true ) {
 		$value = '';
 
-		if ( ! $discard_char ) {
-			while ( null !== ( $one = $this->read_one() ) ) {
+		if ( $discard_char ) {
+			while ( ! is_null( $one = $this->read_one() ) && $one !== $char ) {
 				$value .= $one;
-				if ( $one === $char ) {
-					break;
-				}
 			}
 			return $value;
 		}
 
-		while ( null !== ( $one = $this->read_one() ) ) {
-			if ( $one !== $char ) {
-				$value .= $one;
-				continue;
+		while ( ! is_null( $one = $this->read_one() ) ) {
+			$value .= $one;
+			if ( $one === $char ) {
+				break;
 			}
-			break;
 		}
-
 		return $value;
 	}
 

--- a/classes/helpers/FrmStringReaderHelper.php
+++ b/classes/helpers/FrmStringReaderHelper.php
@@ -46,26 +46,13 @@ class FrmStringReaderHelper {
 	 * By default, discard that final matching character and return the rest.
 	 *
 	 * @param string $char
-	 * @param bool   $discard_char
 	 * @return string
 	 */
-	public function read_until( $char, $discard_char = true ) {
+	public function read_until( $char ) {
 		$value = '';
-
-		if ( $discard_char ) {
-			while ( $this->pos <= $this->max && ! is_null( $one = $this->string[$this->pos++] ) && $one !== $char ) {
-				$value .= $one;
-			}
-			return $value;
-		}
-
-		while ( $this->pos <= $this->max && ! is_null( $one = $this->string[ $this->pos++ ] ) ) {
+		while ( $this->pos <= $this->max && ( $one = $this->string[ $this->pos++ ] ) !== $char ) {
 			$value .= $one;
-			if ( $one === $char ) {
-				break;
-			}
 		}
-
 		return $value;
 	}
 
@@ -80,7 +67,7 @@ class FrmStringReaderHelper {
 	public function read( $count ) {
 		$value = '';
 
-		while ($count > 0 && $this->pos <= $this->max && ($one = $this->string[$this->pos]) !== null) {
+		while ( $count > 0 && $this->pos <= $this->max && ( ( $one = $this->string[ $this->pos ] ) || '0' === $one ) ) {
 			$value .= $one;
 			$this->pos += 1;
 			--$count;

--- a/classes/helpers/FrmStringReaderHelper.php
+++ b/classes/helpers/FrmStringReaderHelper.php
@@ -91,14 +91,13 @@ class FrmStringReaderHelper {
 	}
 
 	/**
-	 * Shift the position. This is used to skip characters that we don't need to read.
+	 * Shift the position. This is used to skip a character that we don't need to read.
 	 *
 	 * @since x.x This was added as an optimization.
 	 *
-	 * @param int $count
 	 * @return void
 	 */
-	public function increment_position( $count = 0 ) {
-		$this->pos += $count;
+	public function skip_next_character() {
+		$this->pos += 1;
 	}
 }

--- a/classes/views/frm-form-actions/settings.php
+++ b/classes/views/frm-form-actions/settings.php
@@ -87,5 +87,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<div class="clear"></div>
 </div>
 
-<?php FrmFormActionsController::list_actions( $form, $values ); ?>
-<?php FrmTipsHelper::pro_tip( 'get_form_action_tip', 'p' ); ?>
+<?php
+FrmFormActionsController::list_actions( $form, $values );
+FrmTipsHelper::pro_tip( 'get_form_action_tip', 'p' );

--- a/classes/views/frm-forms/settings-advanced.php
+++ b/classes/views/frm-forms/settings-advanced.php
@@ -43,10 +43,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</label>
 	</p>
 
-<?php if ( ! $values['is_template'] ) { ?>
-	<?php $first_h3 = ''; ?>
+<?php
+if ( ! $values['is_template'] ) {
+	$first_h3 = '';
 
-	<?php if ( has_action( 'frm_settings_buttons' ) ) { ?>
+	if ( has_action( 'frm_settings_buttons' ) ) {
+		?>
 		<h3 class="<?php echo esc_attr( $first_h3 ); ?>">
 			<?php esc_html_e( 'Form Settings', 'formidable' ); ?>
 		</h3>
@@ -54,9 +56,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php do_action( 'frm_settings_buttons', $values ); ?>
 			<div class="clear"></div>
 		</div>
-		<?php $first_h3 = ''; ?>
-	<?php } ?>
-<?php } ?>
+		<?php
+		$first_h3 = '';
+	}
+}
+?>
 
 <h3 class="<?php echo esc_attr( $first_h3 ); ?>">
 	<?php esc_html_e( 'On Submit', 'formidable' ); ?>
@@ -115,9 +119,9 @@ FrmTipsHelper::pro_tip( 'get_form_settings_tip', 'p' );
 </table>
 
 <!--Permissions Section-->
-<?php do_action( 'frm_add_form_perm_options', $values ); ?>
-
 <?php
+do_action( 'frm_add_form_perm_options', $values );
+
 /*
  * We keep this section to make the frm_add_form_msg_options hook still work after we moved the Success message option
  * to the On Submit action, and moved the Draft message option to the below of its checkbox.


### PR DESCRIPTION
I notice in some support tickets people run out of memory in this code.

I was able to cut back the memory required by about ~17kb, nothing exciting, but I also got this running 31% faster.

Some of the main performance boosts happened from removing `strip_quotes` and moving its logic inline to cut back on the number of functions, and removing `read_one`, moving its logic inline as well. There's also a new `skip_next_character` function for skipping some of the logic when calling read.

I also worked on improving readability a bit and making functions smaller, by adding a new `parse_array`/`parse_string`/`parse_float`/`parse_int`/`parse_bool` functions.

**Other changes**
- The `discard_char` parameter was never used, and has been dropped to simplify the function.

**Using Apache Bench**
`ab -n 10000 -c 100 http://devsite.formidableforms.com:8889/test.php`

**Before** 11762ms
**After** 8109ms

🚀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the organization and readability of the string parsing functionality by separating methods for different data types.
	- Enhanced character reading logic in string reader helper, including adjustments for more accurate string handling and navigation.
	- Refactored the PHP code for better readability in form actions and advanced form settings views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->