### PR TITLE
Update modal close icon color styling

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2679,7 +2679,13 @@ body.rtl .frm-dialog .frm_common_modal .postbox > div:first-child > div:last-chi
 .frm-modal .postbox .frm-modal-title + div:last-child a,
 .frm-modal a.dismiss .frmsvg,
 .frm_common_modal .frm_modal_top a .frmsvg {
-	color: var(--grey-800);
+	color: var(--grey-500);
+}
+
+.frm-modal .postbox .frm-modal-title + div:last-child a:hover,
+.frm-modal a.dismiss .frmsvg:hover,
+.frm_common_modal .frm_modal_top a .frmsvg:hover {
+	color: var(--grey-700);
 }
 
 .frm-modal .frm_modal_content > div.inside,


### PR DESCRIPTION
This is a design update from Razvan,

With this update, the close icon in modals is now a lighter shade of gray, and darkens on hover, to a color that is still slightly lighter than it was before.

<img width="233" alt="Screen Shot 2024-07-04 at 9 59 29 AM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/df31069b-c04e-404c-b960-03f9c5327988">

This is part of the AI generated forms design https://www.figma.com/design/3v8h3KPhiT8wVULnQNAY1p/Create-Form-with-AI?node-id=3-21&t=TQVW3ShqEQ6Deggw-0