### PR TITLE
Drop old vendor prefix webkit clip path

### DIFF
--- a/css/admin/deactivation-feedback.css
+++ b/css/admin/deactivation-feedback.css
@@ -4,7 +4,6 @@
 .frm_screen_reader {
 	border: 0;
 	clip: rect(1px, 1px, 1px, 1px);
-	-webkit-clip-path: inset(50%);
 	clip-path: inset(50%);
 	height: 1px;
 	margin: -1px;

--- a/css/frm_grids.css
+++ b/css/frm_grids.css
@@ -1,7 +1,6 @@
 .frm_screen_reader {
 	border: 0;
 	clip: rect(1px, 1px, 1px, 1px);
-	-webkit-clip-path: inset(50%);
 	clip-path: inset(50%);
 	height: 1px;
 	margin: -1px;


### PR DESCRIPTION
**Related issue** https://github.com/Strategy11/formidable-pro/issues/4839

This just removes some old CSS that we no longer need. This is already covered by the other `clip-path: inset(50%);` line.