### PR TITLE
Prepare for v6.16.1.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 == Changelog ==
+= 6.16.1.2 =
+* The tested to version was updated.
+
 = 6.16.1 =
 * New: Database queries for entry ID data have been optimized, removing a JOIN in cases where it is not required. This should significantly improve performance when searching for entries in a View.
 * Fix: Collapsible sections in the styler settings would no longer open after the recent WordPress 6.7 update.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: forms, form builder, survey, payment form, custom form, contact form, form
 Requires at least: 5.2
 Tested up to: 6.7
 Requires PHP: 7.0
-Stable tag: 6.16.1
+Stable tag: 6.16.1.2
 
 The most advanced WordPress forms plugin. Go beyond contact forms with our drag and drop form builder for surveys, quizzes, and more.
 
@@ -371,6 +371,9 @@ Using our Zapier integration, you can easily connect your website with over 5,00
 See all [Formidable Zapier Integrations](https://zapier.com/apps/formidable/integrations).
 
 == Changelog ==
+= 6.16.1.2 =
+* The tested to version was updated.
+
 = 6.16.1 =
 * New: Database queries for entry ID data have been optimized, removing a JOIN in cases where it is not required. This should significantly improve performance when searching for entries in a View.
 * Fix: Collapsible sections in the styler settings would no longer open after the recent WordPress 6.7 update.


### PR DESCRIPTION
It looks like I need a new stable tag to bump the tested to version now.