### PR TITLE
Remove jquery when validating on change

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -276,7 +276,8 @@ function frmFrontFormJS() {
 		if ( field.type === 'url' ) {
 			maybeAddHttpToUrl( field );
 		}
-		if ( jQuery( field ).closest( 'form' ).hasClass( 'frm_js_validate' ) ) {
+		const form = field.closest( 'form' );
+		if ( form && hasClass( form, 'frm_js_validate' ) ) {
 			validateField( field );
 		}
 	}


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5002

This removes a reference to `.closest()` and `.hasClass`.