### PR TITLE
Revert "Add css classes to summary field"

### DIFF
--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -430,10 +430,9 @@ class FrmFieldFormHtml {
 	private function add_field_div_classes() {
 		$classes = $this->get_field_div_classes();
 
-		if ( in_array( $this->field_obj->get_field_column( 'type' ), array( 'html', 'summary' ), true ) && strpos( $this->html, '[error_class]' ) === false ) {
+		if ( $this->field_obj->get_field_column( 'type' ) === 'html' && strpos( $this->html, '[error_class]' ) === false ) {
 			// there is no error_class shortcode for HTML fields
 			$this->html = str_replace( 'class="frm_form_field', 'class="frm_form_field ' . esc_attr( $classes ), $this->html );
-			return;
 		}
 
 		$this->html = str_replace( '[error_class]', esc_attr( $classes ), $this->html );


### PR DESCRIPTION
Reverts Strategy11/formidable-forms#2005

I merged this before really looking at https://github.com/Strategy11/formidable-pro/pull/5396

I'm concerned this will drop labels from all summary fields for all forms.

I think we might need to come up with a migration or something to fix the data issue.