### PR TITLE
Define typos CLI baseline and fix more typos

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -38,3 +38,4 @@ tests export-ignore
 webpack.config.js export-ignore
 /stripe/js/frmstrp.js export-ignore
 rector.php export-ignore
+_typos.toml export-ignore

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,21 @@
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: Typo Checks
+jobs:
+  run:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v4
+
+    - name: Check spelling of file.txt
+      uses: crate-ci/typos@master

--- a/_typos.toml
+++ b/_typos.toml
@@ -18,8 +18,8 @@ check-file = false
 # Pevent North Dakota from changing to "AND".
 ND = "ND"
 datas = "datas"
-# This typo fix requires deprecating a method. There is an open issue to fix this.
-get_select_atributes = "get_select_atributes"
+# This typo fix requires deprecating a method (get_select_atributes). There is an open issue to fix this.
+atributes = "atributes"
 # This is used like 7ths, 8ths. It is not a typo for the or this.
 ths = "ths"
 # This is part of a #66afe9 color setting. Typos corrects the "afe" to "safe".

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,30 @@
+[type.po]
+extend-glob = ["*.po"]
+check-file = false
+
+[type.map]
+extend-glob = ["*.map"]
+check-file = false
+
+[type.js]
+extend-glob = ["*/bootstrap-multiselect.js","*.min.js"]
+check-file = false
+
+[type.xml]
+extend-glob = ["*.xml"]
+check-file = false
+
+[default.extend-words]
+# Pevent North Dakota from changing to "AND".
+ND = "ND"
+datas = "datas"
+# This typo fix requires deprecating a method. There is an open issue to fix this.
+get_select_atributes = "get_select_atributes"
+# This is used like 7ths, 8ths. It is not a typo for the or this.
+ths = "ths"
+# This is part of a #66afe9 color setting. Typos corrects the "afe" to "safe".
+afe = "afe"
+# This is used in a regex. It is not intended to be "miss" or "mist".
+mis = "mis"
+# This is used for the Faroese locale. It is not a typo.
+fo = "fo"

--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -94,7 +94,8 @@ zip -r $zipname $destination \
 	-x "*/sonar-project.properties" \
 	-x "*/.sonar_lock" \
 	-x "*/report-task.txt" \
-	-x "*/cypress.config.js"
+	-x "*/cypress.config.js" \
+	-x "*/_typos.toml"
 
 if [ ! -z "$3" ]; then
 	rm -rf $destination

--- a/changelog.txt
+++ b/changelog.txt
@@ -854,7 +854,7 @@
 * Fix: In some cases, a PHP warning was shown when redirecting after submit.
 
 = 4.04 =
-* New: Show a warning if a WordPress parameter is used in the redirect URL to prevent unintented results.
+* New: Show a warning if a WordPress parameter is used in the redirect URL to prevent unintended results.
 * New: Added frm_is_field_type hook to set if an individual field is shown as radio or checkbox
 * New: Show the new pricing fields in the builder for product education.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -854,7 +854,7 @@
 * Fix: In some cases, a PHP warning was shown when redirecting after submit.
 
 = 4.04 =
-* New: Show a warning if a WordPress parameter is used in the redirect URL to prevent unintented results.
+* New: Show a warning if a WordPress parameter is used in the redirect URL to prevent unintended results.
 * New: Added frm_is_field_type hook to set if an individual field is shown as radio or checkbox
 * New: Show the new pricing fields in the builder for product education.
 
@@ -1055,7 +1055,7 @@
 = 3.06 =
 * New: Add one-click form creation from a form template and adjust the way a new form is created
 * New: Add a new process for creating a custom form template
-* Tweak: Create smaller XML fiels when exporting forms
+* Tweak: Create smaller XML fields when exporting forms
 * Tweak: Use the name of the form for XML exports when a single form is exported
 * Tweak: Don't limit the width of the color picker in the form styler to avoid conflicts with some color picker plugins
 * Fix: Prevent the 'Advanced' section from hiding on non-Formidable blocks
@@ -2434,7 +2434,7 @@
 = 2.0.09 =
 * Add frm_time_to_check duplicate entries filter
 * Allow custom JavaScript validation
-* Add frm_do_html_shortcodes fiter
+* Add frm_do_html_shortcodes filter
 * Fix the duplicate entry check
 * Include get_columns function in list tables for 4.3
 * Use relative URLs in the stylesheet
@@ -2796,7 +2796,7 @@
 * PRO: Added drafts parameter to view shortcode to show draft entries. [display-frm-data id=40 drafts=1]
 * PRO: Switched star ratings to icon font
 * PRO: Added multiple="multiple" into multiple file upload fields
-* PRO: Allow field keys in the exlude_fields shortcode option
+* PRO: Allow field keys in the exclude_fields shortcode option
 * PRO: Allow updated-at, created-at, updated-by to by used in conditional statements
 * PRO: Added update message and button to global default messages
 * PRO: Added progress bar to csv import

--- a/changelog.txt
+++ b/changelog.txt
@@ -854,7 +854,7 @@
 * Fix: In some cases, a PHP warning was shown when redirecting after submit.
 
 = 4.04 =
-* New: Show a warning if a WordPress parameter is used in the redirect URL to prevent unintended results.
+* New: Show a warning if a WordPress parameter is used in the redirect URL to prevent unintented results.
 * New: Added frm_is_field_type hook to set if an individual field is shown as radio or checkbox
 * New: Show the new pricing fields in the builder for product education.
 

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1207,7 +1207,7 @@ DEFAULT_HTML;
 	protected function select_tag( $values ) {
 		$field       = isset( $values['field'] ) ? $values['field'] : $this->field;
 		$input_html  = $this->get_field_input_html_hook( $field );
-		$select_atts = $this->get_select_attributes( $values );
+		$select_atts = $this->get_select_atributes( $values );
 		$select      = FrmAppHelper::array_to_html_params( $select_atts ) . ' ';
 
 		return '<select' . $select . $input_html . '>';
@@ -1216,7 +1216,7 @@ DEFAULT_HTML;
 	/**
 	 * @since 3.0
 	 */
-	protected function get_select_attributes( $values ) {
+	protected function get_select_atributes( $values ) {
 		$readonly    = ( FrmField::is_read_only( $this->field ) && ! FrmAppHelper::is_admin() );
 		$select_atts = array();
 		if ( ! $readonly ) {

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1207,7 +1207,7 @@ DEFAULT_HTML;
 	protected function select_tag( $values ) {
 		$field       = isset( $values['field'] ) ? $values['field'] : $this->field;
 		$input_html  = $this->get_field_input_html_hook( $field );
-		$select_atts = $this->get_select_atributes( $values );
+		$select_atts = $this->get_select_attributes( $values );
 		$select      = FrmAppHelper::array_to_html_params( $select_atts ) . ' ';
 
 		return '<select' . $select . $input_html . '>';
@@ -1216,7 +1216,7 @@ DEFAULT_HTML;
 	/**
 	 * @since 3.0
 	 */
-	protected function get_select_atributes( $values ) {
+	protected function get_select_attributes( $values ) {
 		$readonly    = ( FrmField::is_read_only( $this->field ) && ! FrmAppHelper::is_admin() );
 		$select_atts = array();
 		if ( ! $readonly ) {


### PR DESCRIPTION
This PR adds automated typo checking using the typos CLI (See https://github.com/crate-ci/typos).

I've added a baseline for the things to ignore as well.