### PR TITLE
Fix cut-off issue for Pro upgrade CTA at the bottom of the global settings page

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -2630,7 +2630,7 @@ h2.frm-h2 + .howto {
 	padding: 10px 20px;
 }
 
-.frm-modal .postbox {
+.frm-modal:not(#frm-dismissable-cta) .postbox {
 	max-height: 600px;
 	overflow: hidden;
 	margin-bottom: 0;


### PR DESCRIPTION
Fixes Pro upgrade CTA being cut off at the bottom of the global settings page.

### Related Issue:
https://github.com/Strategy11/formidable-pro/issues/5386

### Steps to Reproduce:
1. Go to the global settings page.
2. Scroll to the bottom and check if the Pro upgrade CTA is fully visible.

### Before:
![CleanShot 2024-09-19 at 20 19 48@2x](https://github.com/user-attachments/assets/469c47dd-d26a-42ea-82a2-297815dd40e4)

### After:
![CleanShot 2024-09-19 at 20 19 09@2x](https://github.com/user-attachments/assets/35410f26-5da2-4502-ab55-d576b3e97edd)
