### PR TITLE
Fix accordion style

### DIFF
--- a/css/admin/style.css
+++ b/css/admin/style.css
@@ -513,7 +513,6 @@ body.rtl .frm-style-card-separator {
 .frm-right-panel .open.accordion-section {
 	border-bottom: 1px solid var(--grey-300);
 }
-#frm_view_editor_left.frm-right-panel .accordion-section-title,
 .frm-right-panel h3.accordion-section-title {
 	padding: 17px 15px !important;
 	background: transparent;

--- a/css/admin/style.css
+++ b/css/admin/style.css
@@ -515,7 +515,7 @@ body.rtl .frm-style-card-separator {
 }
 #frm_view_editor_left.frm-right-panel .accordion-section-title,
 .frm-right-panel h3.accordion-section-title {
-	padding: 17px 15px;
+	padding: 17px 15px !important;
 	background: transparent;
 	line-height: var(--leading);
 	color: var(--grey-500);


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5659
There seems to be a forced style in the latest core (`common.css`) which affected this.

I have also moved a Views editor style from here to a Views editor style file in https://github.com/Strategy11/formidable-views/pull/628

```
.accordion-container h3.accordion-section-title {
    padding: 0 !important;
}
```
**After**:
<img width="571" alt="image" src="https://github.com/user-attachments/assets/00b96db0-bcb1-4174-b95d-917e0eccffe4" />
