### PR TITLE
Enforce order of since comment tag

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -3,7 +3,9 @@
 $finder = ( new PhpCsFixer\Finder() )->in( __DIR__ );
 $rules  = array(
 	// Keep these rules for sure.
-	'phpdoc_order'                => true,
+	'phpdoc_order'                => array(
+		'order' => array( 'since', 'param', 'throws', 'return' ),
+	),
 	'phpdoc_scalar'               => true,
 	'phpdoc_trim'                 => true,
 	'phpdoc_var_without_name'     => true,

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2822,9 +2822,8 @@ class FrmFormsController {
 	}
 
 	/**
-	 * @return string - 'before', 'after', or 'submit'
-	 *
 	 * @since 4.05.02
+	 * @return string - 'before', 'after', or 'submit'
 	 */
 	private static function message_placement( $form, $message ) {
 		$place = 'before';
@@ -2838,9 +2837,8 @@ class FrmFormsController {
 		}
 
 		/**
-		 * @return string - 'before' or 'after'
-		 *
 		 * @since 4.05.02
+		 * @return string - 'before' or 'after'
 		 */
 		return apply_filters( 'frm_message_placement', $place, compact( 'form', 'message' ) );
 	}

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -1146,10 +1146,9 @@ class FrmStylesController {
 	}
 
 	/**
+	 * @since 3.0
 	 * @param object $style
 	 * @param string $class
-	 *
-	 * @since 3.0
 	 */
 	private static function maybe_add_rtl_class( $style, &$class ) {
 		$is_rtl = isset( $style->post_content['direction'] ) && 'rtl' === $style->post_content['direction'];

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1360,10 +1360,9 @@ class FrmFieldsHelper {
 	}
 
 	/**
+	 * @since 2.0.6
 	 * @param array $args
 	 * @param array $other_args
-	 *
-	 * @since 2.0.6
 	 */
 	private static function set_other_name( $args, &$other_args ) {
 		// Set up name for other field
@@ -1381,10 +1380,10 @@ class FrmFieldsHelper {
 	/**
 	 * Find the parent and pointer, and get text for "other" text field
 	 *
-	 * @param array $args
-	 * @param array $other_args
 	 *
 	 * @since 2.0.6
+	 * @param array $args
+	 * @param array $other_args
 	 */
 	private static function set_other_value( $args, &$other_args ) {
 		$parent  = '';
@@ -1413,9 +1412,9 @@ class FrmFieldsHelper {
 	/**
 	 * If this field includes an other option, show it
 	 *
-	 * @param array $args
 	 *
 	 * @since 2.0.6
+	 * @param array $args
 	 */
 	public static function include_other_input( $args ) {
 		if ( ! $args['other_opt'] ) {

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1380,7 +1380,6 @@ class FrmFieldsHelper {
 	/**
 	 * Find the parent and pointer, and get text for "other" text field
 	 *
-	 *
 	 * @since 2.0.6
 	 * @param array $args
 	 * @param array $other_args
@@ -1411,7 +1410,6 @@ class FrmFieldsHelper {
 
 	/**
 	 * If this field includes an other option, show it
-	 *
 	 *
 	 * @since 2.0.6
 	 * @param array $args

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -62,11 +62,10 @@ class FrmFormsHelper {
 	}
 
 	/**
+	 * @since 2.0.6
 	 * @param string $class
 	 * @param string $param
 	 * @param array  $add_html
-	 *
-	 * @since 2.0.6
 	 */
 	public static function add_html_attr( $class, $param, &$add_html ) {
 		if ( ! empty( $class ) ) {
@@ -407,10 +406,9 @@ class FrmFormsHelper {
 	}
 
 	/**
+	 * @since 2.0.6
 	 * @param array $options
 	 * @param array $values
-	 *
-	 * @since 2.0.6
 	 */
 	public static function fill_form_options( &$options, $values ) {
 		$defaults = self::get_default_opts();
@@ -971,9 +969,9 @@ BEFORE_HTML;
 	/**
 	 * Display the validation error messages when an entry is submitted
 	 *
-	 * @param array $args Includes img, errors.
 	 *
 	 * @since 2.0.6
+	 * @param array $args Includes img, errors.
 	 */
 	public static function show_errors( $args ) {
 		$invalid_msg = self::get_invalid_error_message( $args );
@@ -999,9 +997,9 @@ BEFORE_HTML;
 	 * The image was removed from the styling settings, but it may still be set with a hook
 	 * If the message in the global settings is empty, show every validation message in the error box
 	 *
-	 * @param array $args Includes img, errors, and show_img.
 	 *
 	 * @since 2.0.6
+	 * @param array $args Includes img, errors, and show_img.
 	 */
 	public static function show_error( $args ) {
 		// remove any blank messages

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -969,7 +969,6 @@ BEFORE_HTML;
 	/**
 	 * Display the validation error messages when an entry is submitted
 	 *
-	 *
 	 * @since 2.0.6
 	 * @param array $args Includes img, errors.
 	 */
@@ -996,7 +995,6 @@ BEFORE_HTML;
 	 * Display the error message in the front-end along with the image if set
 	 * The image was removed from the styling settings, but it may still be set with a hook
 	 * If the message in the global settings is empty, show every validation message in the error box
-	 *
 	 *
 	 * @since 2.0.6
 	 * @param array $args Includes img, errors, and show_img.

--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -321,10 +321,9 @@ class FrmStylesHelper {
 	}
 
 	/**
+	 * @since 2.3
 	 * @param string $hex   string  The original color in hex format #ffffff.
 	 * @param int    $steps integer Should be between -255 and 255. Negative = darker, positive = lighter.
-	 *
-	 * @since 2.3
 	 */
 	public static function adjust_brightness( $hex, $steps ) {
 		$steps = max( - 255, min( 255, $steps ) );

--- a/classes/models/FrmDb.php
+++ b/classes/models/FrmDb.php
@@ -600,7 +600,6 @@ class FrmDb {
 	/**
 	 * Prepare and save settings in styles and actions
 	 *
-	 *
 	 * @since 2.05.06
 	 * @param array  $settings
 	 * @param string $group

--- a/classes/models/FrmDb.php
+++ b/classes/models/FrmDb.php
@@ -532,9 +532,8 @@ class FrmDb {
 	}
 
 	/**
-	 * @param string $limit
-	 *
 	 * @since 2.05.06
+	 * @param string $limit
 	 */
 	public static function esc_limit( $limit ) {
 		if ( empty( $limit ) ) {
@@ -601,10 +600,10 @@ class FrmDb {
 	/**
 	 * Prepare and save settings in styles and actions
 	 *
-	 * @param array  $settings
-	 * @param string $group
 	 *
 	 * @since 2.05.06
+	 * @param array  $settings
+	 * @param string $group
 	 */
 	public static function save_settings( $settings, $group ) {
 		$settings                 = (array) $settings;

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -337,9 +337,9 @@ class FrmEntry {
 	/**
 	 * If $entry is numeric, get the entry object
 	 *
-	 * @param int|object $entry By reference.
 	 *
 	 * @since 2.0.9
+	 * @param int|object $entry By reference.
 	 */
 	public static function maybe_get_entry( &$entry ) {
 		if ( $entry && is_numeric( $entry ) ) {

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -337,7 +337,6 @@ class FrmEntry {
 	/**
 	 * If $entry is numeric, get the entry object
 	 *
-	 *
 	 * @since 2.0.9
 	 * @param int|object $entry By reference.
 	 */

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -759,9 +759,9 @@ class FrmForm {
 	/**
 	 * If $form is numeric, get the form object
 	 *
-	 * @param int|object $form
 	 *
 	 * @since 2.0.9
+	 * @param int|object $form
 	 */
 	public static function maybe_get_form( &$form ) {
 		if ( ! is_object( $form ) && ! is_array( $form ) && ! empty( $form ) ) {

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -759,7 +759,6 @@ class FrmForm {
 	/**
 	 * If $form is numeric, get the form object
 	 *
-	 *
 	 * @since 2.0.9
 	 * @param int|object $form
 	 */

--- a/classes/models/FrmPluginSearch.php
+++ b/classes/models/FrmPluginSearch.php
@@ -26,9 +26,9 @@ class FrmPluginSearch {
 	/**
 	 * Add actions and filters only if this is the plugin installation screen and it's the first page.
 	 *
-	 * @param object $screen WP Screen object.
 	 *
 	 * @since 4.12
+	 * @param object $screen WP Screen object.
 	 *
 	 * @return void
 	 */
@@ -183,9 +183,9 @@ class FrmPluginSearch {
 	/**
 	 * Modify URL used to fetch to plugin information so it pulls Formidable plugin page.
 	 *
-	 * @param string $url URL to load in dialog pulling the plugin page from wporg.
 	 *
 	 * @since 4.12
+	 * @param string $url URL to load in dialog pulling the plugin page from wporg.
 	 *
 	 * @return string The URL with 'formidable' instead of 'frm-plugin-search'.
 	 */

--- a/classes/models/FrmPluginSearch.php
+++ b/classes/models/FrmPluginSearch.php
@@ -26,7 +26,6 @@ class FrmPluginSearch {
 	/**
 	 * Add actions and filters only if this is the plugin installation screen and it's the first page.
 	 *
-	 *
 	 * @since 4.12
 	 * @param object $screen WP Screen object.
 	 *
@@ -182,7 +181,6 @@ class FrmPluginSearch {
 
 	/**
 	 * Modify URL used to fetch to plugin information so it pulls Formidable plugin page.
-	 *
 	 *
 	 * @since 4.12
 	 * @param string $url URL to load in dialog pulling the plugin page from wporg.

--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -176,7 +176,6 @@ class FrmTableHTMLGenerator {
 	/**
 	 * Determine if setting is for a color, e.g. text color, background color, or border color
 	 *
-	 *
 	 * @since 2.05
 	 * @param string $setting_key Name of setting.
 	 *
@@ -188,7 +187,6 @@ class FrmTableHTMLGenerator {
 
 	/**
 	 * Get color markup from color setting value
-	 *
 	 *
 	 * @since 2.05
 	 * @param string $color_markup value of a color setting, with format #FFFFF, FFFFFF, or white.

--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -176,9 +176,9 @@ class FrmTableHTMLGenerator {
 	/**
 	 * Determine if setting is for a color, e.g. text color, background color, or border color
 	 *
-	 * @param string $setting_key Name of setting.
 	 *
 	 * @since 2.05
+	 * @param string $setting_key Name of setting.
 	 *
 	 * @return bool
 	 */
@@ -189,9 +189,9 @@ class FrmTableHTMLGenerator {
 	/**
 	 * Get color markup from color setting value
 	 *
-	 * @param string $color_markup value of a color setting, with format #FFFFF, FFFFFF, or white.
 	 *
 	 * @since 2.05
+	 * @param string $color_markup value of a color setting, with format #FFFFF, FFFFFF, or white.
 	 *
 	 * @return string
 	 */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
    - Updated PHPDoc annotations across various classes for improved clarity and order of tags.
    - Corrected and enhanced method descriptions and parameter documentation in multiple files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->