### PR TITLE
Drop payments page a11y test

### DIFF
--- a/tests/cypress/e2e/admin-a11y.cy.js
+++ b/tests/cypress/e2e/admin-a11y.cy.js
@@ -74,15 +74,6 @@ describe('Run some accessibility tests', function() {
         cy.checkA11y();
     });
 
-    it('Check the payments page is accessible', () => {
-        cy.visit('/wp-admin/admin.php?page=formidable-settings&t=stripe_settings');
-        cy.injectAxe();
-        configureAxeWithIgnoredRuleset([
-            ...baselineRules
-        ]);
-        cy.checkA11y();
-    });
-
     it('Check the import/export page is accessible', () => {
         cy.visit('/wp-admin/admin.php?page=formidable-import');
         cy.injectAxe();


### PR DESCRIPTION
We don't need this test since it just covers the global settings page since the payments are not actually set up in the tests.