### PR TITLE
Fix JS error when searching fields

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -8567,7 +8567,12 @@ function frmAdminBuildJS() {
 	 * @returns {Boolean}
 	 */
 	function isContextualShortcode( item ) {
-		const shortcode = item.querySelector( 'a' ).dataset.code;
+		const anchor = item.querySelector( 'a' );
+		if ( ! anchor ) {
+			return false;
+		}
+
+		const shortcode = anchor.dataset.code;
 		return frmAdminJs.contextualShortcodes.address.includes( shortcode ) || frmAdminJs.contextualShortcodes.body.includes( shortcode );
 	}
 


### PR DESCRIPTION
I noticed when searching fields, the section titles were disappearing.

It was because of this JS error introduced in v6.16.3.

<img width="1028" alt="Screen Shot 2025-01-28 at 1 13 19 PM" src="https://github.com/user-attachments/assets/6e175da7-ce9c-479c-bc21-37a330a30b6a" />
