### PR TITLE
Pro issue 5058 update form button settings

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1429,6 +1429,7 @@ class FrmFormsController {
 	 * @since 4.0
 	 *
 	 * @param array $values
+	 * @return void
 	 */
 	public static function advanced_settings( $values ) {
 		$first_h3 = 'frm_first_h3';
@@ -1438,6 +1439,7 @@ class FrmFormsController {
 
 	/**
 	 * @param array $values
+	 * @return void
 	 */
 	public static function render_spam_settings( $values ) {
 		if ( function_exists( 'akismet_http_post' ) ) {
@@ -1451,13 +1453,9 @@ class FrmFormsController {
 	 * @since 4.0
 	 *
 	 * @param array $values
+	 * @return void
 	 */
 	public static function buttons_settings( $values ) {
-		$styles = apply_filters( 'frm_get_style_opts', array() );
-
-		$frm_settings    = FrmAppHelper::get_settings();
-		$no_global_style = $frm_settings->load_style === 'none';
-
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/settings-buttons.php';
 	}
 
@@ -1465,6 +1463,7 @@ class FrmFormsController {
 	 * @since 4.0
 	 *
 	 * @param array $values
+	 * @return void
 	 */
 	public static function html_settings( $values ) {
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/settings-html.php';
@@ -1476,6 +1475,7 @@ class FrmFormsController {
 	 * @since 2.03.08
 	 *
 	 * @param array|bool $values
+	 * @return void
 	 */
 	private static function clean_submit_html( &$values ) {
 		if ( is_array( $values ) && isset( $values['submit_html'] ) ) {
@@ -1944,9 +1944,8 @@ class FrmFormsController {
 	}
 
 	/**
-	 * Education for premium features.
-	 *
 	 * @since 4.05
+	 * @return void
 	 */
 	public static function add_form_style_tab_options() {
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/add_form_style_options.php';
@@ -3233,14 +3232,6 @@ class FrmFormsController {
 	public static function create( $values = array() ) {
 		_deprecated_function( __METHOD__, '4.0', 'FrmFormsController::update' );
 		self::update( $values );
-	}
-
-	/**
-	 * @deprecated 4.08
-	 * @since 3.06
-	 */
-	public static function add_new() {
-		_deprecated_function( __FUNCTION__, '4.08' );
 	}
 
 	/**

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1944,6 +1944,8 @@ class FrmFormsController {
 	}
 
 	/**
+	 * Education for premium features.
+	 *
 	 * @since 4.05
 	 * @return void
 	 */

--- a/classes/views/frm-forms/add_form_style_options.php
+++ b/classes/views/frm-forms/add_form_style_options.php
@@ -4,19 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <tr>
-	<td>
-		<label for="frm_option_transition" class="frm_show_upgrade frm_noallow" data-medium="transitions" data-upgrade="Form transitions">
-			<?php esc_html_e( 'Page Turn Transitions', 'formidable' ); ?>
-		</label>
-	</td>
-	<td>
-		<select id="frm_option_transition" >
-			<option disabled>
-				<?php esc_html_e( 'Slide horizontally', 'formidable' ); ?>
-			</option>
-			<option disabled>
-				<?php esc_html_e( 'Slide vertically', 'formidable' ); ?>
-			</option>
-		</select>
+	<td colspan="2">
+		<div class="frm_note_style" style="margin-top: 0;">
+			<?php esc_html_e( 'Page Turn Transitions setting was moved to the page break field settings in the form builder.', 'formidable' ); ?>
+			<input type="hidden" name="options[transition]" value="<?php echo esc_attr( $values['transition'] ); ?>" />
+		</div>
 	</td>
 </tr>

--- a/classes/views/frm-forms/add_form_style_options.php
+++ b/classes/views/frm-forms/add_form_style_options.php
@@ -7,7 +7,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<td colspan="2">
 		<div class="frm_note_style" style="margin-top: 0;">
 			<?php esc_html_e( 'Page Turn Transitions setting was moved to the page break field settings in the form builder.', 'formidable' ); ?>
-			<input type="hidden" name="options[transition]" value="<?php echo esc_attr( $values['transition'] ); ?>" />
 		</div>
 	</td>
 </tr>

--- a/classes/views/frm-forms/settings-buttons.php
+++ b/classes/views/frm-forms/settings-buttons.php
@@ -3,10 +3,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
 ?>
-<p class="howto">
-	<?php esc_html_e( 'Set your button text.', 'formidable' ); ?>
-</p>
-
 <input type="hidden" name="options[custom_style]" value="<?php echo esc_attr( $values['custom_style'] ); ?>" />
 
 <table class="form-table">


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5058

This update does a few things,

- It updates the buttons settings page to just look like Pro now instead of showing a placeholder input that doesn't exist in Pro anymore. This page isn't terribly marketable and it will be removed soon so I think this is all we need to bother with doing right now.
- I removed an old deprecated `FrmFormsController::add_new` function that I confirmed isn't being referenced anywhere.
- Added some `@return void` comments.
- Removed some variables that aren't being used anymore in `FrmFormsController::buttons_settings`.