### PR TITLE
New duplicate check

### DIFF
--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -51,8 +51,7 @@ class FrmEntry {
 			return false;
 		}
 
-		$is_duplicate = self::maybe_check_for_unique_id_match( $new_values['created_at'] );
-		if ( $is_duplicate ) {
+		if ( self::maybe_check_for_unique_id_match( $new_values['created_at'] ) ) {
 			return true;
 		}
 

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -47,6 +47,13 @@ class FrmEntry {
 	public static function is_duplicate( $new_values, $values ) {
 		$duplicate_entry_time = apply_filters( 'frm_time_to_check_duplicates', 60, $new_values );
 
+		if ( 60 === $duplicate_entry_time ) {
+			$unique_id = FrmAppHelper::get_post_param( 'unique_id', '', 'sanitize_key' );
+			if ( $unique_id && FrmDb::get_var( 'frm_item_metas', array( 'field_id' => 0, 'meta_value' => serialize( compact( 'unique_id' ) ) ), 'id' ) ) {
+				$duplicate_entry_time = MONTH_IN_SECONDS;
+			}
+		}
+
 		if ( false === self::is_duplicate_check_needed( $values, $duplicate_entry_time ) ) {
 			return false;
 		}
@@ -80,6 +87,9 @@ class FrmEntry {
 			$metas       = FrmEntryMeta::get_entry_meta_info( $entry_exist );
 			$field_metas = array();
 			foreach ( $metas as $meta ) {
+				if ( 0 === (int) $meta->field_id ) {
+					continue;
+				}
 				$field_metas[ $meta->field_id ] = $meta->meta_value;
 			}
 

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -51,7 +51,7 @@ class FrmEntry {
 			return false;
 		}
 
-		$duplicate_entry_time = self::maybe_extend_duplicate_entry_time( $duplicate_entry_time );
+		$duplicate_entry_time = self::maybe_extend_duplicate_entry_time( $duplicate_entry_time, $new_values['created_at'] );
 
 		$check_val                 = $new_values;
 		$check_val['created_at >'] = gmdate( 'Y-m-d H:i:s', strtotime( $new_values['created_at'] ) - absint( $duplicate_entry_time ) );
@@ -131,10 +131,11 @@ class FrmEntry {
 	/**
 	 * @since x.x
 	 *
-	 * @param int $duplicate_entry_time
+	 * @param int    $duplicate_entry_time
+	 * @param string $created_at
 	 * @return int
 	 */
-	private static function maybe_extend_duplicate_entry_time( $duplicate_entry_time ) {
+	private static function maybe_extend_duplicate_entry_time( $duplicate_entry_time, $created_at ) {
 		if ( 60 !== $duplicate_entry_time ) {
 			return $duplicate_entry_time;
 		}
@@ -149,7 +150,7 @@ class FrmEntry {
 			array(
 				'field_id'     => 0,
 				'meta_value'   => serialize( compact( 'unique_id' ) ),
-				'created_at >' => gmdate( 'Y-m-d H:i:s', strtotime( $new_values['created_at'] ) - MONTH_IN_SECONDS ),
+				'created_at >' => gmdate( 'Y-m-d H:i:s', strtotime( $created_at ) - MONTH_IN_SECONDS ),
 			),
 			'id'
 		);

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -147,12 +147,17 @@ class FrmEntry {
 			return $duplicate_entry_time;
 		}
 
+		$timestamp = strtotime( $created_at );
+		if ( false === $timestamp ) {
+			$timestamp = time();
+		}
+
 		$unique_id_match = FrmDb::get_var(
 			'frm_item_metas',
 			array(
 				'field_id'     => 0,
 				'meta_value'   => serialize( compact( 'unique_id' ) ),
-				'created_at >' => gmdate( 'Y-m-d H:i:s', strtotime( $created_at ) - MONTH_IN_SECONDS ),
+				'created_at >' => gmdate( 'Y-m-d H:i:s', $timestamp - MONTH_IN_SECONDS ),
 			),
 			'id'
 		);

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -137,11 +137,13 @@ class FrmEntry {
 	 */
 	private static function maybe_extend_duplicate_entry_time( $duplicate_entry_time, $created_at ) {
 		if ( 60 !== $duplicate_entry_time ) {
+			// Only check if the time has not been filtered.
 			return $duplicate_entry_time;
 		}
 
 		$unique_id = FrmAppHelper::get_post_param( 'unique_id', '', 'sanitize_key' );
 		if ( ! $unique_id ) {
+			// Only continue if a unique ID was generated on form submit.
 			return $duplicate_entry_time;
 		}
 
@@ -154,11 +156,9 @@ class FrmEntry {
 			),
 			'id'
 		);
-		if ( ! $unique_id_match ) {
-			return $duplicate_entry_time;
-		}
 
-		return MONTH_IN_SECONDS;
+		// Extend the check to a month when unique ID is detected.
+		return $unique_id_match ? MONTH_IN_SECONDS : $duplicate_entry_time;
 	}
 
 	/**

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -141,6 +141,18 @@ class FrmEntry {
 			return $duplicate_entry_time;
 		}
 
+		/**
+		 * Allow users to opt out of the DB query, in case it causes performance issues.
+		 *
+		 * @since x.x
+		 *
+		 * @param bool $should_extend
+		 */
+		$should_extend = apply_filters( 'frm_extend_duplicate_entry_time_on_unique_id_match', true );
+		if ( ! $should_extend ) {
+			return $duplicate_entry_time;
+		}
+
 		$unique_id = FrmAppHelper::get_post_param( 'unique_id', '', 'sanitize_key' );
 		if ( ! $unique_id ) {
 			// Only continue if a unique ID was generated on form submit.

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -134,7 +134,6 @@ class FrmEntry {
 	/**
 	 * @since x.x
 	 *
-	 * @param int    $duplicate_entry_time
 	 * @param string $created_at
 	 * @return int
 	 */

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -134,18 +134,10 @@ class FrmEntry {
 	 * @since x.x
 	 *
 	 * @param string $created_at
-	 * @return int
+	 * @return false|int
 	 */
 	private static function maybe_check_for_unique_id_match( $created_at ) {
-		/**
-		 * Allow users to opt out of the DB query, in case it causes performance issues.
-		 *
-		 * @since x.x
-		 *
-		 * @param bool $should_extend
-		 */
-		$should_check = apply_filters( 'frm_check_for_unique_id_match', true );
-		if ( ! $should_check ) {
+		if ( ! self::should_check_for_unique_id_match() ) {
 			return false;
 		}
 
@@ -171,6 +163,21 @@ class FrmEntry {
 		);
 
 		return (bool) $unique_id_match;
+	}
+
+	/**
+	 * @since x.x
+	 */
+	public static function should_check_for_unique_id_match() {
+		/**
+		 * Allow users to opt out of the DB query, in case it causes performance issues.
+		 *
+		 * @since x.x
+		 *
+		 * @param bool $should_extend
+		 */
+		$should_check = apply_filters( 'frm_check_for_unique_id_match', true );
+		return (bool) $should_check;
 	}
 
 	/**

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -47,15 +47,26 @@ class FrmEntry {
 	public static function is_duplicate( $new_values, $values ) {
 		$duplicate_entry_time = apply_filters( 'frm_time_to_check_duplicates', 60, $new_values );
 
-		if ( 60 === $duplicate_entry_time ) {
-			$unique_id = FrmAppHelper::get_post_param( 'unique_id', '', 'sanitize_key' );
-			if ( $unique_id && FrmDb::get_var( 'frm_item_metas', array( 'field_id' => 0, 'meta_value' => serialize( compact( 'unique_id' ) ) ), 'id' ) ) {
-				$duplicate_entry_time = MONTH_IN_SECONDS;
-			}
-		}
-
 		if ( false === self::is_duplicate_check_needed( $values, $duplicate_entry_time ) ) {
 			return false;
+		}
+
+		if ( 60 === $duplicate_entry_time ) {
+			$unique_id = FrmAppHelper::get_post_param( 'unique_id', '', 'sanitize_key' );
+			if ( $unique_id ) {
+				$unique_id_match = FrmDb::get_var(
+					'frm_item_metas',
+					array(
+						'field_id'     => 0,
+						'meta_value'   => serialize( compact( 'unique_id' ) ),
+						'created_at >' => gmdate( 'Y-m-d H:i:s', strtotime( $new_values['created_at'] ) - MONTH_IN_SECONDS ),
+					),
+					'id'
+				);
+				if ( $unique_id_match ) {
+					$duplicate_entry_time = MONTH_IN_SECONDS;
+				}
+			}
 		}
 
 		$check_val                 = $new_values;

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -170,7 +170,6 @@ class FrmEntry {
 			'id'
 		);
 
-		// Extend the check to a month when unique ID is detected.
 		return (bool) $unique_id_match;
 	}
 

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -134,7 +134,7 @@ class FrmEntry {
 	 * @since x.x
 	 *
 	 * @param string $created_at
-	 * @return false|int
+	 * @return bool
 	 */
 	private static function maybe_check_for_unique_id_match( $created_at ) {
 		if ( ! self::should_check_for_unique_id_match() ) {

--- a/classes/models/FrmEntryMeta.php
+++ b/classes/models/FrmEntryMeta.php
@@ -125,8 +125,10 @@ class FrmEntryMeta {
 			'field_id'
 		);
 
+		// This unique ID is inserted with JS on form submit.
+		// It is used to check for duplicate entries.
 		$unique_id = FrmAppHelper::get_post_param( 'unique_id', '', 'sanitize_key' );
-		if ( $unique_id ) {
+		if ( $unique_id && FrmEntry::should_check_for_unique_id_match() ) {
 			self::add_entry_meta( $entry_id, 0, '', compact( 'unique_id' ) );
 		}
 

--- a/classes/models/FrmEntryMeta.php
+++ b/classes/models/FrmEntryMeta.php
@@ -125,6 +125,11 @@ class FrmEntryMeta {
 			'field_id'
 		);
 
+		$unique_id = FrmAppHelper::get_post_param( 'unique_id', '', 'sanitize_key' );
+		if ( $unique_id ) {
+			self::add_entry_meta( $entry_id, 0, '', compact( 'unique_id' ) );
+		}
+
 		$values_indexed_by_field_id = array();
 		foreach ( $values as $field_id_or_key => $meta_value ) {
 			$field_id = $field_id_or_key;

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1602,8 +1602,7 @@ function frmFrontFormJS() {
 	function getUniqueKey() {
 		return Array.from( window.crypto.getRandomValues( new Uint8Array( 8 ) ) )
 			.map( b => b.toString( 16 ).padStart( 2, '0' ) )
-			.join( '' )
-			.substring( 0, 9 );
+			.join( '' );
 	}
 
 	return {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1740,6 +1740,12 @@ function frmFrontFormJS() {
 				object.appendChild( antispamInput );
 			}
 
+			const uniqueIDInput = document.createElement( 'input' );
+			uniqueIDInput.type  = 'hidden';
+			uniqueIDInput.name  = 'unique_id';
+			uniqueIDInput.value = Math.random().toString( 36 ).substring( 2, 11 );
+			object.appendChild( uniqueIDInput );
+
 			if ( classList.indexOf( 'frm_ajax_submit' ) > -1 ) {
 				hasFileFields = jQuery( object ).find( 'input[type="file"]' ).filter( function() {
 					return !! this.value;

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1600,8 +1600,8 @@ function frmFrontFormJS() {
 	 * @return {string}
 	 */
 	function getUniqueKey() {
-		return Array.from( window.crypto.getRandomValues( new Uint8Array(8 ) ) )
-			.map( b => b.toString(16).padStart( 2, '0' ) )
+		return Array.from( window.crypto.getRandomValues( new Uint8Array( 8 ) ) )
+			.map( b => b.toString( 16 ).padStart( 2, '0' ) )
 			.join( '' )
 			.substring( 0, 9 );
 	}

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1594,6 +1594,18 @@ function frmFrontFormJS() {
 		window.hcaptcha = null;
 	}
 
+	/**
+	 * @since x.x
+	 *
+	 * @return {string}
+	 */
+	function getUniqueKey() {
+		return Array.from( window.crypto.getRandomValues( new Uint8Array(8 ) ) )
+			.map( b => b.toString(16).padStart( 2, '0' ) )
+			.join( '' )
+			.substring( 0, 9 );
+	}
+
 	return {
 		init: function() {
 			jQuery( document ).off( 'submit.formidable', '.frm-show-form' );
@@ -1740,10 +1752,11 @@ function frmFrontFormJS() {
 				object.appendChild( antispamInput );
 			}
 
+			// Add a unique ID, used for duplicate checks.
 			const uniqueIDInput = document.createElement( 'input' );
 			uniqueIDInput.type  = 'hidden';
 			uniqueIDInput.name  = 'unique_id';
-			uniqueIDInput.value = Math.random().toString( 36 ).substring( 2, 11 );
+			uniqueIDInput.value = getUniqueKey();
 			object.appendChild( uniqueIDInput );
 
 			if ( classList.indexOf( 'frm_ajax_submit' ) > -1 ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1597,7 +1597,7 @@ function frmFrontFormJS() {
 	/**
 	 * @since x.x
 	 *
-	 * @return {string}
+	 * @return {string} Unique key, used for duplicate checks.
 	 */
 	function getUniqueKey() {
 		return Array.from( window.crypto.getRandomValues( new Uint8Array( 8 ) ) )


### PR DESCRIPTION
**Related ticket** https://secure.helpscout.net/conversation/2765614867/215349/

**The issue**
Reopening a page on an iPhone re-submits the POST request. Our duplicate check defaults to 60 seconds, but it's likely someone will open a page again hours later, maybe even days later.

**The solution**
I'm adding a unique string that gets added right before the form is submitted.

If this string is detected, it is checked in the duplicate check, and saved to entry meta under field 0, serialized as an array like `a:1:{s:9:"unique_id";s:9:"a34d2ypgn";}`.

When this exact item meta row is detected, during the duplicate check, it will return true immediately if there is a match.

The refresh events don't re-trigger the JavaScript, so all of these requests will send the same unique string.

**Pre-release**
[formidable-6.16.3b.zip](https://github.com/user-attachments/files/17909053/formidable-6.16.3b.zip)

**To opt out** _In case the database query causes performance issues_
```
add_filter( 'frm_extend_duplicate_entry_time_on_unique_id_match', '__return_false' );
```

_**This has been confirmed by the customer**_