### PR TITLE
Drop old clip css

### DIFF
--- a/css/admin/deactivation-feedback.css
+++ b/css/admin/deactivation-feedback.css
@@ -3,7 +3,6 @@
 }
 .frm_screen_reader {
 	border: 0;
-	clip: rect(1px, 1px, 1px, 1px);
 	clip-path: inset(50%);
 	height: 1px;
 	margin: -1px;

--- a/css/frm_grids.css
+++ b/css/frm_grids.css
@@ -1,6 +1,5 @@
 .frm_screen_reader {
 	border: 0;
-	clip: rect(1px, 1px, 1px, 1px);
 	clip-path: inset(50%);
 	height: 1px;
 	margin: -1px;


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4839

`clip` is now deprecated. The current `clip-path: inset(50%);` should cover this already. Just removing this should be fine.

It's only used in screen reader text, which I didn't see any issues with.