### PR TITLE
Update FrmAppHelper::is_form_builder_page to return true only on the form builder

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -314,7 +314,7 @@ class FrmAppHelper {
 	 * @return bool
 	 */
 	public static function is_form_builder_page( $check_for_settings = true ) {
-		$action = self::simple_get( 'frm_action', 'sanitize_title' );
+		$action        = self::simple_get( 'frm_action', 'sanitize_title' );
 		$check_actions = array( 'edit', 'duplicate' );
 		if ( $check_for_settings ) {
 			$check_actions[] = 'settings';


### PR DESCRIPTION
This updates makes sure `FrmAppHelper::is_form_builder_page` returns true only on the form builder page.