### PR TITLE
Fix entries list appears empty when item meta with 0 field ID exists

### DIFF
--- a/classes/helpers/FrmEntriesListHelper.php
+++ b/classes/helpers/FrmEntriesListHelper.php
@@ -356,7 +356,7 @@ class FrmEntriesListHelper extends FrmListHelper {
 	 * @param object $item
 	 */
 	private function column_value( $item ) {
-		$col_name = $this->column_name;
+		$col_name = $this->maybe_fix_column_name( $this->column_name );
 
 		switch ( $col_name ) {
 			case 'ip':
@@ -417,6 +417,21 @@ class FrmEntriesListHelper extends FrmListHelper {
 		}//end switch
 
 		return $val;
+	}
+
+	/**
+	 * When a form has entries with the 0 item meta value, the values do not appear properly in the entries list.
+	 *
+	 * @since x.x
+	 *
+	 * @param string $column_name
+	 * @return string
+	 */
+	private function maybe_fix_column_name( $column_name ) {
+		if ( 0 === strpos( $column_name, '0_' ) ) {
+			$column_name = substr( $column_name, 2 );
+		}
+		return $column_name;
 	}
 
 	/**


### PR DESCRIPTION
I was seeing this on some forms.

All of the column names are prefixed with `0_`. Removing that fixes the issue.

<img width="1412" alt="Screen Shot 2024-07-19 at 11 24 33 AM" src="https://github.com/user-attachments/assets/9e505974-e7e9-49a0-b52f-d8446270cddd">
