### PR TITLE
Bump minimum pro version

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -354,7 +354,7 @@ class FrmAppController {
 	 */
 	public static function pro_get_started_headline() {
 		self::review_request();
-		FrmAppHelper::min_pro_version_notice( '4.0' );
+		FrmAppHelper::min_pro_version_notice( '6.0' );
 	}
 
 	/**


### PR DESCRIPTION
4.0 is really old. This hasn't been updated in some time. The last update was 5 years ago.