### PR TITLE
Fix: Improve compatibility with old versions of Lite when checking for Chosen

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -4325,4 +4325,19 @@ class FrmAppHelper {
 		</span>
 		<?php
 	}
+
+	/**
+	 * Determines if the chosen JavaScript library should be used.
+	 *
+	 * @return bool
+	 */
+	public static function use_chosen_js() {
+		if ( ! self::pro_is_installed() ) {
+			return false;
+		}
+
+		return is_callable( 'FrmProAppHelper::use_chosen_js' )
+			? FrmProAppHelper::use_chosen_js()
+			: true;
+	}
 }

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -4325,19 +4325,4 @@ class FrmAppHelper {
 		</span>
 		<?php
 	}
-
-	/**
-	 * Determines if the chosen JavaScript library should be used.
-	 *
-	 * @return bool
-	 */
-	public static function use_chosen_js() {
-		if ( ! self::pro_is_installed() ) {
-			return false;
-		}
-
-		return is_callable( 'FrmProAppHelper::use_chosen_js' )
-			? FrmProAppHelper::use_chosen_js()
-			: true;
-	}
 }

--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -740,6 +740,23 @@ class FrmStylesHelper {
 	}
 
 	/**
+	 * Determines if the chosen JavaScript library should be used.
+	 *
+	 * @since x.x
+	 *
+	 * @return bool
+	 */
+	public static function use_chosen_js() {
+		if ( ! FrmAppHelper::pro_is_installed() ) {
+			return false;
+		}
+
+		return is_callable( 'FrmProAppHelper::use_chosen_js' )
+			? FrmProAppHelper::use_chosen_js()
+			: true;
+	}
+
+	/**
 	 * @since 5.5.1
 	 * @deprecated 6.10
 	 * @return void

--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -8,8 +8,9 @@ extract( $settings ); // phpcs:ignore WordPress.PHP.DontExtract
 
 $important = empty( $important_style ) ? '' : ' !important';
 
-$minus_icons = FrmStylesHelper::minus_icons();
-$arrow_icons = FrmStylesHelper::arrow_icons();
+$minus_icons   = FrmStylesHelper::minus_icons();
+$arrow_icons   = FrmStylesHelper::arrow_icons();
+$use_chosen_js = FrmAppHelper::use_chosen_js();
 
 ?>
 .<?php echo esc_html( $style_class ); ?>{

--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -10,7 +10,7 @@ $important = empty( $important_style ) ? '' : ' !important';
 
 $minus_icons   = FrmStylesHelper::minus_icons();
 $arrow_icons   = FrmStylesHelper::arrow_icons();
-$use_chosen_js = FrmAppHelper::use_chosen_js();
+$use_chosen_js = FrmStylesHelper::use_chosen_js();
 
 ?>
 .<?php echo esc_html( $style_class ); ?>{

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -22,7 +22,7 @@ $default_style    = $frm_style->get_default_style( $styles );
 $defaults         = FrmStylesHelper::get_settings_for_output( $default_style );
 $important        = empty( $defaults['important_style'] ) ? '' : ' !important';
 $pro_is_installed = FrmAppHelper::pro_is_installed();
-$use_chosen_js    = FrmAppHelper::use_chosen_js();
+$use_chosen_js    = FrmStylesHelper::use_chosen_js();
 
 ?>
 .with_frm_style{

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -22,7 +22,10 @@ $default_style    = $frm_style->get_default_style( $styles );
 $defaults         = FrmStylesHelper::get_settings_for_output( $default_style );
 $important        = empty( $defaults['important_style'] ) ? '' : ' !important';
 $pro_is_installed = FrmAppHelper::pro_is_installed();
-$use_chosen_js    = $pro_is_installed && FrmProAppHelper::use_chosen_js();
+
+$use_chosen_js =
+	$pro_is_installed
+	&& ( method_exists( 'FrmProAppHelper', 'use_chosen_js' ) ? FrmProAppHelper::use_chosen_js() : true );
 
 ?>
 .with_frm_style{

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -25,7 +25,7 @@ $pro_is_installed = FrmAppHelper::pro_is_installed();
 
 $use_chosen_js =
 	$pro_is_installed
-	&& ( method_exists( 'FrmProAppHelper', 'use_chosen_js' ) ? FrmProAppHelper::use_chosen_js() : true );
+	&& is_callable( 'FrmProAppHelper::use_chosen_js' ) ? FrmProAppHelper::use_chosen_js() : true;
 
 ?>
 .with_frm_style{

--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -22,10 +22,7 @@ $default_style    = $frm_style->get_default_style( $styles );
 $defaults         = FrmStylesHelper::get_settings_for_output( $default_style );
 $important        = empty( $defaults['important_style'] ) ? '' : ' !important';
 $pro_is_installed = FrmAppHelper::pro_is_installed();
-
-$use_chosen_js =
-	$pro_is_installed
-	&& is_callable( 'FrmProAppHelper::use_chosen_js' ) ? FrmProAppHelper::use_chosen_js() : true;
+$use_chosen_js    = FrmAppHelper::use_chosen_js();
 
 ?>
 .with_frm_style{


### PR DESCRIPTION
Ensure the `FrmProAppHelper::use_chosen_js` is called only if it callable.

### Related Issue:
https://github.com/Strategy11/formidable-pro/issues/5309