### PR TITLE
Update how layout classes are sanitized to allow shortcodes

### DIFF
--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -1822,6 +1822,25 @@ BEFORE_HTML;
 	}
 
 	/**
+	 * Strip characters similar to the WordPress sanitize_html_class function, but allow for [ and ].
+	 * This allows shortcodes inside of the layout classes setting.
+	 *
+	 * @since x.x
+	 *
+	 * @param string $classname
+	 * @return string
+	 */
+	public static function sanitize_layout_class( $classname ) {
+		// Strip out any percent-encoded characters.
+		$sanitized = preg_replace( '|%[a-fA-F0-9][a-fA-F0-9]|', '', $classname );
+
+		// Limit to A-Z, a-z, 0-9, '_', '-', '[', ']'.
+		$sanitized = preg_replace( '/[^A-Za-z0-9_\-\[\]]/', '', $sanitized );
+
+		return $sanitized;
+	}
+
+	/**
 	 * @since 3.0
 	 * @deprecated 6.11
 	 *

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -444,7 +444,7 @@ class FrmField {
 		}
 
 		if ( ! empty( $options['classes'] ) ) {
-			$options['classes'] = implode( ' ', array_map( 'sanitize_html_class', explode( ' ', $options['classes'] ) ) );
+			$options['classes'] = implode( ' ', array_map( 'FrmFormsHelper::sanitize_layout_class', explode( ' ', $options['classes'] ) ) );
 		}
 
 		return $options;

--- a/classes/models/FrmFieldFormHtml.php
+++ b/classes/models/FrmFieldFormHtml.php
@@ -476,7 +476,7 @@ class FrmFieldFormHtml {
 		$classes = apply_filters( 'frm_field_div_classes', $classes, $this->field_obj->get_field(), array( 'field_id' => $this->field_id ) );
 
 		// Remove unexpected characters from class.
-		$classes = implode( ' ', array_map( 'sanitize_html_class', explode( ' ', $classes ) ) );
+		$classes = implode( ' ', array_map( 'FrmFormsHelper::sanitize_layout_class', explode( ' ', $classes ) ) );
 
 		return $classes;
 	}


### PR DESCRIPTION
With the https://github.com/Strategy11/formidable-forms/pull/1989 security update, shortcodes used in layout classes stopped working.

This update replaces the calls to `sanitize_html_class` which strips the shortcode characters, with a new function, `FrmFormsHelper::sanitize_layout_class`. This function is mostly copied/pasted from `sanitize_html_class`, but the regex has been updated to support `[` and `]`.