### PR TITLE
Remove IE notice

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3489,7 +3489,7 @@ class FrmAppHelper {
 	}
 
 	/**
-	 * Show a message if the browser or PHP version is below the recommendations.
+	 * Show a message if the PHP version is below the recommendations.
 	 *
 	 * @since 4.0.02
 	 * @return void
@@ -3498,12 +3498,6 @@ class FrmAppHelper {
 		$message = array();
 		if ( version_compare( phpversion(), '7.0', '<' ) ) {
 			$message[] = __( 'The version of PHP on your server is too low. If this is not corrected, you may see issues with Formidable Forms. Please contact your web host and ask to be updated to PHP 7.0+.', 'formidable' );
-		}
-
-		$browser = self::get_server_value( 'HTTP_USER_AGENT' );
-		$is_ie   = strpos( $browser, 'MSIE' ) !== false;
-		if ( $is_ie ) {
-			$message[] = __( 'You are using an outdated browser that is not compatible with Formidable Forms. Please update to a more current browser (we recommend Chrome).', 'formidable' );
 		}
 
 		foreach ( $message as $m ) {


### PR DESCRIPTION
This cleans up some logic. Now `php_version_notice` actually just checks for the PHP version.

I don't think we need an IE notice anymore. We should assume no one is using it.