### PR TITLE
Add null check for fomr name in switcher

### DIFF
--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -127,7 +127,7 @@ class FrmFormsHelper {
 		}
 
 		$name           = $selected === false ? __( 'Switch Form', 'formidable' ) : $selected;
-		$name           = '' === $name ? self::get_no_title_text() : strip_tags( $name );
+		$name           = '' === $name || is_null( $name ) ? self::get_no_title_text() : strip_tags( $name );
 		$truncated_name = FrmAppHelper::truncate( $name, 25 );
 
 		if ( count( $forms ) < 2 ) {


### PR DESCRIPTION
I have a form with `null` for a name, and noticed this message.

> PHP Deprecated:  strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/src/wp-content/plugins/formidable/classes/helpers/FrmFormsHelper.php on line 130
