### PR TITLE
Store and reuse type options for field type

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -12,6 +12,11 @@ class FrmFieldsController {
 	 */
 	private static $field_selection_data;
 
+	/**
+	 * @var array
+	 */
+	private static $field_type_data = array();
+
 	public static function load_field() {
 		FrmAppHelper::permission_check( 'frm_edit_forms' );
 		check_ajax_referer( 'frm_ajax', 'nonce' );
@@ -309,12 +314,11 @@ class FrmFieldsController {
 			$field['read_only'] = false;
 		}
 
-		$field_types = FrmFieldsHelper::get_field_types( $field['type'] );
-
 		$field_selection_data = self::maybe_define_field_selection_data();
 		$all_field_types      = $field_selection_data->all_field_types;
 		$disabled_fields      = $field_selection_data->disabled_fields;
 		$frm_settings         = FrmAppHelper::get_settings();
+		$field_types          = FrmFieldTypeOptionData::get_field_types( $field['type'] );
 
 		if ( ! isset( $all_field_types[ $field['type'] ] ) ) {
 			// Add fallback for an add-on field type that has been deactivated.

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -12,11 +12,6 @@ class FrmFieldsController {
 	 */
 	private static $field_selection_data;
 
-	/**
-	 * @var array
-	 */
-	private static $field_type_data = array();
-
 	public static function load_field() {
 		FrmAppHelper::permission_check( 'frm_edit_forms' );
 		check_ajax_referer( 'frm_ajax', 'nonce' );

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1160,15 +1160,14 @@ class FrmFieldsHelper {
 
 	/**
 	 * @param string $type
-	 * @return array $field_types
+	 * @return array
 	 */
 	public static function get_field_types( $type ) {
-		$single_input   = self::single_input_fields();
-		$multiple_input = array( 'radio', 'checkbox', 'select', 'scale', 'star', 'lookup' );
-
+		$single_input    = self::single_input_fields();
+		$multiple_input  = array( 'radio', 'checkbox', 'select', 'scale', 'star', 'lookup' );
 		$field_selection = FrmField::all_field_selection();
+		$field_types     = array();
 
-		$field_types = array();
 		if ( in_array( $type, $single_input, true ) ) {
 			self::field_types_for_input( $single_input, $field_selection, $field_types );
 		} elseif ( in_array( $type, $multiple_input, true ) ) {

--- a/classes/models/FrmFieldTypeOptionData.php
+++ b/classes/models/FrmFieldTypeOptionData.php
@@ -1,0 +1,27 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'You are not allowed to call this page directly.' );
+}
+
+/**
+ * This class keeps a static record of field type options for each type.
+ * The result is stored in memory so it can be re-used.
+ *
+ * @since x.x
+ */
+class FrmFieldTypeOptionData {
+
+	private static $data = array();
+
+	/**
+	 * @param string $type
+	 * @return array
+	 */
+	public static function get_field_types( $type ) {
+		if ( ! isset( self::$data[ $type ] ) ) {
+			self::$data[ $type ] = FrmFieldsHelper::get_field_types( $type );
+		}
+		return self::$data[ $type ];
+	}
+}


### PR DESCRIPTION
This update stores and re-uses the type options for each field type.

With a really long form, my load page is down from ~68.5 seconds to ~61.7 seconds, a ~6.8 second savings, about 10% faster.

**Before**
<img width="534" alt="Screen Shot 2024-04-22 at 4 11 29 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/b56e2675-e8b9-4226-8ecb-513c1854b478">

**After**
<img width="539" alt="Screen Shot 2024-04-22 at 4 07 38 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/057fae17-f910-4917-bf3f-f75d6ad814ed">
