### PR TITLE
Simplify tab event logic

### DIFF
--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -43,6 +43,7 @@ class FrmSettings {
 	public $re_type;
 	public $re_msg;
 	public $re_multi;
+	public $re_threshold;
 
 	/**
 	 * Settings for hCaptcha.

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1285,7 +1285,7 @@ function frmFrontFormJS() {
 		document.addEventListener( 'keydown', handleKeyUp );
 
 		function handleKeyUp( event ) {
-			if ( 'undefined' !== typeof event.key && 'Tab' === event.key ) {
+			if ( 'Tab' === event.key ) {
 				makeHoneypotFieldsUntabbable();
 				document.removeEventListener( 'keydown', handleKeyUp );
 			}

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1285,15 +1285,7 @@ function frmFrontFormJS() {
 		document.addEventListener( 'keydown', handleKeyUp );
 
 		function handleKeyUp( event ) {
-			let code;
-
-			if ( 'undefined' !== typeof event.key ) {
-				code = event.key;
-			} else if ( 'undefined' !== typeof event.keyCode && 9 === event.keyCode ) {
-				code = 'Tab';
-			}
-
-			if ( 'Tab' === code ) {
+			if ( 'undefined' !== typeof event.key && 'Tab' === event.key ) {
 				makeHoneypotFieldsUntabbable();
 				document.removeEventListener( 'keydown', handleKeyUp );
 			}

--- a/psalm.xml
+++ b/psalm.xml
@@ -464,12 +464,14 @@
 		<ClassMustBeFinal>
 			<errorLevel type="suppress">
 				<directory name="classes" />
+				<directory name="stripe" />
 				<directory name="deprecated" />
 			</errorLevel>
 		</ClassMustBeFinal>
 		<MissingOverrideAttribute>
 			<errorLevel type="suppress">
 				<directory name="classes" />
+				<directory name="stripe" />
 			</errorLevel>
 		</MissingOverrideAttribute>
 	</issueHandlers>

--- a/psalm.xml
+++ b/psalm.xml
@@ -461,5 +461,16 @@
 				<directory name="classes" />
 			</errorLevel>
 		</MissingClassConstType>
+		<ClassMustBeFinal>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+				<directory name="deprecated" />
+			</errorLevel>
+		</ClassMustBeFinal>
+		<MissingOverrideAttribute>
+			<errorLevel type="suppress">
+				<directory name="classes" />
+			</errorLevel>
+		</MissingOverrideAttribute>
 	</issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -474,5 +474,9 @@
 				<directory name="stripe" />
 			</errorLevel>
 		</MissingOverrideAttribute>
+		<InaccessibleProperty>
+			<errorLevel type="suppress">
+				<file name="classes/controllers/FrmFieldsController.php" />
+		</InaccessibleProperty>
 	</issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -477,6 +477,7 @@
 		<InaccessibleProperty>
 			<errorLevel type="suppress">
 				<file name="classes/controllers/FrmFieldsController.php" />
+			</errorLevel>
 		</InaccessibleProperty>
 	</issueHandlers>
 </psalm>


### PR DESCRIPTION
These extra checks were only really required for supporting IE and can now be removed.