### PR TITLE
Add isset check for inbox slidein

### DIFF
--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -511,7 +511,7 @@ class FrmInbox extends FrmFormApi {
 		return array_reduce(
 			$keys_to_return,
 			function ( $total, $key ) use ( $message ) {
-				$total[ $key ] = $message[ $key ];
+				$total[ $key ] = isset( $message[ $key ] ) ? $message[ $key ] : '';
 				return $total;
 			},
 			array()


### PR DESCRIPTION
**Related ticket** https://secure.helpscout.net/conversation/2575367680/196908

This update just adds a check that the keys are actually set first to avoid the warning.

Warning: Undefined array key "image" in /home/1210999.cloudwaysapps.com/xrqfjetdjw/public_html/wp-content/plugins/formidable/classes/models/FrmInbox.php on line 514
