### PR TITLE
Fix HTML display issue for checkbox with text and links

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -816,11 +816,15 @@ a.frm_save_draft{
 }
 
 .with_frm_style .frm_checkbox label,
-.with_frm_style .frm_radio label{
-	display: flex;
-	align-items: center;
-	gap: 9px;
-	white-space: normal;
+.with_frm_style .frm_radio label {
+	display: inline-block;
+	vertical-align: middle;
+	white-space:normal;
+}
+
+.with_frm_style .frm_checkbox label input[type=checkbox],
+.with_frm_style .frm_radio label input[type=radio] {
+	margin-right: 4px;
 }
 
 .with_frm_style .frm_checkbox label:not(.frm-label-disabled),
@@ -830,6 +834,7 @@ a.frm_save_draft{
 
 .with_frm_style .vertical_radio .frm_checkbox label,
 .with_frm_style .vertical_radio .frm_radio label{
+	display: block;
 	width: 100%;
 }
 


### PR DESCRIPTION
This PR resolves an issue where checkboxes with longer text, including `<br>` and `<a>` tags, were not rendering correctly, causing misalignment.

### Related Issue
https://github.com/Strategy11/formidable-pro/issues/5363

### Steps to Reproduce
1. Create a checkbox field with long text and include `<br>`, `<a>` tags in the text.
2. Verify that the issue is fixed and ensure your output matches the "After" section screenshot.

### Before
![CleanShot 2024-09-12 at 17 17 31@2x](https://github.com/user-attachments/assets/1af4a2b2-2d60-4d32-8312-a328e75aca8d)

### After
![CleanShot 2024-09-12 at 17 17 00@2x](https://github.com/user-attachments/assets/e74064c0-5786-4f33-b5a9-cf97b52bb091)
