### PR TITLE
Fix submit button auto order change

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 = 6.16 =
 * New: The sanitizing for layout classes has been updated to allow `[` and `]` characters, enabling the use of basic shortcodes.
 * Fix: JavaScript validation would get skipped when a form included an invisible reCAPTCHA field.
+* Fix: Submit buttons would appear out of place after saving a form.
 * Fix: Nothing would copy when trying to click the icon to copy a style class name.
 * Fix: A white element would appear at the bottom of the plugins page.
 * Fix: A Cannot read properties of undefined at removeFieldError error has been fixed.

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -170,7 +170,7 @@ class FrmFormsController {
 			array(
 				'type'          => FrmSubmitHelper::FIELD_TYPE,
 				'name'          => __( 'Submit', 'formidable' ),
-				'field_order'   => 9999,
+				'field_order'   => FrmSubmitHelper::DEFAULT_ORDER,
 				'form_id'       => $form->id,
 				'field_options' => FrmFieldsHelper::get_default_field_options( FrmSubmitHelper::FIELD_TYPE ),
 				'description'   => '',

--- a/classes/helpers/FrmSubmitHelper.php
+++ b/classes/helpers/FrmSubmitHelper.php
@@ -23,6 +23,13 @@ class FrmSubmitHelper {
 	const FIELD_TYPE = 'submit';
 
 	/**
+	 * Default order for submit field.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_ORDER = 9999;
+
+	/**
 	 * Gets submit field object.
 	 *
 	 * @param int $form_id Form ID.

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -516,7 +516,7 @@ class FrmForm {
 		foreach ( $field_cols as $col => $default ) {
 			$default = $default === '' ? $field->{$col} : $default;
 
-			if ( 'field_order' === $col && $field->type === 'submit' && '9999' === $values['field_options'][ $col . '_' . $field->id ] ) {
+			if ( '9999' === $values['field_options'][ $col . '_' . $field->id ] && $field->type === 'submit' && 'field_order' === $col ) {
 				$new_field[ $col ] = $field->field_order;
 			} else {
 				$new_field[ $col ] = isset( $values['field_options'][ $col . '_' . $field->id ] ) ? $values['field_options'][ $col . '_' . $field->id ] : $default;

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -516,7 +516,7 @@ class FrmForm {
 		foreach ( $field_cols as $col => $default ) {
 			$default = $default === '' ? $field->{$col} : $default;
 
-			$new_value = isset( $values['field_options'][ $col . '_' . $field->id ] ) ? $values['field_options'][ $col . '_' . $field->id ] : $default;
+			$new_value         = isset( $values['field_options'][ $col . '_' . $field->id ] ) ? $values['field_options'][ $col . '_' . $field->id ] : $default;
 			$new_field[ $col ] = FrmSubmitHelper::DEFAULT_ORDER === intval( $new_value ) && $field->type === 'submit' && 'field_order' === $col ? $field->field_order : $new_value;
 		}
 

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -514,10 +514,12 @@ class FrmForm {
 			'name'        => '',
 		);
 		foreach ( $field_cols as $col => $default ) {
-			$default = $default === '' ? $field->{$col} : $default;
+			$default           = $default === '' ? $field->{$col} : $default;
+			$new_field[ $col ] = isset( $values['field_options'][ $col . '_' . $field->id ] ) ? $values['field_options'][ $col . '_' . $field->id ] : $default;
+		}
 
-			$new_value         = isset( $values['field_options'][ $col . '_' . $field->id ] ) ? $values['field_options'][ $col . '_' . $field->id ] : $default;
-			$new_field[ $col ] = FrmSubmitHelper::DEFAULT_ORDER === intval( $new_value ) && $field->type === 'submit' && 'field_order' === $col ? $field->field_order : $new_value;
+		if ( $field->type === 'submit' && isset( $new_field['field_order'] ) && (int) $new_field['field_order'] === FrmSubmitHelper::DEFAULT_ORDER ) {
+			$new_field['field_order'] = $field->field_order;
 		}
 
 		// Don't save the template option.

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -517,7 +517,7 @@ class FrmForm {
 			$default = $default === '' ? $field->{$col} : $default;
 
 			$new_value = isset( $values['field_options'][ $col . '_' . $field->id ] ) ? $values['field_options'][ $col . '_' . $field->id ] : $default;
-			$new_field[ $col ] = ( '9999' === $new_value && $field->type === 'submit' && 'field_order' === $col ) ? $field->field_order : $new_value;
+			$new_field[ $col ] = FrmSubmitHelper::DEFAULT_ORDER === intval( $new_value ) && $field->type === 'submit' && 'field_order' === $col ? $field->field_order : $new_value;
 		}
 
 		// Don't save the template option.

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -516,11 +516,8 @@ class FrmForm {
 		foreach ( $field_cols as $col => $default ) {
 			$default = $default === '' ? $field->{$col} : $default;
 
-			if ( '9999' === $values['field_options'][ $col . '_' . $field->id ] && $field->type === 'submit' && 'field_order' === $col ) {
-				$new_field[ $col ] = $field->field_order;
-			} else {
-				$new_field[ $col ] = isset( $values['field_options'][ $col . '_' . $field->id ] ) ? $values['field_options'][ $col . '_' . $field->id ] : $default;
-			}
+			$new_value = isset( $values['field_options'][ $col . '_' . $field->id ] ) ? $values['field_options'][ $col . '_' . $field->id ] : $default;
+			$new_field[ $col ] = ( '9999' === $new_value && $field->type === 'submit' && 'field_order' === $col ) ? $field->field_order : $new_value;
 		}
 
 		// Don't save the template option.

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -516,7 +516,11 @@ class FrmForm {
 		foreach ( $field_cols as $col => $default ) {
 			$default = $default === '' ? $field->{$col} : $default;
 
-			$new_field[ $col ] = isset( $values['field_options'][ $col . '_' . $field->id ] ) ? $values['field_options'][ $col . '_' . $field->id ] : $default;
+			if ( 'field_order' === $col && $field->type === 'submit' && '9999' === $values['field_options'][ $col . '_' . $field->id ] ) {
+				$new_field[ $col ] = $field->field_order;
+			} else {
+				$new_field[ $col ] = isset( $values['field_options'][ $col . '_' . $field->id ] ) ? $values['field_options'][ $col . '_' . $field->id ] : $default;
+			}
 		}
 
 		// Don't save the template option.

--- a/readme.txt
+++ b/readme.txt
@@ -374,6 +374,7 @@ See all [Formidable Zapier Integrations](https://zapier.com/apps/formidable/inte
 = 6.16 =
 * New: The sanitizing for layout classes has been updated to allow `[` and `]` characters, enabling the use of basic shortcodes.
 * Fix: JavaScript validation would get skipped when a form included an invisible reCAPTCHA field.
+* Fix: Submit buttons would appear out of place after saving a form.
 * Fix: Nothing would copy when trying to click the icon to copy a style class name.
 * Fix: A white element would appear at the bottom of the plugins page.
 * Fix: A Cannot read properties of undefined at removeFieldError error has been fixed.


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5459

### Test steps
1. Create a form and add a field to it.
2. Then click on the Submit button in the builder page and then click on "Update" button at the top right.
3. When the page reloads, confirm that the Submit button's position/order is not changed.

### Screencasts
**Before**:
![CleanShot 2024-11-07 at 15 37 27](https://github.com/user-attachments/assets/bf557263-0505-46cb-8b91-2536b4bc33d8)

**After**
![CleanShot 2024-11-07 at 15 38 29](https://github.com/user-attachments/assets/2b173ba6-bfb6-4fad-a0af-236e1df9426e)
