### PR TITLE
Pro issue 5296 / stop decoding default values for non-array types

### DIFF
--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -1084,9 +1084,14 @@ class FrmField {
 
 		// Allow a single box to be checked for the default value.
 		$before = $results->default_value;
-		FrmAppHelper::unserialize_or_decode( $results->default_value );
-		if ( $before === $results->default_value && ! is_array( $before ) && strpos( $before, '["' ) === 0 ) {
-			$results->default_value = FrmAppHelper::maybe_json_decode( $results->default_value );
+
+		$field_object = FrmFieldFactory::get_field_type( $results->type );
+
+		if ( $field_object->should_unserialize_value() ) {
+			FrmAppHelper::unserialize_or_decode( $results->default_value );
+			if ( $before === $results->default_value && ! is_array( $before ) && strpos( $before, '["' ) === 0 ) {
+				$results->default_value = FrmAppHelper::maybe_json_decode( $results->default_value );
+			}
 		}
 	}
 

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -293,7 +293,12 @@ DEFAULT_HTML;
 
 		$field['html_name'] = $field_name;
 		$field['html_id']   = $html_id;
-		FrmAppHelper::unserialize_or_decode( $field['default_value'] );
+
+		$field_object = FrmFieldFactory::get_field_type( $field['type'] );
+
+		if ( $field_object->should_unserialize_value() ) {
+			FrmAppHelper::unserialize_or_decode( $field['default_value'] );
+		}
 
 		$display = $this->display_field_settings();
 		include $this->include_form_builder_file();

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -291,14 +291,9 @@ DEFAULT_HTML;
 		$html_id    = $this->html_id();
 		$read_only  = isset( $field['read_only'] ) ? $field['read_only'] : 0;
 
-		$field['html_name'] = $field_name;
-		$field['html_id']   = $html_id;
-
-		$field_object = FrmFieldFactory::get_field_type( $field['type'] );
-
-		if ( $field_object->should_unserialize_value() ) {
-			FrmAppHelper::unserialize_or_decode( $field['default_value'] );
-		}
+		$field['html_name']     = $field_name;
+		$field['html_id']       = $html_id;
+		$field['default_value'] = $this->maybe_decode_value( $field['default_value'] );
 
 		$display = $this->display_field_settings();
 		include $this->include_form_builder_file();

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1655,6 +1655,17 @@ DEFAULT_HTML;
 	}
 
 	/**
+	 * Only some field types should unserialize or decode values. This is based on the value of the array_allowed property.
+	 *
+	 * @since x.x
+	 *
+	 * @return bool
+	 */
+	public function should_unserialize_value() {
+		return $this->array_allowed;
+	}
+
+	/**
 	 * This function is deprecated since it has a typo in the name.
 	 *
 	 * @since 3.0


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5296