### PR TITLE
Only add Cloudflare Turnstile captcha for visible elements

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1779,16 +1779,13 @@ function frmTurnstile() {
 	frmCaptcha( '.cf-turnstile' );
 }
 
-function frmElementIsVisible(element) {
-	return element.offsetParent !== null;
-}
-
 function frmCaptcha( captchaSelector ) {
 	let c;
 	const captchas = document.querySelectorAll( captchaSelector );
 	const cl       = captchas.length;
 	for ( c = 0; c < cl; c++ ) {
-		if ( ! frmElementIsVisible( captchas[c] ) ) {
+		const isVisible = captchas[c].offsetParent !== null;
+		if ( ! isVisible ) {
 			continue;
 		}
 		frmFrontForm.renderCaptcha( captchas[c], captchaSelector );

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1779,11 +1779,18 @@ function frmTurnstile() {
 	frmCaptcha( '.cf-turnstile' );
 }
 
+function frmElementIsVisible(element) {
+	return element.offsetParent !== null;
+}
+
 function frmCaptcha( captchaSelector ) {
 	let c;
 	const captchas = document.querySelectorAll( captchaSelector );
 	const cl       = captchas.length;
 	for ( c = 0; c < cl; c++ ) {
+		if ( ! frmElementIsVisible( captchas[c] ) ) {
+			continue;
+		}
 		frmFrontForm.renderCaptcha( captchas[c], captchaSelector );
 	}
 }


### PR DESCRIPTION
## The issue

In a customer's site we found a case where on the same page we may have one form twice, one for desktop and the other for mobile and this can be customized in the page builder (SiteOrigin page builder in our case)
Here we will have only one visible form but if the form contains Cloudflare Turnstile captcha, we will have two captcha fields visible.

## The solution

Here I'm checking if the captcha field is visible before initiating the captcha field.

## Screencast

https://github.com/user-attachments/assets/60f80ccd-9354-4135-8900-532e722e7f59

## Ticket(s)

https://secure.helpscout.net/conversation/2685885705/207895/