### PR TITLE
Add type check before populating field options

### DIFF
--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -293,6 +293,10 @@ class FrmEntriesHelper {
 
 		$atts = apply_filters( 'frm_display_value_atts', $atts, $field, $value );
 
+		if ( is_string( $field->field_options ) ) {
+			$field->field_options = array();
+		}
+
 		if ( ! isset( $field->field_options['post_field'] ) ) {
 			$field->field_options['post_field'] = '';
 		}


### PR DESCRIPTION
**Related ticket** https://secure.helpscout.net/conversation/2541877641/193518

This prevents the following fatal PHP error when `$field->field_options` is not in the expected format.

> Error Message: Une erreur de type E_ERROR a été causée dans la ligne 294 du fichier /home/artxterra_app/webapps/artxterra_app/wp-content/plugins/formidable/classes/helpers/FrmEntriesHelper.php. Message d’erreur : Uncaught TypeError: Cannot access offset of type string on string in /home/artxterra_app/webapps/artxterra_app/wp-content/plugins/formidable/classes/helpers/FrmEntriesHelper.php:294 Stack trace: #0 /home/artxterra_app/webapps/artxterra_app/wp-content/plugins/formidable/classes/helpers/FrmEntriesHelper.php(210): FrmEntriesHelper::display_value() #1 /home/artxterra_app/webapps/artxterra_app/wp-content/plugins/formidable/classes/helpers/FrmEntriesListHelper.php(472): FrmEntriesHelper::prepare_display_value() #2 /home/artxterra_app/webapps/artxterra_app/wp-content/plugins/formidable/classes/helpers/FrmEntriesListHelper.php(395): FrmEntriesListHelper->get_column_value() #3 /home/artxterra_app/webapps/artxterra_app/wp-content/plugins/formidable/classes/helpers/FrmEntriesListHelper.php(316): FrmEntriesListHelper->column_value() #4 /home/artxterra_app/webapps/artxterra_app/wp-content/plugins/formidable/classes/helpers/FrmListHelper.php(160): FrmEntriesListHelper->single_row() #5 /home/artxterra_app/webapps/artxterra_app/wp-content/plugins/formidable/classes/helpers/FrmListHelper.php(1114): FrmListHelper->display_rows() #6 /home/artxterra_app/webapps/artxterra_app/wp-content/plugins/formidable/classes/helpers/FrmListHelper.php(1009): FrmListHelper->display_rows_or_placeholder() #7 /home/artxterra_app/webapps/artxterra_app/wp-content/plugins/formidable/classes/views/frm-entries/list.php(49): FrmListHelper->display() #8 /home/artxterra_app/webapps/artxterra_app/wp-content/plugins/formidable/classes/controllers/FrmEntriesController.php(435): require('...') #9 /home/artxterra_app/webapps/artxterra_app/wp-content/plugins/formidable/classes/controllers/FrmEntriesController.php(57): FrmEntriesController::display_list() #10 /home/artxterra_app/webapps/artxterra_app/wp-includes/class-wp-hook.php(324): FrmEntriesController::route() #11 /home/artxterra_app/webapps/artxterra_app/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters() #12 /home/artxterra_app/webapps/artxterra_app/wp-includes/plugin.php(517): WP_Hook->do_action() #13 /home/artxterra_app/webapps/artxterra_app/wp-admin/admin.php(259): do_action() #14 {main} thrown