### PR TITLE
Optimize field type queries

### DIFF
--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -809,7 +809,7 @@ class FrmField {
 			} else {
 				$where = array( 'field_key' => $id );
 			}
-			$type  = FrmDb::get_var( 'frm_fields', $where, $col );
+			$type = FrmDb::get_var( 'frm_fields', $where, $col );
 		}
 
 		return $type;

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -804,11 +804,11 @@ class FrmField {
 		if ( $field ) {
 			$type = $field->{$col};
 		} else {
-			$where = array(
-				'or'        => 1,
-				'id'        => $id,
-				'field_key' => $id,
-			);
+			if ( is_numeric( $id ) ) {
+				$where = array( 'id' => $id );
+			} else {
+				$where = array( 'field_key' => $id );
+			}
 			$type  = FrmDb::get_var( 'frm_fields', $where, $col );
 		}
 


### PR DESCRIPTION
This simplifies/optimized a query by checking only for the relevant `id` or `field_key`, since field keys are always alphanumeric.