### PR TITLE
Fix pro issue 5303 / Split maximum characters setting and field size …

### DIFF
--- a/classes/views/frm-fields/back-end/max.php
+++ b/classes/views/frm-fields/back-end/max.php
@@ -2,8 +2,13 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
+
+$max_setting_container_atts = array();
+if ( ! empty( $can_fit_label_in_two_columns ) ) {
+	$max_setting_container_atts['class'] = 'frm6 frm_form_field';
+}
 ?>
-<p class="frm6 frm_form_field">
+<p <?php FrmAppHelper::array_to_html_params( $max_setting_container_atts, true ); ?>>
 	<label for="field_options_max_<?php echo esc_attr( $field['id'] ); ?>">
 		<?php
 		if ( 'textarea' === $field['type'] || 'rte' === $field['type'] ) {

--- a/classes/views/frm-fields/back-end/pixels-wide.php
+++ b/classes/views/frm-fields/back-end/pixels-wide.php
@@ -2,8 +2,18 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
+
+$field_size_container_atts = array();
+if ( $display_max ) {
+	$max_characters_label         = __( 'Max Characters', 'formidable' );
+	$can_fit_label_in_two_columns = FrmAppHelper::mb_function( array( 'mb_strlen', 'strlen' ), array( $max_characters_label ) ) < 20;
+
+	if ( $can_fit_label_in_two_columns ) {
+		$field_size_container_atts['class'] = 'frm6 frm_form_field';
+	}
+}
 ?>
-<p class="<?php echo esc_attr( $display_max ? 'frm6 frm_form_field' : '' ); ?>">
+<p <?php FrmAppHelper::array_to_html_params( $field_size_container_atts, true ); ?>>
 	<label for="field_options_size_<?php echo esc_attr( $field['id'] ); ?>">
 		<?php esc_html_e( 'Field Size', 'formidable' ); ?>
 		<span class="frm-sub-label">


### PR DESCRIPTION
…to separate lines for long labels

Fixes https://github.com/Strategy11/formidable-pro/issues/5303

Now when the Maximum Characters setting label is too long, it breaks the Field Size and Maximum Characters into separate lines.

<img width="458" alt="Screen Shot 2024-08-26 at 11 40 19 AM" src="https://github.com/user-attachments/assets/a946f41a-f403-4996-b4e1-93e8c8224c0b">
