### PR TITLE
Stop showing onboarding inbox item after visiting onboarding page or …

### DIFF
--- a/classes/controllers/FrmInboxController.php
+++ b/classes/controllers/FrmInboxController.php
@@ -60,9 +60,15 @@ class FrmInboxController {
 		if ( ! empty( $key ) ) {
 			$message = new FrmInbox();
 			$message->dismiss( $key );
+
 			if ( $key === 'review' ) {
 				$reviews = new FrmReviews();
 				$reviews->dismiss_review();
+			}
+
+			if ( $key === 'onboarding_wizard' ) {
+				// Delete the skipped optino or the inbox message will continue to get added.
+				delete_option( FrmOnboardingWizardController::ONBOARDING_SKIPPED_OPTION );
 			}
 		}
 

--- a/classes/controllers/FrmInboxController.php
+++ b/classes/controllers/FrmInboxController.php
@@ -67,7 +67,7 @@ class FrmInboxController {
 			}
 
 			if ( $key === 'onboarding_wizard' ) {
-				// Delete the skipped optino or the inbox message will continue to get added.
+				// Delete the skipped option or the inbox message will continue to get added.
 				delete_option( FrmOnboardingWizardController::ONBOARDING_SKIPPED_OPTION );
 			}
 		}

--- a/classes/controllers/FrmOnboardingWizardController.php
+++ b/classes/controllers/FrmOnboardingWizardController.php
@@ -200,6 +200,10 @@ class FrmOnboardingWizardController {
 	 */
 	public static function maybe_load_page() {
 		if ( self::is_onboarding_wizard_page() ) {
+			// Dismiss the onboarding wizard message so it stops appearing after it is clicked.
+			$message = new FrmInbox();
+			$message->dismiss( 'onboarding_wizard' );
+
 			add_action( 'admin_menu', __CLASS__ . '::menu', 99 );
 			add_action( 'admin_init', __CLASS__ . '::assign_properties' );
 			add_action( 'admin_enqueue_scripts', __CLASS__ . '::enqueue_assets', 15 );


### PR DESCRIPTION
…clicking dismiss

**Related ticket** https://secure.helpscout.net/conversation/2756274044/214547/

**The issue**
Clicking to dismiss the onboarding message does not dismiss it permanently. It re-appears after every page load. This is because it continues to get added when `has_onboarding_been_skipped()` returns true.

There are also issues where the inbox message continues to appear on the onboarding wizard page after you click it.

**The update**
1. Deletes the skipped option when the inbox message is dismissed.
2. Removes the inbox item when the onboarding page is loading.

**To replicate**
You just need to add the `frm_onboarding_skipped` option to the database with a value like "yes".

![image](https://github.com/user-attachments/assets/94415925-a93b-4ae0-ae48-88b29c68dbea)
