### PR TITLE
Store and reuse field selection data when displaying field type in options

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -627,6 +627,10 @@ DEFAULT_HTML;
 
 	/**
 	 * Store $all_field_types in memory on first call and re-use it to improve the performance of the form builder.
+	 *
+	 * @since x.x
+	 *
+	 * @return array
 	 */
 	private static function get_all_field_types() {
 		if ( ! isset( self::$all_field_types ) ) {

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -88,6 +88,13 @@ abstract class FrmFieldType {
 	private static $should_hide_draft_fields;
 
 	/**
+	 * @since x.x
+	 *
+	 * @var array|null
+	 */
+	private static $all_field_types;
+
+	/**
 	 * @param array|int|object $field
 	 * @param string           $type
 	 */
@@ -434,9 +441,13 @@ DEFAULT_HTML;
 		$this->field_choices_heading( $args );
 
 		echo '<div class="frm_grid_container frm-collapse-me' . esc_attr( $this->extra_field_choices_class() ) . '">';
+		do_action( 'qm/start', 'show_priority_field_choices' );
 		$this->show_priority_field_choices( $args );
+		do_action( 'qm/stop', 'show_priority_field_choices' );
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/field-choices.php';
+		do_action( 'qm/start', 'show_extra_field_choices' );
 		$this->show_extra_field_choices( $args );
+		do_action( 'qm/stop', 'show_extra_field_choices' );
 		echo '</div>';
 	}
 
@@ -599,7 +610,7 @@ DEFAULT_HTML;
 	 * @return void
 	 */
 	protected function field_choices_heading( $args ) {
-		$all_field_types = array_merge( FrmField::pro_field_selection(), FrmField::field_selection() );
+		$all_field_types = self::get_all_field_types();
 		?>
 		<h3 <?php $this->field_choices_heading_attrs( $args ); ?>>
 			<?php
@@ -612,6 +623,16 @@ DEFAULT_HTML;
 			?>
 		</h3>
 		<?php
+	}
+
+	/**
+	 * Store $all_field_types in memory on first call and re-use it to improve the performance of the form builder.
+	 */
+	private static function get_all_field_types() {
+		if ( ! isset( self::$all_field_types ) ) {
+			self::$all_field_types = array_merge( FrmField::pro_field_selection(), FrmField::field_selection() );
+		}
+		return self::$all_field_types;
 	}
 
 	/**

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -441,13 +441,9 @@ DEFAULT_HTML;
 		$this->field_choices_heading( $args );
 
 		echo '<div class="frm_grid_container frm-collapse-me' . esc_attr( $this->extra_field_choices_class() ) . '">';
-		do_action( 'qm/start', 'show_priority_field_choices' );
 		$this->show_priority_field_choices( $args );
-		do_action( 'qm/stop', 'show_priority_field_choices' );
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-fields/back-end/field-choices.php';
-		do_action( 'qm/start', 'show_extra_field_choices' );
 		$this->show_extra_field_choices( $args );
-		do_action( 'qm/stop', 'show_extra_field_choices' );
 		echo '</div>';
 	}
 

--- a/css/font_icons.css
+++ b/css/font_icons.css
@@ -27,7 +27,6 @@
 	-moz-osx-font-smoothing: grayscale;
 	text-rendering: auto;
 	line-height: 1.5;
-	-moz-transition: color .1s ease-in-out, opacity .1s ease-in-out;
 	-webkit-transition: color .1s ease-in-out, opacity .1s ease-in-out;
 	transition: color .1s ease-in-out, opacity .1s ease-in-out;
 	font-size: 18px;


### PR DESCRIPTION
In my form with 1,004 fields, where 214 of which have options, this saves approximately 1.926 seconds from the load time.

This is at a rate of saving `0.009` seconds for each of the `214` fields that need to get this field selection data. `0.009 * 214 = 1.926`.

So it loads in 33.27 seconds instead of 35.196 seconds.

For a 5% reduction in overall page load time.