### PR TITLE
Make frm_after_delete_field hook safer

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4850,7 +4850,10 @@ function frmAdminBuildJS() {
 					// prevent "More Options" tooltips from staying around after their target field is deleted.
 					deleteTooltips();
 				});
-				wp.hooks.doAction( 'frm_after_delete_field', $thisField[0] );
+
+				if ( $thisField.length ) {
+					wp.hooks.doAction( 'frm_after_delete_field', $thisField[0] );
+				}
 			}
 		});
 	}


### PR DESCRIPTION
I noticed an error when I tried to bulk delete a group of fields that included a field I had just deleted.

<img width="1344" alt="Screen Shot 2024-11-15 at 4 52 22 PM" src="https://github.com/user-attachments/assets/0e552110-e3dd-4a6e-9b16-aad4ba9b32b5">
