### PR TITLE
Do not add a new option to conditional logic if renaming an option

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5636,8 +5636,6 @@ function frmAdminBuildJS() {
 					if ( hasMatch ) {
 						continue;
 					}
-					prependValueSelectWithOptionMatch( valueSelect, optionMatch, expectedOption );
-					continue;
 				}
 				prependValueSelectWithOptionMatch( valueSelect, optionMatch, expectedOption );
 			}
@@ -5651,10 +5649,7 @@ function frmAdminBuildJS() {
 
 	function prependValueSelectWithOptionMatch( valueSelect, optionMatch, expectedOption ) {
 		if ( optionMatch === null ) {
-			optionMatch = frmDom.tag( 'option', {
-				text: expectedOption,
-				value: expectedOption
-			});
+			optionMatch = frmDom.tag( 'option', { text: expectedOption });
 			optionMatch.value = expectedOption;
 		}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5632,12 +5632,13 @@ function frmAdminBuildJS() {
 				const expectedChoiceEl = Array.from( fieldChoices ).find( element => element.value === expectedOption );
 				if ( expectedChoiceEl ) {
 					const hasMatch = valueSelect.querySelector( 'option[value="' + expectedChoiceEl.getAttribute( 'data-value-on-focus' ) + '"]' );
-					if ( ! hasMatch ) {
-						prependValueSelectWithOptionMatch( valueSelect, optionMatch, expectedOption );
+					if ( hasMatch ) {
+						continue;
 					}
-				} else {
 					prependValueSelectWithOptionMatch( valueSelect, optionMatch, expectedOption );
+					continue;
 				}
+				prependValueSelectWithOptionMatch( valueSelect, optionMatch, expectedOption );
 			}
 
 			optionMatch = valueSelect.querySelector( 'option[value=""]' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5631,7 +5631,8 @@ function frmAdminBuildJS() {
 				const fieldChoices     = document.querySelectorAll( '#frm_field_' + fieldId + '_opts input[data-value-on-focus]' );
 				const expectedChoiceEl = Array.from( fieldChoices ).find( element => element.value === expectedOption );
 				if ( expectedChoiceEl ) {
-					const hasMatch = valueSelect.querySelector( 'option[value="' + expectedChoiceEl.getAttribute( 'data-value-on-focus' ) + '"]' );
+					const oldValue = expectedChoiceEl.getAttribute( 'data-value-on-focus' );
+					const hasMatch = oldValue && valueSelect.querySelector( 'option[value="' + oldValue + '"]' );
 					if ( hasMatch ) {
 						continue;
 					}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5631,7 +5631,7 @@ function frmAdminBuildJS() {
 				const fieldChoices     = document.querySelectorAll( '#frm_field_' + fieldId + '_opts input[data-value-on-focus]' );
 				const expectedChoiceEl = Array.from( fieldChoices ).find( element => element.value === expectedOption );
 				if ( expectedChoiceEl ) {
-					const oldValue = expectedChoiceEl.getAttribute( 'data-value-on-focus' );
+					const oldValue = expectedChoiceEl.dataset.valueOnFocus;
 					const hasMatch = oldValue && valueSelect.querySelector( 'option[value="' + oldValue + '"]' );
 					if ( hasMatch ) {
 						continue;
@@ -5651,9 +5651,11 @@ function frmAdminBuildJS() {
 
 	function prependValueSelectWithOptionMatch( valueSelect, optionMatch, expectedOption ) {
 		if ( optionMatch === null ) {
-			optionMatch = document.createElement( 'option' );
-			optionMatch.setAttribute( 'value', expectedOption );
-			optionMatch.textContent = expectedOption;
+			optionMatch = frmDom.tag( 'option', {
+				text: expectedOption,
+				value: expectedOption
+			});
+			optionMatch.value = expectedOption;
 		}
 
 		valueSelect.prepend( optionMatch );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5628,13 +5628,16 @@ function frmAdminBuildJS() {
 				expectedOption = fieldOptions[ optionIndex ];
 				optionMatch = valueSelect.querySelector( 'option[value="' + expectedOption + '"]' );
 
-				if ( optionMatch === null ) {
-					optionMatch = document.createElement( 'option' );
-					optionMatch.setAttribute( 'value', expectedOption );
-					optionMatch.textContent = expectedOption;
+				const fieldChoices     = document.querySelectorAll( '#frm_field_' + fieldId + '_opts input[data-value-on-focus]' );
+				const expectedChoiceEl = Array.from( fieldChoices ).find( element => element.value === expectedOption );
+				if ( expectedChoiceEl ) {
+					const hasMatch = valueSelect.querySelector( 'option[value="' + expectedChoiceEl.getAttribute( 'data-value-on-focus' ) + '"]' );
+					if ( ! hasMatch ) {
+						prependValueSelectWithOptionMatch( valueSelect, optionMatch, expectedOption );
+					}
+				} else {
+					prependValueSelectWithOptionMatch( valueSelect, optionMatch, expectedOption );
 				}
-
-				valueSelect.prepend( optionMatch );
 			}
 
 			optionMatch = valueSelect.querySelector( 'option[value=""]' );
@@ -5642,6 +5645,16 @@ function frmAdminBuildJS() {
 				valueSelect.prepend( optionMatch );
 			}
 		}
+	}
+
+	function prependValueSelectWithOptionMatch( valueSelect, optionMatch, expectedOption ) {
+		if ( optionMatch === null ) {
+			optionMatch = document.createElement( 'option' );
+			optionMatch.setAttribute( 'value', expectedOption );
+			optionMatch.textContent = expectedOption;
+		}
+
+		valueSelect.prepend( optionMatch );
 	}
 
 	function getFieldOptions( fieldId ) {


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/2909

### Test steps
1. Create a Product field with some product options.
2. Add another field that conditionally shows based off the product field's value and save.
3. Go the the Product field and rename an option.
4. Go back to the conditional field and confirm that there is no new option added in the conditional logic row. The existing options should have been renamed instead.