### PR TITLE
Load lang on init hook

### DIFF
--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -59,8 +59,10 @@ class FrmHooksController {
 	 * @return void
 	 */
 	public static function load_hooks() {
+		// Use 0 so this gets triggered before FrmFormActionsController::register_post_types.
+		add_action( 'init', 'FrmAppController::load_lang', 0 );
+
 		add_action( 'rest_api_init', 'FrmAppController::create_rest_routes', 0 );
-		add_action( 'init', 'FrmAppController::load_lang', 0 ); // Use 0 so this gets triggered before FrmFormActionsController::register_post_types.
 		add_filter( 'widget_text', 'do_shortcode' );
 
 		// Entries controller.

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -60,7 +60,7 @@ class FrmHooksController {
 	 */
 	public static function load_hooks() {
 		add_action( 'rest_api_init', 'FrmAppController::create_rest_routes', 0 );
-		add_action( 'plugins_loaded', 'FrmAppController::load_lang' );
+		add_action( 'init', 'FrmAppController::load_lang', 0 ); // Use 0 so this gets triggered before FrmFormActionsController::register_post_types.
 		add_filter( 'widget_text', 'do_shortcode' );
 
 		// Entries controller.

--- a/tests/phpunit/misc/test_FrmMisc.php
+++ b/tests/phpunit/misc/test_FrmMisc.php
@@ -14,7 +14,7 @@ class test_FrmMisc extends FrmUnitTest {
 		$this->assertTrue( isset( $frm_vars['load_css'] ) );
 		$this->assertTrue( isset( $frm_vars['pro_is_authorized'] ) );
 
-		$this->assertNotEmpty( has_action( 'plugins_loaded', 'FrmAppController::load_lang' ) );
+		$this->assertNotEmpty( has_action( 'init', 'FrmAppController::load_lang' ) );
 	}
 
 	/**

--- a/tests/phpunit/misc/test_FrmMisc.php
+++ b/tests/phpunit/misc/test_FrmMisc.php
@@ -7,7 +7,6 @@ class test_FrmMisc extends FrmUnitTest {
 
 	/**
 	 * @covers ::load_formidable_forms
-	 * @group mike
 	 */
 	public function test_load_formidable_forms() {
 		global $frm_vars;

--- a/tests/phpunit/misc/test_FrmMisc.php
+++ b/tests/phpunit/misc/test_FrmMisc.php
@@ -7,6 +7,7 @@ class test_FrmMisc extends FrmUnitTest {
 
 	/**
 	 * @covers ::load_formidable_forms
+	 * @group mike
 	 */
 	public function test_load_formidable_forms() {
 		global $frm_vars;
@@ -14,7 +15,7 @@ class test_FrmMisc extends FrmUnitTest {
 		$this->assertTrue( isset( $frm_vars['load_css'] ) );
 		$this->assertTrue( isset( $frm_vars['pro_is_authorized'] ) );
 
-		$this->assertNotEmpty( has_action( 'init', 'FrmAppController::load_lang' ) );
+		$this->assertSame( 0, has_action( 'init', 'FrmAppController::load_lang' ) );
 	}
 
 	/**


### PR DESCRIPTION
Related WP update https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/

After reading into this, it sounds like `init` is the right hook, not `plugins_loaded`, for loading translations.

I used `0` here because translations need to load before we register form actions.