### PR TITLE
Prevent dragging new sections into sections

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1834,7 +1834,7 @@ function frmAdminBuildJS() {
 			return true;
 		}
 
-		const newFieldWillBeAddedToASection = droppable.classList.contains( 'start_divider' ) || null !== droppable.closest( '.start_divider' );
+		const newFieldWillBeAddedToASection = droppable.classList.contains( 'start_divider' ) || droppable.classList.contains( '.start_divider' );
 		if ( newFieldWillBeAddedToASection ) {
 			// Don't allow a section or an embedded form in a section.
 			return ! newEmbedField && ! newSectionField;
@@ -1849,7 +1849,7 @@ function frmAdminBuildJS() {
 
 			return ! newHiddenField && ! newPageBreakField && ! newUserIdField;
 		}
-	
+
 		return true;
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1833,7 +1833,7 @@ function frmAdminBuildJS() {
 		const newEmbedField     = classes.contains( 'frm_tform' );
 		const newUserIdField    = classes.contains( 'frm_tuser_id' );
 
-		const fieldTypeIsAlwaysAllowed = ! newPageBreakField && ! newHiddenField && ! newSectionField && ! newEmbedField;
+		const fieldTypeIsAlwaysAllowed = ! newPageBreakField && ! newHiddenField && ! newUserIdField && ! newSectionField && ! newEmbedField;
 		if ( fieldTypeIsAlwaysAllowed ) {
 			return true;
 		}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1833,16 +1833,6 @@ function frmAdminBuildJS() {
 		const newEmbedField     = classes.contains( 'frm_tform' );
 		const newUserIdField    = classes.contains( 'frm_tuser_id' );
 
-		const newFieldWillBeAddedToAGroup = ! ( 'frm-show-fields' === droppable.id || droppable.classList.contains( 'start_divider' ) );
-		if ( newFieldWillBeAddedToAGroup ) {
-			if ( groupIncludesBreakOrHidden( droppable ) ) {
-				// Never allow any field beside a page break or a hidden field.
-				return false;
-			}
-
-			return ! newHiddenField && ! newPageBreakField && ! newUserIdField;
-		}
-
 		const fieldTypeIsAlwaysAllowed = ! newPageBreakField && ! newHiddenField && ! newSectionField && ! newEmbedField;
 		if ( fieldTypeIsAlwaysAllowed ) {
 			return true;
@@ -1854,6 +1844,16 @@ function frmAdminBuildJS() {
 			return ! newEmbedField && ! newSectionField;
 		}
 
+		const newFieldWillBeAddedToAGroup = ! ( 'frm-show-fields' === droppable.id || droppable.classList.contains( 'start_divider' ) );
+		if ( newFieldWillBeAddedToAGroup ) {
+			if ( groupIncludesBreakOrHidden( droppable ) ) {
+				// Never allow any field beside a page break or a hidden field.
+				return false;
+			}
+
+			return ! newHiddenField && ! newPageBreakField && ! newUserIdField;
+		}
+	
 		return true;
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1842,7 +1842,7 @@ function frmAdminBuildJS() {
 
 		const newFieldWillBeAddedToAGroup = ! ( 'frm-show-fields' === droppable.id || droppable.classList.contains( 'start_divider' ) );
 		if ( newFieldWillBeAddedToAGroup ) {
-			if ( groupIncludesBreakOrHiddenOrUserId( droppable ) ) {
+			if ( groupIncludesBreakOrHidden( droppable ) ) {
 				// Never allow any field beside a page break or a hidden field.
 				return false;
 			}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1846,7 +1846,7 @@ function frmAdminBuildJS() {
 
 		const newFieldWillBeAddedToAGroup = ! ( 'frm-show-fields' === droppable.id || droppable.classList.contains( 'start_divider' ) );
 		if ( newFieldWillBeAddedToAGroup ) {
-			if ( groupIncludesBreakOrHidden( droppable ) ) {
+			if ( groupIncludesBreakOrHiddenOrUserId( droppable ) ) {
 				// Never allow any field beside a page break or a hidden field.
 				return false;
 			}


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5230

**Before**:
![CleanShot 2024-08-07 at 09 37 40](https://github.com/user-attachments/assets/21a96672-8bd0-430e-a9f9-91a2f04366cf)

**After**:
![CleanShot 2024-08-07 at 09 39 00](https://github.com/user-attachments/assets/f0849f5d-dcec-4a72-b944-5ae58458feca)

### Test procedure
1. Create a form and add a section field to it.
2. Drag any field to the section field except a Section field.
3. Now, try dragging and dropping a Section field to the section, beside the field just added above.
4. Confirm that the action is rejected and you cannot add a Section inside a Section field.