### PR TITLE
Track when message settings changed

### DIFF
--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -254,9 +254,11 @@ class FrmUsage {
 			'admin_permission',
 		);
 
+		$default = $settings_list->default_options();
+
 		$message_settings = array();
 		foreach ( $messages as $message ) {
-			$message_settings[ $message ] = $settings_list->$message;
+			$message_settings[ 'changed-' . $message ] = $settings_list->$message === $default[ $message ] ? 0 : 1;
 		}
 
 		return $message_settings;


### PR DESCRIPTION
This was reported by Mike via private message in Slack.

In Lite and Pro plugins, we send the `Message Defaults` settings to the usage endpoint. But in the new usage tracking endpoint, I skipped those settings because they are long and I didn't think we wanted to track them.
Our purpose is to track when those settings are changed. So I created this PR. I will send `changed-{$message_key}` to the endpoint. It has the value `0` (not changed) or `1` (changed).

In the usage endpoint, I removed the code that skips the messages: https://github.com/Strategy11/ff-usage-2/pull/2

The similar PR in Pro: https://github.com/Strategy11/formidable-pro/pull/5603