### PR TITLE
Allow arrays for radio type

### DIFF
--- a/classes/models/fields/FrmFieldRadio.php
+++ b/classes/models/fields/FrmFieldRadio.php
@@ -31,7 +31,7 @@ class FrmFieldRadio extends FrmFieldType {
 	/**
 	 * @var bool
 	 */
-	protected $array_allowed = false;
+	protected $array_allowed = true;
 
 	protected function input_html() {
 		return $this->multiple_input_html();


### PR DESCRIPTION
Since this is getting checked more aggressively, we want this property to be more leniant.

Checkboxes can be changed to Radio buttons, so it's possible we might run into array-like data that we want to decode for a radio button.