### PR TITLE
Use off for autocomplete on honeypot not false

### DIFF
--- a/classes/models/FrmHoneypot.php
+++ b/classes/models/FrmHoneypot.php
@@ -102,7 +102,7 @@ class FrmHoneypot extends FrmValidate {
 		);
 
 		if ( 'strict' !== $honeypot ) {
-			$input_attrs['autocomplete'] = 'false';
+			$input_attrs['autocomplete'] = 'off';
 		}
 		?>
 			<div class="<?php echo esc_attr( $class_name ); ?>">


### PR DESCRIPTION
This is just a tiny tweak that may help with the Honeypot iOS issue?

"false" isn't really a standard option but "off" is.