### PR TITLE
Fix frm_content filter doesn't work with repeater actions

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1693,8 +1693,11 @@ class FrmFormsController {
 			$form = $form->id;
 		}
 
+        /*
+         * Repeater actions adds `parent_entry` to `$entry` store the parent entry data. If `parent_entry` is not empty,
+         * use the parent form ID instead of repeater form ID to fix the parent form field shortcodes doesn't work.
+         */
 		if ( ! empty( $entry->parent_entry ) ) {
-			// If $entry is a repeater entry, the main form field shortcodes won't work. So we use the main form ID.
 			$form = $entry->parent_entry->form_id;
 		}
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1693,6 +1693,11 @@ class FrmFormsController {
 			$form = $form->id;
 		}
 
+		if ( ! empty( $entry->parent_entry ) ) {
+			// If $entry is a repeater entry, the main form field shortcodes won't work. So we use the main form ID.
+			$form = $entry->parent_entry->form_id;
+		}
+
 		$shortcodes = FrmFieldsHelper::get_shortcodes( $content, $form );
 		$content    = apply_filters( 'frm_replace_content_shortcodes', $content, $entry, $shortcodes );
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1693,10 +1693,10 @@ class FrmFormsController {
 			$form = $form->id;
 		}
 
-        /*
-         * Repeater actions adds `parent_entry` to `$entry` store the parent entry data. If `parent_entry` is not empty,
-         * use the parent form ID instead of repeater form ID to fix the parent form field shortcodes doesn't work.
-         */
+		/*
+		 * Repeater actions adds `parent_entry` to `$entry` store the parent entry data. If `parent_entry` is not empty,
+		 * use the parent form ID instead of repeater form ID to fix the parent form field shortcodes doesn't work.
+		 */
 		if ( ! empty( $entry->parent_entry ) ) {
 			$form = $entry->parent_entry->form_id;
 		}


### PR DESCRIPTION
The issue: When running a API form action with a repeater entry, other field shortcodes don't work.

You can use this form to test:
[repeater-actions-form.xml.zip](https://github.com/Strategy11/formidable-forms/files/15427173/repeater-actions-form.xml.zip)

That form contains Text, Repeater 1, and Repeater 2 fields. It has the API form action that sends the request to itself. I use this code to log the request:
```
add_action( 'init', function() {
	if ( isset( $_GET['repeater-actions-test'] ) ) {
		error_log( print_r( file_get_contents('php://input'), true ) );
	}
} );
```

When set the `Run this action for` to `Repeater 1`, the shortcodes for other fields should work.