### PR TITLE
Fix deprecated message when loading gdpr field settings

### DIFF
--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -1096,7 +1096,7 @@ class FrmField {
 
 		if ( $field_object->should_unserialize_value() ) {
 			FrmAppHelper::unserialize_or_decode( $results->default_value );
-			if ( $before === $results->default_value && ! is_array( $before ) && strpos( $before, '["' ) === 0 ) {
+			if ( $before === $results->default_value && is_string( $before ) && strpos( $before, '["' ) === 0 ) {
 				$results->default_value = FrmAppHelper::maybe_json_decode( $results->default_value );
 			}
 		}


### PR DESCRIPTION
> PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /Users/mikeletellier/Local Sites/dev-site/app/public/wp-content/plugins/formidable/classes/models/FrmField.php on line 1099

This comes up with GDPR fields because the default value is `null` but this check expected a `non-array` to be a string.

This just tweaks the type check so it's safer.