### PR TITLE
Hide submit field button from field search result

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -9759,3 +9759,9 @@ Responsive Design
 	transform: rotate(45deg);
 }
 /* End External Link Styles */
+
+/* Always hide submit field button */
+.field_type_list .frm_tsubmit {
+	display: none !important;
+}
+/* End always hide submit field button */


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5192

The submit field button shouldn't show in the field type search result.