### PR TITLE
Do not pass non-customizable fields to Akismet guest info

### DIFF
--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -477,6 +477,7 @@ class FrmEntryValidate {
 		self::add_server_values_to_akismet( $datas );
 
 		self::prepare_values_for_spam_check( $values );
+		self::skip_adding_values_to_akismet( $values );
 
 		self::add_user_info_to_akismet( $datas, $values );
 		self::add_comment_content_to_akismet( $datas, $values );
@@ -657,8 +658,6 @@ class FrmEntryValidate {
 			}
 			unset( $datas['frm_duplicated'] );
 		}
-
-		self::skip_adding_values_to_akismet( $values );
 
 		$datas['comment_content'] = FrmEntriesHelper::entry_array_to_string( $values );
 	}


### PR DESCRIPTION
Fixes #1782 

We did the same thing for comment content. I don't know how to tell Garret to test. I use `error_log()` to test this.