### PR TITLE
Fix JS translation

### DIFF
--- a/languages/formidable.pot
+++ b/languages/formidable.pot
@@ -9,9 +9,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-05-06T15:22:32+00:00\n"
+"POT-Creation-Date: 2024-05-14T04:17:35+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.10.0\n"
+"X-Generator: WP-CLI 2.8.1\n"
 "X-Domain: formidable\n"
 
 #: js/src/common/components/itemselect.js:26
@@ -264,62 +264,20 @@ msgstr ""
 msgid "This site does not have popup modals."
 msgstr ""
 
-#: js/src/form/views.js:18
-#: js/formidable_blocks.js:849
-msgid "Display a Visual View"
-msgstr ""
-
-#: js/src/form/views.js:32
-#: classes/controllers/FrmSMTPController.php:321
-#: classes/helpers/FrmAppHelper.php:3280
-#: classes/helpers/FrmFormMigratorsHelper.php:154
-#: classes/views/shared/upgrade_overlay.php:34
-#: js/formidable_admin.js:6799
-#: js/formidable_blocks.js:863
-msgid "Install"
-msgstr ""
-
-#: js/src/form/views.js:32
-#: classes/controllers/FrmSMTPController.php:338
-#: classes/models/FrmPluginSearch.php:317
-#: classes/views/addons/settings.php:31
-#: js/formidable_admin.js:6796
-#: js/formidable_blocks.js:863
-msgid "Activate"
-msgstr ""
-
-#: js/src/form/views.js:52
-#: js/src/form/views.js:17
-#: js/formidable_blocks.js:848
-#: js/formidable_blocks.js:883
-msgid "Formidable Views"
-msgstr ""
-
-#: js/src/form/views.js:86
-#: js/src/form/views.js:74
-#: js/formidable_blocks.js:905
-#: js/formidable_blocks.js:917
-msgid "Effortlessly transform form data into webpages with Views, the only integrated form & application builder."
-msgstr ""
-
 #. Plugin Name of the plugin
-#: formidable.php
 msgid "Formidable Forms"
 msgstr ""
 
 #. Plugin URI of the plugin
 #. Author URI of the plugin
-#: formidable.php
 msgid "https://formidableforms.com/"
 msgstr ""
 
 #. Description of the plugin
-#: formidable.php
 msgid "Quickly and easily create drag-and-drop forms"
 msgstr ""
 
 #. Author of the plugin
-#: formidable.php
 msgid "Strategy11 Form Builder Team"
 msgstr ""
 
@@ -344,18 +302,18 @@ msgid "There are no plugins on your site that require a license"
 msgstr ""
 
 #: classes/controllers/FrmAddonsController.php:693
-#: classes/helpers/FrmAppHelper.php:3282
+#: classes/helpers/FrmAppHelper.php:3302
 msgid "Installed"
 msgstr ""
 
 #: classes/controllers/FrmAddonsController.php:698
-#: classes/helpers/FrmAppHelper.php:3281
+#: classes/helpers/FrmAppHelper.php:3301
 #: stripe/helpers/FrmTransLiteAppHelper.php:107
 msgid "Active"
 msgstr ""
 
 #: classes/controllers/FrmAddonsController.php:703
-#: classes/helpers/FrmAppHelper.php:3283
+#: classes/helpers/FrmAppHelper.php:3303
 msgid "Not Installed"
 msgstr ""
 
@@ -465,7 +423,7 @@ msgstr ""
 #: classes/controllers/FrmFormsController.php:196
 #: classes/controllers/FrmFormTemplatesController.php:612
 #: classes/controllers/FrmSettingsController.php:275
-#: classes/helpers/FrmAppHelper.php:3240
+#: classes/helpers/FrmAppHelper.php:3260
 #: classes/views/form-templates/modals/create-template-modal.php:62
 #: classes/views/form-templates/modals/name-your-form-modal.php:32
 #: classes/views/shared/admin-header.php:32
@@ -473,7 +431,7 @@ msgstr ""
 #: stripe/controllers/FrmTransLiteSubscriptionsController.php:68
 #: js/admin/style.js:814
 #: js/admin/style.js:939
-#: js/formidable_admin.js:4184
+#: js/formidable_admin.js:4183
 msgid "Cancel"
 msgstr ""
 
@@ -630,7 +588,7 @@ msgid "You are trying to view an entry that does not exist."
 msgstr ""
 
 #: classes/controllers/FrmEntriesController.php:498
-#: classes/controllers/FrmFormActionsController.php:414
+#: classes/controllers/FrmFormActionsController.php:417
 #: classes/controllers/FrmFormsController.php:194
 #: classes/controllers/FrmSettingsController.php:273
 msgid "Verification failed"
@@ -1052,7 +1010,7 @@ msgid "%1$sClick here%2$s if you are not automatically redirected."
 msgstr ""
 
 #: classes/controllers/FrmFormsController.php:3136
-#: classes/helpers/FrmAppHelper.php:1636
+#: classes/helpers/FrmAppHelper.php:1656
 #: classes/helpers/FrmOnSubmitHelper.php:146
 msgid "Select a Page"
 msgstr ""
@@ -1365,12 +1323,31 @@ msgstr ""
 msgid "Install WP Mail SMTP"
 msgstr ""
 
+#: classes/controllers/FrmSMTPController.php:321
+#: classes/helpers/FrmAppHelper.php:3300
+#: classes/helpers/FrmFormMigratorsHelper.php:154
+#: classes/views/shared/upgrade_overlay.php:34
+#: js/formidable_admin.js:6798
+#: js/src/form/views.js:32
+#: js/formidable_blocks.js:863
+msgid "Install"
+msgstr ""
+
 #: classes/controllers/FrmSMTPController.php:333
 msgid "WP Mail SMTP Installed & Activated"
 msgstr ""
 
 #: classes/controllers/FrmSMTPController.php:336
 msgid "Activate WP Mail SMTP"
+msgstr ""
+
+#: classes/controllers/FrmSMTPController.php:338
+#: classes/models/FrmPluginSearch.php:317
+#: classes/views/addons/settings.php:31
+#: js/formidable_admin.js:6795
+#: js/src/form/views.js:32
+#: js/formidable_blocks.js:863
+msgid "Activate"
 msgstr ""
 
 #: classes/controllers/FrmSMTPController.php:357
@@ -1525,16 +1502,16 @@ msgstr ""
 msgid "There are no entries for that form."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:1288
+#: classes/helpers/FrmAppHelper.php:1308
 #: classes/views/xml/import_form.php:17
 msgid "Import"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:1361
+#: classes/helpers/FrmAppHelper.php:1381
 msgid "Add New"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:1373
+#: classes/helpers/FrmAppHelper.php:1393
 #: classes/views/frm-entries/list.php:43
 #: classes/views/frm-forms/list.php:36
 #: classes/views/shared/mb_adv_info.php:41
@@ -1542,743 +1519,743 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:1779
+#: classes/helpers/FrmAppHelper.php:1799
 msgid "Add Entries from Admin Area"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:1780
+#: classes/helpers/FrmAppHelper.php:1800
 msgid "Edit Entries from Admin Area"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:1781
+#: classes/helpers/FrmAppHelper.php:1801
 msgid "View Reports"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:1793
+#: classes/helpers/FrmAppHelper.php:1813
 msgid "Add/Edit Views"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:1812
+#: classes/helpers/FrmAppHelper.php:1832
 msgid "View Forms List"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:1813
+#: classes/helpers/FrmAppHelper.php:1833
 msgid "Add and Edit Forms"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:1814
+#: classes/helpers/FrmAppHelper.php:1834
 msgid "Delete Forms"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:1815
+#: classes/helpers/FrmAppHelper.php:1835
 msgid "Access this Settings Page"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:1816
+#: classes/helpers/FrmAppHelper.php:1836
 msgid "View Entries from Admin Area"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:1817
+#: classes/helpers/FrmAppHelper.php:1837
 msgid "Delete Entries from Admin Area"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2633
+#: classes/helpers/FrmAppHelper.php:2653
 msgid "at"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2777
+#: classes/helpers/FrmAppHelper.php:2797
 #: stripe/helpers/FrmTransLiteAppHelper.php:245
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: classes/helpers/FrmAppHelper.php:2778
+#: classes/helpers/FrmAppHelper.php:2798
 msgid "years"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2782
+#: classes/helpers/FrmAppHelper.php:2802
 #: stripe/helpers/FrmTransLiteAppHelper.php:244
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: classes/helpers/FrmAppHelper.php:2783
+#: classes/helpers/FrmAppHelper.php:2803
 msgid "months"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2787
+#: classes/helpers/FrmAppHelper.php:2807
 #: stripe/helpers/FrmTransLiteAppHelper.php:243
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: classes/helpers/FrmAppHelper.php:2788
+#: classes/helpers/FrmAppHelper.php:2808
 msgid "weeks"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2792
+#: classes/helpers/FrmAppHelper.php:2812
 #: stripe/helpers/FrmTransLiteAppHelper.php:242
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: classes/helpers/FrmAppHelper.php:2793
+#: classes/helpers/FrmAppHelper.php:2813
 msgid "days"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2797
+#: classes/helpers/FrmAppHelper.php:2817
 msgid "hour"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2798
+#: classes/helpers/FrmAppHelper.php:2818
 msgid "hours"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2802
+#: classes/helpers/FrmAppHelper.php:2822
 msgid "minute"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2803
+#: classes/helpers/FrmAppHelper.php:2823
 msgid "minutes"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2807
+#: classes/helpers/FrmAppHelper.php:2827
 msgid "second"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2808
+#: classes/helpers/FrmAppHelper.php:2828
 msgid "seconds"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2907
+#: classes/helpers/FrmAppHelper.php:2927
 msgid "Give this action a label for easy reference."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2908
+#: classes/helpers/FrmAppHelper.php:2928
 msgid "Add one or more recipient addresses separated by a \",\".  FORMAT: Name <name@email.com> or name@email.com.  [admin_email] is the address set in WP General Settings."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2909
+#: classes/helpers/FrmAppHelper.php:2929
 msgid "Add CC addresses separated by a \",\".  FORMAT: Name <name@email.com> or name@email.com."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2910
+#: classes/helpers/FrmAppHelper.php:2930
 msgid "Add BCC addresses separated by a \",\".  FORMAT: Name <name@email.com> or name@email.com."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2911
+#: classes/helpers/FrmAppHelper.php:2931
 msgid "If you would like a different reply to address than the \"from\" address, add a single address here.  FORMAT: Name <name@email.com> or name@email.com."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2912
+#: classes/helpers/FrmAppHelper.php:2932
 msgid "Enter the name and/or email address of the sender. FORMAT: John Bates <john@example.com> or john@example.com."
 msgstr ""
 
 #. translators: %1$s: Form name, %2$s: Date
-#: classes/helpers/FrmAppHelper.php:2914
+#: classes/helpers/FrmAppHelper.php:2934
 msgid "If you leave the subject blank, the default will be used: %1$s Form submitted on %2$s"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:2915
+#: classes/helpers/FrmAppHelper.php:2935
 msgid "This option will open the link in a new browser tab. Please note that some popup blockers may prevent this from happening, in which case the link will be displayed."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3182
-#: classes/helpers/FrmAppHelper.php:3260
+#: classes/helpers/FrmAppHelper.php:3202
+#: classes/helpers/FrmAppHelper.php:3280
 msgid "Please wait while your site updates."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3183
+#: classes/helpers/FrmAppHelper.php:3203
 msgid "Are you sure you want to deauthorize Formidable Forms on this site?"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3188
-#: classes/helpers/FrmAppHelper.php:3216
+#: classes/helpers/FrmAppHelper.php:3208
+#: classes/helpers/FrmAppHelper.php:3236
 msgid "Loading&hellip;"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3217
+#: classes/helpers/FrmAppHelper.php:3237
 msgid "Remove"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3220
+#: classes/helpers/FrmAppHelper.php:3240
 #: classes/helpers/FrmCSVExportHelper.php:374
 msgid "ID"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3221
+#: classes/helpers/FrmAppHelper.php:3241
 msgid "No results match"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3222
+#: classes/helpers/FrmAppHelper.php:3242
 msgid "That file looks like Spam."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3223
+#: classes/helpers/FrmAppHelper.php:3243
 msgid "There is an error in the calculation in the field with key"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3224
+#: classes/helpers/FrmAppHelper.php:3244
 msgid "Please complete the preceding required fields before uploading a file."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3236
+#: classes/helpers/FrmAppHelper.php:3256
 msgid "(Click to add description)"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3237
+#: classes/helpers/FrmAppHelper.php:3257
 msgid "(Blank)"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3238
+#: classes/helpers/FrmAppHelper.php:3258
 msgid "(no label)"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3239
+#: classes/helpers/FrmAppHelper.php:3259
 msgid "OK"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3241
+#: classes/helpers/FrmAppHelper.php:3261
 #: classes/views/frm-fields/back-end/settings.php:281
 msgid "Default"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3242
+#: classes/helpers/FrmAppHelper.php:3262
 msgid "Clear default value when typing"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3243
+#: classes/helpers/FrmAppHelper.php:3263
 msgid "Do not clear default value when typing"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3244
+#: classes/helpers/FrmAppHelper.php:3264
 msgid "Default value will pass form validation"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3245
+#: classes/helpers/FrmAppHelper.php:3265
 msgid "Default value will NOT pass form validation"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3246
+#: classes/helpers/FrmAppHelper.php:3266
 #: classes/views/shared/confirm-overlay.php:15
 #: classes/views/shared/info-overlay.php:15
 msgid "Are you sure?"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3247
+#: classes/helpers/FrmAppHelper.php:3267
 msgid "Are you sure you want to delete this field and all data associated with it?"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3248
+#: classes/helpers/FrmAppHelper.php:3268
 msgid "All fields inside this Section will be deleted along with their data. Are you sure you want to delete this group of fields?"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3249
+#: classes/helpers/FrmAppHelper.php:3269
 msgid "Warning: If you have entries with multiple rows, all but the first row will be lost."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3251
+#: classes/helpers/FrmAppHelper.php:3271
 #: classes/helpers/FrmFieldsHelper.php:330
 msgid "The entered values do not match"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3252
+#: classes/helpers/FrmAppHelper.php:3272
 msgid "Enter Email"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3253
+#: classes/helpers/FrmAppHelper.php:3273
 msgid "Confirm Email"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3254
+#: classes/helpers/FrmAppHelper.php:3274
 #: classes/views/shared/mb_adv_info.php:179
 msgid "Conditional content here"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3255
+#: classes/helpers/FrmAppHelper.php:3275
 #: classes/helpers/FrmFieldsHelper.php:565
 #: classes/helpers/FrmFieldsHelper.php:566
 msgid "New Option"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3256
+#: classes/helpers/FrmAppHelper.php:3276
 msgid "In certain browsers (e.g. Firefox) text will not display correctly if the field height is too small relative to the field padding and text size. Please increase your field height or decrease your field padding."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3257
+#: classes/helpers/FrmAppHelper.php:3277
 msgid "Enter Password"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3258
+#: classes/helpers/FrmAppHelper.php:3278
 msgid "Confirm Password"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3259
+#: classes/helpers/FrmAppHelper.php:3279
 msgid "Import Complete"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3261
+#: classes/helpers/FrmAppHelper.php:3281
 msgid "Warning: There is no way to retrieve unsaved entries."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3262
+#: classes/helpers/FrmAppHelper.php:3282
 msgid "Private"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3265
+#: classes/helpers/FrmAppHelper.php:3285
 msgid "No new licenses were found"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3266
+#: classes/helpers/FrmAppHelper.php:3286
 msgid "This calculation has at least one unmatched ( ) { } [ ]."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3267
+#: classes/helpers/FrmAppHelper.php:3287
 msgid "This calculation may have shortcodes that work in Views but not forms."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3268
+#: classes/helpers/FrmAppHelper.php:3288
 msgid "This calculation may have shortcodes that work in text calculations but not numeric calculations."
 msgstr ""
 
 #. translators: %d is the number of allowed actions per form
-#: classes/helpers/FrmAppHelper.php:3270
+#: classes/helpers/FrmAppHelper.php:3290
 msgid "This form action is limited to %d per form."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3271
+#: classes/helpers/FrmAppHelper.php:3291
 msgid "Please edit the existing form action."
 msgstr ""
 
 #. Translators: %s is the name of a Detail Page Slug that is a reserved word.
-#: classes/helpers/FrmAppHelper.php:3274
+#: classes/helpers/FrmAppHelper.php:3294
 msgid "The Detail Page Slug \"%s\" is reserved by WordPress. This may cause problems. Is this intentional?"
 msgstr ""
 
 #. Translators: %s is the name of a parameter that is a reserved word.  More than one word could be listed here, though that would not be common.
-#: classes/helpers/FrmAppHelper.php:3276
+#: classes/helpers/FrmAppHelper.php:3296
 msgid "The parameter \"%s\" is reserved by WordPress. This may cause problems when included in the URL. Is this intentional? "
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3277
+#: classes/helpers/FrmAppHelper.php:3297
 #: classes/helpers/FrmFormsHelper.php:1602
 msgid "See the list of reserved words in WordPress."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3278
+#: classes/helpers/FrmAppHelper.php:3298
 msgid "Please enter a Repeat Limit that is greater than 1."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3279
+#: classes/helpers/FrmAppHelper.php:3299
 msgid "Please select a limit between 0 and 200."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3284
+#: classes/helpers/FrmAppHelper.php:3304
 #: classes/views/shared/mb_adv_info.php:119
 #: classes/views/shared/mb_adv_info.php:135
 msgid "Select a Field"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3285
+#: classes/helpers/FrmAppHelper.php:3305
 #: classes/helpers/FrmListHelper.php:248
 msgid "No items found."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3286
+#: classes/helpers/FrmAppHelper.php:3306
 msgid "Oops. You have already used that field."
 msgstr ""
 
 #. translators: %1$s: HTML open tag, %2$s: HTML end tag.
-#: classes/helpers/FrmAppHelper.php:3295
+#: classes/helpers/FrmAppHelper.php:3315
 msgid "You can hold %1$sShift%2$s on your keyboard to select multiple fields"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3364
+#: classes/helpers/FrmAppHelper.php:3384
 msgid "You are running an outdated version of Formidable. This plugin may not work correctly if you do not update Formidable."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3392
+#: classes/helpers/FrmAppHelper.php:3412
 msgid "You are running a version of Formidable Forms that may not be compatible with your version of Formidable Forms Pro."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3420
+#: classes/helpers/FrmAppHelper.php:3440
 msgid "The version of PHP on your server is too low. If this is not corrected, you may see issues with Formidable Forms. Please contact your web host and ask to be updated to PHP 7.0+."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3426
+#: classes/helpers/FrmAppHelper.php:3446
 msgid "You are using an outdated browser that is not compatible with Formidable Forms. Please update to a more current browser (we recommend Chrome)."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3444
+#: classes/helpers/FrmAppHelper.php:3464
 msgid "English"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3445
+#: classes/helpers/FrmAppHelper.php:3465
 msgid "Afrikaans"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3446
+#: classes/helpers/FrmAppHelper.php:3466
 msgid "Albanian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3447
+#: classes/helpers/FrmAppHelper.php:3467
 msgid "Algerian Arabic"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3448
+#: classes/helpers/FrmAppHelper.php:3468
 msgid "Amharic"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3449
+#: classes/helpers/FrmAppHelper.php:3469
 msgid "Arabic"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3450
+#: classes/helpers/FrmAppHelper.php:3470
 msgid "Armenian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3451
+#: classes/helpers/FrmAppHelper.php:3471
 msgid "Azerbaijani"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3452
+#: classes/helpers/FrmAppHelper.php:3472
 msgid "Basque"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3453
+#: classes/helpers/FrmAppHelper.php:3473
 msgid "Belarusian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3454
+#: classes/helpers/FrmAppHelper.php:3474
 msgid "Bengali"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3455
+#: classes/helpers/FrmAppHelper.php:3475
 msgid "Bosnian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3456
+#: classes/helpers/FrmAppHelper.php:3476
 msgid "Bulgarian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3457
+#: classes/helpers/FrmAppHelper.php:3477
 msgid "Catalan"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3458
+#: classes/helpers/FrmAppHelper.php:3478
 msgid "Chinese Hong Kong"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3459
+#: classes/helpers/FrmAppHelper.php:3479
 msgid "Chinese Simplified"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3460
+#: classes/helpers/FrmAppHelper.php:3480
 msgid "Chinese Traditional"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3461
+#: classes/helpers/FrmAppHelper.php:3481
 msgid "Croatian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3462
+#: classes/helpers/FrmAppHelper.php:3482
 msgid "Czech"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3463
+#: classes/helpers/FrmAppHelper.php:3483
 msgid "Danish"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3464
+#: classes/helpers/FrmAppHelper.php:3484
 msgid "Dutch"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3465
+#: classes/helpers/FrmAppHelper.php:3485
 msgid "English/UK"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3466
+#: classes/helpers/FrmAppHelper.php:3486
 msgid "Esperanto"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3467
+#: classes/helpers/FrmAppHelper.php:3487
 msgid "Estonian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3468
+#: classes/helpers/FrmAppHelper.php:3488
 msgid "Faroese"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3469
+#: classes/helpers/FrmAppHelper.php:3489
 msgid "Farsi/Persian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3470
+#: classes/helpers/FrmAppHelper.php:3490
 msgid "Filipino"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3471
+#: classes/helpers/FrmAppHelper.php:3491
 msgid "Finnish"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3472
+#: classes/helpers/FrmAppHelper.php:3492
 msgid "French"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3473
+#: classes/helpers/FrmAppHelper.php:3493
 msgid "French/Canadian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3474
+#: classes/helpers/FrmAppHelper.php:3494
 msgid "French/Swiss"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3475
+#: classes/helpers/FrmAppHelper.php:3495
 msgid "Galician"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3476
+#: classes/helpers/FrmAppHelper.php:3496
 msgid "Georgian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3477
+#: classes/helpers/FrmAppHelper.php:3497
 msgid "German"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3478
+#: classes/helpers/FrmAppHelper.php:3498
 msgid "German/Austria"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3479
+#: classes/helpers/FrmAppHelper.php:3499
 msgid "German/Switzerland"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3480
+#: classes/helpers/FrmAppHelper.php:3500
 msgid "Greek"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3481
+#: classes/helpers/FrmAppHelper.php:3501
 msgid "Gujarati"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3482
-#: classes/helpers/FrmAppHelper.php:3483
+#: classes/helpers/FrmAppHelper.php:3502
+#: classes/helpers/FrmAppHelper.php:3503
 msgid "Hebrew"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3484
+#: classes/helpers/FrmAppHelper.php:3504
 msgid "Hindi"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3485
+#: classes/helpers/FrmAppHelper.php:3505
 msgid "Hungarian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3486
+#: classes/helpers/FrmAppHelper.php:3506
 msgid "Icelandic"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3487
+#: classes/helpers/FrmAppHelper.php:3507
 msgid "Indonesian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3488
+#: classes/helpers/FrmAppHelper.php:3508
 msgid "Italian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3489
+#: classes/helpers/FrmAppHelper.php:3509
 msgid "Japanese"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3490
+#: classes/helpers/FrmAppHelper.php:3510
 msgid "Kannada"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3491
+#: classes/helpers/FrmAppHelper.php:3511
 msgid "Kazakh"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3492
+#: classes/helpers/FrmAppHelper.php:3512
 msgid "Khmer"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3493
+#: classes/helpers/FrmAppHelper.php:3513
 msgid "Korean"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3494
+#: classes/helpers/FrmAppHelper.php:3514
 msgid "Kyrgyz"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3495
+#: classes/helpers/FrmAppHelper.php:3515
 msgid "Laothian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3496
+#: classes/helpers/FrmAppHelper.php:3516
 msgid "Latvian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3497
+#: classes/helpers/FrmAppHelper.php:3517
 msgid "Lithuanian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3498
+#: classes/helpers/FrmAppHelper.php:3518
 msgid "Luxembourgish"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3499
+#: classes/helpers/FrmAppHelper.php:3519
 msgid "Macedonian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3500
+#: classes/helpers/FrmAppHelper.php:3520
 msgid "Malayalam"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3501
+#: classes/helpers/FrmAppHelper.php:3521
 msgid "Malaysian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3502
+#: classes/helpers/FrmAppHelper.php:3522
 msgid "Marathi"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3503
+#: classes/helpers/FrmAppHelper.php:3523
 msgid "Norwegian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3504
+#: classes/helpers/FrmAppHelper.php:3524
 msgid "Norwegian Bokmål"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3505
+#: classes/helpers/FrmAppHelper.php:3525
 msgid "Norwegian Nynorsk"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3506
+#: classes/helpers/FrmAppHelper.php:3526
 msgid "Polish"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3507
+#: classes/helpers/FrmAppHelper.php:3527
 msgid "Portuguese"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3508
+#: classes/helpers/FrmAppHelper.php:3528
 msgid "Portuguese/Brazilian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3509
+#: classes/helpers/FrmAppHelper.php:3529
 msgid "Portuguese/Portugal"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3510
+#: classes/helpers/FrmAppHelper.php:3530
 msgid "Romansh"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3511
+#: classes/helpers/FrmAppHelper.php:3531
 msgid "Romanian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3512
+#: classes/helpers/FrmAppHelper.php:3532
 msgid "Russian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3513
-#: classes/helpers/FrmAppHelper.php:3514
+#: classes/helpers/FrmAppHelper.php:3533
+#: classes/helpers/FrmAppHelper.php:3534
 msgid "Serbian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3515
+#: classes/helpers/FrmAppHelper.php:3535
 msgid "Sinhalese"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3516
+#: classes/helpers/FrmAppHelper.php:3536
 msgid "Slovak"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3517
+#: classes/helpers/FrmAppHelper.php:3537
 msgid "Slovenian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3518
+#: classes/helpers/FrmAppHelper.php:3538
 msgid "Spanish"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3519
+#: classes/helpers/FrmAppHelper.php:3539
 msgid "Spanish/Latin America"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3520
+#: classes/helpers/FrmAppHelper.php:3540
 msgid "Swahili"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3521
+#: classes/helpers/FrmAppHelper.php:3541
 msgid "Swedish"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3522
+#: classes/helpers/FrmAppHelper.php:3542
 msgid "Tamil"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3523
+#: classes/helpers/FrmAppHelper.php:3543
 msgid "Telugu"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3524
+#: classes/helpers/FrmAppHelper.php:3544
 msgid "Thai"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3525
+#: classes/helpers/FrmAppHelper.php:3545
 msgid "Tajiki"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3526
+#: classes/helpers/FrmAppHelper.php:3546
 msgid "Turkish"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3527
+#: classes/helpers/FrmAppHelper.php:3547
 msgid "Ukrainian"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3528
+#: classes/helpers/FrmAppHelper.php:3548
 msgid "Urdu"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3529
+#: classes/helpers/FrmAppHelper.php:3549
 msgid "Vietnamese"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3530
+#: classes/helpers/FrmAppHelper.php:3550
 msgid "Welsh"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3531
+#: classes/helpers/FrmAppHelper.php:3551
 msgid "Zulu"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3877
+#: classes/helpers/FrmAppHelper.php:3897
 msgid "Form Landing Pages"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3878
+#: classes/helpers/FrmAppHelper.php:3898
 msgid "Easily manage a landing page for your form. Upgrade to get form landing pages."
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:3960
+#: classes/helpers/FrmAppHelper.php:3980
 #: classes/views/styles/_style-card.php:37
 #: js/admin/applications.js:304
 msgid "NEW"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:4119
+#: classes/helpers/FrmAppHelper.php:4139
 msgctxt "warning message: close icon label"
 msgid "Dismiss"
 msgstr ""
 
-#: classes/helpers/FrmAppHelper.php:4160
+#: classes/helpers/FrmAppHelper.php:4180
 msgid "You're using Formidable Forms Lite - no license needed. Enjoy!"
 msgstr ""
 
@@ -4072,7 +4049,7 @@ msgstr ""
 
 #: classes/helpers/FrmFormsHelper.php:1759
 #: classes/views/form-templates/modals/name-your-form-modal.php:35
-#: js/formidable_admin.js:4189
+#: js/formidable_admin.js:4188
 msgid "Save"
 msgstr ""
 
@@ -5097,31 +5074,31 @@ msgstr ""
 msgid "There are no options for this action."
 msgstr ""
 
-#: classes/models/FrmFormAction.php:950
+#: classes/models/FrmFormAction.php:954
 msgid "Draft is saved"
 msgstr ""
 
-#: classes/models/FrmFormAction.php:951
+#: classes/models/FrmFormAction.php:955
 msgid "Entry is created"
 msgstr ""
 
-#: classes/models/FrmFormAction.php:952
+#: classes/models/FrmFormAction.php:956
 msgid "Entry is updated"
 msgstr ""
 
-#: classes/models/FrmFormAction.php:953
+#: classes/models/FrmFormAction.php:957
 msgid "Entry is deleted"
 msgstr ""
 
-#: classes/models/FrmFormAction.php:954
+#: classes/models/FrmFormAction.php:958
 msgid "Entry is imported"
 msgstr ""
 
-#: classes/models/FrmFormAction.php:967
+#: classes/models/FrmFormAction.php:971
 msgid "Use Conditional Logic"
 msgstr ""
 
-#: classes/models/FrmFormAction.php:977
+#: classes/models/FrmFormAction.php:981
 msgid "Conditional form actions"
 msgstr ""
 
@@ -5465,7 +5442,7 @@ msgstr ""
 #: classes/views/frm-fields/back-end/inline-modal.php:7
 #: classes/views/frm-fields/back-end/inline-modal.php:8
 #: classes/views/shared/admin-header.php:71
-#: js/formidable_admin.js:8964
+#: js/formidable_admin.js:8963
 msgid "Close"
 msgstr ""
 
@@ -8313,51 +8290,51 @@ msgstr ""
 msgid "Are you sure you want to delete these %1$s selected field(s)?"
 msgstr ""
 
-#: js/formidable_admin.js:3882
+#: js/formidable_admin.js:3881
 msgid "Custom layout"
 msgstr ""
 
-#: js/formidable_admin.js:3905
+#: js/formidable_admin.js:3904
 msgid "Break into rows"
 msgstr ""
 
-#: js/formidable_admin.js:3915
+#: js/formidable_admin.js:3914
 msgid "Row Layout"
 msgstr ""
 
-#: js/formidable_admin.js:4169
+#: js/formidable_admin.js:4168
 msgid "Enter number of columns for each field"
 msgstr ""
 
-#: js/formidable_admin.js:4173
+#: js/formidable_admin.js:4172
 msgid "Layouts are based on a 12-column grid system"
 msgstr ""
 
-#: js/formidable_admin.js:4626
+#: js/formidable_admin.js:4625
 msgid "Merge into row"
 msgstr ""
 
-#: js/formidable_admin.js:5988
+#: js/formidable_admin.js:5987
 msgid "Duplicate option value \"%s\" detected"
 msgstr ""
 
-#: js/formidable_admin.js:6795
+#: js/formidable_admin.js:6794
 msgid "This plugin is not activated. Would you like to activate it now?"
 msgstr ""
 
-#: js/formidable_admin.js:6798
+#: js/formidable_admin.js:6797
 msgid "That add-on is not installed. Would you like to install it now?"
 msgstr ""
 
-#: js/formidable_admin.js:8949
+#: js/formidable_admin.js:8948
 msgid "Save and Reload"
 msgstr ""
 
-#: js/formidable_admin.js:9118
+#: js/formidable_admin.js:9117
 msgid "Unable to install template"
 msgstr ""
 
-#: js/formidable_admin.js:9770
+#: js/formidable_admin.js:9769
 msgid "Thank you for signing up!"
 msgstr ""
 
@@ -8367,4 +8344,23 @@ msgstr ""
 
 #: js/packages/floating-links/config.js:79
 msgid "Support & Docs"
+msgstr ""
+
+#: js/src/form/views.js:17
+#: js/src/form/views.js:52
+#: js/formidable_blocks.js:848
+#: js/formidable_blocks.js:883
+msgid "Formidable Views"
+msgstr ""
+
+#: js/src/form/views.js:18
+#: js/formidable_blocks.js:849
+msgid "Display a Visual View"
+msgstr ""
+
+#: js/src/form/views.js:74
+#: js/src/form/views.js:86
+#: js/formidable_blocks.js:905
+#: js/formidable_blocks.js:917
+msgid "Effortlessly transform form data into webpages with Views, the only integrated form & application builder."
 msgstr ""


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5056

I ran `npm run makepot` to update the pot file. I tested and it worked.

@Crabcyborg In the old pot file: `POT-Creation-Date: 2024-05-06T15:22:32+00:00\n`. So this file is generated in the latest release. `npm run makepot` is called in `bin/build-plugin.sh` file.

I'm not sure what's wrong with the previous pot file.

@garretlaxton Can you please test this? You need to deactivate Formidable Pro and Formidable Bootstrap Modal plugins. Then use Loco Translate (or any translation tools) to translate block strings mentioned in the issue. And then check if those strings are translated in the block.