### PR TITLE
Stop including the frmUpdateField function as a global function when …

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3231,19 +3231,20 @@ class FrmAppHelper {
 		global $wp_scripts;
 
 		$script_strings = array(
-			'ajax_url'           => esc_url_raw( self::get_ajax_url() ),
-			'images_url'         => self::plugin_url() . '/images',
-			'loading'            => __( 'Loading&hellip;', 'formidable' ),
-			'remove'             => __( 'Remove', 'formidable' ),
-			'offset'             => apply_filters( 'frm_scroll_offset', 4 ),
-			'nonce'              => wp_create_nonce( 'frm_ajax' ),
-			'id'                 => __( 'ID', 'formidable' ),
-			'no_results'         => __( 'No results match', 'formidable' ),
-			'file_spam'          => __( 'That file looks like Spam.', 'formidable' ),
-			'calc_error'         => __( 'There is an error in the calculation in the field with key', 'formidable' ),
-			'empty_fields'       => __( 'Please complete the preceding required fields before uploading a file.', 'formidable' ),
-			'focus_first_error'  => self::should_focus_first_error(),
-			'include_alert_role' => self::should_include_alert_role_on_field_errors(),
+			'ajax_url'             => esc_url_raw( self::get_ajax_url() ),
+			'images_url'           => self::plugin_url() . '/images',
+			'loading'              => __( 'Loading&hellip;', 'formidable' ),
+			'remove'               => __( 'Remove', 'formidable' ),
+			'offset'               => apply_filters( 'frm_scroll_offset', 4 ),
+			'nonce'                => wp_create_nonce( 'frm_ajax' ),
+			'id'                   => __( 'ID', 'formidable' ),
+			'no_results'           => __( 'No results match', 'formidable' ),
+			'file_spam'            => __( 'That file looks like Spam.', 'formidable' ),
+			'calc_error'           => __( 'There is an error in the calculation in the field with key', 'formidable' ),
+			'empty_fields'         => __( 'Please complete the preceding required fields before uploading a file.', 'formidable' ),
+			'focus_first_error'    => self::should_focus_first_error(),
+			'include_alert_role'   => self::should_include_alert_role_on_field_errors(),
+			'include_update_field' => self::should_include_update_field_function(),
 		);
 
 		$data = $wp_scripts->get_data( 'formidable', 'data' );
@@ -3362,6 +3363,21 @@ class FrmAppHelper {
 	 */
 	public static function should_include_alert_role_on_field_errors() {
 		return (bool) apply_filters( 'frm_include_alert_role_on_field_errors', true );
+	}
+
+	/**
+	 * As of x.x the frmUpdateField function is now included in Pro.
+	 * This was originally included in Lite but was removed because the feature is only supoprted in Pro.
+	 *
+	 * @since x.x
+	 *
+	 * @return bool
+	 */
+	private static function should_include_update_field_function() {
+		if ( ! self::pro_is_installed() ) {
+			return false;
+		}
+		return ! self::meets_min_pro_version( '6.9.2' );
 	}
 
 	/**

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1909,24 +1909,26 @@ function frmAfterRecaptcha( token ) {
 	frmFrontForm.afterSingleRecaptcha( token );
 }
 
-function frmUpdateField( entryId, fieldId, value, message, num ) {
-	jQuery( document.getElementById( 'frm_update_field_' + entryId + '_' + fieldId + '_' + num ) ).html( '<span class="frm-loading-img"></span>' );
-	jQuery.ajax({
-		type: 'POST',
-		url: frm_js.ajax_url, // eslint-disable-line camelcase
-		data: {
-			action: 'frm_entries_update_field_ajax',
-			entry_id: entryId,
-			field_id: fieldId,
-			value: value,
-			nonce: frm_js.nonce // eslint-disable-line camelcase
-		},
-		success: function() {
-			if ( message.replace( /^\s+|\s+$/g, '' ) === '' ) {
-				jQuery( document.getElementById( 'frm_update_field_' + entryId + '_' + fieldId + '_' + num ) ).fadeOut( 'slow' );
-			} else {
-				jQuery( document.getElementById( 'frm_update_field_' + entryId + '_' + fieldId + '_' + num ) ).replaceWith( message );
+if ( frm_js.include_update_field ) {
+	window.frmUpdateField = function( entryId, fieldId, value, message, num ) {
+		jQuery( document.getElementById( 'frm_update_field_' + entryId + '_' + fieldId + '_' + num ) ).html( '<span class="frm-loading-img"></span>' );
+		jQuery.ajax({
+			type: 'POST',
+			url: frm_js.ajax_url, // eslint-disable-line camelcase
+			data: {
+				action: 'frm_entries_update_field_ajax',
+				entry_id: entryId,
+				field_id: fieldId,
+				value: value,
+				nonce: frm_js.nonce // eslint-disable-line camelcase
+			},
+			success: function() {
+				if ( message.replace( /^\s+|\s+$/g, '' ) === '' ) {
+					jQuery( document.getElementById( 'frm_update_field_' + entryId + '_' + fieldId + '_' + num ) ).fadeOut( 'slow' );
+				} else {
+					jQuery( document.getElementById( 'frm_update_field_' + entryId + '_' + fieldId + '_' + num ) ).replaceWith( message );
+				}
 			}
-		}
-	});
+		});
+	};
 }

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1909,7 +1909,7 @@ function frmAfterRecaptcha( token ) {
 	frmFrontForm.afterSingleRecaptcha( token );
 }
 
-if ( frm_js.include_update_field ) {
+if ( frm_js.include_update_field ) { // eslint-disable-line camelcase
 	window.frmUpdateField = function( entryId, fieldId, value, message, num ) {
 		jQuery( document.getElementById( 'frm_update_field_' + entryId + '_' + fieldId + '_' + num ) ).html( '<span class="frm-loading-img"></span>' );
 		jQuery.ajax({


### PR DESCRIPTION
…pro is inactive or if Pro includes a copy of the function

**Related issue** https://github.com/Strategy11/formidable-pro/issues/5002

**Related PR** https://github.com/Strategy11/formidable-pro/pull/5044

This function is moved to Pro. As part of the process of removing jQuery from Lite, I'm removing code that uses jQuery that shouldn't be in Lite.