### PR TITLE
Make Global Settings sidebar and addon settings scrollable independently

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -962,6 +962,11 @@ p.frm_has_shortcodes {
 	z-index: 100;
 }
 
+#form_global_settings .columns-2 > div {
+	overflow: auto;
+    height: calc(100vh - 32px);
+}
+
 #form_global_settings .columns-2 .frm-right-panel,
 #form_settings_page .columns-2 .frm-right-panel,
 #wpbody-content .frm-page-skeleton .frm-right-panel {


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5102