### PR TITLE
Fix pro issue 5064 / Fix format unslashing issue in field cache

### DIFF
--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -1066,7 +1066,7 @@ class FrmField {
 	 * @return void
 	 */
 	private static function add_slashes_to_format_before_setting_field_cache( $result ) {
-		if ( ! is_array( $result->field_options ) || ! isset( $result->field_options ) || empty( $result->field_options['format'] ) ) {
+		if ( ! isset( $result->field_options ) || ! is_array( $result->field_options ) || empty( $result->field_options['format'] ) ) {
 			return;
 		}
 

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -1070,7 +1070,7 @@ class FrmField {
 			return;
 		}
 
-		$result->field_options['format'] = addslashes( $result->field_options['format']  );
+		$result->field_options['format'] = addslashes( $result->field_options['format'] );
 	}
 
 	/**

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -1035,6 +1035,8 @@ class FrmField {
 	private static function format_field_results( &$results ) {
 		if ( is_array( $results ) ) {
 			foreach ( $results as $r_key => $result ) {
+				self::add_slashes_to_format_before_setting_field_cache( $result );
+
 				FrmDb::set_cache( $result->id, $result, 'frm_field' );
 				FrmDb::set_cache( $result->field_key, $result, 'frm_field' );
 
@@ -1051,6 +1053,24 @@ class FrmField {
 
 			self::prepare_options( $results );
 		}
+	}
+
+	/**
+	 * When $result->field_options is an array and not a serialized string there is only a single backslash.
+	 * Cached results are unslashed in FrmField::getAll, so we need to make sure that the cached object has an extra backslash.
+	 * Otherwise the backslash is stripped away on load.
+	 *
+	 * @since x.x
+	 *
+	 * @param stdClass $result
+	 * @return void
+	 */
+	private static function add_slashes_to_format_before_setting_field_cache( $result ) {
+		if ( ! is_array( $result->field_options ) || ! isset( $result->field_options ) || empty( $result->field_options['format'] ) ) {
+			return;
+		}
+
+		$result->field_options['format'] = addslashes( $result->field_options['format']  );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5064

Following up from a previous PR https://github.com/Strategy11/formidable-forms/pull/1746. That solution wasn't ideal as it didn't fix the problem and just changed how fields were queried in the form builder to avoid the problem.

The issue here is that the cached object has only a single backslash and then gets passed through `wp_unslash` in `FrmField::getAll`.

In the database, the backslash is already saved as two backslashes (`\\`). When `field_options` are unserialized, the two backslashes become one `\`.

This update makes sure that if the field options have already been unserialized, that we add slashes to the object before it is cached, so the cached result includes the expected double backslashes (`\\`).

The data should never have issues here with extra backslashes as `wp_unslash` is called after `format_field_results` is, so these added slashes get removed again.

**Pre-release**
[formidable-6.14.2b.zip](https://github.com/user-attachments/files/17061358/formidable-6.14.2b.zip)
