### PR TITLE
Fix simple block title/description options not working properly when off

### DIFF
--- a/classes/controllers/FrmSimpleBlocksController.php
+++ b/classes/controllers/FrmSimpleBlocksController.php
@@ -200,6 +200,11 @@ class FrmSimpleBlocksController {
 		$params['id'] = $params['formId'];
 		unset( $params['formId'] );
 
+		// Still pass false for title and description options if nothing is set,
+		// so a default doesn't overwrite the block option.
+		$params['title']       = ! empty( $params['title'] );
+		$params['description'] = ! empty( $params['description'] );
+
 		$form .= FrmFormsController::get_form_shortcode( $params );
 		return self::maybe_remove_fade_on_load_for_block_preview( $form );
 	}


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-chat/issues/111

When title/description are disabled from the Gutenberg block, it would fallback to the form settings. This update passes the `false` so it doesn't use a default instead.