### PR TITLE
Add css classes to summary field

### DIFF
--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -430,15 +430,12 @@ class FrmFieldFormHtml {
 	private function add_field_div_classes() {
 		$classes = $this->get_field_div_classes();
 
-		if ( $this->field_obj->get_field_column( 'type' ) === 'html' && strpos( $this->html, '[error_class]' ) === false ) {
+		if ( in_array( $this->field_obj->get_field_column( 'type' ), array( 'html', 'summary' ), true ) && strpos( $this->html, '[error_class]' ) === false ) {
 			// there is no error_class shortcode for HTML fields
 			$this->html = str_replace( 'class="frm_form_field', 'class="frm_form_field ' . esc_attr( $classes ), $this->html );
-		}
-
-		if ( $this->field_obj->get_field_column( 'type' ) === 'summary' ) {
-			$this->html = str_replace( ' form-field', esc_attr( ' form-field' . $classes ), $this->html );
 			return;
 		}
+
 		$this->html = str_replace( '[error_class]', esc_attr( $classes ), $this->html );
 	}
 

--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -436,6 +436,9 @@ class FrmFieldFormHtml {
 		}
 
 		$this->html = str_replace( '[error_class]', esc_attr( $classes ), $this->html );
+		if ( $this->field_obj->get_field_column( 'type' ) === 'summary' ) {
+			$this->html = str_replace( ' form-field', esc_attr( ' form-field' . $classes ), $this->html );
+		}
 	}
 
 	/**

--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -435,10 +435,11 @@ class FrmFieldFormHtml {
 			$this->html = str_replace( 'class="frm_form_field', 'class="frm_form_field ' . esc_attr( $classes ), $this->html );
 		}
 
-		$this->html = str_replace( '[error_class]', esc_attr( $classes ), $this->html );
 		if ( $this->field_obj->get_field_column( 'type' ) === 'summary' ) {
 			$this->html = str_replace( ' form-field', esc_attr( ' form-field' . $classes ), $this->html );
+			return;
 		}
+		$this->html = str_replace( '[error_class]', esc_attr( $classes ), $this->html );
 	}
 
 	/**


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5395

The changes made in this pull request involve a modification to the add_field_div_classes method in the FrmFieldFormHtml class. A conditional check is introduced to determine if the field type is 'summary'. If true, the method updates the HTML output by appending additional classes to the existing class string. This adjustment specifically targets how classes are rendered for summary fields within the form.

### Test procedure
1. Create a form and add few fields and then a Summary to field to it.
2. Add a class to the Summary field using the field options. Ex. `frm_half`
3. Save and Preview the form.
4. Confirm that the classes added are effectively styling the field.