### PR TITLE
Make license messages translatable

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1370,7 +1370,7 @@ class FrmAppHelper {
 				printf(
 					/* translators: %1$s: Start link HTML, %2$s: End link HTML */
 					esc_html__( 'You\'re using Formidable Forms Lite. To unlock more features consider %1$supgrading to PRO%2$s.', 'formidable' ),
-					'<a href="' . esc_url( FrmAppHelper::admin_upgrade_link( 'settings-license' ) ) . '">',
+					'<a href="' . esc_url( self::admin_upgrade_link( 'settings-license' ) ) . '">',
 					'</a>'
 				);
 				?>

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1366,8 +1366,14 @@ class FrmAppHelper {
 		}
 		?>
 		<div class="frm-upgrade-bar">
-			<span>You're using Formidable Forms Lite. To unlock more features consider</span>
-			<a href="<?php echo esc_url( self::admin_upgrade_link( 'top-bar' ) ); ?>" target="_blank" rel="noopener">upgrading to Pro</a>.
+				<?php
+				printf(
+					/* translators: %1$s: Start link HTML, %2$s: End link HTML */
+					esc_html__( 'You\'re using Formidable Forms Lite. To unlock more features consider %1$supgrading to PRO%2$s.', 'formidable' ),
+					'<a href="' . esc_url( FrmAppHelper::admin_upgrade_link( 'settings-license' ) ) . '">',
+					'</a>'
+				);
+				?>
 		</div>
 		<?php
 	}

--- a/classes/views/frm-settings/license_box.php
+++ b/classes/views/frm-settings/license_box.php
@@ -19,14 +19,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php echo esc_html( FrmAppHelper::copy_for_lite_license() ); ?>
 		</p>
 		<p>
-				<?php
-				printf(
-					/* translators: %1$s: Start link HTML, %2$s: End link HTML */
-					esc_html__( 'To unlock more features consider %1$supgrading to PRO%2$s.', 'formidable' ),
-					'<a href="' . esc_url( FrmAppHelper::admin_upgrade_link( 'settings-license' ) ) . '">',
-					'</a>'
-				);
-				?>
+			<?php
+			printf(
+				/* translators: %1$s: Start link HTML, %2$s: End link HTML */
+				esc_html__( 'To unlock more features consider %1$supgrading to PRO%2$s.', 'formidable' ),
+				'<a href="' . esc_url( FrmAppHelper::admin_upgrade_link( 'settings-license' ) ) . '">',
+				'</a>'
+			);
+			?>
 		</p>
 	</div>
 </div>


### PR DESCRIPTION
Related issue: https://github.com/Strategy11/formidable-pro/issues/5186