### PR TITLE
Use less jquery when validating

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -174,9 +174,7 @@ function frmFrontFormJS() {
 	 * @return {Array} Errors.
 	 */
 	function validateForm( object ) {
-		let errors, n, nl, fields, field;
-
-		errors = [];
+		let errors = [];
 
 		const vanillaJsObject = 'function' === typeof object.get ? object.get( 0 ) : object;
 
@@ -201,29 +199,26 @@ function frmFrontFormJS() {
 			}
 		);
 
-		fields = vanillaJsObject?.querySelectorAll( 'input,select,textarea' );
-		if ( fields.length ) {
-			fields.forEach(
-				field => {
-					if ( '' === field.value ) {
-						if ( 'number' === field.type ) {
-							// A number field will return an empty string when it is invalid.
-							checkValidity( field, errors );
-						}
-
-						const isConfirmationField = field.name && 0 === field.name.indexOf( 'item_meta[conf_' );
-						if ( ! isConfirmationField ) {
-							// Allow a blank confirmation field to still call validateFieldValue.
-							// If we continue for a confirmation field there are issues with forms submitting with a blank confirmation field.
-							return;
-						}
+		vanillaJsObject?.querySelectorAll( 'input,select,textarea' ).forEach(
+			field => {
+				if ( '' === field.value ) {
+					if ( 'number' === field.type ) {
+						// A number field will return an empty string when it is invalid.
+						checkValidity( field, errors );
 					}
 
-					validateFieldValue( field, errors, true );
-					checkValidity( field, errors );
+					const isConfirmationField = field.name && 0 === field.name.indexOf( 'item_meta[conf_' );
+					if ( ! isConfirmationField ) {
+						// Allow a blank confirmation field to still call validateFieldValue.
+						// If we continue for a confirmation field there are issues with forms submitting with a blank confirmation field.
+						return;
+					}
 				}
-			);
-		}
+
+				validateFieldValue( field, errors, true );
+				checkValidity( field, errors );
+			}
+		);
 
 		// Invisible captchas are processed after validation.
 		// We only want to validate a visible captcha on submit.

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -201,27 +201,28 @@ function frmFrontFormJS() {
 			}
 		);
 
-		fields = jQuery( object ).find( 'input,select,textarea' );
+		fields = vanillaJsObject?.querySelectorAll( 'input,select,textarea' );
 		if ( fields.length ) {
-			for ( n = 0, nl = fields.length; n < nl; n++ ) {
-				field = fields[n];
-				if ( '' === field.value ) {
-					if ( 'number' === field.type ) {
-						// A number field will return an empty string when it is invalid.
-						checkValidity( field, errors );
+			fields.forEach(
+				field => {
+					if ( '' === field.value ) {
+						if ( 'number' === field.type ) {
+							// A number field will return an empty string when it is invalid.
+							checkValidity( field, errors );
+						}
+
+						const isConfirmationField = field.name && 0 === field.name.indexOf( 'item_meta[conf_' );
+						if ( ! isConfirmationField ) {
+							// Allow a blank confirmation field to still call validateFieldValue.
+							// If we continue for a confirmation field there are issues with forms submitting with a blank confirmation field.
+							return;
+						}
 					}
 
-					const isConfirmationField = field.name && 0 === field.name.indexOf( 'item_meta[conf_' );
-					if ( ! isConfirmationField ) {
-						// Allow a blank confirmation field to still call validateFieldValue.
-						// If we continue for a confirmation field there are issues with forms submitting with a blank confirmation field.
-						continue;
-					}
+					validateFieldValue( field, errors, true );
+					checkValidity( field, errors );
 				}
-
-				validateFieldValue( field, errors, true );
-				checkValidity( field, errors );
-			}
+			);
 		}
 
 		// Invisible captchas are processed after validation.


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5002

This update removes a use of `.find()` and `.length`.

I also dropped a lot of variables. Using `.forEach`, we don't need to handle all of the loop variables ourselves.