### PR TITLE
Drop old css moz drop shadow rule

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -1664,7 +1664,6 @@ do_action( 'frm_include_front_css', compact( 'defaults' ) );
 		border-right:1px solid #d3d3d3;
 		border-radius:4px;
 		box-shadow:2px 0px 4px -1px rgba(0,0,0,.08);
-		-moz-box-shadow:2px 0px 4px -1px rgba(0,0,0,.08);
 	}
 
 	.with_frm_style .g-recaptcha iframe,


### PR DESCRIPTION
Firefox is complaining about this even 😅. This legacy style is no longer required.

<img width="556" alt="Screen Shot 2024-05-13 at 10 44 33 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/4a04788c-1e78-4b30-ad5f-ac767be83943">
