### PR TITLE
Stop using jQuery in captcha render code

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1678,7 +1678,7 @@ function frmFrontFormJS() {
 		 * Render a captcha field.
 		 *
 		 * @param {HTMLElement} captcha
-		 * @param {string} captchaSelector
+		 * @param {string}      captchaSelector
 		 * @return {void}
 		 */
 		renderCaptcha: function( captcha, captchaSelector ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1674,32 +1674,42 @@ function frmFrontFormJS() {
 
 		getFieldId,
 
+		/**
+		 * Render a captcha field.
+		 *
+		 * @param {HTMLElement} captcha
+		 * @param {string} captchaSelector
+		 * @return {void}
+		 */
 		renderCaptcha: function( captcha, captchaSelector ) {
-			let formID, captchaID,
-				size = captcha.getAttribute( 'data-size' ),
-				rendered = captcha.getAttribute( 'data-rid' ) !== null,
-				params = {
-					'sitekey': captcha.getAttribute( 'data-sitekey' ),
-					'size': size,
-					'theme': captcha.getAttribute( 'data-theme' )
-				},
-				activeCaptcha = getSelectedCaptcha( captchaSelector ),
-				captchaContainer = typeof turnstile !== 'undefined' && turnstile === activeCaptcha ? '#' + captcha.id : captcha.id;
-
+			const rendered = captcha.getAttribute( 'data-rid' ) !== null;
 			if ( rendered ) {
 				return;
 			}
 
+			const size   = captcha.getAttribute( 'data-size' );
+			const params = {
+				sitekey: captcha.getAttribute( 'data-sitekey' ),
+				size: size,
+				theme: captcha.getAttribute( 'data-theme' )
+			};
+
 			if ( size === 'invisible' ) {
-				formID = jQuery( captcha ).closest( 'form' ).find( 'input[name="form_id"]' ).val();
-				jQuery( captcha ).closest( '.frm_form_field .frm_primary_label' ).hide();
+				const formID = captcha.closest( 'form' )?.querySelector( 'input[name="form_id"]' )?.value;
+
+				const captchaLabel = captcha.closest( '.frm_form_field' )?.querySelector( '.frm_primary_label' );
+				if ( captchaLabel ) {
+					captchaLabel.style.display = 'none';
+				}
+
 				params.callback = function( token ) {
 					frmFrontForm.afterRecaptcha( token, formID );
 				};
 			}
 
-
-			captchaID = activeCaptcha.render( captchaContainer, params );
+			const activeCaptcha    = getSelectedCaptcha( captchaSelector );
+			const captchaContainer = typeof turnstile !== 'undefined' && turnstile === activeCaptcha ? '#' + captcha.id : captcha.id;
+			const captchaID        = activeCaptcha.render( captchaContainer, params );
 
 			captcha.setAttribute( 'data-rid', captchaID );
 		},


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5002

This update removes a use of the jQuery `.hide()` function, as well as `.find()`, and 2 uses of `.closest()`.

This also updates a lot of uses of `let` to `const`, removes some quotes around object keys, and I added some type comments. I also optimized the rendered check, so it happens before we do everything else.

And it fixes a bug. The code was intended to hide the invisible captcha field's label, but the `.closest()` call was incorrect and it would never select anything.