### PR TITLE
Make tooltip icon color used in shortcode inputs consistent

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -6001,7 +6001,8 @@ a.frm_add_logic_link.frm_hidden {
 	vertical-align: top;
 }
 
-.frm_help svg {
+.frm_help svg,
+.frm_help .frmsvg {
 	height: 13px;
 	width: 13px;
 	vertical-align: top;


### PR DESCRIPTION
Related issue: https://github.com/Strategy11/formidable-ai/issues/73

The tooltip icon color is overridden by `.frm_has_shortcodes .frmsvg` and this update just fixes that.

**Before**
<img width="628" alt="image" src="https://github.com/user-attachments/assets/e5c0c08c-b90d-4b92-8661-a1890006727e">

**After**:
<img width="628" alt="image" src="https://github.com/user-attachments/assets/f2f39305-9b90-4823-b475-f77151aba155">
