### PR TITLE
Do not init inbox if there are no importable forms

### DIFF
--- a/classes/helpers/FrmFormMigratorsHelper.php
+++ b/classes/helpers/FrmFormMigratorsHelper.php
@@ -42,9 +42,12 @@ class FrmFormMigratorsHelper {
 	 * @return void
 	 */
 	public static function maybe_add_to_inbox() {
-		$inbox = new FrmInbox();
 		$forms = self::import_links();
+		if ( ! $forms ) {
+			return;
+		}
 
+		$inbox = new FrmInbox();
 		foreach ( $forms as $form ) {
 			$inbox->add_message(
 				array(


### PR DESCRIPTION
This skips some logic that happens on the inbox constructor when it isn't needed.