### PR TITLE
Add more browser compatibility rules to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,8 @@
 		"plugin:jsx-a11y/recommended",
 		"plugin:sonarjs/recommended-legacy",
 		"plugin:cypress/recommended",
-		"plugin:no-jquery/deprecated"
+		"plugin:no-jquery/deprecated",
+		"plugin:compat/recommended"
 	],
 	"env": {
 		"browser": true,
@@ -32,7 +33,7 @@
 		"window": true,
 		"document": true
 	},
-	"plugins": ["react", "jsx-a11y", "sonarjs", "cypress", "no-jquery"],
+	"plugins": ["react", "jsx-a11y", "sonarjs", "cypress", "no-jquery", "compat", "ie11"],
 	"settings": {
 		"react": {
 			"pragma": "wp"
@@ -119,6 +120,10 @@
 		"no-jquery/no-trim": "error",
 		"no-jquery/no-type": "error",
 		"no-jquery/no-unique": "error",
-		"no-jquery/no-when": "error"
+		"no-jquery/no-when": "error",
+		"ie11/no-collection-args": [ "error" ],
+		"ie11/no-for-in-const": [ "error" ],
+		"ie11/no-loop-func": [ "warn" ],
+		"ie11/no-weak-collections": [ "error" ]
 	}
 }

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1,5 +1,5 @@
 /* exported frm_add_logic_row, frm_remove_tag, frm_show_div, frmCheckAll, frmCheckAllLevel */
-/* eslint-disable jsdoc/require-param, prefer-const, no-redeclare, @wordpress/no-unused-vars-before-return, jsdoc/check-types, jsdoc/check-tag-names, @wordpress/i18n-translator-comments, @wordpress/valid-sprintf, jsdoc/require-returns-description, jsdoc/require-param-type, no-unused-expressions */
+/* eslint-disable jsdoc/require-param, prefer-const, no-redeclare, @wordpress/no-unused-vars-before-return, jsdoc/check-types, jsdoc/check-tag-names, @wordpress/i18n-translator-comments, @wordpress/valid-sprintf, jsdoc/require-returns-description, jsdoc/require-param-type, no-unused-expressions, compat/compat, ie11/no-loop-func */
 
 window.FrmFormsConnect = window.FrmFormsConnect || ( function( document, window, $ ) {
 

--- a/js/formidable_admin_global.js
+++ b/js/formidable_admin_global.js
@@ -1,6 +1,6 @@
 /* global jQuery:false, frmGlobal, tb_remove, ajaxurl, adminpage */
 /* exported frm_install_now, frmSelectSubnav, frmCreatePostEntry */
-/* eslint-disable prefer-const */
+/* eslint-disable prefer-const, compat/compat */
 
 jQuery( document ).ready( function() {
     let deauthLink, submenuItem, li,

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,9 @@
 				"cypress": "^13.8.1",
 				"cypress-axe": "^1.5.0",
 				"eslint": "^8.49.0",
+				"eslint-plugin-compat": "^4.2.0",
 				"eslint-plugin-cypress": "^3.2.0",
+				"eslint-plugin-ie11": "^1.0.0",
 				"eslint-plugin-jsdoc": "^48.2.3",
 				"eslint-plugin-jsx-a11y": "^6.7.1",
 				"eslint-plugin-no-jquery": "^2.7.0",
@@ -2465,6 +2467,12 @@
 			"version": "2.0.4",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@mdn/browser-compat-data": {
+			"version": "5.5.26",
+			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.5.26.tgz",
+			"integrity": "sha512-S2tqS5ElUyKhTNKIutzWkBDriFbyFJ+MQJfGA4l5UPMP6PgTBQxCkgGeh0Rb+nKbrzhxaXyBh2Zatjn9k2JKlQ==",
+			"dev": true
 		},
 		"node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
 			"version": "5.1.1-v1",
@@ -6549,6 +6557,15 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/ast-metadata-inferer": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.8.0.tgz",
+			"integrity": "sha512-jOMKcHht9LxYIEQu+RVd22vtgrPaVCtDRQ/16IGmurdzxvYbDd5ynxjnyrzLnieG96eTcAyaoj/wN/4/1FyyeA==",
+			"dev": true,
+			"dependencies": {
+				"@mdn/browser-compat-data": "^5.2.34"
+			}
+		},
 		"node_modules/ast-types": {
 			"version": "0.15.2",
 			"license": "MIT",
@@ -8946,6 +8963,39 @@
 				"ms": "^2.1.1"
 			}
 		},
+		"node_modules/eslint-plugin-compat": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.2.0.tgz",
+			"integrity": "sha512-RDKSYD0maWy5r7zb5cWQS+uSPc26mgOzdORJ8hxILmWM7S/Ncwky7BcAtXVY5iRbKjBdHsWU8Yg7hfoZjtkv7w==",
+			"dev": true,
+			"dependencies": {
+				"@mdn/browser-compat-data": "^5.3.13",
+				"ast-metadata-inferer": "^0.8.0",
+				"browserslist": "^4.21.10",
+				"caniuse-lite": "^1.0.30001524",
+				"find-up": "^5.0.0",
+				"lodash.memoize": "^4.1.2",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=14.x"
+			},
+			"peerDependencies": {
+				"eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-compat/node_modules/semver": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.1.tgz",
+			"integrity": "sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/eslint-plugin-cypress": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-3.2.0.tgz",
@@ -8971,6 +9021,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ie11": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ie11/-/eslint-plugin-ie11-1.0.0.tgz",
+			"integrity": "sha512-PPv2Cbq5roUmoIZJfPWbEEILHvi2Yfp/cRVzaVKL/YJiYGGLJ0/Qrq1HKd2OZKb3RQQOXweCd/hh261bljEe8A==",
+			"dev": true,
+			"dependencies": {
+				"requireindex": "~1.1.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-ie11/node_modules/requireindex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+			"integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.5"
 			}
 		},
 		"node_modules/eslint-plugin-import": {
@@ -12191,6 +12262,12 @@
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",
 			"license": "MIT"
+		},
+		"node_modules/lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"dev": true
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,9 @@
 		"cypress": "^13.8.1",
 		"cypress-axe": "^1.5.0",
 		"eslint": "^8.49.0",
+		"eslint-plugin-compat": "^4.2.0",
 		"eslint-plugin-cypress": "^3.2.0",
+		"eslint-plugin-ie11": "^1.0.0",
 		"eslint-plugin-jsdoc": "^48.2.3",
 		"eslint-plugin-jsx-a11y": "^6.7.1",
 		"eslint-plugin-no-jquery": "^2.7.0",
@@ -81,5 +83,10 @@
 		"type": "git",
 		"url": "https://github.com/Strategy11/formidable-forms.git"
 	},
-	"homepage": "https://formidableforms.com"
+	"homepage": "https://formidableforms.com",
+	"browserslist": [
+		"last 2 versions",
+		"not dead",
+		"ie >= 11"
+	]
 }


### PR DESCRIPTION
This update adds additional validation for IE11 support for our front end JS file.

I plan to make some changes, like changing `var` to `let`/`const`, but want to make sure I'm not introducing any IE11 incompatibilities.