### PR TITLE
Fix phpstan name field constructor issue

### DIFF
--- a/classes/models/fields/FrmFieldName.php
+++ b/classes/models/fields/FrmFieldName.php
@@ -28,7 +28,11 @@ class FrmFieldName extends FrmFieldCombo {
 	 */
 	protected $holds_email_values = true;
 
-	public function __construct( $field = '', $type = '' ) {
+	/**
+	 * @param array|int|object $field
+	 * @param string           $type
+	 */
+	public function __construct( $field = 0, $type = '' ) {
 		parent::__construct( $field, $type );
 
 		$this->register_sub_fields(

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -77,9 +77,6 @@ parameters:
 				- classes/helpers/FrmFormMigratorsHelper.php
 				- classes/models/FrmEntryMeta.php
 		-
-			message: '#of method FrmFieldName::\_\_construct#'
-			path: classes/models/fields/FrmFieldName.php
-		-
 			message: '#callback of function spl_autoload_register expects#'
 			path: formidable.php
 		-


### PR DESCRIPTION
I'm going through our PHPStan exceptions and trying to clean code up a bit.

**The issue**
`$field = ''` is not a good default value since `FrmFieldType` expects `@param array|int|object $field`

**The fix**
I'm updating the constructor parameter default value to match the value used for `FrmFieldType`.