### PR TITLE
Stop using font icons for add option icon

### DIFF
--- a/classes/views/frm-fields/back-end/field-options.php
+++ b/classes/views/frm-fields/back-end/field-options.php
@@ -19,7 +19,9 @@ $field_option_count = is_array( $args['field']['options'] ) ? count( $args['fiel
 
 <div class="frm6 frm_form_field frm_add_opt_container">
 	<a href="javascript:void(0);" data-opttype="single" class="frm_cb_button frm-small-add frm_add_opt frm6 frm_form_field" id="frm_add_opt_<?php echo esc_attr( $args['field']['id'] ); ?>">
-		<span class="frm_icon_font frm_add_tag"></span>
-		<?php echo esc_html( $this->get_add_option_string() ); ?>
+		<?php
+		FrmAppHelper::icon_by_class( 'frm_icon_font frm_plus1_icon frm_add_tag frm_svg13' );
+		echo esc_html( $this->get_add_option_string() );
+		?>
 	</a>
 </div>

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5923,6 +5923,13 @@ p.frm-inline-select,
 	margin-bottom: 5px;
 }
 
+.frm-single-settings .frm_add_opt_container svg.frm_add_tag,
+.frm-single-settings .frm-add-other svg.frm_add_tag {
+	position: relative;
+	top: 5px;
+	margin-right: 4px;
+}
+
 .advanced_settings .frm_logic_row {
 	margin: 14px 0;
 }
@@ -6270,7 +6277,6 @@ span.howto {
 	background: var(--sidebar-color);
 }
 
-/* */
 #frm_form_editor_container #frm_form_key_box {
 	width: 13em;
 	max-width: 30%


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5063
Related Pro PR https://github.com/Strategy11/formidable-pro/pull/5137

<img width="470" alt="Screen Shot 2024-06-18 at 1 43 49 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/149e7760-ae60-4e83-8dd4-926c212f8a64">
