### PR TITLE
Drop padding top firefox-specific style

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -8995,16 +8995,6 @@ Responsive Design
 	}
 }
 
-/* Firefox */
-@-moz-document url-prefix() {
-	.frm-white-body .tablenav select,
-	.frm-white-body .tablenav input[type="text"],
-	.wp-admin .frm_wrap .tablenav select,
-	.frm_wrap .tablenav input[type="text"] {
-		padding-top: 5px;
-	}
-}
-
 /* PRINT */
 @media print {
 	a, .misc-pub-section a {


### PR DESCRIPTION
The pagination inputs are all off because of this padding. The bulk action dropdown also looks better without this rule.

It looks like this was added in v6.0. I'm not sure what it was trying to fix, but I don't think we need this, and having Firefox-specific styles isn't something we really want either.