### PR TITLE
Fix blank confirmation field does not prevent form submit

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -190,7 +190,12 @@ function frmFrontFormJS() {
 						// A number field will return an empty string when it is invalid.
 						checkValidity( field, errors );
 					}
-					continue;
+
+					const isConfirmationField = field.name && 0 === field.name.indexOf( 'item_meta[conf_' );
+					if ( ! isConfirmationField ) {
+						// Allow a blank confirmation field to still call validateFieldValue.
+						continue;
+					}
 				}
 
 				validateFieldValue( field, errors );


### PR DESCRIPTION
This fixes an issue I noticed when testing https://github.com/Strategy11/formidable-forms/pull/1995

That update didn't introduce the issue though. It exists on master.

**To replicate**
1. Add a field with a confirmation. This can be an email or a password field.
2. Enable JS validation.
3. Fill in the main field and leave the confirmation blank.
4. Submit the form.

**Expected result**
The form never submits.

**Actual result**
The page reload with an error. The JS validation misses the issue and the PHP validation catches it instead.