### PR TITLE
Improve upgrade modal messages

### DIFF
--- a/classes/views/shared/upgrade_overlay.php
+++ b/classes/views/shared/upgrade_overlay.php
@@ -27,9 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					?>
 				</h2>
 				<div class="cta-inside">
-					<p class="frm-oneclick frm_hidden">
-						<?php esc_html_e( 'That add-on is not installed. Would you like to install it now?', 'formidable' ); ?>
-					</p>
+					<p class="frm-oneclick frm_hidden"></p>
 					<p class="frm-addon-status"></p>
 
 					<a class="button button-primary frm-button-primary frm_hidden frm-oneclick-button">

--- a/classes/views/shared/upgrade_overlay.php
+++ b/classes/views/shared/upgrade_overlay.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php
 					printf(
 						/* translators: %$1s: Feature name, %$2s: open span tag, %$3s: close span tag. */
-						esc_html__( '%1$s %2$sare not installed%3$s', 'formidable' ),
+						esc_html__( '%1$s %2$sare not available%3$s', 'formidable' ),
 						'<span class="frm_feature_label"></span>',
 						'<span class="frm_are_not_installed">',
 						'</span>'

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6796,8 +6796,15 @@ function frmAdminBuildJS() {
 
 			button.className   = button.className.replace( ' frm-install-addon', '' ).replace( ' frm-activate-addon', '' );
 			button.className   = button.className + ' ' + oneclick.class;
-			button.textContent = __( 'Activate', 'formidable' );
 			button.rel = oneclick.url;
+
+			if ( oneclick.class === 'frm-activate-addon' ) {
+				oneclickMessage.textContent = __( 'This plugin is not activated. Would you like to activate it now?', 'formidable' );
+				button.textContent = __( 'Activate', 'formidable' );
+			} else {
+				oneclickMessage.textContent = __( 'That add-on is not installed. Would you like to install it now?', 'formidable' );
+				button.textContent = __( 'Install', 'formidable' );
+			}
 		}
 
 		if ( ! newMessage ) {


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4745

**Examples**:
Quiz add-on deactive:
<img width="893" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/a123802a-8df3-4396-b570-df1ead2bb661">

Surveys not installed:
<img width="934" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/5e727215-c18e-42fc-af7a-76399d044d06">

### Test steps
1. Uninstall one add-on that has impact on available fields/actions. (Ex. Quiz add-on)
2. Install but deactivate another add-on that has impact on available fields/actions. (Ex. Signature, or Surveys add-ons)
3. Go to form builder and actions to test the upgrade modal's messages related to those add-ons.
4. Confirm that the modal message reflects the current status of the add-ons, i.e the modal cta button should be labelled 'Activate' and message should be `This plugin is not activated. Would you like to activate it now?`  if the add-on is installed but deactivated and 'Install' + (`That add-on is not installed. Would you like to install it now?`) if the add on is not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated messaging in the upgrade overlay to correctly indicate features that are not available rather than not installed.
	- Adjusted button text and messages in the admin panel to reflect the correct action (Activate or Install) based on the component status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->