### PR TITLE
Fix pro issue 5427

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1068,7 +1068,10 @@ function frmFrontFormJS() {
 		const input        = $fieldCont.find( 'input, select, textarea' );
 		let describedBy    = input.attr( 'aria-describedby' );
 
-		$fieldCont.get( 0 ).classList.remove( 'frm_blank_field', 'has-error' );
+		const fieldContainer = $fieldCont.get( 0 );
+		if ( fieldContainer && fieldContainer.classList ) {
+			fieldContainer.classList.remove( 'frm_blank_field', 'has-error' );
+		}
 
 		errorMessage.remove();
 		input.attr( 'aria-invalid', false );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5427

**Pre-release**
[formidable-6.15.1b.zip](https://github.com/user-attachments/files/17346333/formidable-6.15.1b.zip)

It looks like this would have been interested in v6.12 when a change to use vanilla JS from jQuery was made. I didn't know the field container might not always exist here.