### PR TITLE
Set conditional log row's value to the current value after syncing options with bulk edit

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5760,6 +5760,7 @@ function frmAdminBuildJS() {
 			}
 			if ( valueSelect.dataset.selectedValue ) {
 				valueSelect.value = valueSelect.dataset.selectedValue;
+				valueSelect.removeAttribute( 'data-selected-value' );
 			}
 		}
 	}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5758,6 +5758,9 @@ function frmAdminBuildJS() {
 			if ( optionMatch !== null ) {
 				valueSelect.prepend( optionMatch );
 			}
+			if ( valueSelect.dataset.selectedValue ) {
+				valueSelect.value = valueSelect.dataset.selectedValue;
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR sets the conditional logic row's selected value after options are synced using the dataset value set in Pro (https://github.com/Strategy11/formidable-pro/pull/5313).