### PR TITLE
Try to render captcha a second time on a timeout

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1863,8 +1863,9 @@ function frmCaptcha( captchaSelector ) {
 		const formIsVisible = closestForm && closestForm.offsetParent !== null;
 		const captcha       = captchas[c];
 		if ( ! formIsVisible ) {
-			// If the form is not visible, try again in 1 second.
+			// If the form is not visible, try again later in 400ms.
 			// This fixes issues where the form fades visible on page load.
+			// Or whne the form is inside of a modal.
 			const interval = setInterval(
 				function() {
 					if ( closestForm && closestForm.offsetParent !== null ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1861,10 +1861,19 @@ function frmCaptcha( captchaSelector ) {
 	for ( c = 0; c < cl; c++ ) {
 		const closestForm   = captchas[c].closest( 'form' );
 		const formIsVisible = closestForm && closestForm.offsetParent !== null;
+		const captcha       = captchas[c];
 		if ( ! formIsVisible ) {
+			setTimeout(
+				function() {
+					if ( closestForm && closestForm.offsetParent !== null ) {
+						frmFrontForm.renderCaptcha( captcha, captchaSelector );
+					}
+				},
+				1000
+			);
 			continue;
 		}
-		frmFrontForm.renderCaptcha( captchas[c], captchaSelector );
+		frmFrontForm.renderCaptcha( captcha, captchaSelector );
 	}
 }
 

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1865,13 +1865,14 @@ function frmCaptcha( captchaSelector ) {
 		if ( ! formIsVisible ) {
 			// If the form is not visible, try again in 1 second.
 			// This fixes issues where the form fades visible on page load.
-			setTimeout(
+			const interval = setInterval(
 				function() {
 					if ( closestForm && closestForm.offsetParent !== null ) {
 						frmFrontForm.renderCaptcha( captcha, captchaSelector );
+						clearInterval( interval );
 					}
 				},
-				1000
+				400
 			);
 			continue;
 		}

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1863,6 +1863,8 @@ function frmCaptcha( captchaSelector ) {
 		const formIsVisible = closestForm && closestForm.offsetParent !== null;
 		const captcha       = captchas[c];
 		if ( ! formIsVisible ) {
+			// If the form is not visible, try again in 1 second.
+			// This fixes issues where the form fades visible on page load.
 			setTimeout(
 				function() {
 					if ( closestForm && closestForm.offsetParent !== null ) {


### PR DESCRIPTION
Related Slack conversation https://strategy11.slack.com/archives/C799A2R61/p1729107464507059

Now if the form immediately becomes visible (within the next second), the captcha will still render.