### PR TITLE
Pro issue 5418 / Use WordPress date and time settings for entry timestamp in edit/view entry sidebar

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2695,7 +2695,14 @@ class FrmAppHelper {
 		return $formatted;
 	}
 
-	private static function add_time_to_date( $time_format, $date ) {
+	/**
+	 * @since x.x This function was made public.
+	 *
+	 * @param string $time_format
+	 * @param string $date
+	 * @return string
+	 */
+	public static function add_time_to_date( $time_format, $date ) {
 		if ( empty( $time_format ) ) {
 			$time_format = get_option( 'time_format' );
 		}

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2696,13 +2696,11 @@ class FrmAppHelper {
 	}
 
 	/**
-	 * @since x.x This function was made public.
-	 *
 	 * @param string $time_format
 	 * @param string $date
 	 * @return string
 	 */
-	public static function add_time_to_date( $time_format, $date ) {
+	private static function add_time_to_date( $time_format, $date ) {
 		if ( empty( $time_format ) ) {
 			$time_format = get_option( 'time_format' );
 		}

--- a/classes/views/frm-entries/_sidebar-shared-pub.php
+++ b/classes/views/frm-entries/_sidebar-shared-pub.php
@@ -5,7 +5,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! isset( $entry ) ) {
 	$entry = $record;
-} ?>
+}
+?>
 
 <div class="misc-pub-section">
 	<?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_calendar_icon', array( 'aria-hidden' => 'true' ) ); ?>
@@ -25,8 +26,7 @@ if ( ! isset( $entry ) ) {
 		/* translators: %1$s: Entry status %2$s: The date */
 		esc_html__( '%1$s: %2$s', 'formidable' ),
 		esc_html( FrmEntriesHelper::get_entry_status_label( $entry->is_draft ) ),
-		// Here
-		'<b>' . esc_html( FrmAppHelper::get_localized_date( $date_format, $entry->created_at ) . FrmAppHelper::add_time_to_date( '', $entry->created_at ) ) . '</b>'
+		'<b>' . esc_html( FrmAppHelper::get_formatted_time( $entry->created_at, $date_format ) ) . '</b>'
 	);
 	?>
 	</span>
@@ -40,8 +40,7 @@ if ( ! isset( $entry ) ) {
 	printf(
 		/* translators: %1$s: The date */
 		esc_html__( 'Updated: %1$s', 'formidable' ),
-		// And here.
-		'<b>' . esc_html( FrmAppHelper::get_localized_date( $date_format, $entry->updated_at ) . FrmAppHelper::add_time_to_date( '', $entry->updated_at ) ) . '</b>'
+		'<b>' . esc_html( FrmAppHelper::get_formatted_time( $entry->updated_at, $date_format ) ) . '</b>'
 	);
 	?>
 	</span>

--- a/classes/views/frm-entries/_sidebar-shared-pub.php
+++ b/classes/views/frm-entries/_sidebar-shared-pub.php
@@ -11,12 +11,22 @@ if ( ! isset( $entry ) ) {
 	<?php FrmAppHelper::icon_by_class( 'frm_icon_font frm_calendar_icon', array( 'aria-hidden' => 'true' ) ); ?>
 	<span id="timestamp">
 	<?php
-	$date_format = __( 'M j, Y @ G:i', 'formidable' );
+
+	$date_format = get_option( 'date_format' );
+	if ( $date_format ) {
+		// Use short months since the sidebar space is limited.
+		$date_format = str_replace( 'F', 'M', $date_format );
+	} else {
+		// Fallback if there is no option in the database.
+		$date_format = __( 'M j, Y', 'formidable' );
+	}
+
 	printf(
 		/* translators: %1$s: Entry status %2$s: The date */
 		esc_html__( '%1$s: %2$s', 'formidable' ),
 		esc_html( FrmEntriesHelper::get_entry_status_label( $entry->is_draft ) ),
-		'<b>' . esc_html( FrmAppHelper::get_localized_date( $date_format, $entry->created_at ) ) . '</b>'
+		// Here
+		'<b>' . esc_html( FrmAppHelper::get_localized_date( $date_format, $entry->created_at ) . FrmAppHelper::add_time_to_date( '', $entry->created_at ) ) . '</b>'
 	);
 	?>
 	</span>
@@ -30,7 +40,8 @@ if ( ! isset( $entry ) ) {
 	printf(
 		/* translators: %1$s: The date */
 		esc_html__( 'Updated: %1$s', 'formidable' ),
-		'<b>' . esc_html( FrmAppHelper::get_localized_date( $date_format, $entry->updated_at ) ) . '</b>'
+		// And here.
+		'<b>' . esc_html( FrmAppHelper::get_localized_date( $date_format, $entry->updated_at ) . FrmAppHelper::add_time_to_date( '', $entry->updated_at ) ) . '</b>'
 	);
 	?>
 	</span>

--- a/tests/cypress/e2e/Entries/EntriesPageDataValidations.cy.js
+++ b/tests/cypress/e2e/Entries/EntriesPageDataValidations.cy.js
@@ -158,7 +158,7 @@ describe("Entries submitted from a form", () => {
         cy.get(':nth-child(2) > h3').should("contain", "Entry Details");
         cy.get('#timestamp')
             .invoke('text')
-            .should('match', /Submitted: [A-Za-z]{3} \d{1,2}, \d{4} @ \d{1,2}:\d{2}/);
+            .should('match', /Submitted: [A-Za-z]{3} \d{1,2}, \d{4} at \d{1,2}:\d{2} (am|pm)/);
         cy.get(':nth-child(2) > .inside > :nth-child(2)').should("contain", "Entry ID:");
         cy.log('Extract and trim the value after "Entry Key:')
         cy.get(':nth-child(2) > .inside > :nth-child(3)')


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5418

Now I'm using our more commonly used `get_formatted_time` function that adds the time data, and some custom logic for the date format (I change long month names to the short month name so if you have it set to show "November", it will show "Nov" instead to save space).

This generally uses the WordPress setting, and not our global setting in Pro, as the Pro settings are all formats like `Y/m/d` and `Y-m-d`, none of which look as good as the more verbose format options that you can use in the WordPress date setting.

The `@` is now `at` by default, but I think that's okay. It makes it more consistent with our other dates with times which is more important than the possible space saved.

**Using the following settings** _These are set at /wp-admin/options-general.php_
<img width="734" alt="Screen Shot 2024-11-19 at 12 36 36 PM" src="https://github.com/user-attachments/assets/10f4bb36-910c-4f53-92df-c2e5533c3f3c">

**Before**
<img width="350" alt="Screen Shot 2024-11-19 at 12 35 45 PM" src="https://github.com/user-attachments/assets/268697c7-6f99-4d86-81f6-b6b82af1ad2b">

**After**
<img width="355" alt="Screen Shot 2024-11-19 at 12 35 20 PM" src="https://github.com/user-attachments/assets/668346d3-a66f-4720-8aa7-e3d431779f98">
