### PR TITLE
Exclude invalid applications on applications page

### DIFF
--- a/classes/controllers/FrmApplicationsController.php
+++ b/classes/controllers/FrmApplicationsController.php
@@ -141,7 +141,12 @@ class FrmApplicationsController {
 	 */
 	private static function reduce_template( $total, $current ) {
 		$template = new FrmApplicationTemplate( $current );
-		$total[]  = $template->as_js_object();
+
+		$js_object = $template->as_js_object();
+		if ( $js_object ) {
+			$total[] = $js_object;
+		}
+
 		return $total;
 	}
 

--- a/classes/models/FrmApplicationTemplate.php
+++ b/classes/models/FrmApplicationTemplate.php
@@ -181,12 +181,18 @@ class FrmApplicationTemplate {
 		$application['isWebp']           = in_array( $application['key'], self::get_template_keys_with_local_webp_images(), true );
 
 		if ( ! array_key_exists( 'url', $application ) ) {
+			$application['requires'] = FrmFormsHelper::get_plan_required( $application );
+
+			if ( false === $application['requires'] ) {
+				// Application is invalid if the URL is unavailable and there is no plan required.
+				return array();
+			}
+
 			$purchase_url = $this->is_available_for_purchase();
 			if ( false !== $purchase_url ) {
 				$application['forPurchase'] = true;
 			}
 			$application['upgradeUrl'] = $this->get_admin_upgrade_link();
-			$application['requires']   = FrmFormsHelper::get_plan_required( $application );
 			$application['link']       = $application['upgradeUrl'];
 		}
 

--- a/classes/models/FrmStyle.php
+++ b/classes/models/FrmStyle.php
@@ -28,7 +28,7 @@ class FrmStyle {
 	public $id = 0;
 
 	/**
-	 * @param int|string $id The id of the stylsheet or 'default'.
+	 * @param int|string $id The id of the stylesheet or 'default'.
 	 */
 	public function __construct( $id = 0 ) {
 		$this->id = $id;


### PR DESCRIPTION
Now if a template is missing both `url` and a required license, it is omitted from the Applications page.

This helps avoid this "requires false plan" message.

<img width="439" alt="Screen Shot 2024-11-01 at 11 35 35 AM" src="https://github.com/user-attachments/assets/79556061-2a89-426f-bb8e-45334888a1f6">
