### PR TITLE
Dashboard Inbox doesn't refresh properly

### DIFF
--- a/classes/controllers/FrmInboxController.php
+++ b/classes/controllers/FrmInboxController.php
@@ -123,8 +123,8 @@ class FrmInboxController {
 		$message->add_message(
 			array(
 				'key'     => 'free_templates',
-				'message' => 'Add your email address to get a code for 20+ free form templates.',
-				'subject' => 'Get 20+ Free Form Templates',
+				'message' => 'Add your email address to get a code for 30+ free form templates.',
+				'subject' => 'Get 30+ Free Form Templates',
 				'cta'     => '<a href="#" class="frm-button-secondary frm_inbox_dismiss">Dismiss</a> <a href="' . esc_url( $link ) . '" class="button-primary frm-button-primary">Get Now</a>',
 				'type'    => 'feedback',
 			)

--- a/classes/models/FrmAddon.php
+++ b/classes/models/FrmAddon.php
@@ -608,6 +608,8 @@ class FrmAddon {
 		$plugin_slug = FrmAppHelper::get_param( 'plugin', '', 'post', 'sanitize_text_field' );
 		$response    = self::activate_license_for_plugin( $license, $plugin_slug );
 
+		FrmInbox::clear_cache();
+
 		wp_send_json( $response );
 	}
 
@@ -760,6 +762,7 @@ class FrmAddon {
 		}
 
 		$this_plugin->clear_license();
+		FrmInbox::clear_cache();
 
 		wp_send_json( $response );
 	}

--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -591,4 +591,15 @@ class FrmInbox extends FrmFormApi {
 			array()
 		);
 	}
+
+	/**
+	 * Clear the inbox cache by deleting the associated option from the database.
+	 *
+	 * @since x.x
+	 *
+	 * @return void
+	 */
+	public static function clear_cache() {
+		delete_option( 'frm_inbox' );
+	}
 }

--- a/classes/views/form-templates/modals/leave-email-modal.php
+++ b/classes/views/form-templates/modals/leave-email-modal.php
@@ -16,7 +16,7 @@ if ( ! isset( $args ) ) {
 
 $defaults = array(
 	'api_url'     => 'https://sandbox.formidableforms.com/api/wp-json/frm/v2/forms/freetemplates?return=html&exclude_script=jquery&exclude_style=formidable-css',
-	'title'       => esc_html__( 'Get 20+ Free Form Templates', 'formidable' ),
+	'title'       => esc_html__( 'Get 30+ Free Form Templates', 'formidable' ),
 	'description' => esc_html__( 'Just add your email address and we\'ll send you a code for free form templates!', 'formidable' ),
 );
 

--- a/tests/cypress/e2e/Form Templates/FormTemplates.cy.js
+++ b/tests/cypress/e2e/Form Templates/FormTemplates.cy.js
@@ -320,7 +320,7 @@ describe("Form Templates page", () => {
             .click({ force: true });
 
         cy.get('#frm-leave-email-modal').should('be.visible');
-        cy.get('#frm-leave-email-modal > .frm_modal_top > .frm-modal-title > h2').should('contain', 'Get 20+ Free Form Templates');
+        cy.get('#frm-leave-email-modal > .frm_modal_top > .frm-modal-title > h2').should('contain', 'Get 30+ Free Form Templates');
         cy.get('#frm-leave-email-modal p')
             .should('contain.text', "Just add your email address and we'll send you a code for free form templates!");
 


### PR DESCRIPTION
This PR ensures that the Dashboard Inbox refreshes correctly under the following scenarios:

- When the Pro plugin is activated or deactivated.
- When the license is connected or disconnected.

Additionally, this fix updates the number of free templates displayed from 20+ to 30+ where applicable.

### Issue URL:
https://github.com/Strategy11/formidable-pro/issues/4909

### Pro Version PR:
https://github.com/Strategy11/formidable-pro/pull/5566

### How to Test:

1. Activate and deactivate the Pro plugin and confirm the Dashboard Inbox refreshes as expected.
2. Connect and disconnect the license and confirm the Dashboard Inbox refreshes properly.
3. Verify that the number of free templates updates from 20+ to 30+ after the changes.

### Video:
https://share.cleanshot.com/DVQySkxc
