### PR TITLE
Avoid loading Stripe script if Stripe gateway is not selected for a payment action.

### DIFF
--- a/stripe/controllers/FrmStrpLiteActionsController.php
+++ b/stripe/controllers/FrmStrpLiteActionsController.php
@@ -476,7 +476,7 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 		}
 		global $frm_vars;
 		$form_ids = $frm_vars['forms_loaded'];
-		if ( ! is_array( $form_ids ) ) {
+		if ( empty( $form_ids ) || ! is_array( $form_ids ) ) {
 			return false;
 		}
 		$form_ids = array_unique( wp_list_pluck( $form_ids, 'id' ) );

--- a/stripe/controllers/FrmStrpLiteActionsController.php
+++ b/stripe/controllers/FrmStrpLiteActionsController.php
@@ -458,12 +458,13 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 		wp_localize_script( 'formidable-stripe', 'frm_stripe_vars', $stripe_vars );
 	}
 
-	private static function get_payment_actions( $form_id ) {
-		return array();
-		$actions = self::get_actions_before_submit( FrmAppHelper::get_param( 'form_id' ) );
-		return ! empty( $actions );
-	}
-
+	/**
+	 * Returns true if the Stripe script should be loaded.
+	 *
+	 * @since x.x
+	 *
+	 * @return bool
+	 */
 	private static function should_load_stripe_script(){
 		if ( self::$has_loaded_stripe_script ) {
 			return false;
@@ -484,6 +485,14 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 		return false;
 	}
 
+	/**
+	 * Returns true if the Stripe script should be loaded for a form.
+	 *
+	 * @since x.x
+	 * @param int $form_id
+	 *
+	 * @return bool
+	 */
 	private static function should_load_stripe_script_for_form( $form_id ) {
 		$action_status   = array(
 			'post_status' => 'publish',
@@ -501,6 +510,12 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 		return false;
 	}
 
+	/**
+	 * Loads Stripe script if it hasn't been loaded yet and it should be loaded.
+	 *
+	 * @since x.x
+	 * @return void
+	 */
 	private static function maybe_load_stripe_script() {
 		if ( ! self::should_load_stripe_script() ) {
 			return;

--- a/stripe/controllers/FrmStrpLiteActionsController.php
+++ b/stripe/controllers/FrmStrpLiteActionsController.php
@@ -499,10 +499,7 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 	 * @return bool
 	 */
 	private static function should_load_stripe_script_for_form( $form_id ) {
-		$action_status   = array(
-			'post_status' => 'publish',
-		);
-		$payment_actions = FrmFormAction::get_action_for_form( $form_id, 'payment', $action_status );
+		$payment_actions = FrmTransLiteActionsController::get_actions_for_form( $form_id );
 		if ( empty( $payment_actions ) ) {
 			return false;
 		}

--- a/stripe/controllers/FrmStrpLiteActionsController.php
+++ b/stripe/controllers/FrmStrpLiteActionsController.php
@@ -470,7 +470,7 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 	 *
 	 * @return bool
 	 */
-	private static function should_load_stripe_script(){
+	private static function should_load_stripe_script() {
 		if ( self::$has_loaded_stripe_script ) {
 			return false;
 		}

--- a/stripe/controllers/FrmStrpLiteActionsController.php
+++ b/stripe/controllers/FrmStrpLiteActionsController.php
@@ -10,6 +10,11 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 	 */
 	private static $customer;
 
+	/**
+	 * @since x.x
+	 *
+	 * @var bool|null A memoized value for whether the Stripe script has been loaded.
+	 */
 	private static $has_loaded_stripe_script;
 
 	/**

--- a/stripe/controllers/FrmStrpLiteActionsController.php
+++ b/stripe/controllers/FrmStrpLiteActionsController.php
@@ -494,7 +494,7 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 		}
 
 		foreach ( $payment_actions as $action ) {
-			if ( ! empty( $action->post_content['stripe_link'] ) ) {
+			if ( in_array( 'stripe', $action->post_content['gateway'], true ) ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5004

### Test steps
1. Install and activate Authorize.NET add on and configure it as per the documentation: https://formidableforms.com/knowledgebase/authorize-net-aim/
2. Also, make sure Stripe is configured in Global settings.
3. Create a form and add a Payment action to your form.
4. In the Payment action settings, select Authorize.NET as the only payment gateway.
5. Save and preview your form.
6. Confirm that Stripe js is not loaded. I would check the page source for `frmstrp.js` script.
7. Go back to your form settings and check Stripe payment gateway.
8. Save and preview your form again.
9. Confirm the Stripe script is loaded now.