### PR TITLE
Fix missing checkbox marker in backend

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -932,6 +932,7 @@ a.frm_save_draft{
 	background-size: 9px !important;
 	background-repeat: no-repeat !important;
 	background-position: center !important;
+	margin: 0;
 }
 
 <?php if ( $pro_is_installed ) { ?>

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3822,20 +3822,20 @@ input[type="checkbox"] {
 
 .frm-white-body input[type="checkbox"]:checked,
 .frm_wrap input[type="checkbox"]:checked,
-#wpbody-content input[type="checkbox"]:checked {
+body[class*="frm-admin"] #wpbody-content input[type="checkbox"]:checked {
 	background-color: var(--primary-500);
 	border-color: var(--primary-500) !important;
 }
 
 .frm-white-body input[type="checkbox"]:checked:focus,
 .frm_wrap input[type="checkbox"]:checked:focus,
-#wpbody-content input[type="checkbox"]:checked:focus {
+body[class*="frm-admin"] #wpbody-content input[type="checkbox"]:checked:focus {
 	border-color: var(--primary-500);
 }
 
 .frm-white-body input[type="checkbox"]:checked::before,
 .frm_wrap input[type="checkbox"]:checked::before,
-#wpbody-content input[type="checkbox"]:checked::before {
+body[class*="frm-admin"] #wpbody-content input[type="checkbox"]:checked::before {
 	content: '';
 	display: block;
 	width: 100% !important;

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3836,10 +3836,15 @@ input[type="checkbox"] {
 .frm-white-body input[type="checkbox"]:checked::before,
 .frm_wrap input[type="checkbox"]:checked::before,
 #wpbody-content input[type="checkbox"]:checked::before {
-	content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2010%2010%27%3E%3Cpath%20d%3D%27M9.2%202c.2.3.2.7%200%201l-5%205c-.3.2-.6.2-.9%200L.8 5.3a.6.6%200%200%201%20.9-.8l2%202%204.6-4.5c.3-.3.6-.3.9%200Z%27%20fill%3D%27%23fff%27%2F%3E%3C%2Fsvg%3E");
-	height: 12px;
-	width: 12px;
-	margin: 1px;
+	content: '';
+	display: block;
+	width: 100% !important;
+	height: 100% !important;
+	background-image: url("data:image/svg+xml,%3Csvg width='12' height='9' viewBox='0 0 12 9' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M10.6667 1.5L4.25001 7.91667L1.33334 5' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E%0A") !important;
+	background-size: 9px !important;
+	background-repeat: no-repeat !important;
+	background-position: center !important;
+	margin: 0;
 }
 
 .frm_radio input[type="radio"],

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3821,18 +3821,21 @@ input[type="checkbox"] {
 }
 
 .frm-white-body input[type="checkbox"]:checked,
-.frm_wrap input[type="checkbox"]:checked {
+.frm_wrap input[type="checkbox"]:checked,
+#wpbody-content input[type="checkbox"]:checked {
 	background-color: var(--primary-500);
 	border-color: var(--primary-500) !important;
 }
 
 .frm-white-body input[type="checkbox"]:checked:focus,
-.frm_wrap input[type="checkbox"]:checked:focus {
+.frm_wrap input[type="checkbox"]:checked:focus,
+#wpbody-content input[type="checkbox"]:checked:focus {
 	border-color: var(--primary-500);
 }
 
 .frm-white-body input[type="checkbox"]:checked::before,
-.frm_wrap input[type="checkbox"]:checked::before {
+.frm_wrap input[type="checkbox"]:checked::before,
+#wpbody-content input[type="checkbox"]:checked::before {
 	content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2010%2010%27%3E%3Cpath%20d%3D%27M9.2%202c.2.3.2.7%200%201l-5%205c-.3.2-.6.2-.9%200L.8 5.3a.6.6%200%200%201%20.9-.8l2%202%204.6-4.5c.3-.3.6-.3.9%200Z%27%20fill%3D%27%23fff%27%2F%3E%3C%2Fsvg%3E");
 	height: 12px;
 	width: 12px;


### PR DESCRIPTION
This PR fixes the missing checkbox marker in the backend when editing a checkbox. It also resolves a frontend issue where themes apply a margin to the checkbox `input::before` selector.

### Related Issue
https://github.com/Strategy11/formidable-pro/issues/5353

### Frontend steps to reproduce
1. Activate the **Twenty Twenty** theme.
2. Add a checkbox to a form and preview the form.
3. Ensure the checkbox displays without any style issues.

#### Frontend - Before/After 
![CleanShot 2024-09-11 at 20 13 58@2x](https://github.com/user-attachments/assets/c83c6b9f-9057-4815-a36f-e93689cef546)

![CleanShot 2024-09-11 at 20 05 04@2x](https://github.com/user-attachments/assets/eeed1e77-55ff-4b59-a67b-ae231659e7b7)

### Backend steps to reproduce
1. Go to an **entry** that contains a checkbox.
2. Ensure the checkbox displays without any style issues.

#### Backend - Before/After 
![CleanShot 2024-09-11 at 20 11 56@2x](https://github.com/user-attachments/assets/0d9b2ba7-b28f-4f8a-a0fb-06f8534d1bf2)

![CleanShot 2024-09-11 at 20 11 06@2x](https://github.com/user-attachments/assets/cc5bb838-ed0a-43bc-a851-2c68a5e30cce)