### PR TITLE
Memoize unique match result and stop adding meta for repeater entries

### DIFF
--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -7,6 +7,8 @@ class FrmEntry {
 
 	/**
 	 * @since x.x
+	 *
+	 * @var array
 	 */
 	private static $unique_id_match_checks = array();
 

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -53,7 +53,7 @@ class FrmEntry {
 	 * @param string $unique_id
 	 * @return void
 	 */
-	public static function flag_new_unique_key( $unique_id ) {
+	private static function flag_new_unique_key( $unique_id ) {
 		if ( ! isset( self::$unique_id_match_checks[ $unique_id ] ) ) {
 			self::$unique_id_match_checks[ $unique_id ] = false;
 		}

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -197,7 +197,7 @@ class FrmEntry {
 	/**
 	 * @since x.x
 	 */
-	public static function should_check_for_unique_id_match() {
+	private static function should_check_for_unique_id_match() {
 		/**
 		 * Allow users to opt out of the DB query, in case it causes performance issues.
 		 *
@@ -996,7 +996,7 @@ class FrmEntry {
 	 * @return void
 	 */
 	private static function maybe_add_unique_id_meta( $values, $entry_id ) {
-		if ( ! empty( $values['parent_form_id'] ) || empty( $values['unique_id'] ) || ! FrmEntry::should_check_for_unique_id_match() ) {
+		if ( ! empty( $values['parent_form_id'] ) || empty( $values['unique_id'] ) || ! self::should_check_for_unique_id_match() ) {
 			return;
 		}
 

--- a/classes/models/FrmEntryMeta.php
+++ b/classes/models/FrmEntryMeta.php
@@ -125,13 +125,6 @@ class FrmEntryMeta {
 			'field_id'
 		);
 
-		// This unique ID is inserted with JS on form submit.
-		// It is used to check for duplicate entries.
-		$unique_id = FrmAppHelper::get_post_param( 'unique_id', '', 'sanitize_key' );
-		if ( $unique_id && FrmEntry::should_check_for_unique_id_match() ) {
-			self::add_entry_meta( $entry_id, 0, '', compact( 'unique_id' ) );
-		}
-
 		$values_indexed_by_field_id = array();
 		foreach ( $values as $field_id_or_key => $meta_value ) {
 			$field_id = $field_id_or_key;


### PR DESCRIPTION
This fixes an issue with repeater entries failing to validate after merging the new unique ID validation check.