### PR TITLE
Add automated CSS validation with Cypress

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -33,4 +33,4 @@ jobs:
         run: npm run env start
 
       - name: Test
-        run: npm run e2e:run
+        run: npm run e2e:run --env FORMIDABLE_FOLDER=formidable

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -33,4 +33,6 @@ jobs:
         run: npm run env start
 
       - name: Test
-        run: npm run e2e:run --env FORMIDABLE_FOLDER=formidable
+        run: |
+          FORMIDABLE_FOLDER=formidable
+          npm run e2e:run

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -33,6 +33,4 @@ jobs:
         run: npm run env start
 
       - name: Test
-        run: |
-          FORMIDABLE_FOLDER=formidable
-          npm run e2e:run
+        run: npm run e2e:githubrun

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"phpcbf": "./vendor/bin/phpcbf --parallel=10 ./",
 		"env": "wp-env",
 		"start": "wp-scripts start assets/js/scripts.js --webpack-no-externals --output-path=dist",
-		"e2e:run": "cypress run --config-file cypress.config.js"
+		"e2e:run": "cypress run --config-file cypress.config.js",
+		"e2e:githubrun": "cypress run --config-file cypress.config.js --env FORMIDABLE_FOLDER=formidable-forms"
 	},
 	"engines": {
 		"node": ">=18.0.0",

--- a/tests/cypress/e2e/validate-css.cy.js
+++ b/tests/cypress/e2e/validate-css.cy.js
@@ -52,6 +52,9 @@ describe( 'Run some CSS validation', function() {
     });
 
     it('Check genarated CSS for valid CSS', () => {
+        cy.login();
+        cy.visit( '/wp-admin/admin.php?page=formidable-styles' );
+        cy.get( '#frm_submit_side_top' ).click();
         validateCSS( '/wp-content/plugins/formidable/css/formidableforms.css' );
     });
 

--- a/tests/cypress/e2e/validate-css.cy.js
+++ b/tests/cypress/e2e/validate-css.cy.js
@@ -1,4 +1,10 @@
-describe( 'Run some CSS validation', function() {
+describe( 'Run some CSS validation', () => {
+
+    const arrayBufferToJsonObject = arrayBuffer => {
+        const decoder    = new TextDecoder( 'utf-8' );
+        const jsonString = decoder.decode( arrayBuffer );
+        return JSON.parse( jsonString );
+    };
 
     const validateCSS = url => {
         return cy.request( url ).then( response => {
@@ -18,10 +24,7 @@ describe( 'Run some CSS validation', function() {
             }).then( validationResponse => {
                 expect( validationResponse.status ).to.eq( 200 );
 
-                const arrayBuffer = validationResponse.body;
-                const decoder     = new TextDecoder( 'utf-8' );
-                const jsonString  = decoder.decode( arrayBuffer );
-                const jsonObject  = JSON.parse( jsonString );
+               const jsonObject = arrayBufferToJsonObject( validationResponse.body );
 
                 expect( jsonObject.cssvalidation ).to.be.an( 'object' );
                 const validationResults = jsonObject.cssvalidation;

--- a/tests/cypress/e2e/validate-css.cy.js
+++ b/tests/cypress/e2e/validate-css.cy.js
@@ -53,7 +53,7 @@ describe( 'Run some CSS validation', function() {
         validateCSS( '/wp-content/plugins/' + formidableFolder + '/css/frm_admin.css' );
     });
 
-    it('Check genarated CSS for valid CSS', () => {
+    it('Check generated CSS for valid CSS', () => {
         validateCSS( '/wp-content/plugins/' + formidableFolder + '/css/formidableforms.css' );
     });
 

--- a/tests/cypress/e2e/validate-css.cy.js
+++ b/tests/cypress/e2e/validate-css.cy.js
@@ -47,17 +47,14 @@ describe( 'Run some CSS validation', function() {
         });
     };
 
-    
+    const formidableFolder = Cypress.env( 'FORMIDABLE_FOLDER' ) || 'formidable';
 
     it('Check frm_admin.css for valid CSS', () => {
-        validateCSS( '/wp-content/plugins/formidable-forms/css/frm_admin.css' );
+        validateCSS( '/wp-content/plugins/' + formidableFolder + '/css/frm_admin.css' );
     });
 
     it('Check genarated CSS for valid CSS', () => {
-    //    cy.login();
-  //      cy.visit( '/wp-admin/admin.php?page=formidable-styles' );
-//        cy.get( '#frm_submit_side_top' ).click();
-        validateCSS( '/wp-content/plugins/formidable-forms/css/formidableforms.css' );
+        validateCSS( '/wp-content/plugins/' + formidableFolder + '/css/formidableforms.css' );
     });
 
 });

--- a/tests/cypress/e2e/validate-css.cy.js
+++ b/tests/cypress/e2e/validate-css.cy.js
@@ -47,14 +47,16 @@ describe( 'Run some CSS validation', function() {
         });
     };
 
+    
+
     it('Check frm_admin.css for valid CSS', () => {
         validateCSS( '/wp-content/plugins/formidable-forms/css/frm_admin.css' );
     });
 
     it('Check genarated CSS for valid CSS', () => {
-        cy.login();
-        cy.visit( '/wp-admin/admin.php?page=formidable-styles' );
-        cy.get( '#frm_submit_side_top' ).click();
+    //    cy.login();
+  //      cy.visit( '/wp-admin/admin.php?page=formidable-styles' );
+//        cy.get( '#frm_submit_side_top' ).click();
         validateCSS( '/wp-content/plugins/formidable-forms/css/formidableforms.css' );
     });
 

--- a/tests/cypress/e2e/validate-css.cy.js
+++ b/tests/cypress/e2e/validate-css.cy.js
@@ -1,0 +1,58 @@
+describe( 'Run some CSS validation', function() {
+
+    const validateCSS = url => {
+        return cy.request( url ).then( response => {
+            const css      = response.body;
+            const formData = new FormData();
+            formData.append( 'text', css );
+            formData.append( 'profile', 'css3svg' );
+            formData.append( 'output', 'json' );
+
+            return cy.request({
+                method: 'POST',
+                url: 'https://jigsaw.w3.org/css-validator/validator',
+                body: formData,
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                },
+            }).then( validationResponse => {
+                expect( validationResponse.status ).to.eq( 200 );
+
+                const arrayBuffer = validationResponse.body;
+                const decoder     = new TextDecoder( 'utf-8' );
+                const jsonString  = decoder.decode( arrayBuffer );
+                const jsonObject  = JSON.parse( jsonString );
+
+                expect( jsonObject.cssvalidation ).to.be.an( 'object' );
+                const validationResults = jsonObject.cssvalidation;
+                const validationErrors  = validationResults.errors || [];
+
+                const exceptions = [ 'noexistence-at-all' ];
+                const errors     = [];
+
+                validationErrors.forEach(
+                    validationError => {
+                        if ( ! exceptions.includes( validationError.type ) ) {
+                            errors.push( validationError.message + ' on line ' + validationError.line + ' (' + validationError.type + ')' );
+                        }
+                    }
+                );
+
+                // Fail the test if there are validation errors
+                if ( errors.length ) {
+                    console.log( 'CSS Validation errors for ' + url, errors );
+                    throw new Error('CSS validation errors found');
+                }
+            });
+        });
+    };
+
+    it('Check frm_admin.css for valid CSS', () => {
+        validateCSS( '/wp-content/plugins/formidable/css/frm_admin.css' );
+    });
+
+    it('Check genarated CSS for valid CSS', () => {
+        validateCSS( '/wp-content/plugins/formidable/css/formidableforms.css' );
+    });
+
+});

--- a/tests/cypress/e2e/validate-css.cy.js
+++ b/tests/cypress/e2e/validate-css.cy.js
@@ -48,14 +48,14 @@ describe( 'Run some CSS validation', function() {
     };
 
     it('Check frm_admin.css for valid CSS', () => {
-        validateCSS( '/wp-content/plugins/formidable/css/frm_admin.css' );
+        validateCSS( '/wp-content/plugins/formidable-forms/css/frm_admin.css' );
     });
 
     it('Check genarated CSS for valid CSS', () => {
         cy.login();
         cy.visit( '/wp-admin/admin.php?page=formidable-styles' );
         cy.get( '#frm_submit_side_top' ).click();
-        validateCSS( '/wp-content/plugins/formidable/css/formidableforms.css' );
+        validateCSS( '/wp-content/plugins/formidable-forms/css/formidableforms.css' );
     });
 
 });


### PR DESCRIPTION
This update uses Cypress to load CSS files and validate them using https://jigsaw.w3.org/css-validator/.

I initially tried doing this with PHP and WordPress using PHPUnit, but calling the API with curl was always resulting in an error from the API that I couldn't figure out even though it worked fine in Postman.

For now this covers the two main CSS files that get changed the most often and cover most of the styling - `frm_admin.css` and our generated `formidableforms.css` files.

For now this only throws errors if there is a CSS error, ignoring warnings. I also ignore one specific CSS error type which is getting flagged for a false positive.

If our CSS is ever invalid, this should catch that ahead of time.