### PR TITLE
Stop overwriting variable in foreach loop (phpstan)

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1390,7 +1390,7 @@ class FrmFieldsHelper {
 			 * For radio buttons and dropdowns
 			 * Check if saved value equals any of the options. If not, set it as the other value.
 			 */
-			foreach ( $field['options'] as $opt_key => $opt_val ) {
+			foreach ( $field['options'] as $opt_val ) {
 				$temp_val = is_array( $opt_val ) ? $opt_val['value'] : $opt_val;
 				// Multi-select dropdowns - key is not preserved
 				if ( is_array( $field['value'] ) ) {
@@ -1404,7 +1404,7 @@ class FrmFieldsHelper {
 				} else {
 					$other_val = $field['value'];
 				}
-				unset( $opt_key, $opt_val, $temp_val );
+				unset( $opt_val, $temp_val );
 			}
 			// For multi-select dropdowns only
 			if ( is_array( $field['value'] ) && ! empty( $field['value'] ) ) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -99,9 +99,6 @@ parameters:
 			message: '#Foreach overwrites \$ip with its value variable.#'
 			path: classes/helpers/FrmAppHelper.php
 		-
-			message: '#Foreach overwrites \$opt_key with its key variable.#'
-			path: classes/helpers/FrmFieldsHelper.php
-		-
 			message: '#Only numeric types are allowed#'
 			paths:
 				- classes/helpers/FrmCSVExportHelper.php


### PR DESCRIPTION
**The issue**
- `$opt_key` is already defined, and. this loop overwrites a variable already in the function scope.

**The solution**
- This variable isn't even used, so I'm just removing it.