### PR TITLE
Sync conditional logic options after field option deletion

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3589,6 +3589,10 @@ function frmAdminBuildJS() {
 			wp.hooks.doAction( 'frm_before_delete_field_option', this );
 			jQuery( parentLi ).remove();
 
+			setTimeout( () => {
+				resetDisplayedOpts( fieldId );
+			}, 1000 );
+
 			const hasOther = jQuery( parentUl ).find( '.frm_other_option' );
 			if ( hasOther.length < 1 ) {
 				otherInput = document.getElementById( 'other_input_' + fieldId );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3587,9 +3587,7 @@ function frmAdminBuildJS() {
 
 		jQuery( parentLi ).fadeOut( 'slow', function() {
 			wp.hooks.doAction( 'frm_before_delete_field_option', this );
-			jQuery( parentLi ).remove( () => {
-				resetDisplayedOpts( fieldId );
-			});
+			resetDisplayedOpts( fieldId );
 
 			const hasOther = jQuery( parentUl ).find( '.frm_other_option' );
 			if ( hasOther.length < 1 ) {
@@ -10891,6 +10889,7 @@ function frmAdminBuildJS() {
 				},
 				success: function( html ) {
 					document.getElementById( 'frm_field_' + fieldId + '_opts' ).innerHTML = html;
+					wp.hooks.doAction( 'frm_after_update_field_opts', fieldId );
 					resetDisplayedOpts( fieldId );
 
 					if ( typeof modal !== 'undefined' ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3587,11 +3587,9 @@ function frmAdminBuildJS() {
 
 		jQuery( parentLi ).fadeOut( 'slow', function() {
 			wp.hooks.doAction( 'frm_before_delete_field_option', this );
-			jQuery( parentLi ).remove();
-
-			setTimeout( () => {
+			jQuery( parentLi ).remove( () => {
 				resetDisplayedOpts( fieldId );
-			}, 1000 );
+			});
 
 			const hasOther = jQuery( parentUl ).find( '.frm_other_option' );
 			if ( hasOther.length < 1 ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3587,7 +3587,7 @@ function frmAdminBuildJS() {
 
 		jQuery( parentLi ).fadeOut( 'slow', function() {
 			wp.hooks.doAction( 'frm_before_delete_field_option', this );
-			resetDisplayedOpts( fieldId );
+			jQuery( parentLi ).remove();
 
 			const hasOther = jQuery( parentUl ).find( '.frm_other_option' );
 			if ( hasOther.length < 1 ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10889,7 +10889,7 @@ function frmAdminBuildJS() {
 				},
 				success: function( html ) {
 					document.getElementById( 'frm_field_' + fieldId + '_opts' ).innerHTML = html;
-					wp.hooks.doAction( 'frm_after_update_field_opts', fieldId );
+					wp.hooks.doAction( 'frm_after_bulk_edit_opts', fieldId );
 					resetDisplayedOpts( fieldId );
 
 					if ( typeof modal !== 'undefined' ) {


### PR DESCRIPTION
Related issue: https://github.com/Strategy11/formidable-pro/issues/4254
Requires: https://github.com/Strategy11/formidable-pro/pull/5313

### Test steps
1. Add one of those fields mentioned in the title and add some options/choices
2. Add another field to the form and create a conditional logic that uses one of those option fields mentioned in the title
3. Select the option field in Step 1 and delete some of options
4. Go back to the field dependent on this ( the one created in Step 2 ), and confirm the conditional logic, the deleted options should not be available anymore.

![CleanShot 2024-08-19 at 16 18 07](https://github.com/user-attachments/assets/c53ed28b-bc99-410d-82a3-0bb0627a87b6)
