### PR TITLE
Drop old ms box sizing css rule

### DIFF
--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -231,7 +231,6 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 	text-shadow:none;
 	padding:<?php echo esc_html( $submit_padding . $important ); ?>;
 	box-sizing:border-box;
-	-ms-box-sizing:border-box;
 	<?php if ( ! empty( $submit_shadow_color ) ) { ?>
 	box-shadow:0 1px 1px <?php echo esc_html( $submit_shadow_color ); ?>;
 	<?php } ?>


### PR DESCRIPTION
This is covered now by `box-sizing:border-box;` and was only required for old versions of IE.