### PR TITLE
Fix pro issue 5003 / Add deprecated messages for the use HTML5 setting

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -583,6 +583,7 @@ class FrmAppController {
 		}
 
 		self::maybe_add_ip_warning();
+		self::maybe_add_deprecated_message();
 	}
 
 	/**
@@ -1221,48 +1222,6 @@ class FrmAppController {
 	}
 
 	/**
-	 * @deprecated 3.0.04
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @return void
-	 */
-	public static function activation_install() {
-		FrmDeprecated::activation_install();
-	}
-
-	/**
-	 * @deprecated 3.0
-	 * @codeCoverageIgnore
-	 */
-	public static function page_route( $content ) {
-		return FrmDeprecated::page_route( $content );
-	}
-
-	/**
-	 * Include icons on page for Embed Form modal.
-	 *
-	 * @since 5.2
-	 *
-	 * @return void
-	 */
-	public static function include_embed_form_icons() {
-		_deprecated_function( __METHOD__, '5.3' );
-	}
-
-	/**
-	 * @deprecated 1.07.05 This is still referenced in the API add on as of v1.13.
-	 * @codeCoverageIgnore
-	 *
-	 * @param array $atts
-	 * @return string
-	 */
-	public static function get_form_shortcode( $atts ) {
-		_deprecated_function( __FUNCTION__, '1.07.05', 'FrmFormsController::get_form_shortcode' );
-		return FrmFormsController::get_form_shortcode( $atts );
-	}
-
-	/**
 	 * Handles Floating Links' scripts and styles enqueueing.
 	 *
 	 * @since 6.4
@@ -1302,5 +1261,90 @@ class FrmAppController {
 		 * @since 6.8.4
 		 */
 		do_action( 'frm_enqueue_floating_links' );
+	}
+
+	/**
+	 * @return void
+	 */
+	private static function maybe_add_deprecated_message() {
+		$settings = FrmAppHelper::get_settings();
+
+		if ( ! empty( $settings->use_html ) ) {
+			// Dont' show a message if Use HTML 5 is already enabled.
+			return;
+		}
+
+		if ( FrmAppHelper::is_admin_page( 'formidable-settings' ) ) {
+			// Don't show the message on global settings.
+			return;
+		}
+
+		$url = admin_url( 'admin.php?page=formidable-settings&t=misc_settings' );
+
+		add_filter(
+			'frm_message_list',
+			/**
+			 * @param array $messages
+			 * @return array
+			 */
+			function ( $messages ) use ( $url ) {
+				$messages[] = '<p>The option to use HTML5 in forms is currently disabled. In a future release, this setting will be removed and using HTML5 will be a requirement. <a href="' . esc_url( $url ) . '">Click here to enable it in Global Settings now</a>.</p>';
+				return $messages;
+			}
+		);
+
+		$inbox = new FrmInbox();
+		$inbox->add_message(
+			array(
+				'key'     => 'deprecated_use_html',
+				'force'   => true,
+				'subject' => 'The option to use HTML5 in forms will soon be removed',
+				'message' => 'The option to use HTML5 in forms is currently disabled. In a future release, this setting will be removed and using HTML5 will be a requirement.',
+				'icon'    => 'frm_report_problem_icon',
+				'cta'     => '<a class="button-secondary frm-button-secondary" href="' . esc_url( $url ) . '">Enable in Global Settings</a>',
+			)
+		);
+	}
+
+	/**
+	 * Include icons on page for Embed Form modal.
+	 *
+	 * @since 5.2
+	 *
+	 * @return void
+	 */
+	public static function include_embed_form_icons() {
+		_deprecated_function( __METHOD__, '5.3' );
+	}
+
+	/**
+	 * @deprecated 1.07.05 This is still referenced in the API add on as of v1.13.
+	 * @codeCoverageIgnore
+	 *
+	 * @param array $atts
+	 * @return string
+	 */
+	public static function get_form_shortcode( $atts ) {
+		_deprecated_function( __FUNCTION__, '1.07.05', 'FrmFormsController::get_form_shortcode' );
+		return FrmFormsController::get_form_shortcode( $atts );
+	}
+
+	/**
+	 * @deprecated 3.0.04
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return void
+	 */
+	public static function activation_install() {
+		FrmDeprecated::activation_install();
+	}
+
+	/**
+	 * @deprecated 3.0
+	 * @codeCoverageIgnore
+	 */
+	public static function page_route( $content ) {
+		return FrmDeprecated::page_route( $content );
 	}
 }

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -1275,6 +1275,15 @@ class FrmAppController {
 		}
 
 		if ( FrmAppHelper::is_admin_page( 'formidable-settings' ) ) {
+			add_action(
+				'frm_update_settings',
+				function ( $params ) {
+					if ( ! empty( $params['frm_use_html'] ) ) {
+						$inbox = new FrmInbox();
+						$inbox->dismiss( 'deprecated_use_html' );
+					}
+				}
+			);
 			// Don't show the message on global settings.
 			return;
 		}

--- a/classes/views/frm-settings/misc.php
+++ b/classes/views/frm-settings/misc.php
@@ -42,8 +42,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 </p>
 
 <!-- Deprecated settings can only be switched away from the default -->
-<input type="hidden" name="frm_use_html" value="1" />
-
 <?php if ( empty( $frm_settings->use_html ) ) { ?>
 <p>
 	<label for="frm_use_html">
@@ -52,6 +50,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<span class="frm_help frm_icon_font frm_tooltip_icon" title="<?php esc_attr_e( 'We recommend using HTML 5 for your forms. It adds some nifty options like placeholders, patterns, and autocomplete.', 'formidable' ); ?>"></span>
 	</label>
 </p>
+<?php } else { ?>
+	<input type="hidden" name="frm_use_html" value="1" />
 <?php } ?>
 
 <p class="frm_uninstall">

--- a/classes/views/frm-settings/misc.php
+++ b/classes/views/frm-settings/misc.php
@@ -42,16 +42,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 </p>
 
 <!-- Deprecated settings can only be switched away from the default -->
-<input type="hidden" id="frm_use_html" name="frm_use_html" value="1" />
+<input type="hidden" name="frm_use_html" value="1" />
 
 <?php if ( empty( $frm_settings->use_html ) ) { ?>
 <p>
 	<label for="frm_use_html">
 		<input type="checkbox" id="frm_use_html" name="frm_use_html" value="1" <?php checked( $frm_settings->use_html, 1 ); ?> />
 		<?php esc_html_e( 'Use HTML5 in forms', 'formidable' ); ?>
+		<span class="frm_help frm_icon_font frm_tooltip_icon" title="<?php esc_attr_e( 'We recommend using HTML 5 for your forms. It adds some nifty options like placeholders, patterns, and autocomplete.', 'formidable' ); ?>"></span>
 	</label>
-	<span class="frm_help frm_icon_font frm_tooltip_icon"
-	title="<?php esc_attr_e( 'We recommend using HTML 5 for your forms. It adds some nifty options like placeholders, patterns, and autocomplete.', 'formidable' ); ?>"></span>
 </p>
 <?php } ?>
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5003

I'm not positive anyone has this on because of the hidden input that's always set to 1. At least on Firefox, it would set the HTML5 setting on my first save event.

But just in case, I'm still adding these deprecated messages.

<img width="393" alt="Screen Shot 2024-04-24 at 3 32 07 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/6cf4c8af-5a2c-4a4c-9e61-12f4ef900dbf">

<img width="1173" alt="Screen Shot 2024-04-24 at 3 31 33 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/83079b45-3045-4db6-8b5e-058a8aed9313">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a system to display deprecation notices to guide users towards updated practices.

- **Refactor**
	- Improved the organization and clarity of deprecation notices in the application.

- **Bug Fixes**
	- Enhanced HTML5 form compatibility by adjusting form element attributes and related logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->