### PR TITLE
Stop using font icons for removing radio/checkbox/dropdown options

### DIFF
--- a/classes/views/frm-fields/single-option.php
+++ b/classes/views/frm-fields/single-option.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<input type="text" name="field_options[options_<?php echo esc_attr( $field['id'] ); ?>][<?php echo esc_attr( $opt_key ); ?>][label]" value="<?php echo esc_attr( $opt ); ?>" class="field_<?php echo esc_attr( $field['id'] ); ?>_option <?php echo esc_attr( $field['separate_value'] ? 'frm_with_key' : '' ); ?>" id="<?php echo esc_attr( $html_id . '-' . $opt_key . '-label' ); ?>" data-frmchange="trim,updateOption,checkUniqueOpt" />
 
-	<a href="javascript:void(0)" class="frm_icon_font frm_remove_tag" data-fid="<?php echo esc_attr( $field['id'] ); ?>" data-removeid="frm_delete_field_<?php echo esc_attr( $field['id'] . '-' . $opt_key ); ?>_container" data-removemore="#frm_<?php echo esc_attr( $default_type . '_' . $field['id'] . '-' . $opt_key ); ?>" data-showlast="#frm_add_opt_<?php echo esc_attr( $field['id'] ); ?>"></a>
+	<a href="javascript:void(0)" class="frm_remove_tag" data-fid="<?php echo esc_attr( $field['id'] ); ?>" data-removeid="frm_delete_field_<?php echo esc_attr( $field['id'] . '-' . $opt_key ); ?>_container" data-removemore="#frm_<?php echo esc_attr( $default_type . '_' . $field['id'] . '-' . $opt_key ); ?>" data-showlast="#frm_add_opt_<?php echo esc_attr( $field['id'] ); ?>"><?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_minus1_icon' ); ?></a>
 
 	<span class="frm_option_key frm-with-right-icon field_<?php echo esc_attr( $field['id'] ); ?>_option_key<?php echo esc_attr( $field['separate_value'] ? '' : ' frm_hidden' ); ?>">
 		<?php if ( in_array( $default_type, array( 'radio', 'checkbox' ), true ) ) : ?>

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5930,6 +5930,15 @@ p.frm-inline-select,
 	margin-right: 4px;
 }
 
+.frm-single-settings .frm_single_option .frm_remove_tag {
+	position: relative;
+	bottom: 3px;
+}
+
+.frm-single-settings .frm_single_option .frm_remove_tag:before {
+	content: "";
+}
+
 .advanced_settings .frm_logic_row {
 	margin: 14px 0;
 }


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5063

This update changes the `-` icon on the right of an option which triggers removing the option.

<img width="514" alt="Screen Shot 2024-06-18 at 2 01 46 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/639860fa-d026-4300-b29a-8f8a24c83050">
