### PR TITLE
Remove buttons settings tab

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1409,6 +1409,10 @@ class FrmFormsController {
 			),
 		);
 
+		if ( ! has_action( 'frm_add_form_style_tab_options' ) && ! has_action( 'frm_add_form_button_options' ) ) {
+			unset( $sections['buttons'] );
+		}
+
 		foreach ( array( 'landing', 'chat', 'abandonment' ) as $feature ) {
 			if ( ! FrmAppHelper::show_new_feature( $feature ) ) {
 				unset( $sections[ $feature ] );

--- a/classes/views/frm-forms/settings-buttons.php
+++ b/classes/views/frm-forms/settings-buttons.php
@@ -2,11 +2,20 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
+
+// Do not deprecate if the Pro version still use these hooks.
+$should_deprecate_hook = class_exists( 'FrmProDb' ) && version_compare( FrmProDb::$plug_version, '6.16.2' ) >= 0;
 ?>
 <input type="hidden" name="options[custom_style]" value="<?php echo esc_attr( $values['custom_style'] ); ?>" />
 
 <table class="form-table">
-	<?php do_action( 'frm_add_form_style_tab_options', $values ); ?>
+	<?php
+	if ( $should_deprecate_hook ) {
+		do_action_deprecated( 'frm_add_form_style_tab_options', compact( 'values' ), '6.16.2' );
+	} else {
+		do_action( 'frm_add_form_style_tab_options', $values );
+	}
+	?>
 	<tr>
 		<td colspan="2">
 			<h3><?php esc_html_e( 'Buttons', 'formidable' ); ?></h3>
@@ -19,5 +28,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</div>
 		</td>
 	</tr>
-	<?php do_action( 'frm_add_form_button_options', $values ); ?>
+	<?php
+	if ( $should_deprecate_hook ) {
+		do_action_deprecated( 'frm_add_form_button_options', compact( 'values' ), '6.16.2' );
+	} else {
+		do_action( 'frm_add_form_button_options', $values );
+	}
+	?>
 </table>


### PR DESCRIPTION
Related PR: https://github.com/Strategy11/formidable-pro/pull/5479

In the related PR, we won't use `frm_add_form_style_tab_options` and `frm_add_form_button_options` hooks to print hidden inputs anymore. If these hooks are still used by custom code, we will keep the Buttons settings tab, and show the deprecation notices. If these hooks aren't used, we remove the Buttons settings tab completely.