### PR TITLE
Drop old alpha filter css rule

### DIFF
--- a/css/frm_fonts.css
+++ b/css/frm_fonts.css
@@ -13,7 +13,6 @@
 
 .frm_inactive_menu{
 	opacity:.5;
-	filter:alpha(opacity=50);
 }
 
 /* media box button */


### PR DESCRIPTION
I'm trying to get my CSS warnings down.

This isn't required anymore and throws warnings in modern browsers.