### PR TITLE
Unset empty response content

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2803,6 +2803,10 @@ class FrmFormsController {
 			$response_data['fallbackMsg'] = self::get_redirect_fallback_message( $args['success_url'], $args );
 		}//end if
 
+		if ( '' === $response['content'] ) {
+			unset( $response['content'] );
+		}
+
 		return $response_data;
 	}
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2774,10 +2774,12 @@ class FrmFormsController {
 			'redirect' => $args['success_url'],
 			'content'  => '',
 		);
+		$unset_content = true;
 
 		if ( ! empty( $args['form']->options['redirect_delay'] ) ) {
 			$response_data['delay']    = $args['form']->options['redirect_delay_time'];
 			$response_data['content'] .= self::get_redirect_message( $args['success_url'], $args['form']->options['redirect_delay_msg'], $args );
+			$unset_content             = false;
 		}
 
 		if ( ! empty( $args['form']->options['open_in_new_tab'] ) ) {
@@ -2798,12 +2800,13 @@ class FrmFormsController {
 				ob_start();
 				self::show_lone_success_message( $args );
 				$response_data['content'] .= ob_get_clean();
+				$unset_content             = false;
 			}//end if
 
 			$response_data['fallbackMsg'] = self::get_redirect_fallback_message( $args['success_url'], $args );
 		}//end if
 
-		if ( '' === $response_data['content'] ) {
+		if ( $unset_content && '' === $response_data['content'] ) {
 			unset( $response_data['content'] );
 		}
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2803,8 +2803,8 @@ class FrmFormsController {
 			$response_data['fallbackMsg'] = self::get_redirect_fallback_message( $args['success_url'], $args );
 		}//end if
 
-		if ( '' === $response['content'] ) {
-			unset( $response['content'] );
+		if ( '' === $response_data['content'] ) {
+			unset( $response_data['content'] );
 		}
 
 		return $response_data;


### PR DESCRIPTION
This update unsets the `content` if neither condition is hit. This way the output is more consistent with the previous versions.


Related Pro tests failing.

![image](https://github.com/user-attachments/assets/6ccad90f-63a1-4318-886a-9dac46319302)
