### PR TITLE
Fix issue with custom style getting unset on form settings update

### DIFF
--- a/classes/views/frm-forms/settings-advanced.php
+++ b/classes/views/frm-forms/settings-advanced.php
@@ -120,6 +120,8 @@ FrmTipsHelper::pro_tip( 'get_form_settings_tip', 'p' );
 	</tr>
 </table>
 
+<input type="hidden" name="options[custom_style]" value="<?php echo esc_attr( $values['custom_style'] ); ?>" />
+
 <!--Permissions Section-->
 <?php
 do_action( 'frm_add_form_perm_options', $values );

--- a/classes/views/frm-forms/settings-buttons.php
+++ b/classes/views/frm-forms/settings-buttons.php
@@ -6,7 +6,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Do not deprecate if the Pro version still use these hooks.
 $should_deprecate_hook = ! class_exists( 'FrmProDb' ) || version_compare( FrmProDb::$plug_version, '6.16.3' ) >= 0;
 ?>
-<input type="hidden" name="options[custom_style]" value="<?php echo esc_attr( $values['custom_style'] ); ?>" />
 
 <table class="form-table">
 	<?php


### PR DESCRIPTION
This input is on a page that is now getting unset.

I noticed my styles would get disabled after saving form settings after merging https://github.com/Strategy11/formidable-forms/pull/2115/files