### PR TITLE
Check tab content exists before making visible

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -716,17 +716,21 @@ function frmAdminBuildJS() {
 
 	function clickNewTab() {
 		/*jshint validthis:true */
-		const t = this.getAttribute( 'href' ),
-			c = t.replace( '#', '.' ),
-			$link = jQuery( this );
-
+		const t = this.getAttribute( 'href' );
 		if ( typeof t === 'undefined' ) {
 			return false;
 		}
 
+		const c     = t.replace( '#', '.' );
+		const $link = jQuery( this );
+
 		$link.closest( 'li' ).addClass( 'frm-tabs active' ).siblings( 'li' ).removeClass( 'frm-tabs active starttab' );
 		$link.closest( 'div' ).children( '.tabs-panel' ).not( t ).not( c ).hide();
-		document.getElementById( t.replace( '#', '' ) ).style.display = 'block';
+
+		const tabContent = document.getElementById( t.replace( '#', '' ) );
+		if ( tabContent ) {
+			tabContent.style.display = 'block';
+		}
 
 		// clearSettingsBox would hide field settings when opening the fields modal and we want to skip it there.
 		if ( this.id === 'frm_insert_fields_tab' && ! this.closest( '#frm_adv_info' ) ) {


### PR DESCRIPTION
I noticed this error that happens in the visual views editor when you click the conditional tab and there are no fields or no form is selected.

<img width="554" alt="Screen Shot 2024-11-11 at 2 57 17 PM" src="https://github.com/user-attachments/assets/9f10f6da-32ea-4f72-9c05-7c774a91a567">
