### PR TITLE
Exclude repeater forms and entries from summary email

### DIFF
--- a/classes/helpers/FrmEmailSummaryHelper.php
+++ b/classes/helpers/FrmEmailSummaryHelper.php
@@ -295,10 +295,10 @@ class FrmEmailSummaryHelper {
 			'frm_items',
 			array(
 				// The `=` is added after `>` in the query.
-				'created_at >' => $from_date,
-				'created_at <' => $to_date . ' 23:59:59',
-				'is_draft'     => 0,
-				'parent_item_id' => 0,
+				'created_at >'   => $from_date,
+				'created_at <'   => $to_date . ' 23:59:59',
+				'is_draft'       => 0,
+				'parent_item_id' => 0, // Do not count repeater entries.
 			)
 		);
 	}

--- a/classes/helpers/FrmEmailSummaryHelper.php
+++ b/classes/helpers/FrmEmailSummaryHelper.php
@@ -298,6 +298,7 @@ class FrmEmailSummaryHelper {
 				'created_at >' => $from_date,
 				'created_at <' => $to_date . ' 23:59:59',
 				'is_draft'     => 0,
+				'parent_item_id' => 0,
 			)
 		);
 	}
@@ -317,7 +318,7 @@ class FrmEmailSummaryHelper {
 			$wpdb->prepare(
 				"SELECT fr.id AS form_id, fr.name AS form_name, COUNT(*) as items_count
 						FROM {$wpdb->prefix}frm_items AS it INNER JOIN {$wpdb->prefix}frm_forms AS fr ON it.form_id = fr.id
-						WHERE it.created_at BETWEEN %s AND %s AND it.is_draft = 0
+						WHERE it.created_at BETWEEN %s AND %s AND it.is_draft = 0 AND parent_form_id = 0
 						GROUP BY form_id ORDER BY items_count DESC LIMIT %d",
 				$from_date,
 				$to_date . ' 23:59:59',

--- a/classes/helpers/FrmEmailSummaryHelper.php
+++ b/classes/helpers/FrmEmailSummaryHelper.php
@@ -298,7 +298,8 @@ class FrmEmailSummaryHelper {
 				'created_at >'   => $from_date,
 				'created_at <'   => $to_date . ' 23:59:59',
 				'is_draft'       => 0,
-				'parent_item_id' => 0, // Do not count repeater entries.
+				// Do not count repeater entries.
+				'parent_item_id' => 0,
 			)
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5205

To test:
- Use `FrmEmailSummaryHelper::send_monthly();` to send the monthly email. Make sure that there is no repeaters in the top forms list.
- Choose a form with a repeater, then submit an entry with some repeater items.
- Use the above function to send the monthly email again.
- Make sure that the `Entries created` increases by 1.