### PR TITLE
Drop resend email JS

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3278,20 +3278,19 @@ class FrmAppHelper {
 		global $wp_scripts;
 
 		$script_strings = array(
-			'ajax_url'             => esc_url_raw( self::get_ajax_url() ),
-			'images_url'           => self::plugin_url() . '/images',
-			'loading'              => __( 'Loading&hellip;', 'formidable' ),
-			'remove'               => __( 'Remove', 'formidable' ),
-			'offset'               => apply_filters( 'frm_scroll_offset', 4 ),
-			'nonce'                => wp_create_nonce( 'frm_ajax' ),
-			'id'                   => __( 'ID', 'formidable' ),
-			'no_results'           => __( 'No results match', 'formidable' ),
-			'file_spam'            => __( 'That file looks like Spam.', 'formidable' ),
-			'calc_error'           => __( 'There is an error in the calculation in the field with key', 'formidable' ),
-			'empty_fields'         => __( 'Please complete the preceding required fields before uploading a file.', 'formidable' ),
-			'focus_first_error'    => self::should_focus_first_error(),
-			'include_alert_role'   => self::should_include_alert_role_on_field_errors(),
-			'include_resend_email' => self::should_include_resend_email_code(),
+			'ajax_url'           => esc_url_raw( self::get_ajax_url() ),
+			'images_url'         => self::plugin_url() . '/images',
+			'loading'            => __( 'Loading&hellip;', 'formidable' ),
+			'remove'             => __( 'Remove', 'formidable' ),
+			'offset'             => apply_filters( 'frm_scroll_offset', 4 ),
+			'nonce'              => wp_create_nonce( 'frm_ajax' ),
+			'id'                 => __( 'ID', 'formidable' ),
+			'no_results'         => __( 'No results match', 'formidable' ),
+			'file_spam'          => __( 'That file looks like Spam.', 'formidable' ),
+			'calc_error'         => __( 'There is an error in the calculation in the field with key', 'formidable' ),
+			'empty_fields'       => __( 'Please complete the preceding required fields before uploading a file.', 'formidable' ),
+			'focus_first_error'  => self::should_focus_first_error(),
+			'include_alert_role' => self::should_include_alert_role_on_field_errors(),
 		);
 
 		$data = $wp_scripts->get_data( 'formidable', 'data' );
@@ -3410,24 +3409,6 @@ class FrmAppHelper {
 	 */
 	public static function should_include_alert_role_on_field_errors() {
 		return (bool) apply_filters( 'frm_include_alert_role_on_field_errors', true );
-	}
-
-	/**
-	 * @since 6.10
-	 *
-	 * @return bool
-	 */
-	private static function should_include_resend_email_code() {
-		if ( ! self::pro_is_installed() ) {
-			return false;
-		}
-
-		/**
-		 * @since 6.10
-		 *
-		 * @param bool $should_include_resend_email_code_in_lite True by default. This is disabled in Pro v6.10.
-		 */
-		return (bool) apply_filters( 'frm_should_include_resend_email_code_in_lite', true );
 	}
 
 	/**

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3278,19 +3278,21 @@ class FrmAppHelper {
 		global $wp_scripts;
 
 		$script_strings = array(
-			'ajax_url'           => esc_url_raw( self::get_ajax_url() ),
-			'images_url'         => self::plugin_url() . '/images',
-			'loading'            => __( 'Loading&hellip;', 'formidable' ),
-			'remove'             => __( 'Remove', 'formidable' ),
-			'offset'             => apply_filters( 'frm_scroll_offset', 4 ),
-			'nonce'              => wp_create_nonce( 'frm_ajax' ),
-			'id'                 => __( 'ID', 'formidable' ),
-			'no_results'         => __( 'No results match', 'formidable' ),
-			'file_spam'          => __( 'That file looks like Spam.', 'formidable' ),
-			'calc_error'         => __( 'There is an error in the calculation in the field with key', 'formidable' ),
-			'empty_fields'       => __( 'Please complete the preceding required fields before uploading a file.', 'formidable' ),
-			'focus_first_error'  => self::should_focus_first_error(),
-			'include_alert_role' => self::should_include_alert_role_on_field_errors(),
+			'ajax_url'             => esc_url_raw( self::get_ajax_url() ),
+			'images_url'           => self::plugin_url() . '/images',
+			'loading'              => __( 'Loading&hellip;', 'formidable' ),
+			'remove'               => __( 'Remove', 'formidable' ),
+			'offset'               => apply_filters( 'frm_scroll_offset', 4 ),
+			'nonce'                => wp_create_nonce( 'frm_ajax' ),
+			'id'                   => __( 'ID', 'formidable' ),
+			'no_results'           => __( 'No results match', 'formidable' ),
+			'file_spam'            => __( 'That file looks like Spam.', 'formidable' ),
+			'calc_error'           => __( 'There is an error in the calculation in the field with key', 'formidable' ),
+			'empty_fields'         => __( 'Please complete the preceding required fields before uploading a file.', 'formidable' ),
+			'focus_first_error'    => self::should_focus_first_error(),
+			'include_alert_role'   => self::should_include_alert_role_on_field_errors(),
+			// We need to keep this setting for a few versions because Pro checks for this.
+			'include_resend_email' => false,
 		);
 
 		$data = $wp_scripts->get_data( 'formidable', 'data' );

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1066,41 +1066,6 @@ function frmFrontFormJS() {
 		}
 	}
 
-	function resendEmail() {
-		console.warn( 'DEPRECATED: function resendEmail in v6.10 please update to Formidable Pro v6.10' );
-
-		/*jshint validthis:true */
-		let $link = jQuery( this ),
-			entryId = this.getAttribute( 'data-eid' ),
-			formId = this.getAttribute( 'data-fid' ),
-			label = $link.find( '.frm_link_label' );
-		if ( label.length < 1 ) {
-			label = $link;
-		}
-		label.append( '<span class="frm-wait"></span>' );
-
-		jQuery.ajax({
-			type: 'POST',
-			url: frm_js.ajax_url, // eslint-disable-line camelcase
-			data: {
-				action: 'frm_entries_send_email',
-				entry_id: entryId,
-				form_id: formId,
-				nonce: frm_js.nonce // eslint-disable-line camelcase
-			},
-			success: function( msg ) {
-				const admin = document.getElementById( 'wpbody' );
-				if ( admin === null ) {
-					label.html( msg );
-				} else {
-					label.html( '' );
-					$link.after( msg );
-				}
-			}
-		});
-		return false;
-	}
-
 	/**********************************************
 	 * General Helpers
 	 *********************************************/
@@ -1171,7 +1136,7 @@ function frmFrontFormJS() {
 				return;
 			}
 
-			label.addEventListener( 'click', function( e ) {
+			label.addEventListener( 'click', function() {
 				inputsContainer.querySelector( '.frm_form_field:first-child input, .frm_form_field:first-child select, .frm_form_field:first-child textarea' ).focus();
 			});
 		});
@@ -1447,10 +1412,6 @@ function frmFrontFormJS() {
 				}
 			});
 
-			if ( frm_js.include_resend_email ) { // eslint-disable-line camelcase
-				jQuery( document.getElementById( 'frm_resend_email' ) ).on( 'click', resendEmail );
-			}
-
 			jQuery( document ).on( 'change', '.frm-show-form input[name^="item_meta"], .frm-show-form select[name^="item_meta"], .frm-show-form textarea[name^="item_meta"]', frmFrontForm.fieldValueChanged );
 
 			jQuery( document ).on( 'change', '[id^=frm_email_]', onHoneypotFieldChange );
@@ -1521,7 +1482,7 @@ function frmFrontFormJS() {
 			frmFrontForm.submitFormNow( object );
 		},
 
-		afterRecaptcha: function( token, formID ) {
+		afterRecaptcha: function( _, formID ) {
 			const object = jQuery( '#frm_form_' + formID + '_container form' )[0];
 			frmFrontForm.submitFormNow( object );
 		},


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5002

This update removes the only uses of `.html()` in this file.

This only needed to be around for a version or two.

This was deprecated in v6.10, so it will be two big version bumps.

This is now in Pro as part of the entries.js admin script.