### PR TITLE
Do not enqueue popper js on WP Bakery builder

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -916,6 +916,9 @@ class FrmAppController {
 	 * @return void
 	 */
 	private static function register_popper1() {
+		if ( defined( 'WPB_VC_VERSION' ) ) {
+			return;
+		}
 		wp_register_script( 'popper', FrmAppHelper::plugin_url() . '/js/popper.min.js', array( 'jquery' ), '1.16.0', true );
 	}
 


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5150

### Test steps
1. Install and activate WP Bakery builder. Nathanael has put a copy of it [here](https://github.com/Strategy11/formidable-pro/issues/5150#issuecomment-2186509154) if you don't have one.
2. Open a page with WP Bakery builder and try adding elements to your page.
3. Confirm that the following js error is not triggered.
<img width="1088" alt="image" src="https://github.com/Strategy11/formidable-forms/assets/41271840/4ecf8f2a-502d-4449-9db6-555884f89cff">
