### PR TITLE
Fix some phpstan contravariance issues

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1009,6 +1009,8 @@ DEFAULT_HTML;
 	}
 
 	/**
+	 * @param array $args
+	 * @param array $shortcode_atts
 	 * @return string
 	 */
 	public function front_field_input( $args, $shortcode_atts ) {

--- a/classes/models/fields/FrmFieldUserID.php
+++ b/classes/models/fields/FrmFieldUserID.php
@@ -82,10 +82,10 @@ class FrmFieldUserID extends FrmFieldType {
 	}
 
 	/**
-	 * @param string $value
-	 * @param array  $atts
+	 * @param array|string $value
+	 * @param array        $atts
 	 *
-	 * @return string
+	 * @return array|string A string is returned, but the return signature should match FrmFieldType.
 	 */
 	protected function prepare_display_value( $value, $atts ) {
 		$user_info = $this->prepare_user_info_attribute( $atts );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -62,7 +62,12 @@ parameters:
 		- '#of method FrmFieldName::\_\_construct#'
 		- '#callback of function spl_autoload_register expects#'
 		- '#Call to an undefined method FrmFieldType::get\_file\_id#'
-		- '#should be contravariant with#'
+		-
+			message: '#should be contravariant with#'
+			paths:
+				- classes/helpers/FrmFormsListHelper.php
+				- classes/models/FrmInstallerSkin.php
+				- stripe/controllers/FrmStrpLiteActionsController.php
 		- '#Construct empty\(\) is not allowed. Use more strict comparison#'
 		-
 			message: '#Foreach overwrites \$ip with its value variable.#'


### PR DESCRIPTION
This update just makes comment signatures more consistent to adhere to the Liskov substitution principle.