### PR TITLE
Fix views issue 28

### DIFF
--- a/classes/models/fields/FrmFieldUserID.php
+++ b/classes/models/fields/FrmFieldUserID.php
@@ -134,6 +134,10 @@ class FrmFieldUserID extends FrmFieldType {
 	 * @return void
 	 */
 	public function sanitize_value( &$value ) {
+		if ( '' === $value ) {
+			// Allow for an empty User ID. Return early to prevent it from getting set to 0.
+			return;
+		}
 		FrmAppHelper::sanitize_value( 'intval', $value );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-views/issues/28

The issue, is that this call to `intval` changes `''` to `0`, which we don't want. Keeping it blank is better.

I tested with this basic CSV. My form has a "Text" field, and a User ID field. The User ID field isn't in the CSV, since we're trying to import empty.

[250218182012_user-id-test_formidable_entries.csv](https://github.com/user-attachments/files/18851714/250218182012_user-id-test_formidable_entries.csv)
