### PR TITLE
Deprecate more code

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -543,7 +543,6 @@ class FrmAppController {
 	public static function remove_upsells() {
 		remove_action( 'frm_before_settings', 'FrmSettingsController::license_box' );
 		remove_action( 'frm_after_settings', 'FrmSettingsController::settings_cta' );
-		remove_action( 'frm_add_form_style_tab_options', 'FrmFormsController::add_form_style_tab_options' );
 		remove_action( 'frm_after_field_options', 'FrmFormsController::logic_tip' );
 	}
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1982,16 +1982,6 @@ class FrmFormsController {
 	}
 
 	/**
-	 * Education for premium features.
-	 *
-	 * @since 4.05
-	 * @return void
-	 */
-	public static function add_form_style_tab_options() {
-		include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/add_form_style_options.php';
-	}
-
-	/**
 	 * Add education about views.
 	 *
 	 * @since 4.07
@@ -3276,5 +3266,17 @@ class FrmFormsController {
 	public static function create( $values = array() ) {
 		_deprecated_function( __METHOD__, '4.0', 'FrmFormsController::update' );
 		self::update( $values );
+	}
+
+	/**
+	 * Education for premium features.
+	 *
+	 * @since 4.05
+	 * @deprecated x.x
+	 *
+	 * @return void
+	 */
+	public static function add_form_style_tab_options() {
+		include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/add_form_style_options.php';
 	}
 }

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -3277,6 +3277,7 @@ class FrmFormsController {
 	 * @return void
 	 */
 	public static function add_form_style_tab_options() {
+		_deprecated_function( __METHOD__, 'x.x' );
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/add_form_style_options.php';
 	}
 }

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -136,8 +136,8 @@ class FrmHooksController {
 		// Form Actions Controller.
 		if ( FrmAppHelper::is_admin_page( 'formidable' ) ) {
 			add_action( 'frm_before_update_form_settings', 'FrmFormActionsController::update_settings' );
-			add_action( 'frm_add_form_style_tab_options', 'FrmFormsController::add_form_style_tab_options' );
 		}
+
 		add_action( 'frm_after_duplicate_form', 'FrmFormActionsController::duplicate_form_actions', 20, 3 );
 
 		// Forms Controller.

--- a/classes/views/frm-forms/add_form_style_options.php
+++ b/classes/views/frm-forms/add_form_style_options.php
@@ -2,11 +2,4 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
-?>
-<tr>
-	<td colspan="2">
-		<div class="frm_note_style" style="margin-top: 0;">
-			<?php esc_html_e( 'Page Turn Transitions setting was moved to the page break field settings in the form builder.', 'formidable' ); ?>
-		</div>
-	</td>
-</tr>
+_deprecated_file( esc_html( basename( __FILE__ ) ), 'x.x' );


### PR DESCRIPTION
This `frm_add_form_style_tab_options` hook is now deprecated.

This update stops calling `FrmFormsController::add_form_style_tab_options` on this hook.

I also deprecated and cleared out the view file it renders.