### PR TITLE
Add null check for form name

### DIFF
--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -407,7 +407,7 @@ class FrmFormsListHelper extends FrmListHelper {
 	 */
 	private function get_form_name( $item, $actions, $edit_link, $mode = 'list' ) {
 		$form_name = $item->name;
-		if ( trim( $form_name ) == '' ) {
+		if ( is_null( $form_name ) || trim( $form_name ) == '' ) {
 			$form_name = FrmFormsHelper::get_no_title_text();
 		}
 		$form_name = FrmAppHelper::kses( $form_name );


### PR DESCRIPTION
I added a null in my database when testing and now I see this deprecated message.

> PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/src/wp-content/plugins/formidable/classes/helpers/FrmFormsListHelper.php on line 410
