### PR TITLE
Fix redirect issues for upgrade and black friday

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -111,7 +111,10 @@ class FrmAddonsController {
 				'<span class="frm-upgrade-submenu">' . __( 'Upgrade', 'formidable' ) . '</span>',
 				'frm_view_forms',
 				'formidable-pro-upgrade',
-				'FrmAddonsController::upgrade_to_pro'
+				function () {
+					// This function doesn't need to do anything.
+					// The redirect is handled earlier to avoid issues with the headers being sent.
+				}
 			);
 		} elseif ( 'formidable-pro-upgrade' === FrmAppHelper::get_param( 'page' ) ) {
 			wp_safe_redirect( admin_url( 'admin.php?page=formidable' ) );
@@ -874,15 +877,7 @@ class FrmAddonsController {
 	 * @return void
 	 */
 	public static function upgrade_to_pro() {
-		wp_redirect(
-			FrmAppHelper::admin_upgrade_link(
-				array(
-					'medium'  => 'upgrade',
-					'content' => 'submenu-upgrade',
-				)
-			)
-		);
-		die();
+		// TODO deprecate this.
 	}
 
 	/**

--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -870,17 +870,6 @@ class FrmAddonsController {
 	}
 
 	/**
-	 * Handle when the Upgrade submenu item is clicked.
-	 *
-	 * @since x.x This function was changed to no longer render a page, redirecting directly to the upgrade page instead.
-	 *
-	 * @return void
-	 */
-	public static function upgrade_to_pro() {
-		// TODO deprecate this.
-	}
-
-	/**
 	 * @since 5.5.2
 	 *
 	 * @param string $plugin


### PR DESCRIPTION
This fixes issues with the "headers already sent" PHP warning when trying to redirect using the submenu links.