### PR TITLE
Improve email validation

### DIFF
--- a/classes/models/fields/FrmFieldEmail.php
+++ b/classes/models/fields/FrmFieldEmail.php
@@ -48,7 +48,7 @@ class FrmFieldEmail extends FrmFieldType {
 			return array();
 		}
 		$errors = array();
-		if ( ! is_email( $args['value'] ) || strpos( $args['value'], '.@' ) !== false ) {
+		if ( strpos( $args['value'], '.@' ) !== false || ! is_email( $args['value'] ) ) {
 			$errors[ 'field' . $args['id'] ] = FrmFieldsHelper::get_error_msg( $this->field, 'invalid' );
 		}
 		return $errors;

--- a/classes/models/fields/FrmFieldEmail.php
+++ b/classes/models/fields/FrmFieldEmail.php
@@ -47,15 +47,8 @@ class FrmFieldEmail extends FrmFieldType {
 		if ( ! $args['value'] ) {
 			return array();
 		}
-		$errors   = array();
-		$is_email = false;
-		if ( is_email( $args['value'] ) ) {
-			$parts = explode( '@', $args['value'] );
-			if ( $parts && '.' !== $parts[0][ strlen( $parts[0] ) - 1 ] ) {
-				$is_email = true;
-			}
-		}
-		if ( ! $is_email ) {
+		$errors = array();
+		if ( ! is_email( $args['value'] ) || strpos( $args['value'], '.@' ) !== false ) {
 			$errors[ 'field' . $args['id'] ] = FrmFieldsHelper::get_error_msg( $this->field, 'invalid' );
 		}
 		return $errors;

--- a/classes/models/fields/FrmFieldEmail.php
+++ b/classes/models/fields/FrmFieldEmail.php
@@ -48,7 +48,7 @@ class FrmFieldEmail extends FrmFieldType {
 			return array();
 		}
 		$errors = array();
-		if ( strpos( $args['value'], '.@' ) !== false || ! is_email( $args['value'] ) ) {
+		if ( false !== strpos( $args['value'], '.@' ) || ! is_email( $args['value'] ) ) {
 			$errors[ 'field' . $args['id'] ] = FrmFieldsHelper::get_error_msg( $this->field, 'invalid' );
 		}
 		return $errors;

--- a/classes/models/fields/FrmFieldEmail.php
+++ b/classes/models/fields/FrmFieldEmail.php
@@ -44,11 +44,20 @@ class FrmFieldEmail extends FrmFieldType {
 	 * @return array
 	 */
 	public function validate( $args ) {
-		$errors = array();
-		if ( $args['value'] != '' && ! is_email( $args['value'] ) ) {
+		if ( ! $args['value'] ) {
+			return array();
+		}
+		$errors   = array();
+		$is_email = false;
+		if ( is_email( $args['value'] ) ) {
+			$parts = explode( '@', $args['value'] );
+			if ( $parts && '.' !== $parts[0][ strlen( $parts[0] ) - 1 ] ) {
+				$is_email = true;
+			}
+		}
+		if ( ! $is_email ) {
 			$errors[ 'field' . $args['id'] ] = FrmFieldsHelper::get_error_msg( $this->field, 'invalid' );
 		}
-
 		return $errors;
 	}
 


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5527

This update just adds an extra check to valid email values so that if there is a `.` at the end of the email local part (just before `@`), it would be treated as an invalid value.

### Test steps
1. Create a form and add an email field to it.
2. Preview the form and fill the email field with a value that has `.` just before the `@` symbol.
3. Try submitting the form and confirm that an error is thrown indicating an invalid email value.