### PR TITLE
Add type check to avoid php warning

### DIFF
--- a/classes/controllers/FrmSimpleBlocksController.php
+++ b/classes/controllers/FrmSimpleBlocksController.php
@@ -52,7 +52,7 @@ class FrmSimpleBlocksController {
 				'link'      => is_array( $views_addon_info ) && isset( $views_addon_info['link'] ) ? FrmAppHelper::admin_upgrade_link( 'block', $views_addon_info['link'] ) : '',
 				'hasAccess' => is_array( $views_addon_info ) && ! empty( $views_addon_info['url'] ),
 				'url'       => ! empty( $views_addon_info['url'] ) ? $views_addon_info['url'] : '',
-				'installed' => 'installed' === $views_addon['status']['type'],
+				'installed' => is_array( $views_addon ) && 'installed' === $views_addon['status']['type'],
 			),
 			'chartsAddon' => array(
 				'link'      => is_array( $charts_addon ) && isset( $charts_addon['link'] ) ? FrmAppHelper::admin_upgrade_link( 'block', $charts_addon['link'] ) : '',


### PR DESCRIPTION
**Related ticket** https://secure.helpscout.net/conversation/2723585835/211506

This just adds a small check in case the query for add-ons data fails and the views data is unavailable.

```
PHP Warning:  Trying to access array offset on value of type bool in /var/www/src/wp-content/plugins/formidable/classes/controllers/FrmSimpleBlocksController.php on line 55
PHP Warning:  Trying to access array offset on value of type null in /var/www/src/wp-content/plugins/formidable/classes/controllers/FrmSimpleBlocksController.php on line 55
```