### PR TITLE
Fix centered submit button bottom margin value with modern dark theme

### DIFF
--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -944,4 +944,23 @@ class FrmStylesHelper {
 			? FrmProAppHelper::use_chosen_js()
 			: true;
 	}
+
+	/**
+	 * Returns the bottom part from a margin/padding value.
+	 *
+	 * @since x.x
+	 *
+	 * @param string $value The margin/padding value.
+	 * @return string
+	 */
+	public static function get_bottom_value( $value ) {
+		if ( ! $value ) {
+			return $value;
+		}
+		$parts = explode( ' ', $value );
+		if ( count( $parts ) < 3 ) {
+			return $parts[0];
+		}
+		return $parts[2];
+	}
 }

--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -254,7 +254,19 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 }
 
 .<?php echo esc_html( $style_class ); ?>.frm_center_submit .frm_submit .frm_ajax_loading{
-	margin-bottom:<?php echo esc_html( $submit_margin ); ?>;
+		<?php
+		if ( $submit_margin ) {
+			$_submit_margin = explode( ' ', $submit_margin );
+			if ( count( $_submit_margin ) < 3 ) {
+				$bottom_margin = $_submit_margin[0];
+			} else {
+				$bottom_margin = $_submit_margin[2];
+			}
+		} else {
+			$bottom_margin = $submit_margin;
+		}
+		?>
+	margin-bottom:<?php echo esc_html( $bottom_margin ); ?>;
 }
 
 .<?php echo esc_html( $style_class ); ?> .frm-edit-page-btn:focus,

--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -254,19 +254,7 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 }
 
 .<?php echo esc_html( $style_class ); ?>.frm_center_submit .frm_submit .frm_ajax_loading{
-		<?php
-		if ( $submit_margin ) {
-			$_submit_margin = explode( ' ', $submit_margin );
-			if ( count( $_submit_margin ) < 3 ) {
-				$submit_bottom_margin = $_submit_margin[0];
-			} else {
-				$submit_bottom_margin = $_submit_margin[2];
-			}
-		} else {
-			$submit_bottom_margin = $submit_margin;
-		}
-		?>
-	margin-bottom:<?php echo esc_html( $submit_bottom_margin ); ?>;
+	margin-bottom:<?php echo esc_html( FrmStylesHelper::get_bottom_value( $submit_margin ) ); ?>;
 }
 
 .<?php echo esc_html( $style_class ); ?> .frm-edit-page-btn:focus,

--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -258,15 +258,15 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 		if ( $submit_margin ) {
 			$_submit_margin = explode( ' ', $submit_margin );
 			if ( count( $_submit_margin ) < 3 ) {
-				$bottom_margin = $_submit_margin[0];
+				$submit_bottom_margin = $_submit_margin[0];
 			} else {
-				$bottom_margin = $_submit_margin[2];
+				$submit_bottom_margin = $_submit_margin[2];
 			}
 		} else {
-			$bottom_margin = $submit_margin;
+			$submit_bottom_margin = $submit_margin;
 		}
 		?>
-	margin-bottom:<?php echo esc_html( $bottom_margin ); ?>;
+	margin-bottom:<?php echo esc_html( $submit_bottom_margin ); ?>;
 }
 
 .<?php echo esc_html( $style_class ); ?> .frm-edit-page-btn:focus,

--- a/tests/phpunit/styles/test_FrmStylesHelper.php
+++ b/tests/phpunit/styles/test_FrmStylesHelper.php
@@ -234,4 +234,21 @@ class test_FrmStylesHelper extends FrmUnitTest {
 	private function assert_color_brightness( $expected, $color ) {
 		$this->assertEquals( $expected, FrmStylesHelper::get_color_brightness( $color ) );
 	}
+
+	/**
+	 * @covers FrmStylesHelper::get_bottom_value
+	 */
+	public function test_get_bottom_value() {
+		$expected = array(
+			''                   => '',
+			'10px'               => '10px',
+			'5em 10px'           => '5em',
+			'5em 10px 5px'       => '5px',
+			'5em 10px 15px 20px' => '15px',
+		);
+
+		foreach ( $expected as $input => $output ) {
+			$this->assertEquals( $output, FrmStylesHelper::get_bottom_value( $input ) );
+		}
+	}
 }


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5557
Quoting Mike's workaround the issue implemented in this PR:

> We should check for this, and use the bottom value.
> 
> So if the submit_margin has 2 units (vertical, horizontal), we want to use the first value (10px in this case). If there are 4 (top, right, bottom, left), we'll want to use the bottom value (the 3rd one).