### PR TITLE
Keep Stripe pro tip style consistent

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -9492,7 +9492,8 @@ Responsive Design
 }
 
 .frm-right-panel .inside .frm_pro_tip,
-.frm_pro_tip {
+.frm_pro_tip,
+.stripe_settings .frm-light-tip .frm_pro_tip {
 	color: var(--grey-700);
 	background: #FFE7DE;
 	margin: 0 auto;


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5133
**Before**
<img width="1103" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/24a9d319-c3f6-4e70-b50a-7ea5dfe12755">

**After**:
<img width="1103" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/6a0f4d92-6f1f-4c7e-bf8a-1b083128714f">
