### PR TITLE
Fix the Form Templates page new HTML errors

### DIFF
--- a/classes/views/form-templates/categories.php
+++ b/classes/views/form-templates/categories.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		}
 		?>
 
-		<li class="<?php echo esc_attr( $classes ); ?>" data-category="<?php echo esc_attr( $category_slug ); ?>" role="link" tabindex="0" aria-label="<?php echo esc_attr( $aria_label ); ?>">
+		<li class="<?php echo esc_attr( $classes ); ?>" data-category="<?php echo esc_attr( $category_slug ); ?>" tabindex="0" aria-label="<?php echo esc_attr( $aria_label ); ?>">
 			<span class="frm-form-templates-cat-text"><?php echo esc_html( $category_data['name'] ); ?></span>
 			<span class="frm-form-templates-cat-count"><?php echo esc_html( $category_data['count'] ); ?></span>
 		</li>

--- a/classes/views/form-templates/template.php
+++ b/classes/views/form-templates/template.php
@@ -36,7 +36,7 @@ FrmFormTemplatesHelper::prepare_template_details( $template, $pricing, $license_
 
 	<div class="frm-form-templates-item-body">
 		<h3 class="frm-form-templates-item-title frm-font-medium">
-			<div class="frm-form-templates-item-title-text">
+			<span class="frm-form-templates-item-title-text">
 				<?php if ( $template['plan_required'] ) { ?>
 					<span class="frm-form-templates-item-lock-icon">
 						<?php FrmAppHelper::icon_by_class( 'frmfont frm_lock_icon', array( 'aria-label' => __( 'Lock icon', 'formidable' ) ) ); ?>
@@ -46,9 +46,9 @@ FrmFormTemplatesHelper::prepare_template_details( $template, $pricing, $license_
 				<span class="frm-form-template-name">
 					<?php echo esc_html( $template['name'] ); ?>
 				</span>
-			</div>
+			</span>
 
-			<div class="frm-flex-box frm-gap-xs frm-items-center frm-ml-auto">
+			<span class="frm-flex-box frm-gap-xs frm-items-center frm-ml-auto">
 				<?php
 				if ( $template['is_custom'] ) {
 					$trash_links = FrmFormsHelper::delete_trash_links( $template['id'] );
@@ -65,7 +65,7 @@ FrmFormTemplatesHelper::prepare_template_details( $template, $pricing, $license_
 					FrmAppHelper::icon_by_class( 'frmfont ' . $favorite_button_icon );
 					?>
 				</a>
-			</div>
+			</span>
 		</h3>
 
 		<div class="frm-form-templates-item-content">


### PR DESCRIPTION
Fixes HTML errors on the Form Templates page.

### QA URL:
https://qa.formidableforms.com/sherv4/wp-admin/admin.php?page=formidable-form-templates

### Issue URL:
https://github.com/Strategy11/formidable-pro/issues/5114

### Testing Instructions:
1. Open the QA URL.
2. Right-click and select "View Page Source."
3. Copy all the HTML of the source page and paste it into [W3C Validator](https://validator.w3.org/#validate_by_input).
4. Verify that the new HTML errors after releasing the Form Templates are no longer present.