### PR TITLE
Fix JS error when trying to validate readonly time field

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -352,6 +352,12 @@ function frmFrontFormJS() {
 				fieldID = getFieldId( field, true );
 			}
 
+			// Make sure fieldID is a string.
+			// fieldID may be a number which doesn't include a .replace function.
+			if ( 'function' !== typeof fieldID.replace ) {
+				fieldID = fieldID.toString();
+			}
+
 			if ( hasClass( field, 'frm_time_select' ) ) {
 				// set id for time field
 				fieldID = fieldID.replace( '-H', '' ).replace( '-m', '' );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4447

`getFieldId` can return a `0`.

If it does, it triggers a JS error because numbers don't have a `.replace` function.