### PR TITLE
Add object checks to form variables

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -108,9 +108,14 @@ class FrmFormsController {
 	 * @since 2.02.11
 	 *
 	 * @param int|object $form
+	 * @return void
 	 */
 	private static function create_default_email_action( $form ) {
 		FrmForm::maybe_get_form( $form );
+		if (  ! is_object( $form ) ) {
+			return;
+		}
+
 		$create_email = apply_filters( 'frm_create_default_email_action', true, $form );
 
 		if ( $create_email ) {
@@ -128,9 +133,13 @@ class FrmFormsController {
 	 * @since 6.0.0
 	 *
 	 * @param int|object $form Form object or ID.
+	 * @return void
 	 */
 	private static function create_default_on_submit_action( $form ) {
 		FrmForm::maybe_get_form( $form );
+		if ( ! is_object( $form ) ) {
+			return;
+		}
 
 		/**
 		 * Enable or disable the default On Submit action.
@@ -157,9 +166,13 @@ class FrmFormsController {
 	 * @since 6.9
 	 *
 	 * @param int|object $form Form ID or object.
+	 * @return void
 	 */
 	private static function create_submit_button_field( $form ) {
 		FrmForm::maybe_get_form( $form );
+		if ( ! is_object( $form ) ) {
+			return;
+		}
 
 		if ( FrmSubmitHelper::get_submit_field( $form->id ) ) {
 			// Do not create submit button field if it exists.

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -112,7 +112,7 @@ class FrmFormsController {
 	 */
 	private static function create_default_email_action( $form ) {
 		FrmForm::maybe_get_form( $form );
-		if (  ! is_object( $form ) ) {
+		if ( ! is_object( $form ) ) {
 			return;
 		}
 


### PR DESCRIPTION
**Related ticket** https://secure.helpscout.net/conversation/2790635195/217940

**Pre-release**
[formidable-6.16.4b.zip](https://github.com/user-attachments/files/18127914/formidable-6.16.4b.zip)

This just prevents some PHP warnings. It doesn't fix a bug (that there is no form getting created).