### PR TITLE
Drop textdomain for common WP string

### DIFF
--- a/classes/helpers/FrmOnSubmitHelper.php
+++ b/classes/helpers/FrmOnSubmitHelper.php
@@ -444,7 +444,7 @@ class FrmOnSubmitHelper {
 	}
 
 	/**
-	 * Check if the current event has been paased. If not, use create actions.
+	 * Check if the current event has been passed. If not, use create actions.
 	 *
 	 * @since 6.1.1
 	 *

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -36,7 +36,8 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element value="formidable"/>
+				<element value="formidable" />
+				<element value="default" />
 			</property>
 		</properties>
 	</rule>

--- a/stripe/models/FrmTransLiteAction.php
+++ b/stripe/models/FrmTransLiteAction.php
@@ -169,7 +169,7 @@ class FrmTransLiteAction extends FrmFormAction {
 		$has_field = false;
 		?>
 		<select class="frm_with_left_label" name="<?php echo esc_attr( $this->get_field_name( $field_atts['name'] ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( $field_atts['name'] ) ); ?>">
-			<option value=""><?php esc_html_e( '&mdash; Select &mdash;', 'formidable' ); ?></option>
+			<option value=""><?php esc_html_e( '&mdash; Select &mdash;' ); ?></option>
 			<?php
 			foreach ( $form_atts['form_fields'] as $field ) {
 				$type_is_allowed = empty( $field_atts['allowed_fields'] ) || in_array( $field->type, (array) $field_atts['allowed_fields'], true );


### PR DESCRIPTION
This way we don't need to manage the translation.