### PR TITLE
Drop several deprecated global JS functions and deprecate frmUpdateField

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1770,46 +1770,6 @@ function frmFrontFormJS() {
 			}
 		},
 
-		goingToPreviousPage: function( object ) {
-			console.warn( 'DEPRECATED: function frmFrontForm.goingToPreviousPage in v3.0 use frmProForm.goingToPreviousPage' );
-			if ( typeof frmProForm !== 'undefined' ) {
-				return frmProForm.goingToPreviousPage( object );
-			}
-		},
-
-		hideOrShowFields: function() {
-			console.warn( 'DEPRECATED: function frmFrontForm.hideOrShowFields in v3.0 use frmProForm.hideOrShowFields' );
-			if ( typeof frmProForm !== 'undefined' ) {
-				frmProForm.hideOrShowFields();
-			}
-		},
-
-		hidePreviouslyHiddenFields: function() {
-			console.warn( 'DEPRECATED: function frmFrontForm.hidePreviouslyHiddenFields in v3.0 use frmProForm.hidePreviouslyHiddenFields' );
-			if ( typeof frmProForm !== 'undefined' ) {
-				frmProForm.hidePreviouslyHiddenFields();
-			}
-		},
-
-		checkDependentDynamicFields: function( ids ) {
-			console.warn( 'DEPRECATED: function frmFrontForm.checkDependentDynamicFields in v3.0 use frmProForm.checkDependentDynamicFields' );
-			if ( typeof frmProForm !== 'undefined' ) {
-				frmProForm.checkDependentDynamicFields( ids );
-			}
-		},
-
-		checkDependentLookupFields: function( ids ) {
-			console.warn( 'DEPRECATED: function frmFrontForm.checkDependentLookupFields in v3.0 use frmProForm.checkDependentLookupFields' );
-			if ( typeof frmProForm !== 'undefined' ) {
-				frmProForm.checkDependentLookupFields( ids );
-			}
-		},
-
-		loadGoogle: function() {
-			console.warn( 'DEPRECATED: function frmFrontForm.loadGoogle in v3.0 use frmProForm.loadGoogle' );
-			frmProForm.loadGoogle();
-		},
-
 		escapeHtml: function( text ) {
 			return text
 				.replace( /&/g, '&amp;' )
@@ -1871,6 +1831,7 @@ function frmAfterRecaptcha( token ) {
 
 if ( frm_js.include_update_field ) { // eslint-disable-line camelcase
 	window.frmUpdateField = function( entryId, fieldId, value, message, num ) {
+		console.warn( 'DEPRECATED: function frmUpdateField please update to Formidable Pro v6.9.2' );
 		jQuery( document.getElementById( 'frm_update_field_' + entryId + '_' + fieldId + '_' + num ) ).html( '<span class="frm-loading-img"></span>' );
 		jQuery.ajax({
 			type: 'POST',


### PR DESCRIPTION
Pro v.6.9.2 is now live.

Lite likely won't go out for a few weeks with version v6.10. So deprecating `frmUpdateField` for next release shouldn't be an issue.

I'm dropping a lot of old global functions that were deprecated in v3.0. I don't see any references to these in our docs or in GitHub. They should be good to get rid of.