### PR TITLE
Stop using jQuery `.prepend` function

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -791,7 +791,7 @@ function frmFrontFormJS() {
 				if ( contSubmit ) {
 					object.submit();
 				} else {
-					jQuery( object ).prepend( response.error_message );
+					object.insertAdjacentHTML( 'afterbegin', response.error_message );
 					checkForErrorsAndMaybeSetFocus();
 				}
 			} else {


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5002

This update changes our only use a the jQuery `.prepend()` function to vanilla JS.