### PR TITLE
Move frmtoggle logic from front end scripts to admin entries JS

### DIFF
--- a/js/admin/entries.js
+++ b/js/admin/entries.js
@@ -26,9 +26,6 @@ wp.domReady( () => {
 	 */
 	manageShowEmptyFieldsButton();
 
-	// This is used for the "Show empty fields" toggle.
-	jQuery( 'a[data-frmtoggle]' ).on( 'click', toggleDiv );
-
 	function manageShowEmptyFieldsButton() {
 		const showEmptyFieldsButton = document.getElementById( 'frm-entry-show-empty-fields' );
 
@@ -50,22 +47,6 @@ wp.domReady( () => {
 				applyZebraStriping( '.frm-alt-table', newShowState === 'true' ? '' : 'frm-empty-row' );
 			}, newShowState === 'true' ? 0 : 200 );
 		});
-	}
-
-	/**
-	 * Toggle a target element open or closed.
-	 *
-	 * @return {false}
-	 */
-	function toggleDiv() {
-		/*jshint validthis:true */
-		const div = jQuery( this ).data( 'frmtoggle' );
-		if ( jQuery( div ).is( ':visible' ) ) {
-			jQuery( div ).slideUp( 'fast' );
-		} else {
-			jQuery( div ).slideDown( 'fast' );
-		}
-		return false;
 	}
 
 });

--- a/js/admin/entries.js
+++ b/js/admin/entries.js
@@ -48,5 +48,4 @@ wp.domReady( () => {
 			}, newShowState === 'true' ? 0 : 200 );
 		});
 	}
-
 });

--- a/js/admin/entries.js
+++ b/js/admin/entries.js
@@ -26,9 +26,7 @@ wp.domReady( () => {
 	 */
 	manageShowEmptyFieldsButton();
 
-	/**
-	 * This is used for the "Show empty fields" toggle.
-	 */
+	// This is used for the "Show empty fields" toggle.
 	jQuery( 'a[data-frmtoggle]' ).on( 'click', toggleDiv );
 
 	function manageShowEmptyFieldsButton() {

--- a/js/admin/entries.js
+++ b/js/admin/entries.js
@@ -55,7 +55,9 @@ wp.domReady( () => {
 	}
 
 	/**
-	 * @returns Toggle a target element open or closed.
+	 * Toggle a target element open or closed.
+	 *
+	 * @return {false}
 	 */
 	function toggleDiv() {
 		/*jshint validthis:true */

--- a/js/admin/entries.js
+++ b/js/admin/entries.js
@@ -26,6 +26,11 @@ wp.domReady( () => {
 	 */
 	manageShowEmptyFieldsButton();
 
+	/**
+	 * This is used for the "Show empty fields" toggle.
+	 */
+	jQuery( 'a[data-frmtoggle]' ).on( 'click', toggleDiv );
+
 	function manageShowEmptyFieldsButton() {
 		const showEmptyFieldsButton = document.getElementById( 'frm-entry-show-empty-fields' );
 
@@ -48,4 +53,19 @@ wp.domReady( () => {
 			}, newShowState === 'true' ? 0 : 200 );
 		});
 	}
+
+	/**
+	 * @returns Toggle a target element open or closed.
+	 */
+	function toggleDiv() {
+		/*jshint validthis:true */
+		const div = jQuery( this ).data( 'frmtoggle' );
+		if ( jQuery( div ).is( ':visible' ) ) {
+			jQuery( div ).slideUp( 'fast' );
+		} else {
+			jQuery( div ).slideDown( 'fast' );
+		}
+		return false;
+	}
+
 });

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1105,17 +1105,6 @@ function frmFrontFormJS() {
 		return confirm( message );
 	}
 
-	function toggleDiv() {
-		/*jshint validthis:true */
-		const div = jQuery( this ).data( 'frmtoggle' );
-		if ( jQuery( div ).is( ':visible' ) ) {
-			jQuery( div ).slideUp( 'fast' );
-		} else {
-			jQuery( div ).slideDown( 'fast' );
-		}
-		return false;
-	}
-
 	/**
 	 * Check for -webkit-box-shadow css value for input:-webkit-autofill selector.
 	 * If this is a match, the User is autofilling the input on a Webkit browser.
@@ -1462,7 +1451,6 @@ function frmFrontFormJS() {
 			maybeMakeHoneypotFieldsUntabbable();
 
 			jQuery( document ).on( 'click', 'a[data-frmconfirm]', confirmClick );
-			jQuery( 'a[data-frmtoggle]' ).on( 'click', toggleDiv );
 
 			checkForErrorsAndMaybeSetFocus();
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -388,11 +388,7 @@ function frmAdminBuildJS() {
 
 		e.preventDefault();
 
-		if ( items.is( ':visible' ) ) {
-			items.show();
-		} else {
-			items.hide();
-		}
+		items.toggle();
 
 		if ( text !== null && text !== '' ) {
 			this.setAttribute( 'data-toggletext', this.innerHTML );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -382,13 +382,13 @@ function frmAdminBuildJS() {
 
 	function toggleItem( e ) {
 		/*jshint validthis:true */
-		const toggle = this.getAttribute( 'data-frmtoggle' ),
-			text = this.getAttribute( 'data-toggletext' ),
-			items = jQuery( toggle );
+		const toggle = this.getAttribute( 'data-frmtoggle' );
+		const text   = this.getAttribute( 'data-toggletext' );
+		const $items = jQuery( toggle );
 
 		e.preventDefault();
 
-		items.toggle();
+		$items.toggle();
 
 		if ( text !== null && text !== '' ) {
 			this.setAttribute( 'data-toggletext', this.innerHTML );


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5002

This `frmtoggle` logic is only used on the entries list admin page. It isn't part of the front end form logic so it shouldn't be included in this file. It adds bulk to this file that should be as small as possible.

It's also causing funny issues because there are multiple scripts trying to load on this page to handle this attribute. This update fixes the admin code slightly so we can remove the other code.

It also uses some jQuery functions that are difficult to replace.