### PR TITLE
Temporarily remove input shortcodes when rendering forms fix

### DIFF
--- a/classes/views/frm-entries/form.php
+++ b/classes/views/frm-entries/form.php
@@ -3,6 +3,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
 
+// Temporarily remove the [input] shortcode if it exists to avoid conflicts.
+// This includes the Payment form by Paystack plugin.
+global $shortcode_tags;
+
+// Store the current callbacks for the shortcode
+$original_shortcode_callbacks = isset( $shortcode_tags[ 'input' ] ) ? $shortcode_tags[ 'input' ] : false;
+
+// Remove the shortcode
+remove_shortcode( 'input' );
+
 $only_contain_submit = isset( $values['fields'] ) && FrmSubmitHelper::only_contains_submit_field( $values['fields'] );
 if ( empty( $values ) || empty( $values['fields'] ) || $only_contain_submit ) { ?>
 <div class="frm_forms <?php echo esc_attr( FrmFormsHelper::get_form_style_class( $form ) ); ?>" id="frm_form_<?php echo esc_attr( $form->id ); ?>_container">
@@ -138,3 +148,9 @@ if ( FrmForm::show_submit( $form ) && ! FrmSubmitHelper::has_submit_field_on_cur
 <?php if ( has_action( 'frm_entries_footer_scripts' ) ) { ?>
 <script type="text/javascript"><?php do_action( 'frm_entries_footer_scripts', $values['fields'], $form ); ?></script>
 <?php } ?>
+
+<?php
+// Add the shortcode back with the original callbacks
+if ( $original_shortcode_callbacks ) {
+	add_shortcode( 'input', $original_shortcode_callbacks );
+}

--- a/classes/views/frm-entries/form.php
+++ b/classes/views/frm-entries/form.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 global $shortcode_tags;
 
 // Store the current callbacks for the shortcode
-$original_shortcode_callbacks = isset( $shortcode_tags[ 'input' ] ) ? $shortcode_tags[ 'input' ] : false;
+$original_input_shortcode_callback = isset( $shortcode_tags['input'] ) ? $shortcode_tags['input'] : false;
 
 // Remove the shortcode
 remove_shortcode( 'input' );
@@ -151,6 +151,6 @@ if ( FrmForm::show_submit( $form ) && ! FrmSubmitHelper::has_submit_field_on_cur
 
 <?php
 // Add the shortcode back with the original callbacks
-if ( $original_shortcode_callbacks ) {
-	add_shortcode( 'input', $original_shortcode_callbacks );
+if ( $original_input_shortcode_callback ) {
+	add_shortcode( 'input', $original_input_shortcode_callback );
 }


### PR DESCRIPTION
Related Slack conversation https://strategy11.slack.com/archives/C799A2R61/p1731506429943149

Payment forms by Paystack has a global `input` shortcode, which is a pretty horrible practice 😅.

This update unregisters `[input]` before we render our form fields which rely on this internal shortcode. Then we re-apply it back after so it doesn't break Paystack.