### PR TITLE
Update error handling when viewing an entry that does not exist

### DIFF
--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -467,10 +467,13 @@ class FrmEntriesController {
 
 		$entry = FrmEntry::getOne( $id, true );
 		if ( ! $entry ) {
-			echo '<div id="form_show_entry_page" class="wrap">' .
-				esc_html__( 'You are trying to view an entry that does not exist.', 'formidable' ) .
-				'</div>';
-
+			FrmAppController::show_error_modal(
+				array(
+					'title'        => __( 'You can\'t view the entry', 'formidable' ),
+					'body'         => __( 'You are trying to view an entry that does not exist', 'formidable' ),
+					'cancel_url'   => admin_url( 'admin.php?page=formidable' ),
+				)
+			);
 			return;
 		}
 

--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -469,9 +469,9 @@ class FrmEntriesController {
 		if ( ! $entry ) {
 			FrmAppController::show_error_modal(
 				array(
-					'title'        => __( 'You can\'t view the entry', 'formidable' ),
-					'body'         => __( 'You are trying to view an entry that does not exist', 'formidable' ),
-					'cancel_url'   => admin_url( 'admin.php?page=formidable' ),
+					'title'      => __( 'You can\'t view the entry', 'formidable' ),
+					'body'       => __( 'You are trying to view an entry that does not exist', 'formidable' ),
+					'cancel_url' => admin_url( 'admin.php?page=formidable' ),
 				)
 			);
 			return;


### PR DESCRIPTION
I just noticed this error and that it wasn't up-to-date.

This update calls the the `FrmAppController::show_error_modal` function introduced in v6.7.

**Before**
<img width="830" alt="Screen Shot 2024-07-26 at 2 59 38 PM" src="https://github.com/user-attachments/assets/e3ef485a-67d3-43f5-a812-ac2b882d01d3">

**After**
<img width="1321" alt="Screen Shot 2024-07-26 at 2 59 06 PM" src="https://github.com/user-attachments/assets/a711c77a-ff09-4fd9-909c-4f0576bc8519">
