### PR TITLE
Prevent invalid array values and placeholders from triggering deprec…

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -313,7 +313,30 @@ DEFAULT_HTML;
 	protected function builder_text_field( $name = '' ) {
 		$read_only = FrmField::get_option( $this->field, 'read_only' );
 
-		return '<input type="text" name="' . esc_attr( $this->html_name( $name ) ) . '" id="' . esc_attr( $this->html_id() ) . '" value="' . esc_attr( $this->get_field_column( 'default_value' ) ) . '" placeholder="' . esc_attr( FrmField::get_option( $this->field, 'placeholder' ) ) . '" ' . ( $read_only ? ' readonly="readonly" disabled="disabled"' : '' ) . ' />';
+		$placeholder = FrmField::get_option( $this->field, 'placeholder' );
+		if ( is_array( $placeholder ) ) {
+			$placeholder = '';
+		}
+
+		$value = $this->get_field_column( 'default_value' );
+		if ( is_array( $value ) ) {
+			$value = '';
+		}
+
+		$input_atts = array(
+			'type'        => 'text',
+			'name'        => $this->html_name( $name ),
+			'id'          => $this->html_id(),
+			'value'       => $value,
+			'placeholder' => $placeholder,
+		);
+
+		if ( $read_only ) {
+			$input_atts['readonly'] = 'readonly';
+			$input_atts['disabled'] = 'disabled';
+		}
+
+		return '<input ' . FrmAppHelper::array_to_html_params( $input_atts ) . ' />';
 	}
 
 	protected function html_name( $name = '' ) {


### PR DESCRIPTION
…ated messages

This can happen when you try to load a form with an address field after deactivating Pro.

It will revert to a Text field, but some of the array data will not work as expected.

Before they would appear as "Array". Now I'm just treating these values as invalid. I don't think there's a point in trying to use the array data.