### PR TITLE
Support conditional logic with stripe link

### DIFF
--- a/stripe/js/frmstrp.js
+++ b/stripe/js/frmstrp.js
@@ -581,7 +581,7 @@
 	 * Check if the submit button is conditionally disabled.
 	 * This is required for Stripe link so the button does not get enabled at the wrong time after completing the Stripe elements.
 	 *
-	 * @since 3.0
+	 * @since x.x
 	 *
 	 * @param {String} formId
 	 * @returns {bool}
@@ -593,7 +593,7 @@
 	/**
 	 * Check submit button is conditionally "hidden". This is also used for the enabled check and is used in submitButtonIsConditionallyDisabled.
 	 *
-	 * @since 3.0
+	 * @since x.x
 	 *
 	 * @param {String} formId
 	 * @returns bool


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/4908

Reflects changes in Stripe add-on (https://github.com/Strategy11/formidable-stripe/pull/332) in Lite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Stripe payment forms with conditional logic to enable or disable the submit button based on payment element completion, improving user interaction and form handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->