### PR TITLE
Remove old styles for pro features using icon fonts

### DIFF
--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -33,42 +33,6 @@ $arrow_icons = FrmStylesHelper::arrow_icons();
 }
 <?php } ?>
 
-<?php if ( ! empty( $label_color ) ) { ?>
-.<?php echo esc_html( $style_class ); ?> .frm_icon_font{
-	color:<?php echo esc_html( $label_color . $important ); ?>;
-}
-<?php } ?>
-
-.<?php echo esc_html( $style_class ); ?> .frm_icon_font.frm_minus_icon:before{
-	content:"\e<?php echo esc_html( isset( $minus_icons[ $repeat_icon ] ) ? $minus_icons[ $repeat_icon ]['-'] : $minus_icons[1]['-'] ); ?>";
-}
-
-.<?php echo esc_html( $style_class ); ?> .frm_icon_font.frm_plus_icon:before{
-	content:"\e<?php echo esc_html( isset( $minus_icons[ $repeat_icon ] ) ? $minus_icons[ $repeat_icon ]['+'] : $minus_icons[1]['+'] ); ?>";
-}
-
-.<?php echo esc_html( $style_class ); ?> .frm_icon_font.frm_minus_icon:before,
-.<?php echo esc_html( $style_class ); ?> .frm_icon_font.frm_plus_icon:before{
-	<?php if ( ! empty( $submit_text_color ) ) { ?>
-		color:<?php echo esc_html( $submit_text_color . $important ); ?>;
-	<?php } ?>
-	vertical-align:middle;
-}
-
-.<?php echo esc_html( $style_class ); ?> .frm_trigger.active .frm_icon_font.frm_arrow_icon:before{
-	content:"\e<?php echo esc_html( isset( $arrow_icons[ $collapse_icon ] ) ? $arrow_icons[ $collapse_icon ]['-'] : $arrow_icons[1]['-'] ); ?>";
-	<?php if ( ! empty( $section_color ) ) { ?>
-		color:<?php echo esc_html( $section_color . $important ); ?>;
-	<?php } ?>
-}
-
-.<?php echo esc_html( $style_class ); ?> .frm_trigger .frm_icon_font.frm_arrow_icon:before{
-	content:"\e<?php echo esc_html( isset( $arrow_icons[ $collapse_icon ] ) ? $arrow_icons[ $collapse_icon ]['+'] : $arrow_icons[1]['+'] ); ?>";
-	<?php if ( ! empty( $section_color ) ) { ?>
-		color:<?php echo esc_html( $section_color . $important ); ?>;
-	<?php } ?>
-}
-
 <?php if ( ! empty( $field_margin ) ) { ?>
 .<?php echo esc_html( $style_class ); ?> .form-field{
 	margin-bottom:<?php echo esc_html( $field_margin . $important ); ?>;

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -1594,11 +1594,6 @@ select.frm_loading_lookup{
 	display:block;
 }
 
-.with_frm_style .frm_repeat_sec .frm_form_field.frm_repeat_buttons .frm_icon_font::before {
-	color:<?php echo esc_html( $defaults['repeat_icon_color'] . $important ); ?>;
-	color:var(--repeat-icon-color)<?php echo esc_html( $important ); ?>;
-}
-
 .with_frm_style .frm_combo_inputs_container > .frm_form_subfield-first,
 .with_frm_style .frm_combo_inputs_container > .frm_form_subfield-middle,
 .with_frm_style .frm_combo_inputs_container > .frm_form_subfield-last {


### PR DESCRIPTION
These haven't been used since before Pro version 6.4.2, released last August.

`frm_icon_font` is no longer used on the front end so none of these styles should be necessary any longer.