### PR TITLE
Fix recaptcha name function is returning empty string

### DIFF
--- a/classes/models/FrmRecaptchaSettings.php
+++ b/classes/models/FrmRecaptchaSettings.php
@@ -18,14 +18,13 @@ class FrmRecaptchaSettings extends FrmFieldCaptchaSettings {
 	}
 
 	/**
-	 * @since 6.8.4
+	 * @since x.x
 	 *
 	 * @return string
 	 */
-	public function getName() {
+	public function get_name() {
 		return 'reCAPTCHA';
 	}
-
 
 	/**
 	 * @since 6.8.4
@@ -114,5 +113,15 @@ class FrmRecaptchaSettings extends FrmFieldCaptchaSettings {
 	 */
 	private function captcha_is_invisible() {
 		return in_array( $this->frm_settings->re_type, array( 'invisible', 'v3' ), true );
+	}
+
+	/**
+	 * @since 6.8.4
+	 * @deprecated x.x
+	 * @return string
+	 */
+	public function getName() {
+		_deprecated_function( __METHOD__, 'x.x' );
+		return $this->get_name();
 	}
 }


### PR DESCRIPTION
The reCaptcha type name was showing up as an empty string.

**Before**
<img width="466" alt="Screen Shot 2024-07-08 at 4 47 09 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/c05bb577-dead-487f-89d0-f11a2ccf055b">

**After**
<img width="641" alt="Screen Shot 2024-07-08 at 4 47 25 PM" src="https://github.com/Strategy11/formidable-forms/assets/9134515/5c0e528b-f086-4783-9a12-109aee67e8a7">
