### PR TITLE
Unschedule send usage event if it is disabled

### DIFF
--- a/classes/controllers/FrmUsageController.php
+++ b/classes/controllers/FrmUsageController.php
@@ -26,7 +26,16 @@ class FrmUsageController {
 	 * @return void
 	 */
 	public static function schedule_send() {
-		if ( wp_next_scheduled( 'formidable_send_usage' ) ) {
+		$timestamp = wp_next_scheduled( 'formidable_send_usage' );
+		if ( ! self::tracking_allowed() ) {
+			if ( $timestamp ) {
+				// Remove the scheduled event if it's not allowed and it's scheduled.
+				wp_unschedule_event( $timestamp, 'formidable_send_usage' );
+			}
+			return;
+		}
+
+		if ( $timestamp ) {
 			return;
 		}
 
@@ -54,6 +63,18 @@ class FrmUsageController {
 			'display'  => __( 'Once Weekly', 'formidable' ),
 		);
 		return $schedules;
+	}
+
+	/**
+	 * Checks if tracking is allowed.
+	 *
+	 * @since x.x
+	 *
+	 * @return bool
+	 */
+	public static function tracking_allowed() {
+		$settings = FrmAppHelper::get_settings();
+		return $settings->tracking;
 	}
 
 	/**

--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -448,8 +448,7 @@ class FrmUsage {
 	 * @return bool
 	 */
 	private function tracking_allowed() {
-		$settings = FrmAppHelper::get_settings();
-		return $settings->tracking;
+		return FrmUsageController::tracking_allowed();
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/4291

To test, you can use the WP Crontrol to see the list of scheduled events, turn on and off the Send usage feature in the Miscellaneous tab in the Global settings and check if the `formidable_send_usage` event is added or removed.