### PR TITLE
Disable form CSS in visual styler more safely

### DIFF
--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -96,7 +96,7 @@ class FrmStylesController {
 	 * @return void
 	 */
 	private static function disable_form_css() {
-		add_filter( 'get_frm_stylesheet', '__return_false' );
+		add_filter( 'get_frm_stylesheet', '__return_empty_array' );
 	}
 
 	/**


### PR DESCRIPTION
I'm using a PHP 8.4 release candidate now.

This update keeps `$css` as an array, to help avoid conflicts with code like our Authorize.Net add-on that expects `$css` to be an array.

> PHP Deprecated:  Automatic conversion of false to array is deprecated in /var/www/src/wp-content/plugins/formidable-authorize-net/controllers/FrmAuthNetController.php on line 78