### PR TITLE
Update quiz action type limit message

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7324,7 +7324,21 @@ function frmAdminBuildJS() {
 			}
 		}
 
+		if ( frmAdminJs.quiz_action_type_limit && shouldShowQuizActionLimitMessage( this ) ) {
+			message = frmAdminJs.quiz_action_type_limit;
+		}
+
 		infoModal( message );
+	}
+
+	function shouldShowQuizActionLimitMessage( actionLi ) {
+		if ( actionLi.dataset.actiontype !== 'quiz_outcome' && actionLi.dataset.actiontype !== 'quiz' ) {
+			return false;
+		}
+		if ( actionLi.dataset.actiontype === 'quiz_outcome' && document.querySelector( '.frm_form_action_settings.frm_single_quiz_settings' ) ) {
+			return true;
+		}
+		return actionLi.dataset.actiontype === 'quiz' && document.querySelector( '.frm_form_action_settings.frm_single_quiz_outcome_settings' );
 	}
 
 	function addFormLogicRow() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7331,14 +7331,20 @@ function frmAdminBuildJS() {
 		infoModal( message );
 	}
 
-	function shouldShowQuizActionLimitMessage( actionLi ) {
-		if ( actionLi.dataset.actiontype !== 'quiz_outcome' && actionLi.dataset.actiontype !== 'quiz' ) {
+	/**
+	 * Returns true if user is trying to add a quiz action while another type is already added.
+	 *
+	 * @param {HTMLElement} addActionButton
+	 * @returns {Boolean}
+	 */
+	function shouldShowQuizActionLimitMessage( addActionButton ) {
+		if ( addActionButton.dataset.actiontype !== 'quiz_outcome' && addActionButton.dataset.actiontype !== 'quiz' ) {
 			return false;
 		}
-		if ( actionLi.dataset.actiontype === 'quiz_outcome' && document.querySelector( '.frm_form_action_settings.frm_single_quiz_settings' ) ) {
+		if ( addActionButton.dataset.actiontype === 'quiz_outcome' && document.querySelector( '.frm_single_quiz_settings' ) ) {
 			return true;
 		}
-		return actionLi.dataset.actiontype === 'quiz' && document.querySelector( '.frm_form_action_settings.frm_single_quiz_outcome_settings' );
+		return addActionButton.dataset.actiontype === 'quiz' && document.querySelector( '.frm_single_quiz_outcome_settings' );
 	}
 
 	function addFormLogicRow() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7324,7 +7324,7 @@ function frmAdminBuildJS() {
 			}
 		}
 
-		if ( frmAdminJs.quiz_action_type_limit && shouldShowQuizActionLimitMessage( this ) ) {
+		if ( frmAdminJs.quiz_action_type_limit && shouldShowQuizTypeLimitMessage( this ) ) {
 			message = frmAdminJs.quiz_action_type_limit;
 		}
 
@@ -7337,7 +7337,7 @@ function frmAdminBuildJS() {
 	 * @param {HTMLElement} addActionButton
 	 * @returns {Boolean}
 	 */
-	function shouldShowQuizActionLimitMessage( addActionButton ) {
+	function shouldShowQuizTypeLimitMessage( addActionButton ) {
 		if ( addActionButton.dataset.actiontype !== 'quiz_outcome' && addActionButton.dataset.actiontype !== 'quiz' ) {
 			return false;
 		}


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-quizzes/issues/198

Requires https://github.com/Strategy11/formidable-quizzes/pull/201

### Screenshots
<img width="1141" alt="image" src="https://github.com/Strategy11/formidable-quizzes/assets/41271840/8e0aebae-4d30-45e7-b37d-762916e1ae80">

### Test steps
1. Add one type of a Quiz action (either Scored or Outcome)
2. Try adding the other Quiz type not already added
3. Confirm that a message appears that states only one Quiz action type could be included in a given form.