### PR TITLE
Redirect immediately to onboarding when activating a single plugin

### DIFF
--- a/classes/controllers/FrmOnboardingWizardController.php
+++ b/classes/controllers/FrmOnboardingWizardController.php
@@ -156,20 +156,15 @@ class FrmOnboardingWizardController {
 			return;
 		}
 
-		switch ( get_transient( self::TRANSIENT_NAME ) ) {
-			case self::TRANSIENT_VALUE:
-				// For single activations we want to always redirect.
-				break;
-			case self::TRANSIENT_MULTI_VALUE:
-				// For multi-activations we want to only redirect when a user loads a Formidable page.
-				if ( ! FrmAppHelper::is_formidable_admin() ) {
-					return;
-				}
-				break;
-			default:
-				// If the transient is any other value, we do not want to redirect.
-				// The value is likely false, or 'no'.
-				return;
+		$transient_value = get_transient( self::TRANSIENT_NAME );
+		if ( ! in_array( $transient_value, array( self::TRANSIENT_VALUE, self::TRANSIENT_MULTI_VALUE ), true ) ) {
+			self::mark_onboarding_as_skipped();
+			return;
+		}
+
+		if ( self::TRANSIENT_MULTI_VALUE === $transient_value && ! FrmAppHelper::is_formidable_admin() ) {
+			// For multi-activations we want to only redirect when a user loads a Formidable page.
+			return;
 		}
 
 		set_transient( self::TRANSIENT_NAME, 'no', 60 );
@@ -686,7 +681,7 @@ class FrmOnboardingWizardController {
 	 * @return bool True if the Onboarding Wizard page is displayed, false otherwise.
 	 */
 	public static function is_onboarding_wizard_displayed() {
-		// TODO deprecate this.
+		_deprecated_function( __METHOD__, 'x.x' );
 		return get_transient( self::TRANSIENT_NAME ) === self::TRANSIENT_VALUE;
 	}
 }

--- a/classes/controllers/FrmOnboardingWizardController.php
+++ b/classes/controllers/FrmOnboardingWizardController.php
@@ -46,10 +46,19 @@ class FrmOnboardingWizardController {
 
 	/**
 	 * Transient value associated with the redirection to the Onboarding Wizard page.
+	 * Used when activating a single plugin.
 	 *
 	 * @var string
 	 */
 	const TRANSIENT_VALUE = 'formidable-welcome';
+
+	/**
+	 * Transient value associated with the redirection to the Onboarding Wizard page.
+	 * Used when activating multiple plugins at once.
+	 *
+	 * @var string
+	 */
+	const TRANSIENT_MULTI_VALUE = 'formidable-welcome-multi';
 
 	/**
 	 * Option name for storing the redirect status for the Onboarding Wizard page.
@@ -143,9 +152,24 @@ class FrmOnboardingWizardController {
 			return;
 		}
 
-		// Check if we should consider redirection.
-		if ( ! FrmAppHelper::is_formidable_admin() || ! self::is_onboarding_wizard_displayed() || self::has_onboarding_been_skipped() || FrmAppHelper::pro_is_connected() ) {
+		if ( self::has_onboarding_been_skipped() || FrmAppHelper::pro_is_connected() ) {
 			return;
+		}
+
+		switch ( get_transient( self::TRANSIENT_NAME ) ) {
+			case self::TRANSIENT_VALUE:
+				// For single activations we want to always redirect.
+				break;
+			case self::TRANSIENT_MULTI_VALUE:
+				// For multi-activations we want to only redirect when a user loads a Formidable page.
+				if ( ! FrmAppHelper::is_formidable_admin() ) {
+					return;
+				}
+				break;
+			default:
+				// If the transient is any other value, we do not want to redirect.
+				// The value is likely false, or 'no'.
+				return;
 		}
 
 		set_transient( self::TRANSIENT_NAME, 'no', 60 );
@@ -463,17 +487,6 @@ class FrmOnboardingWizardController {
 	}
 
 	/**
-	 * Validates if the Onboarding Wizard page is being displayed.
-	 *
-	 * @since 6.9
-	 *
-	 * @return bool True if the Onboarding Wizard page is displayed, false otherwise.
-	 */
-	public static function is_onboarding_wizard_displayed() {
-		return get_transient( self::TRANSIENT_NAME ) === self::TRANSIENT_VALUE;
-	}
-
-	/**
 	 * Checks if the plugin has already performed a redirect to avoid repeated redirections.
 	 *
 	 * @return bool Returns true if already redirected, otherwise false.
@@ -662,5 +675,18 @@ class FrmOnboardingWizardController {
 	 */
 	public static function get_usage_data() {
 		return get_option( self::USAGE_DATA_OPTION, array() );
+	}
+
+	/**
+	 * Validates if the Onboarding Wizard page is being displayed.
+	 *
+	 * @since 6.9
+	 * @deprecated x.x
+	 *
+	 * @return bool True if the Onboarding Wizard page is displayed, false otherwise.
+	 */
+	public static function is_onboarding_wizard_displayed() {
+		// TODO deprecate this.
+		return get_transient( self::TRANSIENT_NAME ) === self::TRANSIENT_VALUE;
 	}
 }

--- a/classes/controllers/FrmOnboardingWizardController.php
+++ b/classes/controllers/FrmOnboardingWizardController.php
@@ -162,6 +162,16 @@ class FrmOnboardingWizardController {
 			return;
 		}
 
+		$is_multi_activate = isset( $_GET['activate-multi'] );
+		if ( $is_multi_activate ) {
+			set_transient(
+				FrmOnboardingWizardController::TRANSIENT_NAME,
+				FrmOnboardingWizardController::TRANSIENT_MULTI_VALUE,
+				60
+			);
+			return;
+		}
+
 		if ( self::TRANSIENT_MULTI_VALUE === $transient_value && ! FrmAppHelper::is_formidable_admin() ) {
 			// For multi-activations we want to only redirect when a user loads a Formidable page.
 			return;

--- a/classes/controllers/FrmOnboardingWizardController.php
+++ b/classes/controllers/FrmOnboardingWizardController.php
@@ -169,11 +169,7 @@ class FrmOnboardingWizardController {
 			 * $_GET['activate-multi'] is set after activating multiple plugins.
 			 * In this case, change the transient value so we know for future checks.
 			 */
-			set_transient(
-				self::TRANSIENT_NAME,
-				self::TRANSIENT_MULTI_VALUE,
-				60
-			);
+			set_transient( self::TRANSIENT_NAME, self::TRANSIENT_MULTI_VALUE, 60 );
 			return;
 		}
 

--- a/classes/controllers/FrmOnboardingWizardController.php
+++ b/classes/controllers/FrmOnboardingWizardController.php
@@ -170,8 +170,8 @@ class FrmOnboardingWizardController {
 			 * In this case, change the transient value so we know for future checks.
 			 */
 			set_transient(
-				FrmOnboardingWizardController::TRANSIENT_NAME,
-				FrmOnboardingWizardController::TRANSIENT_MULTI_VALUE,
+				self::TRANSIENT_NAME,
+				self::TRANSIENT_MULTI_VALUE,
 				60
 			);
 			return;

--- a/classes/controllers/FrmOnboardingWizardController.php
+++ b/classes/controllers/FrmOnboardingWizardController.php
@@ -135,6 +135,8 @@ class FrmOnboardingWizardController {
 
 	/**
 	 * Performs a safe redirect to the welcome screen when the plugin is activated.
+	 * On single activation, we will redirect immediately.
+	 * When activating multiple plugins, the redirect is delayed until a Formidable page is loaded.
 	 *
 	 * @return void
 	 */
@@ -162,8 +164,11 @@ class FrmOnboardingWizardController {
 			return;
 		}
 
-		$is_multi_activate = isset( $_GET['activate-multi'] );
-		if ( $is_multi_activate ) {
+		if ( isset( $_GET['activate-multi'] ) ) {
+			/**
+			 * $_GET['activate-multi'] is set after activating multiple plugins.
+			 * In this case, change the transient value so we know for future checks.
+			 */
 			set_transient(
 				FrmOnboardingWizardController::TRANSIENT_NAME,
 				FrmOnboardingWizardController::TRANSIENT_MULTI_VALUE,

--- a/formidable.php
+++ b/formidable.php
@@ -138,9 +138,10 @@ add_action( 'activate_' . FrmAppHelper::plugin_folder() . '/formidable.php', 'fr
  */
 function frm_maybe_install() {
 	if ( get_transient( FrmOnboardingWizardController::TRANSIENT_NAME ) !== 'no' ) {
+		$transient_value = isset( $_GET['activate-multi'] ) ? FrmOnboardingWizardController::TRANSIENT_MULTI_VALUE : FrmOnboardingWizardController::TRANSIENT_VALUE;
 		set_transient(
 			FrmOnboardingWizardController::TRANSIENT_NAME,
-			FrmOnboardingWizardController::TRANSIENT_VALUE,
+			$transient_value,
 			60
 		);
 	}

--- a/formidable.php
+++ b/formidable.php
@@ -138,10 +138,9 @@ add_action( 'activate_' . FrmAppHelper::plugin_folder() . '/formidable.php', 'fr
  */
 function frm_maybe_install() {
 	if ( get_transient( FrmOnboardingWizardController::TRANSIENT_NAME ) !== 'no' ) {
-		$transient_value = isset( $_GET['activate-multi'] ) ? FrmOnboardingWizardController::TRANSIENT_MULTI_VALUE : FrmOnboardingWizardController::TRANSIENT_VALUE;
 		set_transient(
 			FrmOnboardingWizardController::TRANSIENT_NAME,
-			$transient_value,
+			isset( $_GET['activate-multi'] ) ? FrmOnboardingWizardController::TRANSIENT_MULTI_VALUE : FrmOnboardingWizardController::TRANSIENT_VALUE,
 			60
 		);
 	}

--- a/formidable.php
+++ b/formidable.php
@@ -140,7 +140,7 @@ function frm_maybe_install() {
 	if ( get_transient( FrmOnboardingWizardController::TRANSIENT_NAME ) !== 'no' ) {
 		set_transient(
 			FrmOnboardingWizardController::TRANSIENT_NAME,
-			isset( $_GET['activate-multi'] ) ? FrmOnboardingWizardController::TRANSIENT_MULTI_VALUE : FrmOnboardingWizardController::TRANSIENT_VALUE,
+			FrmOnboardingWizardController::TRANSIENT_VALUE,
 			60
 		);
 	}


### PR DESCRIPTION
…sient

Fixes https://github.com/Strategy11/formidable-pro/issues/5411

Now we only avoid redirecting immediately when we are not bulk-activating. If the plugin is activated when bulk-activating, we fallback to the old behaviour, where we check for a Formidable admin page.