### PR TITLE
Hide all admin notices that wasn't added by our code (core and addons) from our pages

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -1323,10 +1323,22 @@ class FrmAppController {
 	}
 
 	/**
+	 * Check if we are in our admin pages.
+	 *
+	 * @return bool
+	 */
+	private static function in_our_pages() {
+		global $current_screen;
+		return FrmAppHelper::is_formidable_admin() || ( ! empty( $current_screen->post_type ) && 'frm_logs' === $current_screen->post_type );
+	}
+
+	/**
+	 * Hide all third-parties admin notices only in our admin pages.
+	 *
 	 * @return void
 	 */
 	public static function filter_admin_notices() {
-		if ( ! FrmAppHelper::is_formidable_admin() ) {
+		if ( ! self::in_our_pages() ) {
 			return;
 		}
 

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -1322,6 +1322,9 @@ class FrmAppController {
 		return FrmDeprecated::page_route( $content );
 	}
 
+	/**
+	 * @return void
+	 */
 	public static function filter_admin_notices() {
 		if ( ! FrmAppHelper::is_formidable_admin() ) {
 			return;
@@ -1337,35 +1340,42 @@ class FrmAppController {
 		global $wp_filter;
 
 		foreach ( $actions as $action ) {
-			if ( empty( $wp_filter[ $action ] ) || empty( $wp_filter[ $action ]->callbacks ) ) {
+			if ( empty( $wp_filter[ $action ]->callbacks ) ) {
 				continue;
 			}
 			foreach ( $wp_filter[ $action ]->callbacks as $priority => $callbacks ) {
 				foreach ( $callbacks as $callback_name => $callback ) {
-					if (
-						self::is_our_callback_string( $callback_name ) ||
-						self::is_our_callback_array( $callback )
-					) {
+					if ( self::is_our_callback_string( $callback_name ) || self::is_our_callback_array( $callback ) ) {
 						continue;
 					}
-
 					unset( $wp_filter[ $action ]->callbacks[ $priority ][ $callback_name ] );
 				}
 			}
 		}
 	}
 
+	/**
+	 * Validate that the callback name is ours not from third-party.
+	 *
+	 * @param string $callback_name WordPress callback name.
+	 *
+	 * @return bool
+	 */
 	private static function is_our_callback_string( $callback_name ) {
 		return 0 === stripos( $callback_name, 'frm' );
 	}
 
+	/**
+	 * Validate that the callback array is ours not from third-party.
+	 *
+	 * @param array $callback WordPress callback array.
+	 *
+	 * @return bool
+	 */
 	private static function is_our_callback_array( $callback ) {
 		return ! empty( $callback['function'] ) &&
-		(
 			is_array( $callback['function'] ) &&
 			! empty( $callback['function'][0] ) &&
-			self::is_our_callback_string( is_object( $callback['function'][0] ) ? get_class( $callback['function'][0] ) : $callback['function'][0] )
-		);
+			self::is_our_callback_string( is_object( $callback['function'][0] ) ? get_class( $callback['function'][0] ) : $callback['function'][0] );
 	}
-
 }

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -126,6 +126,7 @@ class FrmHooksController {
 		add_filter( 'admin_footer_text', 'FrmAppController::set_footer_text' );
 		add_action( 'admin_footer', 'FrmAppController::add_admin_footer_links' );
 		add_action( 'wp_ajax_frm_dismiss_review', 'FrmAppController::dismiss_review' );
+		add_action( 'current_screen', 'FrmAppController::filter_admin_notices' );
 
 		// Addons Controller.
 		add_action( 'admin_menu', 'FrmAddonsController::menu', 100 );

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2606,15 +2606,9 @@ h2.frm-h2 + .howto {
 #wpbody-content > .update-nag,
 #wpbody-content > .notice,
 #wpbody-content > .error:not(.frm_previous_install),
-#wpbody-content > [class*="admin-notice"],
 .frm-white-body .updated,
 .frm-white-body .notice,
-.frm-white-body [class*="admin-notice"],
-.frm-white-body [class*="review-banner"],
-.frm-white-body [id$="-review-banner"],
-.frm-white-body #codepeople-review-banner,
 .frm_wrap > .wrap > .notice,
-.frm_wrap > .wrap > [class*="admin-notice"],
 .frm-white-body .error:not(.frm_previous_install)
 {
 	display: none;


### PR DESCRIPTION
Closes https://github.com/Strategy11/formidable-pro/issues/5178

Here we are removing all admin notices that was added by third parties in our admin pages only.

## How to reproduce?

Use the following snippet:
```
add_action( 'admin_notices', 'test_ahmed' );
function test_ahmed() {
	?>
	<div class="tesssssssssssssst" style="background-color: red;color: white;">
		<h1>This is a test notice.</h1>
	</div>
	<?php
}
```

And visit any form settings page or any formidable page, you will see this notice and this causes some UI problems.

## How to validate the fix?

With the above code activated, you shouldn't see the admin notice in our pages at all.