### PR TITLE
Use less jQuery to scroll to first field

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -994,10 +994,14 @@ function frmFrontFormJS() {
 		jQuery( '.frm_error_style' ).remove();
 	}
 
+	/**
+	 * @param {HTMLElement} object Form object.
+	 * @return {void}
+	 */
 	function scrollToFirstField( object ) {
-		const field = jQuery( object ).find( '.frm_blank_field' ).first();
-		if ( field.length ) {
-			frmFrontForm.scrollMsg( field, object, true );
+		const field = object.querySelector( '.frm_blank_field' );
+		if ( field ) {
+			frmFrontForm.scrollMsg( jQuery( field ), object, true );
 		}
 	}
 


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5002

This update removes our only use of `.first()`. It also removes a `.find()`.

The `scrollMsg` function still appears to require a `jQuery` object for the time being. That can be addressed separately though. I'm trying to minimize the size of this change.