### PR TITLE
Check for null in sanitize_embedded_shortcodes

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -943,10 +943,15 @@ class FrmFieldsHelper {
 	 *
 	 * @since 3.01.02
 	 *
-	 * @param array  $atts  Includes entry object.
-	 * @param string $value
+	 * @param array       $atts  Includes entry object.
+	 * @param string|null $value
+	 * @return void
 	 */
 	public static function sanitize_embedded_shortcodes( $atts, &$value ) {
+		if ( is_null( $value ) ) {
+			return;
+		}
+
 		$atts['value']   = $value;
 		$should_sanitize = apply_filters( 'frm_sanitize_shortcodes', true, $atts );
 		if ( $should_sanitize ) {


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2744881693/213579?

They didn't include a full message, but if I pass null to `$subject`, I get this message (in PHP 8.3) which matches what they sent.
> Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated

This is called in various places. Rather than trying to handle the null check everywhere this is called, it's easier to just put a null check in this function.

If the value is null, we don't need to modify it in this function.

**Pre-release**
[formidable-6.16.1b.zip](https://github.com/user-attachments/files/17523318/formidable-6.16.1b.zip)
