### PR TITLE
Avoid double title attributes when previewing form

### DIFF
--- a/classes/views/frm-entries/direct.php
+++ b/classes/views/frm-entries/direct.php
@@ -2,15 +2,30 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
+
+add_filter(
+	'document_title',
+	function ( $title ) use ( $form ) {
+		$form_name = '' === $form->name ? __( '(no title)', 'formidable' ) : $form->name;
+		return get_bloginfo( 'name', 'display' ) . ' | ' . wp_strip_all_tags( $form_name );
+	}
+);
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
-	<title><?php bloginfo( 'name' ); ?> | <?php echo esc_html( $form->name ); ?></title>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-	<?php wp_head(); ?>
-	<?php FrmFormsController::maybe_load_css( $form, 1, false ); ?>
+	<?php
+	if ( ! current_theme_supports( 'title-tag' ) ) {
+		?>
+		<title><?php bloginfo( 'name' ); ?> | <?php echo esc_html( $form->name ); ?></title>
+		<?php
+	}
+
+	wp_head();
+	FrmFormsController::maybe_load_css( $form, 1, false );
+	?>
 </head>
 <body class="frm_preview_page">
 	<?php


### PR DESCRIPTION
I caught this issue when validating our form preview HTML.

The WP theme adds a title attribute, and we're adding a second one.

This update checks if the theme supports the `title-tag` option. If it doesn't, we show a title tag. If it does, we use the `document_title` filter to overwrite the text.

Also, to avoid `|` and nothing (when there is no title), I've added a `(no title)` fallback to the title.

<img width="649" alt="Screen Shot 2024-06-04 at 9 46 16 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/51266f45-8c31-4b3a-835d-b2ab5679d497">
