### PR TITLE
Drop old css rule ms-pointer-events

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -524,7 +524,6 @@ legend.frm_hidden{
 	font-weight: normal;
 	font-weight: var(--field-weight);
 
-	-ms-pointer-events: none;
 	pointer-events: none;
 }
 


### PR DESCRIPTION
This was only necessary for old versions of IE and should be safe to remove now.