### PR TITLE
Deprecate unused function frmFrontForm.escapeHtml

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1941,6 +1941,7 @@ function frmFrontFormJS() {
 		},
 
 		escapeHtml: function( text ) {
+			console.warn( 'DEPRECATED: function frmFrontForm.escapeHtml in vx.x' );
 			return text
 				.replace( /&/g, '&amp;' )
 				.replace( /</g, '&lt;' )


### PR DESCRIPTION
I found this being used in old v2.0 code. But it hasn't been used since v3.0+.