### PR TITLE
Deprecate and conditionally include resend email logic

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3245,6 +3245,7 @@ class FrmAppHelper {
 			'focus_first_error'    => self::should_focus_first_error(),
 			'include_alert_role'   => self::should_include_alert_role_on_field_errors(),
 			'include_update_field' => self::should_include_update_field_function(),
+			'include_resend_email' => self::should_include_resend_email_code(),
 		);
 
 		$data = $wp_scripts->get_data( 'formidable', 'data' );
@@ -3378,6 +3379,24 @@ class FrmAppHelper {
 			return false;
 		}
 		return ! self::meets_min_pro_version( '6.9.2' );
+	}
+
+	/**
+	 * @since x.x
+	 *
+	 * @return bool
+	 */
+	private static function should_include_resend_email_code() {
+		if ( ! self::pro_is_installed() ) {
+			return false;
+		}
+
+		/**
+		 * @since x.x
+		 *
+		 * @param bool $should_include_resend_email_code_in_lite True by default. This is disabled in Pro vx.x.
+		 */
+		return apply_filters( 'frm_should_include_resend_email_code_in_lite', true );
 	}
 
 	/**

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1066,6 +1066,8 @@ function frmFrontFormJS() {
 	}
 
 	function resendEmail() {
+		console.warn( 'DEPRECATED: function resendEmail in vx.x please update to Formidable Pro vx.x' );
+
 		/*jshint validthis:true */
 		let $link = jQuery( this ),
 			entryId = this.getAttribute( 'data-eid' ),
@@ -1495,7 +1497,9 @@ function frmFrontFormJS() {
 			jQuery( document ).on( 'blur', '.frm_toggle_default', replaceDefault );
 			jQuery( '.frm_toggle_default' ).trigger( 'blur' );
 
-			jQuery( document.getElementById( 'frm_resend_email' ) ).on( 'click', resendEmail );
+			if ( frm_js.should_include_resend_email_code ) { // eslint-disable-line camelcase
+				jQuery( document.getElementById( 'frm_resend_email' ) ).on( 'click', resendEmail );
+			}
 
 			jQuery( document ).on( 'change', '.frm-show-form input[name^="item_meta"], .frm-show-form select[name^="item_meta"], .frm-show-form textarea[name^="item_meta"]', frmFrontForm.fieldValueChanged );
 

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1497,7 +1497,7 @@ function frmFrontFormJS() {
 			jQuery( document ).on( 'blur', '.frm_toggle_default', replaceDefault );
 			jQuery( '.frm_toggle_default' ).trigger( 'blur' );
 
-			if ( frm_js.should_include_resend_email_code ) { // eslint-disable-line camelcase
+			if ( frm_js.include_resend_email ) { // eslint-disable-line camelcase
 				jQuery( document.getElementById( 'frm_resend_email' ) ).on( 'click', resendEmail );
 			}
 


### PR DESCRIPTION
This is only included in Pro on the entries page sidebar.

I'm moving it into the Pro entries.js code now, out of Lite, where it isn't required.

Related PR https://github.com/Strategy11/formidable-pro/pull/5046
