### PR TITLE
Fix cypress upgrade bar issue

### DIFF
--- a/tests/cypress/e2e/Forms/formPageDataValidation.cy.js
+++ b/tests/cypress/e2e/Forms/formPageDataValidation.cy.js
@@ -13,7 +13,7 @@ describe("Forms page", () => {
     it("should validate all data in list view", () => {
         cy.log("Validate all header data");
         cy.log("Validate the upgrade link");
-        cy.get('.frm-upgrade-bar > a')
+        cy.get('.frm-upgrade-bar .frm-upgrade-bar-inner > a')
             .should('have.text', 'upgrading to PRO').click();
         cy.origin('https://formidableforms.com', () => { 
             cy.get('h1').then(($h1) => {


### PR DESCRIPTION
This is related to the Lite to Pro changes. The anchor tag is no longer a direct children, but a child of a new wrapper element.