### PR TITLE
Remove error classes from field using vanilla JS

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -983,7 +983,8 @@ function frmFrontFormJS() {
 			input = $fieldCont.find( 'input, select, textarea' ),
 			describedBy = input.attr( 'aria-describedby' );
 
-		$fieldCont.removeClass( 'frm_blank_field has-error' );
+		$fieldCont.get( 0 ).classList.remove( 'frm_blank_field', 'has-error' );
+
 		errorMessage.remove();
 		input.attr( 'aria-invalid', false );
 		input.removeAttr( 'aria-describedby' );

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -977,11 +977,18 @@ function frmFrontFormJS() {
 		return 'frm_error_' + input.id;
 	}
 
+	/**
+	 * Removes errors before validating with JS.
+	 * This prevents issues with stale errors that has since been fixed.
+	 *
+	 * @param {object} $fieldCont jQuery object.
+	 * @return {void}
+	 */
 	function removeFieldError( $fieldCont ) {
-		let errorMessage = $fieldCont.find( '.frm_error' ),
-			errorId = errorMessage.attr( 'id' ),
-			input = $fieldCont.find( 'input, select, textarea' ),
-			describedBy = input.attr( 'aria-describedby' );
+		const errorMessage = $fieldCont.find( '.frm_error' );
+		const errorId      = errorMessage.attr( 'id' );
+		const input        = $fieldCont.find( 'input, select, textarea' );
+		let describedBy    = input.attr( 'aria-describedby' );
 
 		$fieldCont.get( 0 ).classList.remove( 'frm_blank_field', 'has-error' );
 

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -981,7 +981,7 @@ function frmFrontFormJS() {
 	 * Removes errors before validating with JS.
 	 * This prevents issues with stale errors that has since been fixed.
 	 *
-	 * @param {object} $fieldCont jQuery object.
+	 * @param {Object} $fieldCont jQuery object.
 	 * @return {void}
 	 */
 	function removeFieldError( $fieldCont ) {


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5002

This update stops the use of the jQuery `.removeClass()` function in one place.