### PR TITLE
Add "NEW" to payment field

### DIFF
--- a/classes/views/frm-forms/add_field_links.php
+++ b/classes/views/frm-forms/add_field_links.php
@@ -42,6 +42,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<a href="#" class="frm_add_field frm_animate_bg" title="<?php echo esc_attr( $field_label ); ?>">
 							<?php FrmAppHelper::icon_by_class( FrmFormsHelper::get_field_link_icon( $field_type ) ); ?>
 							<span><?php echo esc_html( $field_label ); ?></span>
+							<?php
+							if ( 'credit_card' === $field_key && ! FrmTransLiteAppHelper::payments_table_exists() ) {
+								FrmAppHelper::show_pill_text();
+							}
+							?>
 						</a>
 					</li>
 					<?php

--- a/classes/views/frm-forms/add_field_links.php
+++ b/classes/views/frm-forms/add_field_links.php
@@ -51,7 +51,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</li>
 					<?php
 					unset( $field_key, $field_type );
-				}
+				}//end foreach
 				?>
 			</ul>
 			<div class="clear"></div>

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -3019,6 +3019,10 @@ body.frm-body-with-open-modal {
 	vertical-align: text-bottom;
 }
 
+.frm_add_field span + .frm-meta-tag {
+	margin-left: 0;
+}
+
 /* Start entry statuses */
 .frm-entry-status {
 	font-weight: 500;


### PR DESCRIPTION
We have this "NEW" text in our payments submenu.

<img width="131" alt="Screen Shot 2024-10-25 at 1 58 25 PM" src="https://github.com/user-attachments/assets/89ef9479-c7f3-482a-98a0-6bb2c968d4e6">

But I was think we might draw more attention to payments as well if we put a "NEW" flag directly beside the Payment field as well.
<img width="354" alt="Screen Shot 2024-10-25 at 1 59 19 PM" src="https://github.com/user-attachments/assets/b60163ee-d12c-496d-a3df-34a2e180ae84">

I put this behind a check so it doesn't appear if you have a payments table already installed. This would apply to anyone using the PayPal add-on, Authorize.Net, or anyone who has used Stripe already.