### PR TITLE
Stop using deprecated "alpha" in css

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7907,7 +7907,6 @@ input[disabled],
 li.frm_noallow.button,
 .frm_noallow {
 	opacity: .5;
-	filter: alpha(opacity=50);
 }
 
 .frm_actions_list a.frm_show_upgrade.frm_inactive_action:before,


### PR DESCRIPTION
The `opacity: 0.5` rule covers this.

The other rule must have been for old browsers. It's no longer required, and since it's deprecated it throws warnings.