### PR TITLE
Fix undefined function: groupIncludesBreakOrHidden

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1835,7 +1835,7 @@ function frmAdminBuildJS() {
 
 		const newFieldWillBeAddedToAGroup = ! ( 'frm-show-fields' === droppable.id || droppable.classList.contains( 'start_divider' ) );
 		if ( newFieldWillBeAddedToAGroup ) {
-			if ( groupIncludesBreakOrHidden( droppable ) ) {
+			if ( groupIncludesBreakOrHiddenOrUserId( droppable ) ) {
 				// Never allow any field beside a page break or a hidden field.
 				return false;
 			}


### PR DESCRIPTION
Fixes an error introduced in https://github.com/Strategy11/formidable-forms/commit/9e1b2cda5e40a26472158811f1a522d970883c36
<img width="894" alt="image" src="https://github.com/user-attachments/assets/6393381d-8ce9-446d-ad3e-0ec6fc95d916">
