### PR TITLE
Add no jquery ruleset to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,8 @@
 		"plugin:react/recommended",
 		"plugin:jsx-a11y/recommended",
 		"plugin:sonarjs/recommended-legacy",
-		"plugin:cypress/recommended"
+		"plugin:cypress/recommended",
+		"plugin:no-jquery/deprecated"
 	],
 	"env": {
 		"browser": true,
@@ -31,7 +32,7 @@
 		"window": true,
 		"document": true
 	},
-	"plugins": ["react", "jsx-a11y", "sonarjs", "cypress"],
+	"plugins": ["react", "jsx-a11y", "sonarjs", "cypress", "no-jquery"],
 	"settings": {
 		"react": {
 			"pragma": "wp"
@@ -73,6 +74,51 @@
 		"sonarjs/prefer-single-boolean-return": "off",
 		"sonarjs/no-collapsible-if": "off",
 		"sonarjs/no-duplicated-branches": "off",
-		"sonarjs/no-nested-template-literals": "off"
+		"sonarjs/no-nested-template-literals": "off",
+		"no-jquery/no-ready-shorthand": "off",
+		"no-jquery/no-ajax-events": "error",
+		"no-jquery/no-animate-toggle": "error",
+		"no-jquery/no-bind": "error",
+		"no-jquery/no-box-model": "error",
+		"no-jquery/no-browser": "error",
+		"no-jquery/no-camel-case": "error",
+		"no-jquery/no-constructor-attributes": "error",
+		"no-jquery/no-contains": "error",
+		"no-jquery/no-deferred": "error",
+		"no-jquery/no-delegate": "error",
+		"no-jquery/no-error": "error",
+		"no-jquery/no-escape-selector": "error",
+		"no-jquery/no-extend": "error",
+		"no-jquery/no-fx-interval": "error",
+		"no-jquery/no-global-eval": "error",
+		"no-jquery/no-has": "error",
+		"no-jquery/no-hold-ready": "error",
+		"no-jquery/no-is-array": "error",
+		"no-jquery/no-is-empty-object": "error",
+		"no-jquery/no-is-function": "error",
+		"no-jquery/no-is-numeric": "error",
+		"no-jquery/no-is-plain-object": "error",
+		"no-jquery/no-is-window": "error",
+		"no-jquery/no-load": "error",
+		"no-jquery/no-load-shorthand": "error",
+		"no-jquery/no-map": "error",
+		"no-jquery/no-map-collection": "error",
+		"no-jquery/no-map-util": "error",
+		"no-jquery/no-merge": "error",
+		"no-jquery/no-node-name": "error",
+		"no-jquery/no-noop": "error",
+		"no-jquery/no-now": "error",
+		"no-jquery/no-other-utils": "error",
+		"no-jquery/no-param": "error",
+		"no-jquery/no-parse-json": "error",
+		"no-jquery/no-parse-xml": "error",
+		"no-jquery/no-proxy": "error",
+		"no-jquery/no-selector-prop": "error",
+		"no-jquery/no-sizzle": "error",
+		"no-jquery/no-sub": "error",
+		"no-jquery/no-trim": "error",
+		"no-jquery/no-type": "error",
+		"no-jquery/no-unique": "error",
+		"no-jquery/no-when": "error"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
 				"eslint-plugin-cypress": "^3.2.0",
 				"eslint-plugin-jsdoc": "^48.2.3",
 				"eslint-plugin-jsx-a11y": "^6.7.1",
+				"eslint-plugin-no-jquery": "^2.7.0",
 				"eslint-plugin-prettier": "^5.0.0",
 				"eslint-plugin-react": "^7.20.6",
 				"eslint-plugin-sonarjs": "^1.0.3",
@@ -9165,6 +9166,15 @@
 			"version": "0.14.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/eslint-plugin-no-jquery": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-2.7.0.tgz",
+			"integrity": "sha512-Aeg7dA6GTH1AcWLlBtWNzOU9efK5KpNi7b0EhBO0o0M+awyzguUUo8gF6hXGjQ9n5h8/uRtYv9zOqQkeC5CG0w==",
+			"dev": true,
+			"peerDependencies": {
+				"eslint": ">=2.3.0"
+			}
 		},
 		"node_modules/eslint-plugin-prettier": {
 			"version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"eslint-plugin-cypress": "^3.2.0",
 		"eslint-plugin-jsdoc": "^48.2.3",
 		"eslint-plugin-jsx-a11y": "^6.7.1",
+		"eslint-plugin-no-jquery": "^2.7.0",
 		"eslint-plugin-prettier": "^5.0.0",
 		"eslint-plugin-react": "^7.20.6",
 		"eslint-plugin-sonarjs": "^1.0.3",


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5002

This update adds a ton of rules that will throw errors if a specific jQuery function is used.

This way we won't add any more jQuery code using a new function that may be hard to replace with vanilla JS.