### PR TITLE
Improve support for null when preparing esc value

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1088,6 +1088,9 @@ DEFAULT_HTML;
 	 */
 	protected function prepare_esc_value() {
 		$value = $this->field['value'];
+		if ( is_null( $value ) ) {
+			return '';
+		}
 		if ( is_array( $value ) ) {
 			$value = implode( ', ', $value );
 		}


### PR DESCRIPTION
Fixes this message I was seeing in my logs.

> PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/src/wp-content/plugins/formidable/classes/models/fields/FrmFieldType.php on line 1094
