### PR TITLE
Store and re-use field selection data

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -5,6 +5,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class FrmFieldsController {
 
+	/**
+	 * This is stored statically so we can re-use this data for every field.
+	 *
+	 * @var FrmFieldSelectionData|null
+	 */
+	private static $field_selection_data;
+
 	public static function load_field() {
 		FrmAppHelper::permission_check( 'frm_edit_forms' );
 		check_ajax_referer( 'frm_ajax', 'nonce' );
@@ -304,10 +311,10 @@ class FrmFieldsController {
 
 		$field_types = FrmFieldsHelper::get_field_types( $field['type'] );
 
-		$pro_field_selection = FrmField::pro_field_selection();
-		$all_field_types     = array_merge( $pro_field_selection, FrmField::field_selection() );
-		$disabled_fields     = FrmAppHelper::pro_is_installed() ? array() : $pro_field_selection;
-		$frm_settings        = FrmAppHelper::get_settings();
+		$field_selection_data = self::maybe_define_field_selection_data();
+		$all_field_types      = $field_selection_data->all_field_types;
+		$disabled_fields      = $field_selection_data->disabled_fields;
+		$frm_settings         = FrmAppHelper::get_settings();
 
 		if ( ! isset( $all_field_types[ $field['type'] ] ) ) {
 			// Add fallback for an add-on field type that has been deactivated.
@@ -334,6 +341,18 @@ class FrmFieldsController {
 		}
 
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/settings.php';
+	}
+
+	/**
+	 * @since x.x
+	 *
+	 * @return FrmFieldSelectionData
+	 */
+	private static function maybe_define_field_selection_data() {
+		if ( ! isset( self::$field_selection_data ) ) {
+			self::$field_selection_data = new FrmFieldSelectionData();
+		}
+		return self::$field_selection_data;
 	}
 
 	/**

--- a/classes/models/FrmFieldSelectionData.php
+++ b/classes/models/FrmFieldSelectionData.php
@@ -23,8 +23,8 @@ class FrmFieldSelectionData {
 	public $disabled_fields;
 
 	public function __construct() {
-		$pro_field_selection = FrmField::pro_field_selection();
-		$this->all_field_types     = array_merge( $pro_field_selection, FrmField::field_selection() );
-		$this->disabled_fields     = FrmAppHelper::pro_is_installed() ? array() : $pro_field_selection;
+		$pro_field_selection   = FrmField::pro_field_selection();
+		$this->all_field_types = array_merge( $pro_field_selection, FrmField::field_selection() );
+		$this->disabled_fields = FrmAppHelper::pro_is_installed() ? array() : $pro_field_selection;
 	}
 }

--- a/classes/models/FrmFieldSelectionData.php
+++ b/classes/models/FrmFieldSelectionData.php
@@ -1,0 +1,30 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'You are not allowed to call this page directly.' );
+}
+
+/**
+ * This is a simple data object for field selection data.
+ * Used in the form builder.
+ *
+ * @since x.x
+ */
+class FrmFieldSelectionData {
+
+	/**
+	 * @var array
+	 */
+	public $all_field_types;
+
+	/**
+	 * @var array
+	 */
+	public $disabled_fields;
+
+	public function __construct() {
+		$pro_field_selection = FrmField::pro_field_selection();
+		$this->all_field_types     = array_merge( $pro_field_selection, FrmField::field_selection() );
+		$this->disabled_fields     = FrmAppHelper::pro_is_installed() ? array() : $pro_field_selection;
+	}
+}


### PR DESCRIPTION
This code is called for every field shown in the form.

```
$pro_field_selection = FrmField::pro_field_selection();
$all_field_types        = array_merge( $pro_field_selection, FrmField::field_selection() );
$disabled_fields       = FrmAppHelper::pro_is_installed() ? array() : $pro_field_selection;
```

The result is always the same though, and this code isn't free.

This update takes my page loads (for a very large form) from ~77 seconds to ~69 seconds, saving approximately 8 seconds. for a ~10.5% speed improvement.

**Before**
<img width="542" alt="Screen Shot 2024-04-22 at 3 44 24 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/caa462cf-fca5-419d-92bb-14ed36a10a50">

**After**
<img width="558" alt="Screen Shot 2024-04-22 at 3 42 42 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/f6c9cee0-c9a0-4f1b-a3ce-d7e5bf8125cd">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced enhanced field selection data management in the form builder, improving the handling and storage of field types and attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->