### PR TITLE
Alternative fix to API issue 176

### DIFF
--- a/classes/models/fields/FrmFieldName.php
+++ b/classes/models/fields/FrmFieldName.php
@@ -128,6 +128,11 @@ class FrmFieldName extends FrmFieldCombo {
 	 * @return string      Most of cases, this will return string.
 	 */
 	protected function prepare_display_value( $value, $atts ) {
+		if ( ! empty( $atts['return_array'] ) ) {
+			// When this setting is passed we want to keep $value as an array.
+			return $value;
+		}
+
 		if ( ! is_array( $value ) ) {
 			return $value;
 		}


### PR DESCRIPTION
**Fixes** https://github.com/Strategy11/formidable-api/issues/176
**Related PR** https://github.com/Strategy11/formidable-forms/pull/1771

**Wait to review this. It's failing an e2e test because Name fields display differently now. This update is more destructive than I had expected.**

_It looks like we may be able to fix this in `FrmAPIEntriesController::switch_displayed_value_to_saved` instead._

I tried to dig a little deeper into the issue here.

- `$args['value']` was a string. This is the main issue.
- This happens because `FrmAPIEntriesController::get_item_object` calls `FrmEntriesController::show_entry_shortcode`.
- The name value is getting set to string when `FrmFieldName::prepare_display_value` is called. The `$atts['return_array']` option is set to `1` though, and we should not be changing the value to a string.
- This fix checks for `$atts['return_array']` and leaves `$value` as an array so the validation works as expected.