### PR TITLE
Drop unused vars minus icons and arrow icons

### DIFF
--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -11,8 +11,6 @@ FrmStylesPreviewHelper::get_additional_preview_style( $settings, $is_loaded_via_
 
 $important = empty( $important_style ) ? '' : ' !important';
 
-$minus_icons   = FrmStylesHelper::minus_icons();
-$arrow_icons   = FrmStylesHelper::arrow_icons();
 $submit_bg_img = FrmStylesHelper::get_submit_image_bg_url( $settings );
 $use_chosen_js = FrmStylesHelper::use_chosen_js();
 


### PR DESCRIPTION
These were referenced when we were using font icons on the front end.

When we removed the references, the variables were left behind.