### PR TITLE
Fix issue with enabling draft button after lookup is finished

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -153,7 +153,8 @@ function frmFrontFormJS() {
 	 * @param {Object} $form
 	 */
 	function enableSaveDraft( $form ) {
-		$form.find( 'a.frm_save_draft' ).css( 'pointer-events', '' );
+		$form.find( '.frm_save_draft' ).css( 'pointer-events', '' );
+		$form.find( '.frm_save_draft' ).prop( 'disabled', false );
 	}
 
 	function validateForm( object ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -153,12 +153,10 @@ function frmFrontFormJS() {
 	 * @param {Object} $form
 	 */
 	function enableSaveDraft( $form ) {
-		const saveDraftButton = $form[0].querySelector( '.frm_save_draft' );
-		if ( ! saveDraftButton ) {
-			return;
-		}
-		saveDraftButton.disabled            = false;
-		saveDraftButton.style.pointerEvents = '';
+		$form[0].querySelectorAll( '.frm_save_draft' ).forEach( saveDraftButton => {
+			saveDraftButton.disabled            = false;
+			saveDraftButton.style.pointerEvents = '';
+		});
 	}
 
 	function validateForm( object ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -153,8 +153,12 @@ function frmFrontFormJS() {
 	 * @param {Object} $form
 	 */
 	function enableSaveDraft( $form ) {
-		$form.find( '.frm_save_draft' ).css( 'pointer-events', '' );
-		$form.find( '.frm_save_draft' ).prop( 'disabled', false );
+		const saveDraftButton = $form[0].querySelector( '.frm_save_draft' );
+		if ( ! saveDraftButton ) {
+			return;
+		}
+		saveDraftButton.disabled            = false;
+		saveDraftButton.style.pointerEvents = ''
 	}
 
 	function validateForm( object ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -158,7 +158,7 @@ function frmFrontFormJS() {
 			return;
 		}
 		saveDraftButton.disabled            = false;
-		saveDraftButton.style.pointerEvents = ''
+		saveDraftButton.style.pointerEvents = '';
 	}
 
 	function validateForm( object ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -153,6 +153,9 @@ function frmFrontFormJS() {
 	 * @param {Object} $form
 	 */
 	function enableSaveDraft( $form ) {
+		if ( ! $form.length ) {
+			return;
+		}
 		$form[0].querySelectorAll( '.frm_save_draft' ).forEach( saveDraftButton => {
 			saveDraftButton.disabled            = false;
 			saveDraftButton.style.pointerEvents = '';


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5194

The issue happens because of an outdated element selector in `enableSaveDraft` function.

**Before**
![CleanShot 2024-07-12 at 22 20 54](https://github.com/user-attachments/assets/cabbdf5c-124c-4827-9284-a07c6820a715)

**After**:
![CleanShot 2024-07-12 at 22 20 07](https://github.com/user-attachments/assets/f550ec18-85c6-4a62-8ca7-2cef59a33f14)

### Test steps

1. Create a simple form and enable draft saving
2. Add a lookup field to get value from another form
3. Add another lookup field to watch the first field
4. Save the form and preview the form
5. Change the value of the first Lookup field and confirm that the draft button is enabled back when the lookup is done