### PR TITLE
Strip unexpected characters from CSS output var names

### DIFF
--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -445,9 +445,19 @@ class FrmStylesHelper {
 			}
 			$show = empty( $defaults ) || ( $settings[ $var ] !== '' && $settings[ $var ] !== $defaults[ $var ] );
 			if ( $show ) {
-				echo '--' . esc_html( str_replace( '_', '-', $var ) ) . ':' . self::css_var_prepare_value( $settings, $var ) . ';'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo '--' . esc_html( self::clean_var_name( str_replace( '_', '-', $var ) ) ) . ':' . self::css_var_prepare_value( $settings, $var ) . ';'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 		}
+	}
+
+	/**
+	 * Remove anything that isn't used as a CSS variable name.
+	 *
+	 * @param string $var_name
+	 * @return string
+	 */
+	private static function clean_var_name( $var_name ) {
+		return preg_replace( '/[^a-zA-Z0-9_-]/', '', $var_name );
 	}
 
 	/**


### PR DESCRIPTION
Related Slack conversation https://strategy11.slack.com/archives/C799A2R61/p1732218176807229

This should help prevent broken CSS issues.