### PR TITLE
Fix rootline/progress bar not show after and before submit button

### DIFF
--- a/classes/models/fields/FrmFieldSubmit.php
+++ b/classes/models/fields/FrmFieldSubmit.php
@@ -104,7 +104,19 @@ DEFAULT_HTML;
 		$values      = FrmAppHelper::setup_edit_vars( $form, 'forms' );
 
 		ob_start();
+
+		/**
+		 * @since 5.5.1
+		 */
+		do_action( 'frm_before_submit_btn', compact( 'form' ) );
+
 		FrmFormsHelper::get_custom_submit( $values['submit_html'], $form, $submit, $form_action, $values );
+
+		/**
+		 * @since 5.5.1
+		 */
+		do_action( 'frm_after_submit_btn', compact( 'form' ) );
+
 		return ob_get_clean();
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5011

Steps to replicate are in the issue.

There are 2 hooks are missing in the submit button field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new hooks to enhance extensibility, allowing custom actions to be executed before and after the submit button is rendered in forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->