### PR TITLE
Drop old references to use HTML and jQuery CSS settings

### DIFF
--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -8,8 +8,6 @@ class FrmSettings {
 	public $option_name = 'frm_options';
 	public $menu;
 	public $mu_menu;
-	public $use_html;
-	public $jquery_css;
 	public $accordion_js;
 	public $fade_form;
 	public $old_css;
@@ -136,8 +134,6 @@ class FrmSettings {
 		return array(
 			'menu'                      => apply_filters( 'frm_default_menu', 'Formidable' ),
 			'mu_menu'                   => 0,
-			'use_html'                  => true,
-			'jquery_css'                => false,
 			'accordion_js'              => false,
 			'fade_form'                 => false,
 			'old_css'                   => false,
@@ -406,7 +402,7 @@ class FrmSettings {
 		$this->from_email        = $params['frm_from_email'];
 		$this->currency          = $params['frm_currency'];
 
-		$checkboxes = array( 'mu_menu', 're_multi', 'use_html', 'jquery_css', 'accordion_js', 'fade_form', 'no_ips', 'custom_header_ip', 'tracking', 'admin_bar', 'summary_emails' );
+		$checkboxes = array( 'mu_menu', 're_multi', 'accordion_js', 'fade_form', 'no_ips', 'custom_header_ip', 'tracking', 'admin_bar', 'summary_emails' );
 		foreach ( $checkboxes as $set ) {
 			$this->$set = isset( $params[ 'frm_' . $set ] ) ? absint( $params[ 'frm_' . $set ] ) : 0;
 		}

--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -9,7 +9,6 @@ class FrmSettings {
 	public $menu;
 	public $mu_menu;
 	public $fade_form;
-	public $old_css;
 	public $admin_bar;
 
 	public $success_msg;
@@ -134,7 +133,6 @@ class FrmSettings {
 			'menu'                      => apply_filters( 'frm_default_menu', 'Formidable' ),
 			'mu_menu'                   => 0,
 			'fade_form'                 => false,
-			'old_css'                   => false,
 			'admin_bar'                 => false,
 
 			're_multi'                  => 1,

--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -8,7 +8,6 @@ class FrmSettings {
 	public $option_name = 'frm_options';
 	public $menu;
 	public $mu_menu;
-	public $accordion_js;
 	public $fade_form;
 	public $old_css;
 	public $admin_bar;
@@ -134,7 +133,6 @@ class FrmSettings {
 		return array(
 			'menu'                      => apply_filters( 'frm_default_menu', 'Formidable' ),
 			'mu_menu'                   => 0,
-			'accordion_js'              => false,
 			'fade_form'                 => false,
 			'old_css'                   => false,
 			'admin_bar'                 => false,
@@ -402,7 +400,7 @@ class FrmSettings {
 		$this->from_email        = $params['frm_from_email'];
 		$this->currency          = $params['frm_currency'];
 
-		$checkboxes = array( 'mu_menu', 're_multi', 'accordion_js', 'fade_form', 'no_ips', 'custom_header_ip', 'tracking', 'admin_bar', 'summary_emails' );
+		$checkboxes = array( 'mu_menu', 're_multi', 'fade_form', 'no_ips', 'custom_header_ip', 'tracking', 'admin_bar', 'summary_emails' );
 		foreach ( $checkboxes as $set ) {
 			$this->$set = isset( $params[ 'frm_' . $set ] ) ? absint( $params[ 'frm_' . $set ] ) : 0;
 		}

--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -197,9 +197,7 @@ class FrmUsage {
 		);
 		$pass_settings = array(
 			'load_style',
-			'use_html',
 			'fade_form',
-			'jquery_css',
 			're_type',
 			're_lang',
 			're_multi',
@@ -375,7 +373,7 @@ class FrmUsage {
 	private function form_field_count( $form_id ) {
 		global $wpdb;
 
-		$join = $wpdb->prefix . 'frm_fields fi LEFT OUTER JOIN ' . $wpdb->prefix . 'frm_forms fo ON (fi.form_id=fo.id)';
+		$join = $wpdb->prefix . 'frm_fields fi JOIN ' . $wpdb->prefix . 'frm_forms fo ON (fi.form_id=fo.id)';
 
 		$field_query = array(
 			'or'             => 1,

--- a/classes/views/frm-settings/misc.php
+++ b/classes/views/frm-settings/misc.php
@@ -41,16 +41,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php } ?>
 </p>
 
-<?php
-/*
-Deprecated setting. This is always on now.
-Leave this for now for backward compatibility.
-This is to prevent this from being disabled.
-Pro could possibly check for `use_html` and think it is still false.
-*/
-?>
-<input type="hidden" name="frm_use_html" value="1" />
-
 <p class="frm_uninstall">
 	<label>
 		<input type="checkbox" id="frm-uninstall-box" value="1" onchange="frm_show_div('frm_uninstall_now',this.checked,true,'#')" />


### PR DESCRIPTION
As well as "Accordion JS" and "Old CSS", which were removed even longer ago.

There's also a small database query optimization.