### PR TITLE
Optimize field queries

### DIFF
--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -1004,7 +1004,7 @@ class FrmField {
 
 		$limit = FrmDb::esc_limit( $limit );
 
-		$query      = "SELECT fi.*, fr.name as form_name  FROM {$table_name} fi LEFT OUTER JOIN {$form_table_name} fr ON fi.form_id=fr.id";
+		$query      = "SELECT fi.*, fr.name as form_name FROM {$table_name} fi JOIN {$form_table_name} fr ON fi.form_id=fr.id";
 		$query_type = $limit === ' LIMIT 1' || $limit == 1 ? 'row' : 'results';
 
 		if ( is_array( $where ) ) {
@@ -1012,7 +1012,7 @@ class FrmField {
 				'order_by' => $order_by,
 				'limit'    => $limit,
 			);
-			$results = FrmDb::get_var( $table_name . ' fi LEFT OUTER JOIN ' . $form_table_name . ' fr ON fi.form_id=fr.id', $where, 'fi.*, fr.name as form_name', $args, '', $query_type );
+			$results = FrmDb::get_var( $table_name . ' fi JOIN ' . $form_table_name . ' fr ON fi.form_id=fr.id', $where, 'fi.*, fr.name as form_name', $args, '', $query_type );
 		} else {
 			// if the query is not an array, then it has already been prepared
 			$query .= FrmDb::prepend_and_or_where( ' WHERE ', $where ) . $order_by . $limit;


### PR DESCRIPTION
I don't believe we need these `LEFT OUTER` joins since we should always expect the forms to exist when querying for fields. The `LEFT OUTER` joins are much slower than the default join.