### PR TITLE
Update deploy workflow

### DIFF
--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -8,6 +8,8 @@ jobs:
     name: New tag
     runs-on: ubuntu-latest
     steps:
+    - name: Install Subversion
+      run: sudo apt-get update && sudo apt-get install -y subversion
     - uses: actions/checkout@master
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@2.0.0


### PR DESCRIPTION
New issue with ubuntu latest https://github.com/10up/action-wordpress-plugin-deploy/issues/158#issuecomment-2564633557

SVN is no longer included.