### PR TITLE
Allow field search to also match plural

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9452,7 +9452,7 @@ function frmAdminBuildJS() {
 					items[i].classList.remove( 'frm_hidden' );
 				}
 				items[i].classList.remove( 'frm-search-result' );
-			} else if ( ( regEx && new RegExp( searchText ).test( innerText ) ) || innerText.indexOf( searchText ) >= 0 ) {
+			} else if ( ( regEx && new RegExp( searchText ).test( innerText ) ) || innerText.indexOf( searchText ) >= 0 || textMatchesPlural( innerText, searchText ) ) {
 				if ( itemCanBeShown ) {
 					items[i].classList.remove( 'frm_hidden' );
 				}
@@ -9467,6 +9467,29 @@ function frmAdminBuildJS() {
 		updateCatHeadingVisibility();
 
 		jQuery( this ).trigger( 'frmAfterSearch' );
+	}
+
+	/**
+	 * Allow a search for "signatures" to still match "signature" for example when searching fields.
+	 *
+	 * @since x.x
+	 *
+	 * @param {string} text       The text in the element we are checking for a match.
+	 * @param {string} searchText The text value that is being searched.
+	 * @return {boolean}
+	 */
+	function textMatchesPlural( text, searchText ) {
+		if ( searchText === 's' ) {
+			// Don't match everything when just "s" is searched.
+			return false;
+		}
+
+		if ( text[ text.length - 1 ] === 's' ) {
+			// Do not match something with double s if the text already ends in s.
+			return false;
+		}
+
+		return ( text + 's' ).indexOf( searchText ) >= 0;
 	}
 
 	/**


### PR DESCRIPTION
Laura noted this in QA https://github.com/Strategy11/formidable-forms/pull/1963#issuecomment-2371697547

If you search for "signatures", it won't match "signature".

This update adds a little check for basic plural matches. I basically do a second check if the `item's value + 's'` matches.

I have a couple small checks in place so searching `'s'` on its own wont return every field, and if you search `ss` it won't match everything with a single `s`.
