### PR TITLE
Update tracking for bootstrap settings

### DIFF
--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -206,7 +206,7 @@ class FrmUsage {
 			'no_ips',
 			'custom_header_ip',
 			'btsp_css',
-			'btsp_errors',
+			'btsp_version',
 			'admin_bar',
 			'summary_emails',
 			'active_captcha',


### PR DESCRIPTION
Two small tracking updates related to our Bootstrap add-on.

1. `btsp_errors` is old and has been removed for some time.
2. `btsp_version` is newer, and isn't being tracked yet.