### PR TITLE
[I18n] Fix issues and add improvements to JavaScript internationalization

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -69,6 +69,7 @@ class FrmAddonsController {
 		wp_register_script( self::SCRIPT_HANDLE, $plugin_url . '/js/addons-page.js', $js_dependencies, $version, true );
 		wp_localize_script( self::SCRIPT_HANDLE, 'frmAddonsVars', self::get_js_variables() );
 		wp_enqueue_script( self::SCRIPT_HANDLE );
+		wp_set_script_translations( self::SCRIPT_HANDLE, 'formidable' );
 
 		FrmAppHelper::dequeue_extra_global_scripts();
 	}

--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -819,7 +819,9 @@ class FrmAppController {
 			wp_enqueue_style( 'widgets' );
 			self::maybe_deregister_popper2();
 			wp_enqueue_script( 'formidable_admin' );
+			wp_set_script_translations( 'formidable_admin', 'formidable' );
 			wp_enqueue_script( 'formidable_embed' );
+			wp_set_script_translations( 'formidable_embed', 'formidable' );
 			FrmAppHelper::localize_script( 'admin' );
 
 			wp_enqueue_style( 'formidable-animations' );

--- a/classes/models/FrmReviews.php
+++ b/classes/models/FrmReviews.php
@@ -111,7 +111,7 @@ class FrmReviews {
 
 		$title = sprintf(
 			/* translators: %s: User name, %2$d: number of entries */
-			esc_html__( 'Congratulations%1$s! You have collected %2$d form submissions.', 'formidable' ),
+			esc_html__( 'Congratulations %1$s! You have collected %2$d form submissions.', 'formidable' ),
 			esc_html( $name ),
 			absint( $entries )
 		);

--- a/js/admin/applications.js
+++ b/js/admin/applications.js
@@ -5,7 +5,7 @@
 		return;
 	}
 
-	const __ = wp.i18n.__;
+	const { __, sprintf } = wp.i18n;
 	const { tag, div, span, a, svg, img } = frmDom;
 	const { maybeCreateModal, footerButton } = frmDom.modal;
 	const { newSearchInput } = frmDom.search;
@@ -210,7 +210,7 @@
 
 	function getAllItemsCategory() {
 		/* translators: %d: Number of application templates. */
-		return __( 'All Items (%d)', 'formidable' ).replace( '%d', state.templates.length );
+		return sprintf( __( 'All Items (%d)', 'formidable' ), state.templates.length );
 	}
 
 	function handleCategorySelect( category ) {
@@ -374,7 +374,7 @@
 		});
 		control.setAttribute( 'role', 'button' );
 		/* translators: %s: Application Template Name */
-		const ariaDescription = __( '%s Template' ).replace( '%s', data.name );
+		const ariaDescription = sprintf( __( '%s Template', 'formidable' ), data.name );
 		control.setAttribute( 'aria-description', ariaDescription );
 		control.addEventListener(
 			'click',
@@ -419,8 +419,7 @@
 					children: [
 						span(
 							/* translators: %s: The required license type (ie. Plus, Business, or Elite) */
-							__( 'Access to this application requires the %s plan.', 'formidable' )
-								.replace( '%s', data.requires )
+							sprintf( __( 'Access to this application requires the %s plan.', 'formidable' ), data.requires )
 						),
 						a({
 							text: getUpgradeNowText(),

--- a/js/admin/embed.js
+++ b/js/admin/embed.js
@@ -5,7 +5,7 @@
 		return;
 	}
 
-	const __ = wp.i18n.__;
+	const { __, sprintf } = wp.i18n;
 	const { div, tag, svg } = frmDom;
 	const { maybeCreateModal, footerButton } = frmDom.modal;
 
@@ -74,7 +74,7 @@
 
 	function openEmbedModal() {
 		/* translators: %s type: ie form, view. */
-		const title = __( 'Embed %s', 'formidable' ).replace( '%s', getTypeDescription() );
+		const title = sprintf( __( 'Embed %s', 'formidable' ), getTypeDescription() );
 
 		modal = maybeCreateModal(
 			'frm_embed_modal',
@@ -129,13 +129,13 @@
 		const typeDescription = getTypeDescription();
 
 		/* translators: %s type: ie form, view. */
-		const existingPageDescription = __( 'Embed your %s into an existing page.', 'formidable' ).replace( '%s', typeDescription );
+		const existingPageDescription = sprintf( __( 'Embed your %s into an existing page.', 'formidable' ), typeDescription );
 
 		/* translators: %s type: ie form, view. */
-		const newPageDescription = __( 'Put your %s on a newly created page.', 'formidable' ).replace( '%s', typeDescription );
+		const newPageDescription = sprintf( __( 'Put your %s on a newly created page.', 'formidable' ), typeDescription );
 
 		/* translators: %s type: ie form, view. */
-		const insertManuallyDescription = __( 'Use shortcodes or PHP code to put the %s anywhere.', 'formidable' ).replace( '%s', typeDescription );
+		const insertManuallyDescription = sprintf( __( 'Use shortcodes or PHP code to put the %s anywhere.', 'formidable' ), typeDescription );
 
 		const options = [
 			{
@@ -178,7 +178,7 @@
 						const typeDescription = getTypeDescription();
 
 						/* translators: %s: type (ie. view, form). */
-						const titleText = __( 'Select the page you want to embed your %s into.', 'formidable' ).replace( '%s', typeDescription );
+						const titleText = sprintf( __( 'Select the page you want to embed your %s into.', 'formidable' ), typeDescription );
 
 						const title = getLabel( titleText );
 						title.setAttribute( 'for', 'frm_page_dropdown' );
@@ -189,7 +189,7 @@
 						doneButton = modal.querySelector( '.frm_modal_footer .button-primary' );
 						doneButton.classList.remove( 'dismiss' );
 						/* translators: %s: type (ie. view, form). */
-						doneButton.textContent = __( 'Insert %s', 'formidable' ).replace( '%s', typeDescription );
+						doneButton.textContent = sprintf( __( 'Insert %s', 'formidable' ), typeDescription );
 						doneButton.addEventListener( 'click', redirectToExistingPageWithInjectedShortcode );
 
 						const dropdownWrapper = div();
@@ -448,7 +448,7 @@
 		icon.setAttribute( 'tabindex', 0 );
 		icon.setAttribute( 'role', 'button' );
 		/* translators: %s: Example type (ie. WordPress shortcode, API Form script) */
-		icon.setAttribute( 'aria-label', __( 'Copy %s', 'formidable' ).replace( '%s', label ) );
+		icon.setAttribute( 'aria-label', sprintf( __( 'Copy %s', 'formidable' ), label ) );
 		icon.addEventListener(
 			'click',
 			() => copyExampleToClipboard( icon.parentNode.querySelector( '.frm_embed_example' ) )

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -10,7 +10,7 @@
 		return;
 	}
 
-	const { __ }                                                 = wp.i18n;
+	const { __, sprintf }                                        = wp.i18n;
 	const state                                                  = {
 		showingSampleForm: document.getElementById( 'frm_active_style_form' ).classList.contains( 'frm_hidden' ), // boolean
 		unsavedChanges: false, // boolean
@@ -152,7 +152,8 @@
 							card => card.classList.add( 'frm_hidden' )
 						);
 						const hiddenCount         = wrapper.querySelectorAll( '.frm-style-card.frm_hidden' ).length;
-						showAllAnchor.textContent = __( 'Show all (%d)', 'formidable' ).replace( '%d', hiddenCount );
+						/* translators: %d: The number of hidden items to show. */
+						showAllAnchor.textContent = sprintf( __( 'Show all (%d)', 'formidable' ), hiddenCount );
 					}
 				);
 			}
@@ -425,8 +426,7 @@
 				children: [
 					span(
 						/* translators: %s: The required license type (ie. Plus, Business, or Elite) */
-						__( 'Access to this style requires the %s plan.', 'formidable' )
-							.replace( '%s', card.dataset.requires )
+						sprintf( __( 'Access to this style requires the %s plan.', 'formidable' ), card.dataset.requires )
 					),
 					a({
 						text: getUpgradeNowText(),

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -866,7 +866,7 @@ function frmAdminBuildJS() {
 		if ( isFieldGroup( draggable ) ) {
 			const newTextFieldClone = document.getElementById( 'frm-insert-fields' ).querySelector( '.frm_ttext' ).cloneNode( true );
 			newTextFieldClone.querySelector( 'use' ).setAttributeNS( 'http://www.w3.org/1999/xlink', 'href', '#frm_field_group_layout_icon' );
-			newTextFieldClone.querySelector( 'span' ).textContent = __( 'Field Group' );
+			newTextFieldClone.querySelector( 'span' ).textContent = __( 'Field Group', 'formidable' );
 			newTextFieldClone.classList.add( 'frm_field_box' );
 			newTextFieldClone.classList.add( 'ui-sortable-helper' );
 			return newTextFieldClone;

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -3640,7 +3640,7 @@ function frmAdminBuildJS() {
 
 	function confirmFieldsDeleteMessage( numberOfFields ) {
 		/* translators: %1$s: Number of fields that are selected to be deleted. */
-		return __( 'Are you sure you want to delete these %1$s selected field(s)?', 'formidable' ).replace( '%1$s', numberOfFields );
+		return sprintf( __( 'Are you sure you want to delete these %1$s selected field(s)?', 'formidable' ), numberOfFields );
 	}
 
 	function clickDeleteField() {
@@ -6110,7 +6110,8 @@ function frmAdminBuildJS() {
 		);
 
 		if ( conflicts.length ) {
-			infoModal( __( 'Duplicate option value "%s" detected', 'formidable' ).replace( '%s', purifyHtml( targetInput.value ) ) );
+			/* translators: %s: The detected option value. */
+			infoModal( sprintf( __( 'Duplicate option value "%s" detected', 'formidable' ), purifyHtml( targetInput.value ) ) );
 		}
 	}
 
@@ -6851,7 +6852,7 @@ function frmAdminBuildJS() {
 		h2.style.borderBottom = 'none';
 
 		/* translators: %s: Form Setting section name (ie Form Permissions, Form Scheduling). */
-		h2.textContent = __( '%s are not installed', 'formidable' ).replace( '%s', title );
+		h2.textContent = sprintf( __( '%s are not installed', 'formidable' ), title );
 
 		container.classList.add( 'frmcenter' );
 

--- a/stripe/helpers/FrmTransLiteListHelper.php
+++ b/stripe/helpers/FrmTransLiteListHelper.php
@@ -140,7 +140,7 @@ class FrmTransLiteListHelper extends FrmListHelper {
 
 			if ( $counts[ $status ] || 'published' === $status ) {
 				$links[ $status ] = '<a href="' . esc_url( '?page=formidable-payments&trans_type=' . $status ) . '" ' . $class . '>'
-					// translators: %1$s: Transaction type (Payments or Subscriptions), %2$s: Span start tag, %3$s: Count, %3$s: Span close tag.
+					// translators: %1$s: Transaction type (Payments or Subscriptions), %2$s: Span start tag, %3$s: Count, %4$s: Span close tag.
 					. sprintf( esc_html__( '%1$s %2$s(%3$s)%4$s', 'formidable' ), esc_html( $name ), '<span class="count">', number_format_i18n( $counts[ $status ] ), '</span>' )
 					. '</a>';
 			}


### PR DESCRIPTION
Hi,

This PR improves the JavaScript i18n of the plugin with the below items:
- [x] Fix: Add missing script translations (`wp_set_script_translations()`).
- [x] Improvement: Use standard `sprintf()` instead of .replace().
- [x] Improvement: Add missing comment to translators.
- [x] Improvement: Add missing space before placeholder in translation string.
- [x] Fix: Use correct placeholder numbering in comment to translators.
- [x] Fix: Add missing textdomain.

<hr>

Here is a screenshot of the dropdown as currently is:
![imagem](https://github.com/user-attachments/assets/0f4c3aa4-636e-420f-8f10-7e1aa17a5c65)

Here is a screenshot after adding `wp_set_script_translations( 'formidable_admin', 'formidable' );`
![imagem](https://github.com/user-attachments/assets/eb448a95-0641-43d8-aa2b-0185fed14e1e)

<hr>
Fixes #2033 