### PR TITLE
Replace font icons with SVGs for edd license status

### DIFF
--- a/classes/views/addons/settings.php
+++ b/classes/views/addons/settings.php
@@ -21,13 +21,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<label class="frm4 frm_form_field" for="edd_<?php echo esc_attr( $slug ); ?>_license_key"><?php echo esc_html( $plugin->plugin_name ); ?></label>
 			<div class="edd_frm_authorized frm8 frm_form_field <?php echo esc_attr( $activate === 'activate' ) ? 'frm_hidden' : ''; ?>">
 				<span class="edd_frm_license"><?php esc_html_e( 'Good to go!', 'formidable' ); ?></span>
-				<span><?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_check1_icon frm_action_icon edd_frm_status_icon frm_inactive_icon' ); ?></span>
+				<span class="frm_icon_font frm_action_success"><?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_check1_icon frm_action_icon edd_frm_status_icon frm_inactive_icon' ); ?></span>
+				<span class="frm_icon_font frm_action_error frm_hidden"><?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_cancel1_icon edd_frm_status_icon' ); ?></span>
 				<input type="button" class="button-secondary frm-button-secondary edd_frm_save_license" data-plugin="<?php echo esc_attr( $slug ); ?>" name="edd_<?php echo esc_attr( $slug ); ?>_license_deactivate" value="<?php esc_attr_e( 'Deactivate', 'formidable' ); ?>"/>
 				<p class="frm_license_msg"></p>
 			</div>
 			<div class="edd_frm_unauthorized frm8 frm_form_field <?php echo esc_attr( $activate === 'deactivate' ) ? 'frm_hidden' : ''; ?>">
 				<input id="edd_<?php echo esc_attr( $slug ); ?>_license_key" name="edd_<?php echo esc_attr( $slug ); ?>_license_key" type="text" class="frm_addon_license_key auto_width" value="" />
-				<span><?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_cancel1_icon edd_frm_status_icon ' . esc_attr( $icon_class ) ); ?></span>
+				<span class="frm_icon_font frm_action_success <?php echo esc_attr( $icon_class ); ?>"><?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_check1_icon edd_frm_status_icon' ); ?></span>
+				<span class="frm_icon_font frm_action_error frm_hidden"><?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_cancel1_icon edd_frm_status_icon' ); ?></span>
 				<input type="button" class="button-secondary frm-button-secondary edd_frm_save_license" data-plugin="<?php echo esc_attr( $slug ); ?>" name="edd_<?php echo esc_attr( $slug ); ?>_license_activate" value="<?php esc_attr_e( 'Activate', 'formidable' ); ?>"/>
 				<p class="frm_license_msg"></p>
 			</div>

--- a/classes/views/addons/settings.php
+++ b/classes/views/addons/settings.php
@@ -21,13 +21,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<label class="frm4 frm_form_field" for="edd_<?php echo esc_attr( $slug ); ?>_license_key"><?php echo esc_html( $plugin->plugin_name ); ?></label>
 			<div class="edd_frm_authorized frm8 frm_form_field <?php echo esc_attr( $activate === 'activate' ) ? 'frm_hidden' : ''; ?>">
 				<span class="edd_frm_license"><?php esc_html_e( 'Good to go!', 'formidable' ); ?></span>
-				<span class="frm_icon_font frm_action_icon frm_error_icon edd_frm_status_icon frm_inactive_icon"></span>
+				<span><?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_check1_icon frm_action_icon edd_frm_status_icon frm_inactive_icon' ); ?></span>
 				<input type="button" class="button-secondary frm-button-secondary edd_frm_save_license" data-plugin="<?php echo esc_attr( $slug ); ?>" name="edd_<?php echo esc_attr( $slug ); ?>_license_deactivate" value="<?php esc_attr_e( 'Deactivate', 'formidable' ); ?>"/>
 				<p class="frm_license_msg"></p>
 			</div>
 			<div class="edd_frm_unauthorized frm8 frm_form_field <?php echo esc_attr( $activate === 'deactivate' ) ? 'frm_hidden' : ''; ?>">
 				<input id="edd_<?php echo esc_attr( $slug ); ?>_license_key" name="edd_<?php echo esc_attr( $slug ); ?>_license_key" type="text" class="frm_addon_license_key auto_width" value="" />
-				<span class="frm_icon_font frm_action_icon frm_error_icon edd_frm_status_icon <?php echo esc_attr( $icon_class ); ?>"></span>
+				<span class="frm_icon_font frm_error_icon edd_frm_status_icon <?php echo esc_attr( $icon_class ); ?>"></span>
+				<span><?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_cancel1_icon edd_frm_status_icon' ); ?></span>
 				<input type="button" class="button-secondary frm-button-secondary edd_frm_save_license" data-plugin="<?php echo esc_attr( $slug ); ?>" name="edd_<?php echo esc_attr( $slug ); ?>_license_activate" value="<?php esc_attr_e( 'Activate', 'formidable' ); ?>"/>
 				<p class="frm_license_msg"></p>
 			</div>

--- a/classes/views/addons/settings.php
+++ b/classes/views/addons/settings.php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</div>
 			<div class="edd_frm_unauthorized frm8 frm_form_field <?php echo esc_attr( $activate === 'deactivate' ) ? 'frm_hidden' : ''; ?>">
 				<input id="edd_<?php echo esc_attr( $slug ); ?>_license_key" name="edd_<?php echo esc_attr( $slug ); ?>_license_key" type="text" class="frm_addon_license_key auto_width" value="" />
-				<span><?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_cancel1_icon edd_frm_status_icon' ); ?></span>
+				<span><?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_cancel1_icon edd_frm_status_icon ' . esc_attr( $icon_class ) ); ?></span>
 				<input type="button" class="button-secondary frm-button-secondary edd_frm_save_license" data-plugin="<?php echo esc_attr( $slug ); ?>" name="edd_<?php echo esc_attr( $slug ); ?>_license_activate" value="<?php esc_attr_e( 'Activate', 'formidable' ); ?>"/>
 				<p class="frm_license_msg"></p>
 			</div>

--- a/classes/views/addons/settings.php
+++ b/classes/views/addons/settings.php
@@ -27,7 +27,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</div>
 			<div class="edd_frm_unauthorized frm8 frm_form_field <?php echo esc_attr( $activate === 'deactivate' ) ? 'frm_hidden' : ''; ?>">
 				<input id="edd_<?php echo esc_attr( $slug ); ?>_license_key" name="edd_<?php echo esc_attr( $slug ); ?>_license_key" type="text" class="frm_addon_license_key auto_width" value="" />
-				<span class="frm_icon_font frm_error_icon edd_frm_status_icon <?php echo esc_attr( $icon_class ); ?>"></span>
 				<span><?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_cancel1_icon edd_frm_status_icon' ); ?></span>
 				<input type="button" class="button-secondary frm-button-secondary edd_frm_save_license" data-plugin="<?php echo esc_attr( $slug ); ?>" name="edd_<?php echo esc_attr( $slug ); ?>_license_activate" value="<?php esc_attr_e( 'Activate', 'formidable' ); ?>"/>
 				<p class="frm_license_msg"></p>

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5204,7 +5204,7 @@ label.frm-example-icon {
 }
 
 .edd_frm_license_row .frm_action_success .frmsvg {
-	fill: green;
+	color: green;
 }
 
 .edd_frm_license_row .frm_action_error .frmsvg {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5204,8 +5204,16 @@ label.frm-example-icon {
 	margin: 0 5px;
 }
 
-.edd_frm_status_icon.frm_icon_font.frm_inactive_icon {
-	color: green;
+.edd_frm_status_icon.frmsvg {
+	margin: 0;
+}
+
+.edd_frm_status_icon.frmsvg {
+	fill: #D54E21;
+}
+
+.edd_frm_status_icon.frmsvg.frm_inactive_icon {
+	fill: green;
 }
 
 /* Hide the install steps for solutions */

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5208,7 +5208,7 @@ label.frm-example-icon {
 }
 
 .edd_frm_license_row .frm_action_error .frmsvg {
-	fill: #D54E21;
+	color: #D54E21;
 }
 
 /* Hide the install steps for solutions */

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5204,7 +5204,7 @@ label.frm-example-icon {
 	margin: 0 5px;
 }
 
-.edd_frm_status_icon.frmsvg.frm_inactive_icon {
+.edd_frm_status_icon.frmsvg.frm_check1_icon {
 	fill: green;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5199,17 +5199,9 @@ label.frm-example-icon {
 	display: none;
 }
 
-.edd_frm_status_icon.frm_icon_font {
+.edd_frm_status_icon.frmsvg {
 	color: #D54E21;
 	margin: 0 5px;
-}
-
-.edd_frm_status_icon.frmsvg {
-	margin: 0;
-}
-
-.edd_frm_status_icon.frmsvg {
-	fill: #D54E21;
 }
 
 .edd_frm_status_icon.frmsvg.frm_inactive_icon {

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5203,11 +5203,11 @@ label.frm-example-icon {
 	margin: 0 5px;
 }
 
-.edd_frm_status_icon.frm_check1_icon {
+.edd_frm_license_row .frm_action_success .frmsvg {
 	fill: green;
 }
 
-.edd_frm_status_icon.frm_cancel1_icon {
+.edd_frm_license_row .frm_action_error .frmsvg {
 	fill: #D54E21;
 }
 

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -5200,12 +5200,15 @@ label.frm-example-icon {
 }
 
 .edd_frm_status_icon.frmsvg {
-	color: #D54E21;
 	margin: 0 5px;
 }
 
-.edd_frm_status_icon.frmsvg.frm_check1_icon {
+.edd_frm_status_icon.frm_check1_icon {
 	fill: green;
+}
+
+.edd_frm_status_icon.frm_cancel1_icon {
+	fill: #D54E21;
 }
 
 /* Hide the install steps for solutions */

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8704,7 +8704,7 @@ function frmAdminBuildJS() {
 							thisRow.get(0).querySelector( '.edd_frm_unauthorized' ).classList.toggle( 'frm_hidden', actionIsActivate )
 							thisRow.get(0).querySelector( '.edd_frm_authorized' ).classList.toggle( 'frm_hidden', ! actionIsActivate )
 						}
-					}, 5000 );
+					}, 2000 );
 				}
 			}
 		});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8687,8 +8687,11 @@ function frmAdminBuildJS() {
 				}
 				thisRow.find( '.edd_frm_license' ).html( license );
 				if ( msg.success === true ) {
-					thisRow.find( '.frm_icon_font' ).removeClass( 'frm_hidden' );
-					thisRow.find( 'div.alignleft' ).toggleClass( 'frm_hidden', 1000 );
+					thisRow.find( '.frm_icon_font.frm_action_success' ).removeClass( 'frm_hidden' );
+					thisRow.find( '.frm_icon_font.frm_action_error' ).addClass( 'frm_hidden' );
+				} else {
+					thisRow.find( '.frm_icon_font.frm_action_success' ).addClass( 'frm_hidden' );
+					thisRow.find( '.frm_icon_font.frm_action_error' ).removeClass( 'frm_hidden' );
 				}
 
 				const messageBox = thisRow.find( '.frm_license_msg' );
@@ -8696,6 +8699,7 @@ function frmAdminBuildJS() {
 				if ( msg.message !== '' ) {
 					setTimeout( function() {
 						messageBox.html( '' );
+						thisRow.find( '.frm_icon_font' ).addClass( 'frm_hidden' );
 					}, 15000 );
 				}
 			}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8710,7 +8710,7 @@ function frmAdminBuildJS() {
 							thisRow.find( '.edd_frm_unauthorized' ).removeClass( 'frm_hidden' )
 							thisRow.find( '.edd_frm_authorized' ).addClass( 'frm_hidden' )
 						}
-					}, 10000 );
+					}, 5000 );
 				}
 			}
 		});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8701,8 +8701,8 @@ function frmAdminBuildJS() {
 						thisRow.find( '.frm_icon_font' ).addClass( 'frm_hidden' );
 						if ( actionIsSuccess ) {
 							const actionIsActivate = action === 'activate';
-							thisRow.get(0).querySelector( '.edd_frm_unauthorized' ).classList.toggle( 'frm_hidden', actionIsActivate )
-							thisRow.get(0).querySelector( '.edd_frm_authorized' ).classList.toggle( 'frm_hidden', ! actionIsActivate )
+							thisRow.get(0).querySelector( '.edd_frm_unauthorized' ).classList.toggle( 'frm_hidden', actionIsActivate );
+							thisRow.get(0).querySelector( '.edd_frm_authorized' ).classList.toggle( 'frm_hidden', ! actionIsActivate );
 						}
 					}, 2000 );
 				}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8700,7 +8700,17 @@ function frmAdminBuildJS() {
 					setTimeout( function() {
 						messageBox.html( '' );
 						thisRow.find( '.frm_icon_font' ).addClass( 'frm_hidden' );
-					}, 15000 );
+						if ( msg.success === false ) {
+							return;
+						}
+						if ( action === 'activate' ) {
+							thisRow.find( '.edd_frm_unauthorized' ).addClass( 'frm_hidden' )
+							thisRow.find( '.edd_frm_authorized' ).removeClass( 'frm_hidden' )
+						} else {
+							thisRow.find( '.edd_frm_unauthorized' ).removeClass( 'frm_hidden' )
+							thisRow.find( '.edd_frm_authorized' ).addClass( 'frm_hidden' )
+						}
+					}, 10000 );
 				}
 			}
 		});

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8676,10 +8676,12 @@ function frmAdminBuildJS() {
 		const pluginSlug = this.getAttribute( 'data-plugin' );
 		const action = buttonName.replace( 'edd_' + pluginSlug + '_license_', '' );
 		let license = document.getElementById( 'edd_' + pluginSlug + '_license_key' ).value;
+		button.get(0).disabled = true;
 		jQuery.ajax({
 			type: 'POST', url: ajaxurl, dataType: 'json',
 			data: {action: 'frm_addon_' + action, license: license, plugin: pluginSlug, nonce: frmGlobal.nonce},
 			success: function( msg ) {
+				button.get(0).disabled = false;
 				const thisRow = button.closest( '.edd_frm_license_row' );
 				if ( action === 'deactivate' ) {
 					license = '';
@@ -8688,7 +8690,7 @@ function frmAdminBuildJS() {
 				thisRow.find( '.edd_frm_license' ).html( license );
 				const eddWrapper = button.get(0).closest( '.frm_form_field' );
 				const actionIsSuccess = msg.success === true;
-				eddWrapper.querySelector( `.frm_icon_font.frm_action_success` ).classList.toggle( 'frm_hidden', ! actionIsSuccess );
+				eddWrapper.querySelector( `.frm_icon_font.frm_action_success` ).classList.toggle( 'frm_hidden', ! actionIsSuccess || action === 'deactivate' );
 				eddWrapper.querySelector( `.frm_icon_font.frm_action_error` ).classList.toggle( 'frm_hidden', actionIsSuccess);
 
 				const messageBox = thisRow.find( '.frm_license_msg' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8686,13 +8686,10 @@ function frmAdminBuildJS() {
 					document.getElementById( 'edd_' + pluginSlug + '_license_key' ).value = '';
 				}
 				thisRow.find( '.edd_frm_license' ).html( license );
-				if ( msg.success === true ) {
-					thisRow.find( '.frm_icon_font.frm_action_success' ).removeClass( 'frm_hidden' );
-					thisRow.find( '.frm_icon_font.frm_action_error' ).addClass( 'frm_hidden' );
-				} else {
-					thisRow.find( '.frm_icon_font.frm_action_success' ).addClass( 'frm_hidden' );
-					thisRow.find( '.frm_icon_font.frm_action_error' ).removeClass( 'frm_hidden' );
-				}
+				const eddWrapper = button.get(0).closest( '.frm_form_field' );
+				const actionIsSuccess = msg.success === true;
+				eddWrapper.querySelector( `.frm_icon_font.frm_action_success` ).classList.toggle( 'frm_hidden', ! actionIsSuccess );
+				eddWrapper.querySelector( `.frm_icon_font.frm_action_error` ).classList.toggle( 'frm_hidden', actionIsSuccess);
 
 				const messageBox = thisRow.find( '.frm_license_msg' );
 				messageBox.html( msg.message );
@@ -8700,15 +8697,10 @@ function frmAdminBuildJS() {
 					setTimeout( function() {
 						messageBox.html( '' );
 						thisRow.find( '.frm_icon_font' ).addClass( 'frm_hidden' );
-						if ( msg.success === false ) {
-							return;
-						}
-						if ( action === 'activate' ) {
-							thisRow.find( '.edd_frm_unauthorized' ).addClass( 'frm_hidden' )
-							thisRow.find( '.edd_frm_authorized' ).removeClass( 'frm_hidden' )
-						} else {
-							thisRow.find( '.edd_frm_unauthorized' ).removeClass( 'frm_hidden' )
-							thisRow.find( '.edd_frm_authorized' ).addClass( 'frm_hidden' )
+						if ( actionIsSuccess ) {
+							const actionIsActivate = action === 'activate';
+							thisRow.get(0).querySelector( '.edd_frm_unauthorized' ).classList.toggle( 'frm_hidden', actionIsActivate )
+							thisRow.get(0).querySelector( '.edd_frm_authorized' ).classList.toggle( 'frm_hidden', ! actionIsActivate )
 						}
 					}, 5000 );
 				}


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5251

Enhancements:
- Switched from using font icons to SVGs.
- User can add/remove license without refreshing the page.
- The activate/deactivate button is disabled until response is received for the prior request

### Test steps
1. Go to the Plugin Licenses tab in the Global Settings and try adding and removing add-on licenses.
2. Confirm that the icons reflect the action of success/error action as expected.
3. Also confirm that, a user can add/remove a license for an add-on without leaving the page, since the 'Activate' and 'Deactivate' elements toggle after few seconds of action.