### PR TITLE
Drop unused var/db query for all templates

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1215,8 +1215,7 @@ class FrmFormsController {
 
 		self::maybe_update_form_builder_message( $message );
 
-		$all_templates = FrmForm::getAll( array( 'is_template' => 1 ), 'name' );
-		$has_fields    = ! empty( $values['fields'] ) && ! FrmSubmitHelper::only_contains_submit_field( $values['fields'] );
+		$has_fields = ! empty( $values['fields'] ) && ! FrmSubmitHelper::only_contains_submit_field( $values['fields'] );
 
 		if ( defined( 'DOING_AJAX' ) ) {
 			wp_die();

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,7 @@ parameters:
 		- */vendor/*
 		- */fonts/*
 		- */deprecated/*
+		- */rector.php
 	strictRules:
 		disallowedLooseComparison: false
 		booleansInConditions: false

--- a/rector.php
+++ b/rector.php
@@ -21,7 +21,6 @@ use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
 use Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector;
 use Rector\CodeQuality\Rector\Concat\JoinStringConcatRector;
 use Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector;
-use Rector\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\Expression\RemoveDeadStmtRector;
 use Rector\DeadCode\Rector\FunctionLike\RemoveDeadReturnRector;
@@ -82,7 +81,6 @@ return RectorConfig::configure()
 			LocallyCalledStaticMethodToNonStaticRector::class,
 			JoinStringConcatRector::class,
 			ChangeArrayPushToArrayAssignRector::class,
-			CallableThisArrayToAnonymousFunctionRector::class,
 			RemoveUselessParamTagRector::class,
 			RemoveDeadStmtRector::class,
 			RemoveDeadReturnRector::class,


### PR DESCRIPTION
This `$all_templates` var is never referenced.

Removing this appears to have no issue while removing a db query on every form builder load.