### PR TITLE
Fix pro issue 4956 / Add checks that add on variables are array with …

### DIFF
--- a/classes/controllers/FrmSimpleBlocksController.php
+++ b/classes/controllers/FrmSimpleBlocksController.php
@@ -45,17 +45,17 @@ class FrmSimpleBlocksController {
 			'link'        => FrmAppHelper::admin_upgrade_link( 'block' ),
 			'url'         => FrmAppHelper::plugin_url(),
 			'modalAddon'  => array(
-				'link'      => FrmAppHelper::admin_upgrade_link( 'block', $modal_addon['link'] ),
-				'hasAccess' => ! empty( $modal_addon['url'] ),
+				'link'      => is_array( $modal_addon ) && isset( $modal_addon['link'] ) ? FrmAppHelper::admin_upgrade_link( 'block', $modal_addon['link'] ) : '',
+				'hasAccess' => is_array( $modal_addon ) && ! empty( $modal_addon['url'] ),
 			),
 			'viewsAddon'  => array(
-				'link'      => FrmAppHelper::admin_upgrade_link( 'block', $views_addon_info['link'] ),
+				'link'      => is_array( $views_addon_info ) && isset( $views_addon_info['link'] ) ? FrmAppHelper::admin_upgrade_link( 'block', $views_addon_info['link'] ) : '',
 				'hasAccess' => ! empty( $views_addon_info['url'] ),
 				'url'       => ! empty( $views_addon_info['url'] ) ? $views_addon_info['url'] : '',
 				'installed' => 'installed' === $views_addon['status']['type'],
 			),
 			'chartsAddon' => array(
-				'link'      => FrmAppHelper::admin_upgrade_link( 'block', $charts_addon['link'] ),
+				'link'      => is_array( $charts_addon ) && isset( $charts_addon['link'] ) ? FrmAppHelper::admin_upgrade_link( 'block', $charts_addon['link'] ) : '',
 				'hasAccess' => ! empty( $charts_addon['url'] ),
 				'installed' => class_exists( 'FrmChartsAppController' ),
 			),

--- a/classes/controllers/FrmSimpleBlocksController.php
+++ b/classes/controllers/FrmSimpleBlocksController.php
@@ -50,13 +50,13 @@ class FrmSimpleBlocksController {
 			),
 			'viewsAddon'  => array(
 				'link'      => is_array( $views_addon_info ) && isset( $views_addon_info['link'] ) ? FrmAppHelper::admin_upgrade_link( 'block', $views_addon_info['link'] ) : '',
-				'hasAccess' => ! empty( $views_addon_info['url'] ),
+				'hasAccess' => is_array( $views_addon_info ) && ! empty( $views_addon_info['url'] ),
 				'url'       => ! empty( $views_addon_info['url'] ) ? $views_addon_info['url'] : '',
 				'installed' => 'installed' === $views_addon['status']['type'],
 			),
 			'chartsAddon' => array(
 				'link'      => is_array( $charts_addon ) && isset( $charts_addon['link'] ) ? FrmAppHelper::admin_upgrade_link( 'block', $charts_addon['link'] ) : '',
-				'hasAccess' => ! empty( $charts_addon['url'] ),
+				'hasAccess' => is_array( $charts_addon ) && ! empty( $charts_addon['url'] ),
 				'installed' => class_exists( 'FrmChartsAppController' ),
 			),
 		);


### PR DESCRIPTION
…keys set

Fixes https://github.com/Strategy11/formidable-pro/issues/4956

There is a condition,
```
if ( $this->is_running() ) {
    // If there's no saved cache, we'll need to wait for the current request to finish.
    return array();
}
```

Where it can return an empty array. There may be other paths, but this one is at least for sure. When it's empty, these warnings are triggered.