### PR TITLE
Deprecate old JS functions

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1962,11 +1962,21 @@ function frmFrontFormJS() {
 				.replace( /'/g, '&#039;' );
 		},
 
+		/**
+		 * This function was used in old back end code in v2.0.
+		 */
 		invisible: function( classes ) {
+			// TODO: Deprecate this.
+			console.warn( 'DEPRECATED: function frmFrontForm.invisible in vx.x' );
 			jQuery( classes ).css( 'visibility', 'hidden' );
 		},
 
+		/**
+		 * This function was used in old back end code in v2.0.
+		 */
 		visible: function( classes ) {
+			// TODO: Deprecate this.
+			console.warn( 'DEPRECATED: function frmFrontForm.visible in vx.x' );
 			jQuery( classes ).css( 'visibility', 'visible' );
 		},
 

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1964,18 +1964,22 @@ function frmFrontFormJS() {
 
 		/**
 		 * This function was used in old back end code in v2.0.
+		 *
+		 * @param {string} classes
+		 * @return {void}
 		 */
 		invisible: function( classes ) {
-			// TODO: Deprecate this.
 			console.warn( 'DEPRECATED: function frmFrontForm.invisible in vx.x' );
 			jQuery( classes ).css( 'visibility', 'hidden' );
 		},
 
 		/**
 		 * This function was used in old back end code in v2.0.
+		 *
+		 * @param {string} classes
+		 * @return {void}
 		 */
 		visible: function( classes ) {
-			// TODO: Deprecate this.
 			console.warn( 'DEPRECATED: function frmFrontForm.visible in vx.x' );
 			jQuery( classes ).css( 'visibility', 'visible' );
 		},


### PR DESCRIPTION
I could only find references to this in old Lite code (pre 3.0). It looks like it was really used to toggle elements in the back end.

I think we should be good to remove these functions. For now, I'm deprecating them just in case.