### PR TITLE
Add check for WP error before trying to inject a suggestion fix

### DIFF
--- a/classes/models/FrmPluginSearch.php
+++ b/classes/models/FrmPluginSearch.php
@@ -57,6 +57,11 @@ class FrmPluginSearch {
 			return $result;
 		}
 
+		if ( is_wp_error( $result ) ) {
+			// This may happen if the request failed due to an internet connection issue.
+			return $result;
+		}
+
 		$addon_list = $this->get_addons();
 
 		// Lowercase, trim, remove punctuation/special chars, decode url, remove 'formidable'.


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5312

If I disable my internet connection I can replicate this.

The `$result` is an error in this case and should be returned early.