### PR TITLE
Drop more inbox page code

### DIFF
--- a/classes/controllers/FrmInboxController.php
+++ b/classes/controllers/FrmInboxController.php
@@ -25,21 +25,6 @@ class FrmInboxController {
 	}
 
 	/**
-	 * @since 4.06
-	 *
-	 * @return void
-	 */
-	public static function dismiss_all_button( $atts ) {
-		if ( empty( $atts['messages'] ) ) {
-			return;
-		}
-
-		echo '<button class="frm-button-secondary" id="frm-dismiss-inbox" type="button">' .
-			esc_html__( 'Dismiss All', 'formidable' ) .
-			'</button>';
-	}
-
-	/**
 	 * @since 6.8
 	 *
 	 * @return array
@@ -141,22 +126,12 @@ class FrmInboxController {
 	}
 
 	/**
-	 * @since 4.05
-	 * @deprecated 6.8
+	 * @since 4.06
+	 * @deprecated x.x
 	 *
 	 * @return void
 	 */
-	public static function menu() {
-		_deprecated_function( __METHOD__, '6.8' );
-	}
-
-	/**
-	 * @since 4.05
-	 * @deprecated 6.8
-	 *
-	 * @return void
-	 */
-	public static function inbox() {
-		_deprecated_function( __METHOD__, '6.8' );
+	public static function dismiss_all_button( $atts ) {
+		_deprecated_function( __METHOD__, 'x.x' );
 	}
 }

--- a/classes/views/frm-form-actions/_email_settings.php
+++ b/classes/views/frm-form-actions/_email_settings.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<label for="<?php echo esc_attr( $this->get_field_id( 'email_to' ) ); ?>" <?php FrmAppHelper::maybe_add_tooltip( 'email_to' ); ?>>
 		<?php esc_html_e( 'To', 'formidable' ); ?>
 	</label>
-	<input type="text" name="<?php echo esc_attr( $this->get_field_name( 'email_to' ) ); ?>" value="<?php echo esc_attr( $form_action->post_content['email_to'] ); ?>" class="frm_not_email_to frm_email_blur large-text <?php FrmAppHelper::maybe_add_tooltip( 'email_to', 'open' ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'email_to' ) ); ?>" />
+	<input type="text" name="<?php echo esc_attr( $this->get_field_name( 'email_to' ) ); ?>" value="<?php echo esc_attr( $form_action->post_content['email_to'] ); ?>" class="frm_not_email_to large-text <?php FrmAppHelper::maybe_add_tooltip( 'email_to', 'open' ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'email_to' ) ); ?>" />
 </p>
 
 <p class="frm_has_shortcodes frm_cc_row frm_email_row<?php echo empty( $form_action->post_content['cc'] ) ? ' frm_hidden' : ''; ?>">
@@ -49,7 +49,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php esc_html_e( 'From', 'formidable' ); ?>
 	</label>
 
-	<input type="text" name="<?php echo esc_attr( $this->get_field_name( 'from' ) ); ?>" value="<?php echo esc_attr( $form_action->post_content['from'] ); ?>" class="frm_not_email_to frm_email_blur large-text <?php FrmAppHelper::maybe_add_tooltip( 'from', 'open' ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'from' ) ); ?>" />
+	<input type="text" name="<?php echo esc_attr( $this->get_field_name( 'from' ) ); ?>" value="<?php echo esc_attr( $form_action->post_content['from'] ); ?>" class="frm_not_email_to large-text <?php FrmAppHelper::maybe_add_tooltip( 'from', 'open' ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'from' ) ); ?>" />
 </p>
 
 <p class="frm_error_style frm_from_to_match_row <?php echo ( $form_action->post_content['from'] !== $form_action->post_content['email_to'] ? 'frm_hidden' : '' ); ?>" data-emailrow="from_to_warning">

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10843,25 +10843,13 @@ function frmAdminBuildJS() {
 								if ( 1 === message.parentNode.querySelectorAll( '.frm-inbox-message-container' ).length ) {
 									document.getElementById( 'frm_empty_inbox' ).classList.remove( 'frm_hidden' );
 									message.parentNode.closest( '.frm-active' ).classList.add( 'frm-empty-inbox' );
+									showActiveCampaignForm();
 								}
 								message.parentNode.removeChild( message );
 							}
 						);
 					}
 				);
-			});
-			jQuery( '#frm-dismiss-inbox' ).on( 'click', function() {
-				data = {
-					action: 'frm_inbox_dismiss',
-					key: 'all',
-					nonce: frmGlobal.nonce
-				};
-				postAjax( data, function() {
-					fadeOut( document.getElementById( 'frm_message_list' ), function() {
-						document.getElementById( 'frm_empty_inbox' ).classList.remove( 'frm_hidden' );
-						showActiveCampaignForm();
-					});
-				});
 			});
 
 			if ( false === document.getElementById( 'frm_empty_inbox' )?.classList.contains( 'frm_hidden' ) ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10228,8 +10228,8 @@ function frmAdminBuildJS() {
 			} else if ( document.getElementById( 'frm_dyncontent' ) !== null ) {
 				// only load on views settings page
 				frmAdminBuild.viewInit();
-			} else if ( document.getElementById( 'frm_inbox_page' ) !== null || null !== document.querySelector( '.frm-inbox-wrapper' ) ) {
-				// Inbox page
+			} else if ( null !== document.querySelector( '.frm-inbox-wrapper' ) ) {
+				// Dashboard page inbox.
 				frmAdminBuild.inboxInit();
 			} else if ( document.getElementById( 'frm-welcome' ) !== null ) {
 				// Solution install page
@@ -10794,7 +10794,7 @@ function frmAdminBuildJS() {
 		},
 
 		inboxInit: function() {
-			jQuery( '.frm_inbox_dismiss, footer .frm-button-secondary, footer .frm-button-primary' ).on( 'click', function( e ) {
+			jQuery( '.frm_inbox_dismiss' ).on( 'click', function( e ) {
 				const message                  = this.parentNode.parentNode;
 				const key                      = message.getAttribute( 'data-message' );
 				const href                     = this.getAttribute( 'href' );

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7630,16 +7630,6 @@ function frmAdminBuildJS() {
 		}
 	}
 
-	function formatEmailSetting() {
-		/*jshint validthis:true */
-		/*var val = jQuery( this ).val();
-		var email = val.match( /(\s[a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9._-]+)/gi );
-		if(email !== null && email.length) {
-			//has email
-			//TODO: add < > if they aren't there
-		}*/
-	}
-
 	function checkDupPost() {
 		/*jshint validthis:true */
 		const postField = jQuery( 'select.frm_single_post_field' );
@@ -10562,7 +10552,6 @@ function frmAdminBuildJS() {
 
 			formSettings = jQuery( '.frm_form_settings' );
 			formSettings.on( 'click', '.frm_add_form_logic', addFormLogicRow );
-			formSettings.on( 'blur', '.frm_email_blur', formatEmailSetting );
 			formSettings.on( 'click', '.frm_already_used', actionLimitMessage );
 
 			formSettings.on( 'change', '#logic_link_submit', toggleSubmitLogic );


### PR DESCRIPTION
This code is still used for the dashboard inbox.

I'm just removing the references to the inbox page. The footer listeners here seem like they are best removed.

I also fixed an issue where the active campaign sign up wouldn't actually work after dismissing every inbox item.