### PR TITLE
fix: prevent php warning when fields are removed

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1205,6 +1205,9 @@ class FrmFieldsHelper {
 
 	private static function field_types_for_input( $inputs, $fields, &$field_types ) {
 		foreach ( $inputs as $input ) {
+			if ( ! isset( $field_types[ $input ] ) ) {
+				continue;
+			}
 			$field_types[ $input ] = $fields[ $input ];
 			unset( $input );
 		}


### PR DESCRIPTION
When fields are disabled with the `frm_pro_available_fields` or `frm_available_fields` filters it can generate php warnings within the `field_types_for_input()` method. This commit prevent it from happening by checking if the key is set before dealing with it.