### PR TITLE
Add missing static method stubs and drop some old deprecated functions

### DIFF
--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -517,16 +517,6 @@ class FrmEntriesController {
 		self::display_list( $message );
 	}
 
-	/**
-	 * @deprecated 4.02.04 - Moved to Pro since it was unused in Lite.
-	 */
-	public static function destroy_all() {
-		_deprecated_function( __METHOD__, '4.02.04', 'FrmProEntriesController::destroy_all' );
-		if ( is_callable( 'FrmProEntriesController::destroy_all' ) ) {
-			FrmProEntriesController::destroy_all();
-		}
-	}
-
 	public static function process_entry( $errors = '', $ajax = false ) {
 		$form_id = FrmAppHelper::get_post_param( 'form_id', '', 'absint' );
 		if ( FrmAppHelper::is_admin() || empty( $_POST ) || empty( $form_id ) || ! isset( $_POST['item_key'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -4192,17 +4192,6 @@ class FrmAppHelper {
 	}
 
 	/**
-	 * @since 2.0
-	 * @deprecated 5.0.13
-	 *
-	 * @return string The base Google APIS url for the current version of jQuery UI
-	 */
-	public static function jquery_ui_base_url() {
-		_deprecated_function( __FUNCTION__, '5.0.13', 'FrmProAppHelper::jquery_ui_base_url' );
-		return is_callable( 'FrmProAppHelper::jquery_ui_base_url' ) ? FrmProAppHelper::jquery_ui_base_url() : '';
-	}
-
-	/**
 	 * @since 4.07
 	 * @deprecated 6.0
 	 */

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -267,7 +267,7 @@ class FrmFieldsHelper {
 	 *
 	 * @param object $field
 	 *
-	 * @return array
+	 * @return FrmFieldType
 	 */
 	private static function get_original_field( $field ) {
 		$original_type = FrmField::get_option( $field, 'original_type' );

--- a/classes/models/FrmApplicationTemplate.php
+++ b/classes/models/FrmApplicationTemplate.php
@@ -113,6 +113,10 @@ class FrmApplicationTemplate {
 	 * @return array
 	 */
 	public function as_js_object() {
+		if ( ! is_array( self::$keys ) ) {
+			return array();
+		}
+
 		$application = array();
 		foreach ( self::$keys as $key ) {
 			if ( ! isset( $this->api_data[ $key ] ) ) {

--- a/classes/views/xml/posts_xml.php
+++ b/classes/views/xml/posts_xml.php
@@ -78,13 +78,15 @@ while ( $next_posts = array_splice( $item_ids, 0, 20 ) ) {
 
 		if ( 'frm_display' === $post->post_type && is_callable( 'FrmViewsLayout::get_layouts_for_view' ) ) {
 			$layouts = FrmViewsLayout::get_layouts_for_view( $post->ID );
-			foreach ( $layouts as $layout ) {
-				?>
+			if ( is_array( $layouts ) ) {
+				foreach ( $layouts as $layout ) {
+					?>
 		<layout>
 			<type><?php echo esc_html( $layout->type ); ?></type>
 			<data><?php echo FrmXMLHelper::cdata( $layout->data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></data>
 		</layout>
 <?php
+				}
 			}
 		}
 		?>

--- a/deprecated/FrmDeprecated.php
+++ b/deprecated/FrmDeprecated.php
@@ -398,11 +398,11 @@ class FrmDeprecated {
 	/**
 	 * @deprecated 3.0
 	 *
-	 * @param string $html
-	 * @param array $field
-	 * @param array $errors
-	 * @param object $form
-	 * @param array $args
+	 * @param string       $html
+	 * @param array        $field
+	 * @param array        $errors
+	 * @param object|false $form
+	 * @param array        $args
 	 *
 	 * @return string
 	 */

--- a/deprecated/FrmDeprecated.php
+++ b/deprecated/FrmDeprecated.php
@@ -401,7 +401,7 @@ class FrmDeprecated {
 	 * @param string       $html
 	 * @param array        $field
 	 * @param array        $errors
-	 * @param object|false $form
+	 * @param false|object $form
 	 * @param array        $args
 	 *
 	 * @return string

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -41,7 +41,6 @@ parameters:
 		- '#might not be defined.#'
 		- '#no (typehint|value type|return typehint)+ specified.#'
 		- '#of echo cannot be converted to string.#'
-		- '#Call to an undefined static method#'
 		- '#on an unknown class (Elementor)#'
 		- '#get_mailer\(\) expects#'
 		- '#only iterables are supported#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -36,7 +36,7 @@
 		</InvalidGlobal>
 		<UndefinedDocblockClass>
 			<errorLevel type="suppress">
-				<directory name="classes" />
+				<file name="classes/controllers/FrmSMTPController.php" />
 			</errorLevel>
 		</UndefinedDocblockClass>
 		<UndefinedFunction>
@@ -47,11 +47,6 @@
 				<referencedFunction name="__autoload" />
 			</errorLevel>
 		</UndefinedFunction>
-		<InvalidParamDefault>
-			<errorLevel type="suppress">
-				<directory name="deprecated" />
-			</errorLevel>
-		</InvalidParamDefault>
 		<!-- Add exceptions for classes/views files. -->
 		<UndefinedGlobalVariable>
 			<errorLevel type="suppress">
@@ -130,8 +125,12 @@
 		</InvalidArgument>
 		<PossiblyUndefinedVariable>
 			<errorLevel type="suppress">
-				<directory name="classes" />
-				<directory name="stripe" />
+				<file name="stripe/views/action-settings/payments-options.php" />
+				<file name="classes/controllers/FrmApplicationsController.php" />
+				<file name="classes/controllers/FrmFieldsController.php" />
+				<file name="classes/controllers/FrmStylesController.php" />
+				<file name="classes/helpers/FrmCSVExportHelper.php" />
+				<file name="stripe/models/FrmStrpLiteAuth.php" />
 			</errorLevel>
 		</PossiblyUndefinedVariable>
 		<MissingClosureParamType>
@@ -294,12 +293,6 @@
 				<file name="formidable.php" />
 			</errorLevel>
 		</RedundantCondition>
-		<PossiblyNullIterator>
-			<errorLevel type="suppress">
-				<directory name="classes" />
-				<directory name="stripe" />
-			</errorLevel>
-		</PossiblyNullIterator>
 		<MoreSpecificImplementedParamType>
 			<errorLevel type="suppress">
 				<directory name="classes" />
@@ -413,12 +406,6 @@
 				<directory name="stripe" />
 			</errorLevel>
 		</UnsafeInstantiation>
-		<InvalidMethodCall>
-			<errorLevel type="suppress">
-				<directory name="classes" />
-				<directory name="stripe" />
-			</errorLevel>
-		</InvalidMethodCall>
 		<InvalidArrayAccess>
 			<errorLevel type="suppress">
 				<directory name="classes" />

--- a/stripe/models/FrmTransLiteSubscription.php
+++ b/stripe/models/FrmTransLiteSubscription.php
@@ -79,7 +79,7 @@ class FrmTransLiteSubscription extends FrmTransLiteDb {
 	}
 
 	/**
-	 * @return array|object|null
+	 * @return array
 	 */
 	public function get_overdue_subscriptions() {
 		global $wpdb;

--- a/stubs.php
+++ b/stubs.php
@@ -27,6 +27,11 @@ namespace {
 	}
 	class FrmProApplicationsHelper {
 		public static function get_custom_applications_capability() {}
+		/**
+		 * @return string
+		 */
+		public static function get_required_templates_capability() {
+		}
 	}
 	class FrmProFileImport {
 		public static function import_attachment( $val, $field ) {
@@ -47,6 +52,29 @@ namespace {
 		 */
 		public static function plugin_path() {
 		}
+		/**
+		 * @return bool
+		 */
+		public static function use_chosen_js() {
+		}
+		/**
+		 * @param array|string $selected
+		 * @param string       $current
+		 * @param bool         $echo
+		 * @return string
+		 */
+		public static function selected( $selected, $current, $echo = true ) {
+		}
+		/**
+		 * @return string
+		 */
+		public static function plugin_url() {
+		}
+		/**
+		 * @return FrmProEddController
+		 */
+		public static function get_updater() {
+		}
 	}
 	class FrmProEntryMetaHelper {
 		public static function get_post_or_meta_value( $entry, $field, $atts = array() ) {
@@ -63,19 +91,96 @@ namespace {
 		}
 	}
 	class FrmProFormActionsController {
+		/**
+		 * @param WP_Post  $action
+		 * @param stdClass $entry
+		 * @return bool
+		 */
+		public static function action_conditions_met( $action, $entry ) {
+		}
 	}
 	class FrmViewsLayout {
+		/**
+		 * @param int    $view_id
+		 * @param string $listing_layout
+		 * @param string $detail_layout
+		 */
+		public static function maybe_create_layouts_for_view( $view_id, $listing_layout, $detail_layout ) {
+		}
+		/**
+		 * @param int          $view_id
+		 * @param false|string $type
+		 * @return array|false|object
+		 */
+		public static function get_layouts_for_view( $view_id, $type = false ) {
+		}
 	}
 	class FrmProDisplaysHelper {
 		public static function get_shortcodes( $content, $form_id ) {
 		}
 	}
 	class FrmProAddonsController {
+		/**
+		 * @param bool $force_type
+		 * @return string
+		 */
+		public static function license_type( $force_type = false ) {
+		}
+		/**
+		 * @return bool|int
+		 */
+		public static function is_license_expiring() {
+		}
+		/**
+		 * @param string       $plugin
+		 * @param array|string $upgrade_link_args
+		 * @return void
+		 */
+		public static function conditional_action_button( $plugin, $upgrade_link_args ) {
+		}
+		/**
+		 * @param array $atts
+		 * @return void
+		 */
+		public static function show_conditional_action_button( $atts ) {
+		}
+		/**
+		 * @return bool
+		 */
+		public static function admin_banner() {
+		}
+		/**
+		 * @return string
+		 */
+		public static function get_readable_license_type() {
+		}
 	}
 	class FrmProDb {
 		public static $plug_version;
 	}
 	class FrmProStylesController extends FrmStylesController {
+		/**
+		 * @param int $form_id
+		 * @return WP_Post
+		 */
+		public static function get_active_style_for_form( $form_id ) {
+		}
+		/**
+		 * @param WP_Post|stdClass $active_style
+		 * @return array<WP_Post>
+		 */
+		public static function get_styles_for_styler( $active_style ) {
+		}
+		/**
+		 * @return array<string>
+		 */
+		public static function get_notes_for_styler_preview() {
+		}
+		/**
+		 * @return false|string
+		 */
+		public static function get_disabled_javascript_features() {
+		}
 	}
 	class FrmProPost {
 		/**
@@ -95,9 +200,35 @@ namespace {
 		 */
 		public static function entry_delete_link( $atts ) {
 		}
+		/**
+		 * @param string   $method
+		 * @param stdClass $form
+		 * @param int      $entry_id
+		 * @param array    $args
+		 */
+		public static function confirmation( $method, $form, $form_options, $entry_id, $args = array() ) {
+		}
+		/**
+		 * @param object $form
+		 * @return bool
+		 */
+		public static function is_form_displayed_after_edit( $form ) {
+		}
+		/**
+		 * @param object $entry
+		 * @param array  $args
+		 * @return void
+		 */
+		public static function show_front_end_form_with_entry( $entry, $args ) {
+		}
 	}
 	class FrmProFormsHelper {
 		public static function &post_type( $form ) {
+		}
+		/**
+		 * @return array
+		 */
+		public static function get_default_opts() {
 		}
 	}
 	class FrmProEntry {
@@ -139,6 +270,11 @@ namespace {
 		}
 	}
 	class FrmViewsAppHelper {
+		/**
+		 * @return string
+		 */
+		public static function plugin_version() {
+		}
 	}
 	class FrmProCreditCardsController {
 		/**
@@ -177,6 +313,31 @@ namespace {
 		public static $db_opt_name = 'frm_pay_db_version';
 	}
 	class FrmProDashboardHelper {
+		/**
+		 * @return bool
+		 */
+		public static function should_display_videos() {
+		}
+		/**
+		 * @param array $entries_template
+		 * @return void
+		 */
+		public static function get_main_widget( $entries_template ) {
+		}
+		/**
+		 * @param array $entries_template
+		 * @return void
+		 */
+		public static function get_bottom_widget( $entries_template ) {
+		}
+		/**
+		 * @param array $template
+		 * @return void
+		 */
+		public static function load_license_management( $template ) {
+		}
+	}
+	class FrmProEddController extends FrmAddon {
 	}
 	function load_formidable_pro() {
 	}

--- a/stubs.php
+++ b/stubs.php
@@ -166,7 +166,7 @@ namespace {
 		public static function get_active_style_for_form( $form_id ) {
 		}
 		/**
-		 * @param WP_Post|stdClass $active_style
+		 * @param stdClass|WP_Post $active_style
 		 * @return array<WP_Post>
 		 */
 		public static function get_styles_for_styler( $active_style ) {


### PR DESCRIPTION
I noticed this during code review. Static methods weren't requiring new stubs.

This update adds that requirement.

There's also some Psalm clean up here. I dropped a couple old methods that required stubs as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed deprecated methods and updated method return types in various classes for consistency and future-proofing.
  
- **Bug Fixes**
  - Added necessary checks to prevent errors when processing data that might not be in the expected format.

- **Documentation**
  - Removed outdated function related to jQuery UI, reflecting the previous deprecation in version updates.

- **New Features**
  - Introduced new capabilities and enhancements across the application to improve functionality and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->