### PR TITLE
Add frm_get_ajax_form_errors event

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1629,6 +1629,11 @@ function frmFrontFormJS() {
 				}
 			}
 
+			triggerCustomEvent( document, 'frm_get_ajax_form_errors', {
+				formEl: object,
+				errors: jsErrors
+			});
+
 			return jsErrors;
 		},
 


### PR DESCRIPTION
This is required to add JS validation for minimum selections.