### PR TITLE
Enhance error messages in Visual Styler page

### DIFF
--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -330,6 +330,7 @@ class FrmStylesController {
 				'cancel_url' => admin_url( 'admin.php?page=formidable' ),
 			);
 			FrmAppController::show_error_modal( $error_args );
+			return;
 		}
 
 		$form_id = FrmAppHelper::simple_get( 'form', 'absint', 0 );
@@ -338,6 +339,7 @@ class FrmStylesController {
 		}
 
 		$form = FrmForm::getOne( $form_id );
+		
 		if ( ! is_object( $form ) ) {
 			$error_args   = array(
 				'title'      => __( 'No forms', 'formidable' ),
@@ -345,6 +347,7 @@ class FrmStylesController {
 				'cancel_url' => admin_url( 'admin.php?page=formidable' ),
 			);
 			FrmAppController::show_error_modal( $error_args );
+			return;
 		}
 
 		$frm_style     = new FrmStyle( $style_id );

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -339,7 +339,7 @@ class FrmStylesController {
 		}
 
 		$form = FrmForm::getOne( $form_id );
-		
+
 		if ( ! is_object( $form ) ) {
 			$error_args   = array(
 				'title'      => __( 'No forms', 'formidable' ),

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -340,7 +340,7 @@ class FrmStylesController {
 
 		$form = FrmForm::getOne( $form_id );
 		
-		if ( ! is_object( $form ) ) {
+		if ( true ) {
 			$error_args   = array(
 				'title'      => __( 'No forms', 'formidable' ),
 				'body'       => __( 'You must have a form to use the Visual Styler.', 'formidable' ),

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -340,7 +340,7 @@ class FrmStylesController {
 
 		$form = FrmForm::getOne( $form_id );
 		
-		if ( true ) {
+		if ( ! is_object( $form ) ) {
 			$error_args   = array(
 				'title'      => __( 'No forms', 'formidable' ),
 				'body'       => __( 'You must have a form to use the Visual Styler.', 'formidable' ),

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -324,7 +324,12 @@ class FrmStylesController {
 
 		$style_id = self::get_style_id_for_styler();
 		if ( ! $style_id ) {
-			wp_die( esc_html__( 'Invalid route', 'formidable' ), esc_html__( 'Invalid route', 'formidable' ), 400 );
+			$error_args   = array(
+				'title'      => __( 'No styles', 'formidable' ),
+				'body'       => __( 'You must have a style to use the Visual Styler.', 'formidable' ),
+				'cancel_url' => admin_url( 'admin.php?page=formidable' ),
+			);
+			FrmAppController::show_error_modal( $error_args );
 		}
 
 		$form_id = FrmAppHelper::simple_get( 'form', 'absint', 0 );
@@ -334,7 +339,12 @@ class FrmStylesController {
 
 		$form = FrmForm::getOne( $form_id );
 		if ( ! is_object( $form ) ) {
-			wp_die( esc_html__( 'Invalid route', 'formidable' ), esc_html__( 'Invalid route', 'formidable' ), 400 );
+			$error_args   = array(
+				'title'      => __( 'No forms', 'formidable' ),
+				'body'       => __( 'You must have a form to use the Visual Styler.', 'formidable' ),
+				'cancel_url' => admin_url( 'admin.php?page=formidable' ),
+			);
+			FrmAppController::show_error_modal( $error_args );
 		}
 
 		$frm_style     = new FrmStyle( $style_id );

--- a/classes/helpers/FrmOnSubmitHelper.php
+++ b/classes/helpers/FrmOnSubmitHelper.php
@@ -444,7 +444,7 @@ class FrmOnSubmitHelper {
 	}
 
 	/**
-	 * Check if the current event has been paased. If not, use create actions.
+	 * Check if the current event has been passed. If not, use create actions.
 	 *
 	 * @since 6.1.1
 	 *


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5324
![CleanShot 2024-09-02 at 12 51 31](https://github.com/user-attachments/assets/95049329-1691-479d-9afd-2a4b961b6489)

### Test procedure
1. Delete all forms from your site and try going to the Styles page.
2. Confirm that the error message makes more sense and shows in modal on this branch differently from master branch.