### PR TITLE
Remove old ajax submit compatibillty code

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1708,7 +1708,7 @@ class FrmFormsController {
 			self::add_js_validate_form_to_global_vars( $form );
 		}
 
-		if ( ! FrmFormsHelper::should_use_pro_for_ajax_submit() && FrmForm::is_ajax_on( $form ) ) {
+		if ( FrmForm::is_ajax_on( $form ) ) {
 			echo ' frm_ajax_submit ';
 		}
 	}

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -1806,18 +1806,6 @@ BEFORE_HTML;
 	}
 
 	/**
-	 * Check if Pro isn't up to date yet.
-	 * If Pro is active but using a version earlier than v6.2 fallback to Pro for AJAX submit (so things don't all happen twice).
-	 *
-	 * @since 6.2
-	 *
-	 * @return bool
-	 */
-	public static function should_use_pro_for_ajax_submit() {
-		return is_callable( 'FrmProForm::is_ajax_on' ) && ! is_callable( 'FrmProFormsHelper::lite_supports_ajax_submit' );
-	}
-
-	/**
 	 * Outputs the appropriate button text in the publish box.
 	 *
 	 * @return void
@@ -1871,5 +1859,19 @@ BEFORE_HTML;
 		$trash_link = self::delete_trash_info( $form_id, $status );
 		$links      = self::get_action_links( $form_id, $status );
 		include FrmAppHelper::plugin_path() . '/classes/views/frm-forms/actions-dropdown.php';
+	}
+
+	/**
+	 * Check if Pro isn't up to date yet.
+	 * If Pro is active but using a version earlier than v6.2 fallback to Pro for AJAX submit (so things don't all happen twice).
+	 *
+	 * @since 6.2
+	 * @deprecated x.x
+	 *
+	 * @return bool
+	 */
+	public static function should_use_pro_for_ajax_submit() {
+		_deprecated_function( __METHOD__, 'x.x' );
+		return false;
 	}
 }

--- a/classes/views/frm-forms/settings-advanced.php
+++ b/classes/views/frm-forms/settings-advanced.php
@@ -107,17 +107,15 @@ FrmTipsHelper::pro_tip( 'get_form_settings_tip', 'p' );
 		</td>
 	</tr>
 	<?php do_action( 'frm_add_form_ajax_options', $values ); ?>
-	<?php if ( ! FrmFormsHelper::should_use_pro_for_ajax_submit() ) { ?>
-		<tr>
-			<td>
-				<label for="ajax_submit">
-					<input type="checkbox" name="options[ajax_submit]" id="ajax_submit" value="1" <?php checked( $values['ajax_submit'], 1 ); ?> />
-					<?php esc_html_e( 'Submit this form with AJAX', 'formidable' ); ?>
-					<?php FrmAppHelper::tooltip_icon( __( 'Submit the form without refreshing the page.', 'formidable' ) ); ?>
-				</label>
-			</td>
-		</tr>
-	<?php } ?>
+	<tr>
+		<td>
+			<label for="ajax_submit">
+				<input type="checkbox" name="options[ajax_submit]" id="ajax_submit" value="1" <?php checked( $values['ajax_submit'], 1 ); ?> />
+				<?php esc_html_e( 'Submit this form with AJAX', 'formidable' ); ?>
+				<?php FrmAppHelper::tooltip_icon( __( 'Submit the form without refreshing the page.', 'formidable' ) ); ?>
+			</label>
+		</td>
+	</tr>
 	<tr>
 		<td>
 			<label for="js_validate" class="frm_inline_block">


### PR DESCRIPTION
We don't need the old checks anymore. v6.2 is old enough, going back to Apr 6, 2023.