### PR TITLE
Replace nbsp from plain email content

### DIFF
--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -420,7 +420,7 @@ class FrmEmail {
 
 		if ( $this->is_plain_text ) {
 			$this->message = wp_specialchars_decode( strip_tags( $this->message ), ENT_QUOTES );
-			$this->message = str_replace( '&nbsp;', "\r\n", $this->message );
+			$this->message = str_replace( '&nbsp;', '', $this->message );
 		} else {
 			$this->add_autop();
 		}

--- a/classes/models/FrmEmail.php
+++ b/classes/models/FrmEmail.php
@@ -420,6 +420,7 @@ class FrmEmail {
 
 		if ( $this->is_plain_text ) {
 			$this->message = wp_specialchars_decode( strip_tags( $this->message ), ENT_QUOTES );
+			$this->message = str_replace( '&nbsp;', "\r\n", $this->message );
 		} else {
 			$this->add_autop();
 		}


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/1970

**Before**
<img width="800" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/360a6cb9-0d33-4335-af3f-ed75fca79c88">

**After**
<img width="915" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/f38a3430-831f-404c-b790-46f6b1d131a4">

### Test steps
1. Create a form and adda an RTE field to it.
2. Create an email action, checking `Send Emails in Plain Text`.
3. Preview the form, switch to "Visual" mode and fill the RTE with a text that has line breaks.
4. View the email sent and confirm that there are no `&nbsp;` strings displayed in the email body.