### PR TITLE
allow & to work in format validation

### DIFF
--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -238,6 +238,7 @@ class FrmEntryValidate {
 			$pattern = FrmField::get_option( $field, 'format' );
 		}
 
+		$pattern = html_entity_decode($pattern);
 		$pattern = apply_filters( 'frm_phone_pattern', $pattern, $field );
 
 		// Create a regexp if format is not already a regexp


### PR DESCRIPTION
using a regex like `^[^&]*$` in a field Format setting does not work because preg_match is faced with `&amp;`