### PR TITLE
Add screen reader label for form dropdown filter

### DIFF
--- a/classes/helpers/FrmEntriesListHelper.php
+++ b/classes/helpers/FrmEntriesListHelper.php
@@ -247,6 +247,8 @@ class FrmEntriesListHelper extends FrmListHelper {
 			// Override the referrer to prevent it from being used for the screen options.
 			echo '<input type="hidden" name="_wp_http_referer" value="" />';
 
+			echo '<label for="form" class="screen-reader-text">' . esc_html__( 'Filter by form', 'formidable' ) . '</label>';
+
 			FrmFormsHelper::forms_dropdown( 'form', $form_id, array( 'blank' => __( 'View all forms', 'formidable' ) ) );
 			submit_button( __( 'Filter', 'formidable' ), 'filter_action action', '', false, array( 'id' => 'post-query-submit' ) );
 			echo '</div>';

--- a/languages/formidable.pot
+++ b/languages/formidable.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-07-25T13:58:13+00:00\n"
+"POT-Creation-Date: 2024-07-26T14:12:47+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.10.0\n"
 "X-Domain: formidable\n"
@@ -461,7 +461,7 @@ msgstr ""
 msgid "Global Settings"
 msgstr ""
 
-#: classes/controllers/FrmAppController.php:1253
+#: classes/controllers/FrmAppController.php:1266
 #: classes/controllers/FrmFormsController.php:214
 #: classes/controllers/FrmFormTemplatesController.php:612
 #: classes/controllers/FrmSettingsController.php:275
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: classes/controllers/FrmAppController.php:1257
+#: classes/controllers/FrmAppController.php:1270
 #: classes/views/onboarding-wizard/steps/install-formidable-pro-step.php:70
 msgid "Continue"
 msgstr ""
@@ -2570,15 +2570,19 @@ msgid "Learn how to prevent them."
 msgstr ""
 
 #: classes/helpers/FrmEntriesListHelper.php:250
+msgid "Filter by form"
+msgstr ""
+
+#: classes/helpers/FrmEntriesListHelper.php:252
 #: stripe/helpers/FrmTransLiteListHelper.php:197
 msgid "View all forms"
 msgstr ""
 
-#: classes/helpers/FrmEntriesListHelper.php:251
+#: classes/helpers/FrmEntriesListHelper.php:253
 msgid "Filter"
 msgstr ""
 
-#: classes/helpers/FrmEntriesListHelper.php:430
+#: classes/helpers/FrmEntriesListHelper.php:447
 #: classes/views/frm-entries/sidebar-shared.php:43
 #: stripe/helpers/FrmTransLiteListHelper.php:361
 #: stripe/helpers/FrmTransLiteListHelper.php:382
@@ -2586,11 +2590,11 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: classes/helpers/FrmEntriesListHelper.php:434
+#: classes/helpers/FrmEntriesListHelper.php:451
 msgid "Permanently delete this entry?"
 msgstr ""
 
-#: classes/helpers/FrmEntriesListHelper.php:434
+#: classes/helpers/FrmEntriesListHelper.php:451
 #: classes/helpers/FrmFormsHelper.php:1237
 #: classes/helpers/FrmFormsListHelper.php:144
 #: classes/views/frm-form-actions/form_action.php:36
@@ -2602,7 +2606,7 @@ msgid "Delete"
 msgstr ""
 
 #. translators: %1$s: HTML break line, %2$s: HTML bold text
-#: classes/helpers/FrmEntriesListHelper.php:491
+#: classes/helpers/FrmEntriesListHelper.php:508
 msgid "ALL entries in this form will be permanently deleted.%1$sWant to proceed? Type %2$s below."
 msgstr ""
 
@@ -4926,12 +4930,12 @@ msgstr ""
 msgid "There was a problem with your submission. Please try again."
 msgstr ""
 
-#: classes/models/FrmEntryValidate.php:315
-#: classes/models/FrmEntryValidate.php:325
+#: classes/models/FrmEntryValidate.php:318
+#: classes/models/FrmEntryValidate.php:328
 msgid "Your entry appears to be spam!"
 msgstr ""
 
-#: classes/models/FrmEntryValidate.php:317
+#: classes/models/FrmEntryValidate.php:320
 msgid "Your entry appears to be blocked spam!"
 msgstr ""
 
@@ -5789,7 +5793,7 @@ msgid "Referrer:"
 msgstr ""
 
 #: classes/views/frm-entries/_sidebar-shared-pub.php:14
-#: stripe/controllers/FrmTransLitePaymentsController.php:69
+#: stripe/controllers/FrmTransLitePaymentsController.php:79
 #: stripe/controllers/FrmTransLiteSubscriptionsController.php:13
 msgid "M j, Y @ G:i"
 msgstr ""
@@ -7712,7 +7716,7 @@ msgid "Payment was Successfully Deleted"
 msgstr ""
 
 #: stripe/controllers/FrmTransLiteListsController.php:29
-#: stripe/controllers/FrmTransLitePaymentsController.php:40
+#: stripe/controllers/FrmTransLitePaymentsController.php:30
 #: stripe/helpers/FrmTransLiteListHelper.php:114
 #: stripe/views/lists/list.php:12
 msgid "Payments"
@@ -7781,30 +7785,30 @@ msgstr ""
 
 #. translators: %d: Entry ID.
 #. translators: %d: ID of the deleted entry.
-#: stripe/controllers/FrmTransLitePaymentsController.php:129
+#: stripe/controllers/FrmTransLitePaymentsController.php:139
 #: stripe/helpers/FrmTransLiteListHelper.php:406
 msgid "%d (Deleted)"
 msgstr ""
 
-#: stripe/controllers/FrmTransLitePaymentsController.php:148
-#: stripe/controllers/FrmTransLitePaymentsController.php:203
+#: stripe/controllers/FrmTransLitePaymentsController.php:158
+#: stripe/controllers/FrmTransLitePaymentsController.php:213
 #: stripe/helpers/FrmTransLiteAppHelper.php:95
 msgid "Refunded"
 msgstr ""
 
-#: stripe/controllers/FrmTransLitePaymentsController.php:150
+#: stripe/controllers/FrmTransLitePaymentsController.php:160
 msgid "Are you sure you want to refund that payment?"
 msgstr ""
 
-#: stripe/controllers/FrmTransLitePaymentsController.php:154
+#: stripe/controllers/FrmTransLitePaymentsController.php:164
 msgid "Refund"
 msgstr ""
 
-#: stripe/controllers/FrmTransLitePaymentsController.php:194
+#: stripe/controllers/FrmTransLitePaymentsController.php:204
 msgid "Oops! No payment was selected for refund."
 msgstr ""
 
-#: stripe/controllers/FrmTransLitePaymentsController.php:205
+#: stripe/controllers/FrmTransLitePaymentsController.php:215
 #: stripe/controllers/FrmTransLiteSubscriptionsController.php:110
 #: stripe/helpers/FrmTransLiteAppHelper.php:94
 msgid "Failed"

--- a/tests/cypress/e2e/admin-a11y.cy.js
+++ b/tests/cypress/e2e/admin-a11y.cy.js
@@ -38,20 +38,7 @@ describe('Run some accessibility tests', function() {
         configureAxeWithIgnoredRuleset([
             ...baselineRules,
             { id: 'empty-table-header', enabled: false },
-            { id: 'label', enabled: false },
-            { id: 'select-name', enabled: false }
-        ]);
-        cy.checkA11y();
-    });
-
-    it('Check the views page is accessible', () => {
-        cy.visit('/wp-admin/admin.php?page=formidable-entries');
-        cy.injectAxe();
-        configureAxeWithIgnoredRuleset([
-            ...baselineRules,
-            { id: 'empty-table-header', enabled: false },
-            { id: 'label', enabled: false },
-            { id: 'select-name', enabled: false }
+            { id: 'label', enabled: false }
         ]);
         cy.checkA11y();
     });


### PR DESCRIPTION
This is a small accessibility improvement to remove the `select-name` exception in our Cypress tests.

The views list test here is also incorrect, checking the entries page instead. But since views isn't part of core this test doesn't really fit the scope either way and won't work with just Lite active.