### PR TITLE
Use field keys for errors not ids

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -985,16 +985,11 @@ function frmFrontFormJS() {
 	 * @return {string}
 	 */
 	function getErrorElementId( key, input ) {
-		var split;
-
 		if ( isNaN( key ) || ! input.id ) {
 			// If key isn't a number, assume it's already in the right format.
 			return 'frm_error_field_' + key;
 		}
-
-		split = input.id.split( '_' );
-		split.shift();
-		return 'frm_error_field_' + split.join( '_' );
+		return 'frm_error_' + input.id;
 	}
 
 	function removeFieldError( $fieldCont ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -943,7 +943,14 @@ function frmFrontFormJS() {
 		if ( $fieldCont.length && $fieldCont.is( ':visible' ) ) {
 			$fieldCont.addClass( 'frm_blank_field' );
 			input = $fieldCont.find( 'input, select, textarea' );
-			id = 'frm_error_field_' + key;
+
+			// Key is a field ID, but we expect the error to use field key.
+			if ( ! isNaN( key ) && input.length && input.get( 0 ).id ) {
+				id = getErrorElementId( input.get( 0 ) );
+			} else {
+				id = 'frm_error_field_' + key;
+			}
+
 			describedBy = input.attr( 'aria-describedby' );
 
 			if ( typeof frmThemeOverride_frmPlaceError === 'function' ) { // eslint-disable-line camelcase
@@ -974,6 +981,18 @@ function frmFrontFormJS() {
 
 			jQuery( document ).trigger( 'frmAddFieldError', [ $fieldCont, key, jsErrors ]);
 		}
+	}
+
+	/**
+	 * Get the ID to use for an error element added when submitting with AJAX.
+	 *
+	 * @param {HTMLElement} input
+	 * @return {string}
+	 */
+	function getErrorElementId( input ) {
+		var split = input.id.split( '_' );
+		split.shift();
+		return 'frm_error_field_' + split.join( '_' );
 	}
 
 	function removeFieldError( $fieldCont ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -944,12 +944,7 @@ function frmFrontFormJS() {
 			$fieldCont.addClass( 'frm_blank_field' );
 			input = $fieldCont.find( 'input, select, textarea' );
 
-			// Key is a field ID, but we expect the error to use field key.
-			if ( ! isNaN( key ) && input.length && input.get( 0 ).id ) {
-				id = getErrorElementId( input.get( 0 ) );
-			} else {
-				id = 'frm_error_field_' + key;
-			}
+			id = getErrorElementId( key, input.get( 0 ) );
 
 			describedBy = input.attr( 'aria-describedby' );
 
@@ -986,11 +981,19 @@ function frmFrontFormJS() {
 	/**
 	 * Get the ID to use for an error element added when submitting with AJAX.
 	 *
+	 * @param {string}      key
 	 * @param {HTMLElement} input
 	 * @return {string}
 	 */
-	function getErrorElementId( input ) {
-		var split = input.id.split( '_' );
+	function getErrorElementId( key, input ) {
+		var split;
+
+		if ( isNaN( key ) || ! input.id ) {
+			// If key isn't a number, assume it's already in the right format.
+			return 'frm_error_field_' + key;
+		}
+
+		split = input.id.split( '_' );
 		split.shift();
 		return 'frm_error_field_' + split.join( '_' );
 	}

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -943,7 +943,6 @@ function frmFrontFormJS() {
 		if ( $fieldCont.length && $fieldCont.is( ':visible' ) ) {
 			$fieldCont.addClass( 'frm_blank_field' );
 			input = $fieldCont.find( 'input, select, textarea' );
-
 			id = getErrorElementId( key, input.get( 0 ) );
 
 			describedBy = input.attr( 'aria-describedby' );

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -982,7 +982,7 @@ function frmFrontFormJS() {
 	 *
 	 * @param {string}      key
 	 * @param {HTMLElement} input
-	 * @return {string}
+	 * @return {string} The ID to use for the error element.
 	 */
 	function getErrorElementId( key, input ) {
 		if ( isNaN( key ) || ! input.id ) {


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2590327517/198659

The inconsistency here is that we usually use the `html_id` for the error which is really `'field_' . $field['field_key']` and possibly more for an embedded/repeated form.

The `key` variable in this case is really an integer field ID, so it's inconsistent.

To replicate,
1. Add a field to a form. Make it required
2. Enable AJAX submit.
3. Submit the form.

**Expected result**
- The error should use the id `frm_error_field_29yf4d`.

**Actual result**
- The error is formatted like `frm_error_field_3` instead.

**Pre-release,**
[formidable-6.9.2b.zip](https://github.com/Strategy11/formidable-forms/files/15238502/formidable-6.9.2b.zip)
