### PR TITLE
Stop hiding deprecated messages in phpcs config

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,9 +2,6 @@
 <ruleset name="Formidable Forms">
 	<description>Formidable Forms rules for PHP_CodeSniffer</description>
 
-	<!-- This is required to run PHPCS in PHP 8 -->
-	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
-
 	<exclude-pattern>vendor/*</exclude-pattern>
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>deprecated/*</exclude-pattern>


### PR DESCRIPTION
This isn't necessary anymore. Just for the old version of phpcs that was being used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed specific settings to enhance compatibility with PHP 8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->