### PR TITLE
Fix response replace is not a function error

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -842,13 +842,14 @@ function frmFrontFormJS() {
 
 			if ( response === null ) {
 				response = defaultResponse;
-			}
-
-			response = response.replace( /^\s+|\s+$/g, '' );
-			if ( response.indexOf( '{' ) === 0 ) {
-				response = JSON.parse( response );
 			} else {
-				response = defaultResponse;
+				// Response is a string. Convert it to an object.
+				response = response.replace( /^\s+|\s+$/g, '' );
+				if ( response.indexOf( '{' ) === 0 ) {
+					response = JSON.parse( response );
+				} else {
+					response = defaultResponse;
+				}
 			}
 
 			if ( typeof response.redirect !== 'undefined' ) {
@@ -866,7 +867,7 @@ function frmFrontFormJS() {
 				}
 			}
 
-			if ( response.content !== '' ) {
+			if ( 'string' === typeof response.content && response.content !== '' ) {
 				// the form or success message was returned
 
 				if ( shouldTriggerEvent ) {


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2825361874/220419

**Pre-release**
[formidable-6.17.2b.zip](https://github.com/user-attachments/files/18496525/formidable-6.17.2b.zip)

> Uncaught TypeError: response.replace is not a function

This would imply `response` was `null`, and `defaultResponse` was being used instead.