### PR TITLE
Remove screen options on entry edit page

### DIFF
--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -133,8 +133,10 @@ class FrmEntriesController {
 	 * @since 3.0
 	 */
 	public static function remove_screen_options( $show_screen, $screen ) {
-		$menu_name = sanitize_title( FrmAppHelper::get_menu_name() );
-		if ( $screen->id == $menu_name . '_page_formidable-entries' ) {
+		$menu_name    = sanitize_title( FrmAppHelper::get_menu_name() );
+		$unread_count = FrmEntriesHelper::get_visible_unread_inbox_count();
+
+		if ( $screen->id === $menu_name . ( $unread_count ? '-' . $unread_count : '' ) . '_page_formidable-entries' ) {
 			$show_screen = false;
 		}
 


### PR DESCRIPTION
With the new inbox counts it's possible to see the screen options on some pages where we're trying to hide them (View/Edit entry).

This issue isn't major but it's good to fix.