### PR TITLE
Make implode code safer

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2118,6 +2118,20 @@ class FrmAppHelper {
 	}
 
 	/**
+	 * Flatten an array before imploding it to avoid Array to string conversion warnings.
+	 *
+	 * @since x.x
+	 *
+	 * @param string $sep
+	 * @param array  $array
+	 * @return string
+	 */
+	public static function safe_implode( $sep, $array ) {
+		$array = self::array_flatten( $array );
+		return implode( $sep, $array );
+	}
+
+	/**
 	 * @param string $text
 	 * @param bool   $is_rich_text
 	 * @return string

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1036,7 +1036,7 @@ class FrmFieldsHelper {
 			$string_value = $replace_with;
 			if ( is_array( $replace_with ) ) {
 				$sep          = isset( $atts['sep'] ) ? $atts['sep'] : ', ';
-				$string_value = implode( $sep, $replace_with );
+				$string_value = FrmAppHelper::safe_implode( $sep, $replace_with );
 			}
 
 			if ( empty( $string_value ) && $string_value != '0' ) {

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1440,11 +1440,11 @@ DEFAULT_HTML;
 		$value = $this->prepare_display_value( $value, $atts );
 
 		if ( is_array( $value ) ) {
-			if ( isset( $atts['show'] ) && $atts['show'] && isset( $value[ $atts['show'] ] ) ) {
+			if ( ! empty( $atts['show'] ) && isset( $value[ $atts['show'] ] ) ) {
 				$value = $value[ $atts['show'] ];
-			} elseif ( ! isset( $atts['return_array'] ) || ! $atts['return_array'] ) {
+			} elseif ( empty( $atts['return_array'] ) ) {
 				$sep   = isset( $atts['sep'] ) ? $atts['sep'] : ', ';
-				$value = implode( $sep, $value );
+				$value = FrmAppHelper::safe_implode( $sep, $value );
 			}
 		}
 


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2744881693/213579/

If an array contains arrays and it is passed to the second parameter of `implode` an "Array to string conversion" warning is logged.

**Pre-release**
[formidable-6.16.1b.zip](https://github.com/user-attachments/files/17557272/formidable-6.16.1b.zip)
