### PR TITLE
Fix: replace strlen with mb_strlen in FrmFieldText class and add ext-mbstring dependency to composer.json

### DIFF
--- a/classes/models/fields/FrmFieldText.php
+++ b/classes/models/fields/FrmFieldText.php
@@ -41,7 +41,7 @@ class FrmFieldText extends FrmFieldType {
 		$errors     = parent::validate( $args );
 		$max_length = intval( FrmField::get_option( $this->field, 'max' ) );
 
-		if ( $max_length && strlen( $args['value'] ) > $max_length ) {
+		if ( $max_length && mb_strlen( $args['value'] ) > $max_length ) {
 			$errors[ 'field' . $args['id'] ] = FrmFieldsHelper::get_error_msg( $this->field, 'invalid' );
 		}
 

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 	],
 	"type": "wordpress-plugin",
 	"require": {
+		"ext-mbstring": "*",
 		"composer/installers": "~1.0",
 		"phpmailer/phpmailer": ">=5.2.25"
 	},


### PR DESCRIPTION
### Summary
This pull request addresses a significant issue with character counting in the FrmFieldText component, specifically when handling multibyte characters such as those in the Cyrillic alphabet. The original implementation relied on the strlen function, which does not accurately compute the length of strings that contain multibyte characters.

### Changes made
- Replaced instances of strlen with mb_strlen in classes/models/field/FrmFieldText.php
- Updated composer.json to include the requirement for the mbstring extension: "ext-mbstring": "*"

### Reason for the changes
When using the strlen function on strings that contain multibyte characters, such as those found in Cyrillic, the result is incorrect because strlen only counts bytes. Multibyte characters can consist of multiple bytes, which results in an inaccurate character count. By switching to mb_strlen, we ensure that the count reflects the actual number of characters in the string.

### Other potential issues
Aside from Cyrillic, other languages that utilize multibyte character encodings may also encounter incorrect character length calculation using strlen. This includes languages such as:
- Chinese (Han characters)
- Japanese (Kanji, Hiragana, and Katakana)
- Korean (Hangul)
- Arabic (which may have distinct character forms)

These changes are crucial for ensuring accurate string handling in applications dealing with diverse languages and character sets.