### PR TITLE
Get cypress passing

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -1359,7 +1359,7 @@ class FrmAppController {
 		wp_enqueue_style( 's11-floating-links', $plugin_url . '/css/packages/s11-floating-links.css', array(), $version );
 
 		// Enqueue the Floating Links script.
-		wp_enqueue_script( 's11-floating-links', $plugin_url . '/js/packages/floating-links/s11-floating-links.js', array(), $version, true );
+		wp_enqueue_script( 's11-floating-links', $plugin_url . '/js/packages/floating-links/s11-floating-links.js', array( 'formidable_admin' ), $version, true );
 
 		// Enqueue the config script.
 		wp_enqueue_script( 's11-floating-links-config', $plugin_url . '/js/packages/floating-links/config.js', array( 'wp-i18n' ), $version, true );

--- a/classes/controllers/FrmOnboardingWizardController.php
+++ b/classes/controllers/FrmOnboardingWizardController.php
@@ -160,7 +160,6 @@ class FrmOnboardingWizardController {
 
 		$transient_value = get_transient( self::TRANSIENT_NAME );
 		if ( ! in_array( $transient_value, array( self::TRANSIENT_VALUE, self::TRANSIENT_MULTI_VALUE ), true ) ) {
-			self::mark_onboarding_as_skipped();
 			return;
 		}
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -15,5 +15,6 @@ module.exports = defineConfig({
     setupNodeEvents(on) {
       htmlvalidate.install( on );
     },
+    experimentalRunAllSpecs: true
   },
 });

--- a/js/packages/floating-links/s11-floating-links.js
+++ b/js/packages/floating-links/s11-floating-links.js
@@ -113,6 +113,7 @@ class S11FloatingLinks {
 			children
 		});
 		slideIn.setAttribute( 'data-message', frmGlobal.inboxSlideIn.key );
+		slideIn.setAttribute( 'role', 'alert' );
 		slideIn.insertAdjacentHTML( 'beforeend', frmAdminBuild.purifyHtml( frmGlobal.inboxSlideIn.cta ) );
 		slideIn.querySelector( '.frm-button-secondary' )?.remove();
 		this.updateSlideInCtaUtm( slideIn );

--- a/tests/cypress/e2e/Applications/validateApplicationsPage.cy.js
+++ b/tests/cypress/e2e/Applications/validateApplicationsPage.cy.js
@@ -39,7 +39,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Business Directory Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/business-directory.png');
+                .and('include', '/images/applications/thumbnails/business-directory.png');
             cy.get('h3 .frm-inner-text').should('contain.text', 'Business Directory').click();
         });
 
@@ -51,7 +51,7 @@ describe("Applications page", () => {
                     .should('contain.text', 'Access to this application requires the Elite plan.');
                 cy.get('.frm-application-image-wrapper img')
                     .should('have.attr', 'src')
-                    .and('include', '/plugins/formidable-forms/images/applications/placeholder.png');
+                    .and('include', '/images/applications/placeholder.png');
                 cy.get('.frm-application-modal-details .frm-application-modal-label')
                     .should('contain.text', 'Description');
                 cy.get('.frm-application-modal-details div')
@@ -84,7 +84,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Business Hours Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/business-hours.png');
+                .and('include', '/images/applications/thumbnails/business-hours.png');
         });
 
         cy.get('#frm_application_templates_grid')
@@ -96,7 +96,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Certificate Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/certificate.webp');
+                .and('include', '/images/applications/thumbnails/certificate.webp');
         });
 
         cy.get('#frm_application_templates_grid')
@@ -108,7 +108,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Charity Tracker Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/charity-tracker.webp');
+                .and('include', '/images/applications/thumbnails/charity-tracker.webp');
         });
 
         cy.get('#frm_application_templates_grid')
@@ -120,7 +120,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Contract Agreement Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/contract-agreement.webp');
+                .and('include', '/images/applications/thumbnails/contract-agreement.webp');
         });
 
         cy.get('#frm_application_templates_grid')
@@ -132,7 +132,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'FAQ Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/faq-template-wordpress.png');
+                .and('include', '/images/applications/thumbnails/faq-template-wordpress.png');
         });
 
         cy.get('#frm_application_templates_grid')
@@ -144,7 +144,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Freelance Invoice Generator Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/freelance-invoice-generator.webp');
+                .and('include', '/images/applications/thumbnails/freelance-invoice-generator.webp');
         });
 
         cy.get('#frm_application_templates_grid')
@@ -156,7 +156,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Invoice PDF Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/invoice-pdf.webp');
+                .and('include', '/images/applications/thumbnails/invoice-pdf.webp');
         });
 
         cy.get('#frm_application_templates_grid')
@@ -167,7 +167,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Letter of Recommendation Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/letter-of-recommendation.webp');
+                .and('include', '/images/applications/thumbnails/letter-of-recommendation.webp');
             cy.get('h3 .frm-inner-text').should('contain.text', 'Letter of Recommendation').click();
         });
 
@@ -179,7 +179,7 @@ describe("Applications page", () => {
                     .should('contain.text', 'Access to this application requires the Business plan');
                 cy.get('.frm-application-image-wrapper img')
                     .should('have.attr', 'src')
-                    .and('include', '/plugins/formidable-forms/images/applications/placeholder.png');
+                    .and('include', '/images/applications/placeholder.png');
                 cy.get('.frm-application-modal-details .frm-application-modal-label')
                     .should('contain.text', 'Description');
                 cy.get('.frm-application-modal-details div')
@@ -212,7 +212,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Link in Bio Instagram Page Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/link-in-bio-instagram.webp');
+                .and('include', '/images/applications/thumbnails/link-in-bio-instagram.webp');
         });
 
         cy.get('#frm_application_templates_grid')
@@ -224,7 +224,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Member Directory Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/member-directory.webp');
+                .and('include', '/images/applications/thumbnails/member-directory.webp');
         });
 
         cy.get('#frm_application_templates_grid')
@@ -236,7 +236,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Product Review and Purchase Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/product-review.png');
+                .and('include', '/images/applications/thumbnails/product-review.png');
         });
 
         cy.get('#frm_application_templates_grid')
@@ -248,7 +248,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Real Estate Listing Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/real-estate-listings.png');
+                .and('include', '/images/applications/thumbnails/real-estate-listings.png');
         });
 
         cy.get('#frm_application_templates_grid')
@@ -260,7 +260,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Restaurant Menu Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/restaurant-menu.png');
+                .and('include', '/images/applications/thumbnails/restaurant-menu.png');
         });
 
         cy.get('#frm_application_templates_grid')
@@ -272,7 +272,7 @@ describe("Applications page", () => {
                 .and('have.attr', 'aria-description', 'Team Directory Template');
             cy.get('.frm-application-card-image-wrapper img')
                 .should('have.attr', 'src')
-                .and('include', '/plugins/formidable-forms/images/applications/thumbnails/team-directory.png');
+                .and('include', '/images/applications/thumbnails/team-directory.png');
         });
 
         cy.get('#frm_application_templates_grid')
@@ -283,7 +283,7 @@ describe("Applications page", () => {
             .and('have.attr', 'aria-description', 'Testimonials Template');
           cy.get('.frm-application-card-image-wrapper img')
             .should('have.attr', 'src')
-            .and('include', '/plugins/formidable-forms/images/applications/thumbnails/testimonials.webp');
+            .and('include', '/images/applications/thumbnails/testimonials.webp');
           cy.get('h3 .frm-inner-text').should('contain.text', 'Testimonials').click();
         });
       
@@ -296,7 +296,7 @@ describe("Applications page", () => {
                     .should('contain.text', 'Access to this application requires the Business plan');
                 cy.get('.frm-application-image-wrapper img')
                     .should('have.attr', 'src')
-                    .and('include', '/plugins/formidable-forms/images/applications/placeholder.png');
+                    .and('include', '/images/applications/placeholder.png');
                 cy.get('.frm-application-modal-details .frm-application-modal-label')
                     .should('contain.text', 'Description');
                 cy.get('.frm-application-modal-details div')
@@ -338,7 +338,7 @@ describe("Applications page", () => {
             .and('have.attr', 'aria-description', 'Business Directory Template');
           cy.get('.frm-application-card-image-wrapper img')
             .should('have.attr', 'src')
-            .and('include', '/plugins/formidable-forms/images/applications/thumbnails/business-directory.png');
+            .and('include', '/images/applications/thumbnails/business-directory.png');
         });
         cy.get('#frm_application_templates_grid')
         .contains('.frm-application-template-card.frm-search-result', 'Business Hours')
@@ -348,7 +348,7 @@ describe("Applications page", () => {
             .and('have.attr', 'aria-description', 'Business Hours Template');
           cy.get('.frm-application-card-image-wrapper img')
             .should('have.attr', 'src')
-            .and('include', '/plugins/formidable-forms/images/applications/thumbnails/business-hours.png');
+            .and('include', '/images/applications/thumbnails/business-hours.png');
         });
         cy.log("Search for non-valid application templates");
         cy.get('#frm-application-search').clear().type("Application does not exist");


### PR DESCRIPTION
- Path checks in applications tests have been modified to remove the `formidable-forms` slug from the check. In many cases, the `formidable` name is used instead.
- The alert role has been added to the slidein message to improve accessibility. A new slidein message appearing when running e2e tests is catching an accessibility issue with the slidein popup that we don't have in our exception list.
- `experimentalRunAllSpecs` is now set. This allows you to run all specs when using Chrome.