### PR TITLE
Avoid corrupted custom html when duplicating field

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1512,7 +1512,7 @@ class FrmFieldsHelper {
 			foreach ( $val as $k => $v ) {
 				if ( is_string( $v ) ) {
 					if ( 'custom_html' === $k ) {
-						$val[ $k ] = self::switch_ids_except_strings( $replace, $replace_with, array( '[if description]', '[/if description]' ), $v );
+						$val[ $k ] = self::switch_ids_except_strings( $replace, $replace_with, array( '[if description]', '[description]', '[/if description]' ), $v );
 						unset( $k, $v );
 						continue;
 					}

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1512,19 +1512,7 @@ class FrmFieldsHelper {
 			foreach ( $val as $k => $v ) {
 				if ( is_string( $v ) ) {
 					if ( 'custom_html' === $k ) {
-						$replace_copy      = $replace;
-						$replace_with_copy = $replace_with;
-						$if_description    = array_search( '[if description]', $replace, true );
-						if ( false !== $if_description ) {
-							unset( $replace_copy[ $if_description ] );
-							unset( $replace_with_copy[ $if_description ] );
-						}
-						$if_description_end = array_search( '[/if description]', $replace, true );
-						if ( false !== $if_description_end ) {
-							unset( $replace_copy[ $if_description_end ] );
-							unset( $replace_with_copy[ $if_description_end ] );
-						}
-						$val[ $k ] = str_replace( $replace_copy, $replace_with_copy, $v );
+						$val[ $k ] = self::switch_ids_except_strings( $replace, $replace_with, array( '[if description]', '[/if description]' ), $v );
 						unset( $k, $v );
 						continue;
 					}
@@ -1537,6 +1525,31 @@ class FrmFieldsHelper {
 		}
 
 		return $val;
+	}
+
+	/**
+	 * Removes exception strings from replacement arrays and replaces the rest in the provided value string.
+	 *
+	 * @since x.x
+	 *
+	 * @param array  $replace      Values to be replaced.
+	 * @param array  $replace_with Replacement values.
+	 * @param array  $exceptions   Array of strings to skip.
+	 * @param string $value        Value to be updated.
+	 *
+	 * @return string
+	 */
+	private static function switch_ids_except_strings( $replace, $replace_with, $exceptions, $value ) {
+		foreach ( $exceptions as $exception ) {
+			$index = array_search( $exception, $replace, true );
+			if ( false === $index ) {
+				continue;
+			}
+			unset( $replace[ $index ] );
+			unset( $replace_with[ $index ] );
+		}
+		$value = str_replace( $replace, $replace_with, $value );
+		return $value;
 	}
 
 	/**

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1510,22 +1510,20 @@ class FrmFieldsHelper {
 		}//end foreach
 		if ( is_array( $val ) ) {
 			foreach ( $val as $k => $v ) {
-				if ( $k === 'custom_html' ) {
-					$replace_copy      = $replace;
-					$replace_with_copy = $replace_with;
-					$if_description    = array_search( '[if description]', $replace, true );
-					if ( false !== $if_description ) {
-						unset( $replace_copy[ $if_description ] );
-						unset( $replace_with_copy[ $if_description ] );
-					}
-					$if_description_end = array_search( '[/if description]', $replace, true );
-					if ( false !== $if_description_end ) {
-						unset( $replace_copy[ $if_description_end ] );
-						unset( $replace_with_copy[ $if_description_end ] );
-					}
-				}
 				if ( is_string( $v ) ) {
 					if ( 'custom_html' === $k ) {
+						$replace_copy      = $replace;
+						$replace_with_copy = $replace_with;
+						$if_description    = array_search( '[if description]', $replace, true );
+						if ( false !== $if_description ) {
+							unset( $replace_copy[ $if_description ] );
+							unset( $replace_with_copy[ $if_description ] );
+						}
+						$if_description_end = array_search( '[/if description]', $replace, true );
+						if ( false !== $if_description_end ) {
+							unset( $replace_copy[ $if_description_end ] );
+							unset( $replace_with_copy[ $if_description_end ] );
+						}
 						$val[ $k ] = str_replace( $replace_copy, $replace_with_copy, $v );
 						unset( $k, $v );
 						continue;

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1510,7 +1510,26 @@ class FrmFieldsHelper {
 		}//end foreach
 		if ( is_array( $val ) ) {
 			foreach ( $val as $k => $v ) {
+				if ( $k === 'custom_html' ) {
+					$replace_copy      = $replace;
+					$replace_with_copy = $replace_with;
+					$if_description    = array_search( '[if description]', $replace, true );
+					if ( false !== $if_description ) {
+						unset( $replace_copy[ $if_description ] );
+						unset( $replace_with_copy[ $if_description ] );
+					}
+					$if_description_end = array_search( '[/if description]', $replace, true );
+					if ( false !== $if_description_end ) {
+						unset( $replace_copy[ $if_description_end ] );
+						unset( $replace_with_copy[ $if_description_end ] );
+					}
+				}
 				if ( is_string( $v ) ) {
+					if ( 'custom_html' === $k ) {
+						$val[ $k ] = str_replace( $replace_copy, $replace_with_copy, $v );
+						unset( $k, $v );
+						continue;
+					}
 					$val[ $k ] = str_replace( $replace, $replace_with, $v );
 					unset( $k, $v );
 				}


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5248

### Test steps
0. Download the XML from https://drive.google.com/file/d/1zJL2dhe0XdbIZ8K_3xBp2_nsYgfOni8C/view?usp=sharing and import it.
1. Try duplicating the form with title: `Towards Accessible Waterways 2023 Exhibitor Form`
2. Preview the duplicate
3. Confirm that there is no `[if field_ix]...` shortcodes in place of the field descriptions like below:
<img width="798" alt="image" src="https://github.com/user-attachments/assets/9ac8f118-b9da-4b88-bb09-bca528420db4">
4. Try updating the field descriptions for the imported field and check everything works as expected on the form preview.