### PR TITLE
Add more global settings to usage tracking

### DIFF
--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -206,9 +206,12 @@ class FrmUsage {
 			'menu',
 			'mu_menu',
 			'no_ips',
+			'custom_header_ip',
 			'btsp_css',
 			'btsp_errors',
 			'admin_bar',
+			'summary_emails',
+			'active_captcha',
 		);
 
 		foreach ( $pass_settings as $setting ) {


### PR DESCRIPTION
While working on setting up some metabase examples, I noticed a few things we weren't tracking.

- Captcha Type
- Whether Summary Emails is enabled
- Whether the Customer Header IPs setting is enabled

@truongwp This probably requires some changes in the other repo as well. I could use your help getting that updated.