### PR TITLE
Add array check to input shortcode sanitize fix

### DIFF
--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -468,7 +468,13 @@ class FrmField {
 			 * @return string
 			 */
 			function ( $match ) {
-				$attr      = shortcode_parse_atts( $match[3] );
+				$attr = shortcode_parse_atts( $match[3] );
+
+				if ( ! is_array( $attr ) ) {
+					// In old versions of WordPress (older than 6.5), this might not be an array.
+					return '[input]';
+				}
+
 				$safe_atts = array();
 				foreach ( $attr as $attr_key => $att ) {
 					if ( ! is_numeric( $attr_key ) ) {


### PR DESCRIPTION
Some pro unit tests are failing because of this code.
Old versions of WordPress (prior to v6.5), can return other types, not just arrays.