### PR TITLE
Alt solution to PR 1773

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1211,6 +1211,7 @@ class FrmFieldsHelper {
 	 */
 	private static function field_types_for_input( $inputs, $fields, &$field_types ) {
 		foreach ( $inputs as $input ) {
+			// This may not be set if a field type was removed using the frm_available_fields or frm_pro_available_fields filters.
 			if ( array_key_exists( $input, $fields ) ) {
 				$field_types[ $input ] = $fields[ $input ];
 			}

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1203,9 +1203,17 @@ class FrmFieldsHelper {
 		return apply_filters( 'frm_single_input_fields', $fields );
 	}
 
+	/**
+	 * @param string[] $inputs
+	 * @param array    $fields
+	 * @param array    $field_types
+	 * @return void
+	 */
 	private static function field_types_for_input( $inputs, $fields, &$field_types ) {
 		foreach ( $inputs as $input ) {
-			$field_types[ $input ] = $fields[ $input ];
+			if ( array_key_exists( $input, $fields ) ) {
+				$field_types[ $input ] = $fields[ $input ];
+			}
 			unset( $input );
 		}
 	}


### PR DESCRIPTION
See https://github.com/Strategy11/formidable-forms/pull/1773/

When removing a field type, something like
```
add_filter(
	'frm_pro_available_fields',
	function( $fields ) {
		unset( $fields['date'] );
		return $fields;
	}
);
```

A warning will be thrown in the form builder
> PHP Warning:  Undefined array key "date" in /var/www/src/wp-content/plugins/formidable/classes/helpers/FrmFieldsHelper.php on line 1208

And a blank option will appear when trying to change field type.
<img width="241" alt="Screen Shot 2024-06-04 at 12 48 33 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/3e22845e-33ee-44a1-8e6b-a57499eab8f2">
