### PR TITLE
Fix International Phone Field Validation Issue

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -476,13 +476,13 @@ function frmFrontFormJS() {
 		if ( format !== '' && text !== '' ) {
 			fieldID = getFieldId( field, true );
 			if ( ! ( fieldID in errors ) ) {
-				format = new RegExp( '^' + format + '$', 'i' );
-				if ( format.test( text ) === false ) {
-					if ( 'object' === typeof window.frmProForm && 'function' === typeof window.frmProForm.isIntlPhoneInput && window.frmProForm.isIntlPhoneInput( field ) ) {
-						if ( ! window.frmProForm.validateIntlPhoneInput( field ) ) {
-							errors[ fieldID ] = getFieldValidationMessage( field, 'data-invmsg' );
-						}
-					} else {
+				if ( 'object' === typeof window.frmProForm && 'function' === typeof window.frmProForm.isIntlPhoneInput && window.frmProForm.isIntlPhoneInput( field ) ) {
+					if ( ! window.frmProForm.validateIntlPhoneInput( field ) ) {
+						errors[ fieldID ] = getFieldValidationMessage( field, 'data-invmsg' );
+					}
+				} else {
+					format = new RegExp( '^' + format + '$', 'i' );
+					if ( format.test( text ) === false ) {
 						errors[ fieldID ] = getFieldValidationMessage( field, 'data-invmsg' );
 					}
 				}


### PR DESCRIPTION
This PR addresses the issue with the international phone field not correctly validating phone numbers.

## Related PR:

[Strategy11/formidable-pro/issues/5208](https://github.com/Strategy11/formidable-pro/issues/5208)

## Replicate the Issue

1. Create a form with a phone field.
2. Ensure it uses the international format.
3. Enable the "Validate this form with JavaScript" setting in the form settings.
4. Open the form and choose Egypt (as an example).
5. Enter the following number: `01011140`.
6. You will see that it's marked as valid, but it isn't. The correct number is `01011140144`.

## Expected Output:

![CleanShot 2024-07-26 at 01 07 58](https://github.com/user-attachments/assets/e2274f86-6615-4db4-a61f-e3b9d68ac051)
