### PR TITLE
Drop references to old class frm_dashicon_font

### DIFF
--- a/css/font_icons.css
+++ b/css/font_icons.css
@@ -15,8 +15,7 @@
 }
 
 .frmfont,
-.frm_icon_font,
-.frm_dashicon_font{
+.frm_icon_font{
 	text-decoration:none;
 	text-shadow: none;
 	font-weight:normal;
@@ -57,8 +56,7 @@ a.frm_icon_font:hover{
 }
 
 .frmfont:focus,
-.frm_icon_font:focus,
-.frm_dashicon_font:focus{
+.frm_icon_font:focus{
 	box-shadow:none;
 }
 


### PR DESCRIPTION
It looks like this hasn't been referenced in a long time.