### PR TITLE
Remove some code that does nothing

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -792,16 +792,12 @@ function frmFrontFormJS() {
 	}
 
 	/**
-	 * @param {HTMLElement}      object
-	 * @param {string|undefined} action
+	 * @param {HTMLElement} object
+	 * @param {string}      action
 	 * @return {void}
 	 */
 	function getFormErrors( object, action ) {
 		let fieldset, data, success, error, shouldTriggerEvent;
-
-		if ( typeof action === 'undefined' ) {
-			jQuery( object ).find( 'input[name="frm_action"]' ).val();
-		}
 
 		fieldset = jQuery( object ).find( '.frm_form_field' );
 		fieldset.addClass( 'frm_doing_ajax' );


### PR DESCRIPTION
I noticed this while trying to replace jQuery code. This line isn't required at all.

This logic should have been setting `action =`, but instead just gets the value and does nothing with it.

Since this has always been this way, I don't think we need this code. This function is really only called by `checkFormErrors` which isn't referenced in our documentation or other plugins, and it uses the same logic more-or-less to get the action before it gets sent to this function.