### PR TITLE
Reduce file scope of some phpstan exceptions

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,16 +31,13 @@ parameters:
 		- '#Cannot access (offset|property)+#'
 		- '#Cannot (call method|cast|assign offset)+#'
 		- '#Function (apply_filters)+ invoked with#'
-		- '#Possibly invalid array key type#'
 		- '#code above always terminates.#'
 		- '#does not (accept|exist on)+#'
 		- '#expects (array|string|int|callable|object|stdClass|float|bool|resource)+#'
-		- '#has (an unused parameter|invalid type)+#'
 		- '#is always (false|true)+.#'
 		- '#might not be defined.#'
 		- '#no (typehint|value type|return typehint)+ specified.#'
 		- '#of echo cannot be converted to string.#'
-		- '#get_mailer\(\) expects#'
 		- '#only iterables are supported#'
 		- '#results in an error.#'
 		- '#should return#'
@@ -48,20 +45,52 @@ parameters:
 		- '#has no return type specified#'
 		- '#with no type specified#'
 		- '#in isset\(\) does not exist.#'
-		- '#has no type specified.#'
-		-
-			message: '#has invalid return type#'
-			path: classes/controllers/FrmSMTPController.php
 		- '#is unused.#'
 		- '#is never read, only written#'
 		- '#in empty\(\) is not falsy.#'
-		- '#Cannot access an offset on mixed.#'
 		- '#always exists and is not falsy.#'
-		- '#has an unused use#'
-		- '#Cannot use array destructuring on#'
-		- '#of method FrmFieldName::\_\_construct#'
-		- '#callback of function spl_autoload_register expects#'
-		- '#Call to an undefined method FrmFieldType::get\_file\_id#'
+		- '#has no type specified.#'
+		-
+			message: '#has an unused parameter#'
+			paths:
+				- classes/models/FrmFieldOption.php
+				- classes/models/FrmInbox.php
+				- classes/models/FrmSolution.php
+				- stubs.php
+		-
+			message: '#has invalid type#'
+			path: stubs.php
+		-
+			message: '#Possibly invalid array key type#'
+			paths:
+				- classes/helpers/FrmCSVExportHelper.php
+				- classes/helpers/FrmFormsListHelper.php
+		-
+			message: '#get_mailer\(\) expects#'
+			path: classes/controllers/FrmSMTPController.php
+		-
+			message: '#has invalid return type#'
+			path: classes/controllers/FrmSMTPController.php
+		-
+			message: '#has an unused use#'
+			path: classes/views/styles/manage.php
+		-
+			message: '#Cannot access an offset on mixed.#'
+			paths:
+				- classes/helpers/FrmFormMigratorsHelper.php
+				- classes/models/FrmEntryMeta.php
+		-
+			message: '#of method FrmFieldName::\_\_construct#'
+			path: classes/models/fields/FrmFieldName.php
+		-
+			message: '#callback of function spl_autoload_register expects#'
+			path: formidable.php
+		-
+			message: '#Call to an undefined method FrmFieldType::get\_file\_id#'
+			path: classes/helpers/FrmXMLHelper.php
+		-
+			message: '#Cannot use array destructuring on#'
+			path: classes/helpers/FrmStylesHelper.php
 		-
 			message: '#should be contravariant with#'
 			paths:


### PR DESCRIPTION
This update changes a lot of global exceptions so they only apply to a couple of problematic files.