### PR TITLE
Use field keys not ids for js validation errors

### DIFF
--- a/classes/controllers/FrmEntriesAJAXSubmitController.php
+++ b/classes/controllers/FrmEntriesAJAXSubmitController.php
@@ -163,18 +163,11 @@ class FrmEntriesAJAXSubmitController {
 	 * @return string
 	 */
 	private static function maybe_modify_ajax_error( $error, $field_id, $form, $errors ) {
-		if ( false !== strpos( $field_id, '-' ) ) {
-			// repeated fields look like field_id-repeater_id-iteration, so pull the first value for the field id.
-			list( $use_field_id ) = explode( '-', $field_id );
-		} else {
-			$use_field_id = $field_id;
-		}
-
-		if ( ! is_numeric( $use_field_id ) ) {
+		if ( ! is_numeric( $field_id ) ) {
 			return $error;
 		}
 
-		$use_field = FrmField::getOne( $use_field_id );
+		$use_field = FrmField::getOne( $field_id );
 
 		if ( ! $use_field ) {
 			return $error;
@@ -185,7 +178,7 @@ class FrmEntriesAJAXSubmitController {
 
 		if ( false !== $error_body ) {
 			$error = str_replace( '[error]', $error, $error_body );
-			$error = str_replace( '[key]', $field_id, $error );
+			$error = str_replace( '[key]', $use_field['field_key'], $error );
 		}
 
 		return $error;

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -569,24 +569,45 @@ function frmFrontFormJS() {
 		return errors;
 	}
 
+	/**
+	 * 
+	 * @param {HTMLElement} field
+	 * @param {string}      messageType
+	 * @return {string}
+	 */
 	function getFieldValidationMessage( field, messageType ) {
-		let msg, errorHtml;
-
-		msg = field.getAttribute( messageType );
+		let msg = field.getAttribute( messageType );
 		if ( null === msg ) {
 			msg = '';
 		}
 
 		if ( '' !== msg && shouldWrapErrorHtmlAroundMessageType( messageType ) ) {
-			errorHtml = field.getAttribute( 'data-error-html' );
-			if ( null !== errorHtml ) {
-				errorHtml = errorHtml.replace( /\+/g, '%20' );
-				msg = decodeURIComponent( errorHtml ).replace( '[error]', msg );
-				msg = msg.replace( '[key]', getFieldId( field, false ) );
-			}
+			msg = wrapErrorHtml( msg, field );
 		}
 
 		return msg;
+	}
+
+	/**
+	 * @param {string}      msg
+	 * @param {HTMLElement} field
+	 * @return {string}
+	 */
+	function wrapErrorHtml( msg, field ) {
+		let errorHtml = field.getAttribute( 'data-error-html' );
+		if ( null === errorHtml ) {
+			return msg;
+		}
+
+		errorHtml          = errorHtml.replace( /\+/g, '%20' );
+		msg                = decodeURIComponent( errorHtml ).replace( '[error]', msg );
+		const fieldId      = getFieldId( field, false );
+		const split        = fieldId.split( '-' );
+		const fieldIdParts = field.id.split( '_' );
+		fieldIdParts.shift(); // Drop the "field" value from the front.
+		split[0]       = fieldIdParts.join( '_' );
+		const errorKey = split.join( '-' );
+		return msg.replace( '[key]', errorKey );
 	}
 
 	function shouldWrapErrorHtmlAroundMessageType( type ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -570,10 +570,9 @@ function frmFrontFormJS() {
 	}
 
 	/**
-	 * 
 	 * @param {HTMLElement} field
 	 * @param {string}      messageType
-	 * @return {string}
+	 * @return {string} The error message to display.
 	 */
 	function getFieldValidationMessage( field, messageType ) {
 		let msg = field.getAttribute( messageType );
@@ -591,7 +590,7 @@ function frmFrontFormJS() {
 	/**
 	 * @param {string}      msg
 	 * @param {HTMLElement} field
-	 * @return {string}
+	 * @return {string} The error HTML to use.
 	 */
 	function wrapErrorHtml( msg, field ) {
 		let errorHtml = field.getAttribute( 'data-error-html' );

--- a/tests/phpunit/entries/test_FrmEntriesAJAXSubmitController.php
+++ b/tests/phpunit/entries/test_FrmEntriesAJAXSubmitController.php
@@ -14,6 +14,7 @@ class test_FrmEntriesAJAXSubmitController extends FrmUnitTest {
 		$field_id = $this->factory->field->create(
 			array(
 				'form_id'       => $form->id,
+				'field_key'     => 'modify_ajax_error_test_key',
 				'type'          => 'text',
 				'field_options' => array(
 					'custom_html' => '
@@ -30,7 +31,7 @@ class test_FrmEntriesAJAXSubmitController extends FrmUnitTest {
 			)
 		);
 		$this->assertEquals(
-			'<div class="frm_error my_custom_error_class" id="frm_error_field_' . $field_id . '">My custom error label: This field cannot be blank.</div>',
+			'<div class="frm_error my_custom_error_class" id="frm_error_field_modify_ajax_error_test_key">My custom error label: This field cannot be blank.</div>',
 			$this->maybe_modify_ajax_error( $error, $field_id, $form )
 		);
 	}


### PR DESCRIPTION
Related ticket https://github.com/Strategy11/formidable-pro/pull/5131
Related PR for AJAX validation issues when Pro is active https://github.com/Strategy11/formidable-pro/pull/5131

This fixes the issue when JS validation is on.

I also dropped some repeater logic from `maybe_modify_ajax_error` since this code is never reached when Pro is active so there's no reason to check for repeaters.

**Pre-release,**
[formidable-6.11b.zip](https://github.com/user-attachments/files/15805493/formidable-6.11b.zip)
