### PR TITLE
Fix fatal error when field options is a string fix

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -2110,7 +2110,7 @@ class FrmFieldsHelper {
 	 * @return array
 	 */
 	public static function convert_field_object_to_flat_array( $field ) {
-		$field_options = $field->field_options;
+		$field_options = is_array( $field->field_options ) ? $field->field_options : array();
 		$field_array   = get_object_vars( $field );
 		unset( $field_array['field_options'] );
 


### PR DESCRIPTION
**Related ticket** https://secure.helpscout.net/conversation/2774027191/216280

**Pre-release**
[formidable-6.16.3b.zip](https://github.com/user-attachments/files/17925759/formidable-6.16.3b.zip)

> Unsupported operand types: array + string in /var/web/site/public_html/wp-content/plugins/formidable/classes/helpers/FrmFieldsHelper.php:2117 PHP Stacktrace: 