### PR TITLE
Stop using jit/opcache in phpstan workflow

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           php-version: 8.0
           coverage: none
-          ini-values: display_errors = on, error_reporting = E_ALL, opcache.enable_cli=1, opcache.jit=tracing, opcache.jit_buffer_size=64M
+          ini-values: display_errors = on, error_reporting = E_ALL
           tools: composer
 
       - name: "💽  Installing Composer Packages"


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5243

The workflow is segfaulting.

Related issue https://github.com/phpstan/phpstan/issues/6646

They recommend not running PHPStan with opcache in that issue.