### PR TITLE
Skip rendering captcha only if closest form is hidden

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1784,8 +1784,9 @@ function frmCaptcha( captchaSelector ) {
 	const captchas = document.querySelectorAll( captchaSelector );
 	const cl       = captchas.length;
 	for ( c = 0; c < cl; c++ ) {
-		const isVisible = captchas[c].offsetParent !== null;
-		if ( ! isVisible ) {
+		const closestForm   = captchas[c].closest( 'form' );
+		const formIsVisible = closestForm && closestForm.offsetParent !== null;
+		if ( ! formIsVisible ) {
 			continue;
 		}
 		frmFrontForm.renderCaptcha( captchas[c], captchaSelector );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-chat/issues/180

Instead of checking if the field is invisible, this update checks the form.

A conversational form hides fields until they are active. Checking if the form is visible is more reliable.