### PR TITLE
Hide notice from some plugins

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2601,13 +2601,15 @@ h2.frm-h2 + .howto {
 #wpbody-content > .update-nag,
 #wpbody-content > .notice,
 #wpbody-content > .error:not(.frm_previous_install),
-#wpbody-content > .cky-admin-notice,
+#wpbody-content > [class*="admin-notice"],
 .frm-white-body .updated,
 .frm-white-body .notice,
-.frm-white-body .cky-admin-notice,
+.frm-white-body [class*="admin-notice"],
+.frm-white-body [class*="review-banner"],
+.frm-white-body [id$="-review-banner"],
 .frm-white-body #codepeople-review-banner,
 .frm_wrap > .wrap > .notice,
-.frm_wrap > .wrap > .cky-admin-notice,
+.frm_wrap > .wrap > [class*="admin-notice"],
 .frm-white-body .error:not(.frm_previous_install)
 {
 	display: none;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2605,6 +2605,7 @@ h2.frm-h2 + .howto {
 .frm-white-body .updated,
 .frm-white-body .notice,
 .frm-white-body .cky-admin-notice,
+.frm-white-body #codepeople-review-banner,
 .frm_wrap > .wrap > .notice,
 .frm_wrap > .wrap > .cky-admin-notice,
 .frm-white-body .error:not(.frm_previous_install)

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2601,9 +2601,12 @@ h2.frm-h2 + .howto {
 #wpbody-content > .update-nag,
 #wpbody-content > .notice,
 #wpbody-content > .error:not(.frm_previous_install),
+#wpbody-content > .cky-admin-notice,
 .frm-white-body .updated,
 .frm-white-body .notice,
+.frm-white-body .cky-admin-notice,
 .frm_wrap > .wrap > .notice,
+.frm_wrap > .wrap > .cky-admin-notice,
 .frm-white-body .error:not(.frm_previous_install)
 {
 	display: none;


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5178

To replicate, I modified the plugin code to always show their notices.