### PR TITLE
Drop deprecated frmUpdateField front end function

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3285,7 +3285,6 @@ class FrmAppHelper {
 			'empty_fields'         => __( 'Please complete the preceding required fields before uploading a file.', 'formidable' ),
 			'focus_first_error'    => self::should_focus_first_error(),
 			'include_alert_role'   => self::should_include_alert_role_on_field_errors(),
-			'include_update_field' => self::should_include_update_field_function(),
 			'include_resend_email' => self::should_include_resend_email_code(),
 		);
 
@@ -3405,21 +3404,6 @@ class FrmAppHelper {
 	 */
 	public static function should_include_alert_role_on_field_errors() {
 		return (bool) apply_filters( 'frm_include_alert_role_on_field_errors', true );
-	}
-
-	/**
-	 * As of 6.10 the frmUpdateField function is now included in Pro.
-	 * This was originally included in Lite but was removed because the feature is only supoprted in Pro.
-	 *
-	 * @since 6.10
-	 *
-	 * @return bool
-	 */
-	private static function should_include_update_field_function() {
-		if ( ! self::pro_is_installed() ) {
-			return false;
-		}
-		return ! self::meets_min_pro_version( '6.9.2' );
 	}
 
 	/**

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1825,28 +1825,3 @@ function getSelectedCaptcha( captchaSelector ) {
 function frmAfterRecaptcha( token ) {
 	frmFrontForm.afterSingleRecaptcha( token );
 }
-
-if ( frm_js.include_update_field ) { // eslint-disable-line camelcase
-	window.frmUpdateField = function( entryId, fieldId, value, message, num ) {
-		console.warn( 'DEPRECATED: function frmUpdateField please update to Formidable Pro v6.9.2' );
-		jQuery( document.getElementById( 'frm_update_field_' + entryId + '_' + fieldId + '_' + num ) ).html( '<span class="frm-loading-img"></span>' );
-		jQuery.ajax({
-			type: 'POST',
-			url: frm_js.ajax_url, // eslint-disable-line camelcase
-			data: {
-				action: 'frm_entries_update_field_ajax',
-				entry_id: entryId,
-				field_id: fieldId,
-				value: value,
-				nonce: frm_js.nonce // eslint-disable-line camelcase
-			},
-			success: function() {
-				if ( message.replace( /^\s+|\s+$/g, '' ) === '' ) {
-					jQuery( document.getElementById( 'frm_update_field_' + entryId + '_' + fieldId + '_' + num ) ).fadeOut( 'slow' );
-				} else {
-					jQuery( document.getElementById( 'frm_update_field_' + entryId + '_' + fieldId + '_' + num ) ).replaceWith( message );
-				}
-			}
-		});
-	};
-}


### PR DESCRIPTION
People should be on the newer versions of Pro by now. v6.9.2 came out on May 8, making this over a month ago now, and a few versions behind as we're currently on v6.10.1 and this will be introduced in v6.11.