### PR TITLE
Avoid selecting text when multiselecting fields

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4411,9 +4411,6 @@ function frmAdminBuildJS() {
 						}
 					}
 				);
-
-				// when holding shift and clicking, text gets selected. unselect it.
-				document.getSelection().removeAllRanges();
 			}
 		} else {
 			// not multi-selecting
@@ -10706,6 +10703,9 @@ function frmAdminBuildJS() {
 			handleShowPasswordLiveUpdate();
 			document.addEventListener( 'scroll', updateShortcodesPopupPosition, true );
 			document.addEventListener( 'change', handleBuilderChangeEvent );
+			document.onselectstart = function( e ) {
+				return e.target.closest( '.frm_form_builder' );
+			};
 		},
 
 		settingsInit: function() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10703,8 +10703,10 @@ function frmAdminBuildJS() {
 			handleShowPasswordLiveUpdate();
 			document.addEventListener( 'scroll', updateShortcodesPopupPosition, true );
 			document.addEventListener( 'change', handleBuilderChangeEvent );
-			document.querySelector( '.frm_form_builder' ).addEventListener( 'selectstart', function( e ) {
-				return false;
+			document.querySelector( '.frm_form_builder' ).addEventListener( 'mousedown', event => {
+				if ( event.shiftKey ) {
+				  event.preventDefault();
+				}
 			});
 		},
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10703,9 +10703,9 @@ function frmAdminBuildJS() {
 			handleShowPasswordLiveUpdate();
 			document.addEventListener( 'scroll', updateShortcodesPopupPosition, true );
 			document.addEventListener( 'change', handleBuilderChangeEvent );
-			document.onselectstart = function( e ) {
-				return e.target.closest( '.frm_form_builder' );
-			};
+			document.querySelector( '.frm_form_builder' ).addEventListener( 'selectstart', function( e ) {
+				e.preventDefault();
+			});
 		},
 
 		settingsInit: function() {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10704,7 +10704,7 @@ function frmAdminBuildJS() {
 			document.addEventListener( 'scroll', updateShortcodesPopupPosition, true );
 			document.addEventListener( 'change', handleBuilderChangeEvent );
 			document.querySelector( '.frm_form_builder' ).addEventListener( 'selectstart', function( e ) {
-				e.preventDefault();
+				return false;
 			});
 		},
 


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5224

This is just an implementation improvement than a feature to test. We have been unselecting selected text after fields are multiselected but we are now preventing text selection at the first place.