### PR TITLE
Add error style to checkbox and radio fields when there is error with them

### DIFF
--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -338,6 +338,8 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 .<?php echo esc_html( $style_class ); ?> .frm_blank_field input[type=tel],
 .<?php echo esc_html( $style_class ); ?> .frm_blank_field input[type=number],
 .<?php echo esc_html( $style_class ); ?> .frm_blank_field input[type=email],
+.<?php echo esc_html( $style_class ); ?> .frm_blank_field input[type=checkbox],
+.<?php echo esc_html( $style_class ); ?> .frm_blank_field input[type=radio],
 .<?php echo esc_html( $style_class ); ?> .frm_blank_field textarea,
 .<?php echo esc_html( $style_class ); ?> .frm_blank_field .mce-edit-area iframe,
 .<?php echo esc_html( $style_class ); ?> .frm_blank_field select:not(.ui-datepicker-month):not(.ui-datepicker-year),


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5564

Before:
<img width="524" alt="image" src="https://github.com/user-attachments/assets/7585defe-1b5d-45f8-be52-eb6b385d0611" />

After:
<img width="524" alt="image" src="https://github.com/user-attachments/assets/76398675-797e-46c7-ac41-c409e5fc849f" />
