### PR TITLE
Add a check for current form name (no title) to show the form name modal

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2090,7 +2090,7 @@ class FrmFormsController {
 				array(
 					'parent' => 'frm-forms',
 					'id'     => 'edit_form_' . $form_id,
-					'title'  => empty( $name ) ? __( '(no title)', 'formidable' ) : $name,
+					'title'  => empty( $name ) ? FrmFormsHelper::get_no_title_text() : $name,
 					'href'   => FrmForm::get_edit_link( $form_id ),
 				)
 			);

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3277,6 +3277,17 @@ class FrmAppHelper {
 	}
 
 	/**
+	 * Returns a text used when no title is set.
+	 *
+	 * @since x.x
+	 *
+	 * @return string
+	 */
+	public static function get_no_title_text() {
+		return __( '(no title)', 'formidable' );
+	}
+
+	/**
 	 * @param string $location
 	 * @return void
 	 */
@@ -3368,6 +3379,7 @@ class FrmAppHelper {
 
 				// translators: %1$s: HTML open tag, %2$s: HTML end tag.
 				'holdShiftMsg'       => esc_html__( 'You can hold %1$sShift%2$s on your keyboard to select multiple fields', 'formidable' ),
+				'noTitleText'        => self::get_no_title_text(),
 			);
 			/**
 			 * @param array $admin_script_strings

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3277,17 +3277,6 @@ class FrmAppHelper {
 	}
 
 	/**
-	 * Returns a text used when no title is set.
-	 *
-	 * @since x.x
-	 *
-	 * @return string
-	 */
-	public static function get_no_title_text() {
-		return __( '(no title)', 'formidable' );
-	}
-
-	/**
 	 * @param string $location
 	 * @return void
 	 */
@@ -3379,7 +3368,7 @@ class FrmAppHelper {
 
 				// translators: %1$s: HTML open tag, %2$s: HTML end tag.
 				'holdShiftMsg'       => esc_html__( 'You can hold %1$sShift%2$s on your keyboard to select multiple fields', 'formidable' ),
-				'noTitleText'        => self::get_no_title_text(),
+				'noTitleText'        => FrmFormsHelper::get_no_title_text(),
 			);
 			/**
 			 * @param array $admin_script_strings

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -63,7 +63,7 @@ class FrmFormsHelper {
 			<?php } ?>
 			<?php foreach ( $forms as $form ) { ?>
 				<option value="<?php echo esc_attr( $form->id ); ?>" <?php selected( $field_value, $form->id ); ?>>
-					<?php echo esc_html( '' === $form->name ? __( '(no title)', 'formidable' ) : FrmAppHelper::truncate( $form->name, 50 ) . ( $form->parent_form_id ? __( ' (child)', 'formidable' ) : '' ) ); ?>
+					<?php echo esc_html( '' === $form->name ? FrmFormsHelper::get_no_title_text() : FrmAppHelper::truncate( $form->name, 50 ) . ( $form->parent_form_id ? __( ' (child)', 'formidable' ) : '' ) ); ?>
 				</option>
 			<?php } ?>
 		</select>
@@ -127,7 +127,7 @@ class FrmFormsHelper {
 		}
 
 		$name           = $selected === false ? __( 'Switch Form', 'formidable' ) : $selected;
-		$name           = '' === $name ? __( '(no title)', 'formidable' ) : strip_tags( $name );
+		$name           = '' === $name ? FrmFormsHelper::get_no_title_text() : strip_tags( $name );
 		$truncated_name = FrmAppHelper::truncate( $name, 25 );
 
 		if ( count( $forms ) < 2 ) {
@@ -183,7 +183,7 @@ class FrmFormsHelper {
 					}
 
 					$url       = isset( $base ) ? add_query_arg( $args, $base ) : add_query_arg( $args );
-					$form_name = empty( $form->name ) ? __( '(no title)', 'formidable' ) : $form->name;
+					$form_name = empty( $form->name ) ? FrmFormsHelper::get_no_title_text() : $form->name;
 					?>
 					<li class="frm-dropdown-form">
 						<a href="<?php echo esc_url( $url ); ?>" tabindex="-1" class="frm-justify-between">
@@ -1125,13 +1125,24 @@ BEFORE_HTML;
 	}
 
 	/**
+	 * Returns a text used when no title is set.
+	 *
+	 * @since x.x
+	 *
+	 * @return string
+	 */
+	public static function get_no_title_text() {
+		return __( '(no title)', 'formidable' );
+	}
+
+	/**
 	 * @param int|object|string $data
 	 * @return string
 	 */
 	public static function edit_form_link_label( $data ) {
 		$name = self::get_form_name_from_data( $data );
 		if ( ! $name ) {
-			return __( '(no title)', 'formidable' );
+			return FrmFormsHelper::get_no_title_text();
 		}
 		return FrmAppHelper::truncate( $name, 40 );
 	}

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -63,7 +63,7 @@ class FrmFormsHelper {
 			<?php } ?>
 			<?php foreach ( $forms as $form ) { ?>
 				<option value="<?php echo esc_attr( $form->id ); ?>" <?php selected( $field_value, $form->id ); ?>>
-					<?php echo esc_html( '' === $form->name ? FrmFormsHelper::get_no_title_text() : FrmAppHelper::truncate( $form->name, 50 ) . ( $form->parent_form_id ? __( ' (child)', 'formidable' ) : '' ) ); ?>
+					<?php echo esc_html( '' === $form->name ? self::get_no_title_text() : FrmAppHelper::truncate( $form->name, 50 ) . ( $form->parent_form_id ? __( ' (child)', 'formidable' ) : '' ) ); ?>
 				</option>
 			<?php } ?>
 		</select>
@@ -127,7 +127,7 @@ class FrmFormsHelper {
 		}
 
 		$name           = $selected === false ? __( 'Switch Form', 'formidable' ) : $selected;
-		$name           = '' === $name ? FrmFormsHelper::get_no_title_text() : strip_tags( $name );
+		$name           = '' === $name ? self::get_no_title_text() : strip_tags( $name );
 		$truncated_name = FrmAppHelper::truncate( $name, 25 );
 
 		if ( count( $forms ) < 2 ) {
@@ -183,7 +183,7 @@ class FrmFormsHelper {
 					}
 
 					$url       = isset( $base ) ? add_query_arg( $args, $base ) : add_query_arg( $args );
-					$form_name = empty( $form->name ) ? FrmFormsHelper::get_no_title_text() : $form->name;
+					$form_name = empty( $form->name ) ? self::get_no_title_text() : $form->name;
 					?>
 					<li class="frm-dropdown-form">
 						<a href="<?php echo esc_url( $url ); ?>" tabindex="-1" class="frm-justify-between">
@@ -1142,7 +1142,7 @@ BEFORE_HTML;
 	public static function edit_form_link_label( $data ) {
 		$name = self::get_form_name_from_data( $data );
 		if ( ! $name ) {
-			return FrmFormsHelper::get_no_title_text();
+			return self::get_no_title_text();
 		}
 		return FrmAppHelper::truncate( $name, 40 );
 	}

--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -243,7 +243,7 @@ class FrmFormsListHelper extends FrmListHelper {
 		$checkbox_label_text = sprintf(
 			// translators: Form title
 			__( 'Select %s', 'formidable' ),
-			! empty( $item->name ) ? $item->name : __( '(no title)', 'formidable' )
+			! empty( $item->name ) ? $item->name : FrmFormsHelper::get_no_title_text()
 		);
 
 		$checkbox .= '<label for="cb-item-action-' . absint( $item->id ) . '"><span class="screen-reader-text">' . esc_html( $checkbox_label_text ) . '</span></label>';
@@ -408,7 +408,7 @@ class FrmFormsListHelper extends FrmListHelper {
 	private function get_form_name( $item, $actions, $edit_link, $mode = 'list' ) {
 		$form_name = $item->name;
 		if ( trim( $form_name ) == '' ) {
-			$form_name = __( '(no title)', 'formidable' );
+			$form_name = FrmFormsHelper::get_no_title_text();
 		}
 		$form_name = FrmAppHelper::kses( $form_name );
 		if ( 'excerpt' != $mode ) {

--- a/classes/views/frm-entries/direct.php
+++ b/classes/views/frm-entries/direct.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_filter(
 	'document_title',
 	function ( $title ) use ( $form ) {
-		$form_name = '' === $form->name ? __( '(no title)', 'formidable' ) : $form->name;
+		$form_name = '' === $form->name ? FrmFormsHelper::get_no_title_text() : $form->name;
 		return get_bloginfo( 'name', 'display' ) . ' | ' . wp_strip_all_tags( $form_name );
 	}
 );

--- a/classes/views/styles/_manage-styles-row.php
+++ b/classes/views/styles/_manage-styles-row.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
 
-$form_name   = ! empty( $form->name ) ? $form->name : __( '(no title)', 'formidable' );
+$form_name   = ! empty( $form->name ) ? $form->name : FrmFormsHelper::get_no_title_text();
 $dropdown_id = 'frm_style_dropdown_' . absint( $form->id );
 ?>
 <tr>

--- a/classes/views/xml/import_form.php
+++ b/classes/views/xml/import_form.php
@@ -157,7 +157,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 								</td>
 								<td>
 									<label for="export_form_<?php echo esc_attr( $form->id ); ?>">
-										<?php echo esc_html( '' === $form->name ? __( '(no title)', 'formidable' ) : $form->name ); ?>
+										<?php echo esc_html( '' === $form->name ? FrmFormsHelper::get_no_title_text() : $form->name ); ?>
 									</label>
 								</td>
 								<td>

--- a/classes/widgets/FrmElementorWidget.php
+++ b/classes/widgets/FrmElementorWidget.php
@@ -74,7 +74,7 @@ if ( class_exists( '\Elementor\Widget_Base' ) ) {
 			$options = array( '' => '' );
 
 			foreach ( $forms as $form ) {
-				$form_title           = '' === $form->name ? __( '(no title)', 'formidable' ) : FrmAppHelper::truncate( $form->name, 50 );
+				$form_title           = '' === $form->name ? FrmFormsHelper::get_no_title_text() : FrmAppHelper::truncate( $form->name, 50 );
 				$options[ $form->id ] = esc_html( $form_title );
 			}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6608,7 +6608,7 @@ function frmAdminBuildJS() {
 			return false;
 		}
 
-		return 'true' === urlParams.get( 'new_template' ) && document.querySelector( '#frm_top_bar #frm_bs_dropdown .frm_bstooltip' )?.textContent.trim() === frm_admin_js.noTitleText;
+		return 'true' === urlParams.get( 'new_template' ) && document.querySelector( '#frm_top_bar #frm_bs_dropdown .frm_bstooltip' )?.textContent.trim() === frm_admin_js.noTitleText; // eslint-disable-line camelcase
 	}
 
 	/**

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6607,7 +6607,8 @@ function frmAdminBuildJS() {
 		if ( formNameInput && formNameInput.value.trim() !== '' ) {
 			return false;
 		}
-		return 'true' === urlParams.get( 'new_template' );
+
+		return 'true' === urlParams.get( 'new_template' ) && document.querySelector( '#frm_top_bar #frm_bs_dropdown .frm_bstooltip' ).textContent.trim() === `(${__( 'no title', 'formidable' )})`;
 	}
 
 	/**

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6608,7 +6608,7 @@ function frmAdminBuildJS() {
 			return false;
 		}
 
-		return 'true' === urlParams.get( 'new_template' ) && document.querySelector( '#frm_top_bar #frm_bs_dropdown .frm_bstooltip' ).textContent.trim() === `(${__( 'no title', 'formidable' )})`;
+		return 'true' === urlParams.get( 'new_template' ) && document.querySelector( '#frm_top_bar #frm_bs_dropdown .frm_bstooltip' )?.textContent.trim() === `(${__( 'no title', 'formidable' )})`;
 	}
 
 	/**

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6608,7 +6608,7 @@ function frmAdminBuildJS() {
 			return false;
 		}
 
-		return 'true' === urlParams.get( 'new_template' ) && document.querySelector( '#frm_top_bar #frm_bs_dropdown .frm_bstooltip' )?.textContent.trim() === `(${__( 'no title', 'formidable' )})`;
+		return 'true' === urlParams.get( 'new_template' ) && document.querySelector( '#frm_top_bar #frm_bs_dropdown .frm_bstooltip' )?.textContent.trim() === frm_admin_js.noTitleText;
 	}
 
 	/**


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5442

### Test procedure
1. Create a form from Template, Formidable > Forms > Add New and pick a template clicking on 'Use template'.
2. Try saving the form and confirm that the form name modal doesn't appear as the form is already named by the template name.