### PR TITLE
Move Styles & Scripts settings to Manage Styles tab

### DIFF
--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -733,6 +733,7 @@ class FrmStylesController {
 		$frm_style     = new FrmStyle();
 		$styles        = $frm_style->get_all();
 		$default_style = $frm_style->get_default_style( $styles );
+		$frm_settings  = FrmAppHelper::get_settings();
 
 		if ( ! $forms ) {
 			$forms = FrmForm::get_published_forms();

--- a/classes/views/frm-settings/general.php
+++ b/classes/views/frm-settings/general.php
@@ -14,25 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <h3><?php esc_html_e( 'Styling & Scripts', 'formidable' ); ?></h3>
 
-<p class="frm_grid_container">
-	<label class="frm4 frm_form_field" for="frm_load_style">
-		<?php esc_html_e( 'Load form styling', 'formidable' ); ?>
-	</label>
-	<select id="frm_load_style" name="frm_load_style" class="frm8 frm_form_field">
-		<option value="all" <?php selected( $frm_settings->load_style, 'all' ); ?>>
-			<?php esc_html_e( 'on every page of my site', 'formidable' ); ?>
-		</option>
-		<option value="dynamic" <?php selected( $frm_settings->load_style, 'dynamic' ); ?>>
-			<?php esc_html_e( 'only on applicable pages', 'formidable' ); ?>
-		</option>
-		<option value="none" <?php selected( $frm_settings->load_style, 'none' ); ?>>
-			<?php esc_html_e( 'Don\'t use form styling on any page', 'formidable' ); ?>
-		</option>
-	</select>
-</p>
-
-<?php do_action( 'frm_style_general_settings', $frm_settings ); ?>
-
 <h3><?php esc_html_e( 'Other', 'formidable' ); ?></h3>
 
 <p class="frm_grid_container">

--- a/classes/views/frm-settings/general.php
+++ b/classes/views/frm-settings/general.php
@@ -12,8 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php do_action( 'frm_before_settings' ); ?>
 </div>
 
-<h3><?php esc_html_e( 'Styling & Scripts', 'formidable' ); ?></h3>
-
 <h3><?php esc_html_e( 'Other', 'formidable' ); ?></h3>
 
 <p class="frm_grid_container">

--- a/classes/views/styles/manage.php
+++ b/classes/views/styles/manage.php
@@ -4,6 +4,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <div>
+	<p class="frm_grid_container">
+		<label class="frm4 frm_form_field" for="frm_load_style">
+			<?php esc_html_e( 'Load form styling', 'formidable' ); ?>
+		</label>
+		<select id="frm_load_style" name="frm_load_style" class="frm8 frm_form_field">
+			<option value="all" <?php selected( $frm_settings->load_style, 'all' ); ?>>
+				<?php esc_html_e( 'on every page of my site', 'formidable' ); ?>
+			</option>
+			<option value="dynamic" <?php selected( $frm_settings->load_style, 'dynamic' ); ?>>
+				<?php esc_html_e( 'only on applicable pages', 'formidable' ); ?>
+			</option>
+			<option value="none" <?php selected( $frm_settings->load_style, 'none' ); ?>>
+				<?php esc_html_e( 'Don\'t use form styling on any page', 'formidable' ); ?>
+			</option>
+		</select>
+	</p>
+
+	<?php do_action( 'frm_style_general_settings', $frm_settings ); ?>
+
 	<p class="howto">
 		<?php esc_html_e( 'Easily change which style your forms are using by making changes below.', 'formidable' ); ?>
 	</p>


### PR DESCRIPTION
Fixes: https://github.com/Strategy11/formidable-pro/issues/5187

This PR will move 2 settings mentioned in the issue to the Manage Styles tab. We will move the `Fade in forms with conditional logic on page load` setting to Other section in General Settings tab in another PR in Pro.