### PR TITLE
Improve bulk form trash

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -766,6 +766,10 @@ class FrmFormsController {
 			}
 		}
 
+		if ( ! $count ) {
+			return '';
+		}
+
 		$current_page = FrmAppHelper::get_simple_request(
 			array(
 				'param' => 'form_type',

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -604,6 +604,10 @@ class FrmForm {
 			return false;
 		}
 
+		if ( $form->status === 'trash' ) {
+			return false;
+		}
+
 		$options               = $form->options;
 		$options['trash_time'] = time();
 


### PR DESCRIPTION
This exits early if it tries to trash a form that is already trash, and prevents it from showing a message again if you try to refresh the page.