### PR TITLE
Fix default email setting is never used

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1077,7 +1077,7 @@ class FrmFieldsHelper {
 				break;
 			case 'get':
 				$new_value = self::process_get_shortcode( $atts, $return_array );
-		}
+		}//end switch
 
 		return $new_value;
 	}

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -846,6 +846,8 @@ class FrmFieldsHelper {
 			'siteurl',
 			'sitename',
 			'admin_email',
+			'default-email',
+			'default-from-email',
 			'post[-|_]id',
 			'created[-|_]at',
 			'updated[-|_]at',
@@ -968,7 +970,7 @@ class FrmFieldsHelper {
 			'ip'  => $atts['entry']->ip,
 		);
 
-		$dynamic_default = array( 'admin_email', 'siteurl', 'frmurl', 'sitename', 'get' );
+		$dynamic_default = array( 'admin_email', 'siteurl', 'frmurl', 'sitename', 'get', 'default-email', 'default-from-email' );
 
 		if ( isset( $shortcode_values[ $atts['tag'] ] ) ) {
 			$replace_with = $shortcode_values[ $atts['tag'] ];
@@ -1055,6 +1057,14 @@ class FrmFieldsHelper {
 		switch ( $tag ) {
 			case 'admin_email':
 				$new_value = get_option( 'admin_email' );
+				break;
+			case 'default-email':
+				$frm_settings = FrmAppHelper::get_settings();
+				$new_value    = ! empty( $frm_settings->default_email ) && is_email( $frm_settings->default_email ) ? $frm_settings->default_email : get_option( 'admin_email' );
+				break;
+			case 'default-from-email':
+				$frm_settings = FrmAppHelper::get_settings();
+				$new_value    = ! empty( $frm_settings->from_email ) && is_email( $frm_settings->from_email ) ? $frm_settings->from_email : get_option( 'admin_email' );
 				break;
 			case 'siteurl':
 				$new_value = FrmAppHelper::site_url();

--- a/classes/views/frm-form-actions/email_action.php
+++ b/classes/views/frm-form-actions/email_action.php
@@ -28,9 +28,13 @@ class FrmEmailAction extends FrmFormAction {
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-form-actions/_email_settings.php';
 	}
 
+	/**
+	 * @return array
+	 */
 	public function get_defaults() {
+		$frm_settings = FrmAppHelper::get_settings();
 		return array(
-			'email_to'      => '[admin_email]',
+			'email_to'      => ! empty( $frm_settings->default_email ) && is_email( $frm_settings->default_email ) ? $frm_settings->default_email : '[admin_email]',
 			'cc'            => '',
 			'bcc'           => '',
 			'from'          => '[sitename] <[admin_email]>',

--- a/classes/views/frm-form-actions/email_action.php
+++ b/classes/views/frm-form-actions/email_action.php
@@ -32,9 +32,8 @@ class FrmEmailAction extends FrmFormAction {
 	 * @return array
 	 */
 	public function get_defaults() {
-		$frm_settings = FrmAppHelper::get_settings();
-		$to_email     = ! empty( $frm_settings->default_email ) && is_email( $frm_settings->default_email ) ? $frm_settings->default_email : '[admin_email]';
-		$from_email   = ! empty( $frm_settings->from_email ) && is_email( $frm_settings->from_email ) ? $frm_settings->from_email : '[admin_email]';
+		$to_email   = '[default-email]';
+		$from_email = '[default-from-email]';
 		return array(
 			'email_to'      => $to_email,
 			'cc'            => '',

--- a/classes/views/frm-form-actions/email_action.php
+++ b/classes/views/frm-form-actions/email_action.php
@@ -32,13 +32,11 @@ class FrmEmailAction extends FrmFormAction {
 	 * @return array
 	 */
 	public function get_defaults() {
-		$to_email   = '[default-email]';
-		$from_email = '[default-from-email]';
 		return array(
-			'email_to'      => $to_email,
+			'email_to'      => '[default-email]',
 			'cc'            => '',
 			'bcc'           => '',
-			'from'          => '[sitename] <' . $from_email . '>',
+			'from'          => '[sitename] <[default-from-email]>',
 			'reply_to'      => '',
 			'email_subject' => '',
 			'email_message' => '[default-message]',

--- a/classes/views/frm-form-actions/email_action.php
+++ b/classes/views/frm-form-actions/email_action.php
@@ -33,11 +33,13 @@ class FrmEmailAction extends FrmFormAction {
 	 */
 	public function get_defaults() {
 		$frm_settings = FrmAppHelper::get_settings();
+		$to_email     = ! empty( $frm_settings->default_email ) && is_email( $frm_settings->default_email ) ? $frm_settings->default_email : '[admin_email]';
+		$from_email   = ! empty( $frm_settings->from_email ) && is_email( $frm_settings->from_email ) ? $frm_settings->from_email : '[admin_email]';
 		return array(
-			'email_to'      => ! empty( $frm_settings->default_email ) && is_email( $frm_settings->default_email ) ? $frm_settings->default_email : '[admin_email]',
+			'email_to'      => $to_email,
 			'cc'            => '',
 			'bcc'           => '',
-			'from'          => '[sitename] <[admin_email]>',
+			'from'          => '[sitename] <' . $from_email . '>',
 			'reply_to'      => '',
 			'email_subject' => '',
 			'email_message' => '[default-message]',


### PR DESCRIPTION
**Related Slack conversation** https://strategy11.slack.com/archives/C799A2R61/p1727465741085109

New email actions now use `[default-email]` and `[default-from-email]` shortcodes.

<img width="593" alt="Screen Shot 2024-10-01 at 2 59 11 PM" src="https://github.com/user-attachments/assets/833292bb-9832-4459-9b23-f19bdae91811">

These settings are currently only set in the onboarding wizard. You can find them at the `/wp-admin/admin.php?page=formidable-onboarding-wizard` URL.

When these settings are empty or not valid emails, the admin email is used instead.