### PR TITLE
Fix issue when scrolling to first field when handling stripe error

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1013,10 +1013,14 @@ function frmFrontFormJS() {
 	}
 
 	/**
-	 * @param {HTMLElement} object Form object.
+	 * @param {HTMLElement|Object} object Form object.
 	 * @return {void}
 	 */
 	function scrollToFirstField( object ) {
+		if ( 'function' === typeof object.get ) {
+			// Get the HTMLElement from a jQuery object.
+			object = object.get( 0 );
+		}
 		const field = object.querySelector( '.frm_blank_field' );
 		if ( field ) {
 			frmFrontForm.scrollMsg( jQuery( field ), object, true );


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2686690712/207983/

This is essentially the same issue as https://github.com/Strategy11/formidable-forms/pull/1932. I just missed another place where the `object` variable might be an HTMLElement or a jQuery object.

**Patch release**
[formidable-6.12.1b.zip](https://github.com/user-attachments/files/16711283/formidable-6.12.1b.zip)
