### PR TITLE
Remove some old IE polyfills

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1140,51 +1140,6 @@ function frmFrontFormJS() {
 		return false;
 	}
 
-	/**********************************************
-	 * Fallback functions
-	 *********************************************/
-
-	function addTrimFallbackForIE() {
-		if ( typeof String.prototype.trim !== 'function' ) {
-			String.prototype.trim = function() {
-				return this.replace( /^\s+|\s+$/g, '' );
-			};
-		}
-	}
-
-	function addFilterFallbackForIE() {
-		var t, len, res, thisp, i, val;
-
-		if ( ! Array.prototype.filter ) {
-
-			Array.prototype.filter = function( fun /*, thisp */ ) {
-
-				if ( this === void 0 || this === null ) {
-					throw new TypeError();
-				}
-
-				t = Object( this );
-				len = t.length >>> 0;
-				if ( typeof fun !== 'function' ) {
-					throw new TypeError();
-				}
-
-				res = [];
-				thisp = arguments[1];
-				for ( i = 0; i < len; i++ ) {
-					if ( i in t ) {
-						val = t[i]; // in case fun mutates this
-						if ( fun.call( thisp, val, i, t ) ) {
-							res.push( val );
-						}
-					}
-				}
-
-				return res;
-			};
-		}
-	}
-
 	/**
 	 * Check for -webkit-box-shadow css value for input:-webkit-autofill selector.
 	 * If this is a match, the User is autofilling the input on a Webkit browser.
@@ -1581,10 +1536,6 @@ function frmFrontFormJS() {
 
 			// Focus on the first sub field when clicking to the primary label of combo field.
 			changeFocusWhenClickComboFieldLabel();
-
-			// Add fallbacks for IE.
-			addTrimFallbackForIE(); // Trim only works in IE10+.
-			addFilterFallbackForIE(); // Filter is not supported in any version of IE.
 
 			initFloatingLabels();
 			maybeShowNewTabFallbackMessage();


### PR DESCRIPTION
I checked and these should both work in IE 10+. We don't really need to support anything older than IE11 at this point.

I added the `// Filter is not supported in any version of IE.` comment. It looks like I got that comment wrong when I last visited this code. I tested and confirmed it works fine in Browserstack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed outdated fallback functions for `trim` and `filter` operations to streamline form interactions and CSS value handling, enhancing performance and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->