### PR TITLE
Prefer method over function when calling doing it wrong

### DIFF
--- a/classes/helpers/FrmCurrencyHelper.php
+++ b/classes/helpers/FrmCurrencyHelper.php
@@ -326,7 +326,7 @@ class FrmCurrencyHelper {
 		if ( is_array( $filtered_currencies ) ) {
 			$currencies = $filtered_currencies;
 		} else {
-			_doing_it_wrong( __FUNCTION__, 'Only arrays should be returned when using the frm_currencies filter.', '6.5' );
+			_doing_it_wrong( __METHOD__, 'Only arrays should be returned when using the frm_currencies filter.', '6.5' );
 		}
 
 		return $currencies;

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -429,7 +429,7 @@ class FrmFieldsHelper {
 		if ( is_array( $filtered_substrings ) ) {
 			$substrings = $filtered_substrings;
 		} else {
-			_doing_it_wrong( __FUNCTION__, 'Only arrays should be returned when using the frm_error_substrings_to_replace_with_field_name filter.', '6.8.3' );
+			_doing_it_wrong( __METHOD__, 'Only arrays should be returned when using the frm_error_substrings_to_replace_with_field_name filter.', '6.8.3' );
 		}
 
 		return $substrings;

--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -56,7 +56,7 @@ class FrmEntryValidate {
 		if ( is_array( $filtered_errors ) ) {
 			$errors = $filtered_errors;
 		} else {
-			_doing_it_wrong( __FUNCTION__, 'Only arrays should be returned when using the frm_validate_entry filter.', '6.3' );
+			_doing_it_wrong( __METHOD__, 'Only arrays should be returned when using the frm_validate_entry filter.', '6.3' );
 		}
 
 		return $errors;

--- a/stripe/models/FrmStrpLitePaymentTypeHandler.php
+++ b/stripe/models/FrmStrpLitePaymentTypeHandler.php
@@ -68,7 +68,7 @@ class FrmStrpLitePaymentTypeHandler {
 		);
 
 		if ( ! is_array( $payment_method_types ) ) {
-			_doing_it_wrong( __FUNCTION__, 'Payment method types should be an array or the string "automatic". All other values are invalid.', '3.1' );
+			_doing_it_wrong( __METHOD__, 'Payment method types should be an array or the string "automatic". All other values are invalid.', '3.1' );
 			// Fallback to automatic when an invalid value is used.
 			$payment_method_types = array();
 		}

--- a/stripe/models/FrmTransLiteDb.php
+++ b/stripe/models/FrmTransLiteDb.php
@@ -178,7 +178,7 @@ class FrmTransLiteDb {
 	 */
 	public function get_one_by( $id, $field = 'receipt_id' ) {
 		if ( ! in_array( $field, array( 'receipt_id', 'sub_id', 'item_id' ), true ) ) {
-			_doing_it_wrong( __FUNCTION__, 'Items can only be retrieved by receipt id or sub id.', '6.5' );
+			_doing_it_wrong( __METHOD__, 'Items can only be retrieved by receipt id or sub id.', '6.5' );
 			return null;
 		}
 
@@ -205,7 +205,7 @@ class FrmTransLiteDb {
 		$field = sanitize_text_field( $field );
 
 		if ( ! in_array( $field, array( 'receipt_id', 'sub_id', 'item_id' ), true ) ) {
-			_doing_it_wrong( __FUNCTION__, 'Items can only be retrieved by item id or sub id.', '6.5' );
+			_doing_it_wrong( __METHOD__, 'Items can only be retrieved by item id or sub id.', '6.5' );
 			return array();
 		}
 


### PR DESCRIPTION
It looks like the big difference here is that `__FUNCTION__` excludes the class name. In all of cases I think we want to know the class as well.