### PR TITLE
Store and reuse field selection data when outputting shortcode options optimization

### DIFF
--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -6,6 +6,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmFormsHelper {
 
 	/**
+	 * @var array|null
+	 */
+	static $field_type_data_for_insert_opt_html;
+
+	/**
 	 * @since 2.2.10
 	 */
 	public static function form_error_class() {
@@ -579,7 +584,7 @@ BEFORE_HTML;
 	 */
 	public static function insert_opt_html( $args ) {
 		$class  = isset( $args['class'] ) ? $args['class'] : '';
-		$fields = FrmField::all_field_selection();
+		$fields = self::get_field_type_data_for_insert_opt_html();
 		$field  = isset( $fields[ $args['type'] ] ) ? $fields[ $args['type'] ] : array();
 
 		self::prepare_field_type( $field );
@@ -614,6 +619,21 @@ BEFORE_HTML;
 			</a>
 		</li>
 		<?php
+	}
+
+	/**
+	 * Store and re-use field selection data for use when outputting shortcodes options in shortcode pop up.
+	 * This significantly improves performance by avoiding repeat calls to FrmField::all_field_selection.
+	 *
+	 * @since x.x
+	 *
+	 * @return array
+	 */
+	private static function get_field_type_data_for_insert_opt_html() {
+		if ( ! isset( self::$field_type_data_for_insert_opt_html ) ) {
+			self::$field_type_data_for_insert_opt_html = FrmField::all_field_selection();
+		}
+		return self::$field_type_data_for_insert_opt_html;
 	}
 
 	/**

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -6,6 +6,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmFormsHelper {
 
 	/**
+	 * Store and re-use field type data for the insert_opt_html function (to avoid multiple calls to FrmField::all_field_selection).
+	 *
+	 * @since x.x
+	 *
 	 * @var array|null
 	 */
 	static $field_type_data_for_insert_opt_html;

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -12,7 +12,7 @@ class FrmFormsHelper {
 	 *
 	 * @var array|null
 	 */
-	static $field_type_data_for_insert_opt_html;
+	private static $field_type_data_for_insert_opt_html;
 
 	/**
 	 * @since 2.2.10


### PR DESCRIPTION
Using my slow form with 1,0004 fields, the form settings page is pretty slow to load.

It's mostly because of these calls to `FrmField::all_field_selection()`. By calling it only once (instead of nearly 900 times), it cuts my page load by about 69% 🚀.

This optimization also helps on the form builder where we also use this sidebar for populating HTML/Rich Text fields.

_On form settings_
**Before**
~10.43 seconds

**After**
~3.24 seconds

**~7.19 seconds faster**

_In the form builder_
**Before**
~48.3 seconds

**After**
~41.31 seconds

**~6.99 seconds faster**