### PR TITLE
Drop down arrow icon from insert form pop up

### DIFF
--- a/classes/views/frm-forms/insert_form_popup.php
+++ b/classes/views/frm-forms/insert_form_popup.php
@@ -30,17 +30,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 						</div>
 
 						<div class="media-frame-title">
-							<h1><?php esc_html_e( 'Insert a Form', 'formidable' ); ?>
-								<span class="spinner"></span>
-								<span class="frm_icon_font frm_arrowdown4_icon"></span>
-							</h1>
+							<h1><?php esc_html_e( 'Insert a Form', 'formidable' ); ?></h1>
 						</div>
 
 						<div class="media-frame-content">
 							<div class="attachments-browser">
-								<div id="frm_shortcode_options" class="media-embed">
-
-								</div>
+								<div id="frm_shortcode_options" class="media-embed"></div>
 							</div>
 						</div>
 


### PR DESCRIPTION
This just gets rid of a non-functional icon that just causes confusion.

<img width="438" alt="Screen Shot 2024-07-02 at 1 52 50 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/95b578ac-b39a-4186-8709-57f3d7c49c21">
