### PR TITLE
Allow word breaking on dashboard entries table

### DIFF
--- a/css/admin/dashboard.css
+++ b/css/admin/dashboard.css
@@ -259,6 +259,7 @@
 
 .frm-dashboard-widget table.wp-list-table td {
 	font-size: var(--text-sm);
+	word-break: break-word;
 }
 
 .frm-dashboard-widget table.wp-list-table td abbr {


### PR DESCRIPTION
I had a long entry, and it caused the table to pretty much break.