### PR TITLE
Make gdpr field required even if the setting is disabled

### DIFF
--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -112,6 +112,9 @@ class FrmHooksController {
 
 		FrmTransLiteHooksController::load_hooks();
 		FrmStrpLiteHooksController::load_hooks();
+
+		// GDPR
+		add_filter( 'frm_is_field_required', 'FrmFieldGdpr::force_required_field', 10, 2 );
 	}
 
 	/**

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3151,7 +3151,8 @@ class FrmAppHelper {
 		}
 
 		if ( is_serialized( $value ) ) {
-			$value = self::maybe_unserialize_array( $value );
+			$value = maybe_unserialize( $value );
+			//$value = self::maybe_unserialize_array( $value );
 		} else {
 			$value = self::maybe_json_decode( $value, false );
 		}

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3151,8 +3151,7 @@ class FrmAppHelper {
 		}
 
 		if ( is_serialized( $value ) ) {
-			$value = maybe_unserialize( $value );
-			//$value = self::maybe_unserialize_array( $value );
+			$value = self::maybe_unserialize_array( $value );
 		} else {
 			$value = self::maybe_json_decode( $value, false );
 		}

--- a/classes/models/fields/FrmFieldGdpr.php
+++ b/classes/models/fields/FrmFieldGdpr.php
@@ -189,10 +189,6 @@ class FrmFieldGdpr extends FrmFieldType {
 	 * @return bool
 	 */
 	public static function force_required_field( $required, $field ) {
-		if ( $required ) {
-			return $required;
-		}
-
 		if ( ! $required && 'gdpr' === $field['type'] && ! FrmFieldGdprHelper::hide_gdpr_field() ) {
 			$required = true;
 		}

--- a/classes/models/fields/FrmFieldGdpr.php
+++ b/classes/models/fields/FrmFieldGdpr.php
@@ -171,7 +171,8 @@ class FrmFieldGdpr extends FrmFieldType {
 			$required = FrmField::get_option( $this->field, 'required' );
 
 			if ( ! $required && empty( $args['value'] ) ) {
-				$errors[ 'field' . $args['id'] ] = sprintf( __( '%s cannot be blank.', 'formidable' ), is_object( $this->field ) ? $this->field->name : $this->field['name'] );
+				$frm_settings                    = FrmAppHelper::get_settings();
+				$errors[ 'field' . $args['id'] ] = str_replace( '[field_name]', is_object( $this->field ) ? $this->field->name : $this->field['name'],  $frm_settings->blank_msg );
 			}
 		}
 

--- a/classes/models/fields/FrmFieldGdpr.php
+++ b/classes/models/fields/FrmFieldGdpr.php
@@ -155,4 +155,47 @@ class FrmFieldGdpr extends FrmFieldType {
 		}
 		return $html;
 	}
+
+	/**
+	 * Make sure the GDPR field is required even if the required setting is disabled.
+	 *
+	 * @since x.x
+	 *
+	 * @param array $args
+	 * @return array
+	 */
+	public function validate( $args ) {
+		$errors = parent::validate( $args );
+
+		if ( ! $errors && ! FrmFieldGdprHelper::hide_gdpr_field() ) {
+			$required = FrmField::get_option( $this->field, 'required' );
+
+			if ( ! $required && empty( $args['value'] ) ) {
+				$errors[ 'field' . $args['id'] ] = sprintf( __( '%s cannot be blank.', 'formidable' ), is_object( $this->field ) ? $this->field->name : $this->field['name'] );
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Make sure the GDPR field is required even if the required setting is disabled.
+	 *
+	 * @since x.x
+	 *
+	 * @param bool   $required
+	 * @param array  $field
+	 * @return bool
+	 */
+	public static function force_required_field( $required, $field ) {
+		if ( $required ) {
+			return $required;
+		}
+
+		if ( ! $required && 'gdpr' === $field['type'] && ! FrmFieldGdprHelper::hide_gdpr_field() ) {
+			$required = true;
+		}
+
+		return $required;
+	}
 }

--- a/classes/models/fields/FrmFieldGdpr.php
+++ b/classes/models/fields/FrmFieldGdpr.php
@@ -184,8 +184,8 @@ class FrmFieldGdpr extends FrmFieldType {
 	 *
 	 * @since x.x
 	 *
-	 * @param bool   $required
-	 * @param array  $field
+	 * @param bool  $required
+	 * @param array $field
 	 * @return bool
 	 */
 	public static function force_required_field( $required, $field ) {

--- a/classes/models/fields/FrmFieldGdpr.php
+++ b/classes/models/fields/FrmFieldGdpr.php
@@ -172,7 +172,7 @@ class FrmFieldGdpr extends FrmFieldType {
 
 			if ( ! $required && empty( $args['value'] ) ) {
 				$frm_settings                    = FrmAppHelper::get_settings();
-				$errors[ 'field' . $args['id'] ] = str_replace( '[field_name]', is_object( $this->field ) ? $this->field->name : $this->field['name'],  $frm_settings->blank_msg );
+				$errors[ 'field' . $args['id'] ] = str_replace( '[field_name]', is_object( $this->field ) ? $this->field->name : $this->field['name'], $frm_settings->blank_msg );
 			}
 		}
 

--- a/classes/views/frm-fields/back-end/settings.php
+++ b/classes/views/frm-fields/back-end/settings.php
@@ -85,7 +85,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php if ( $display['required'] ) { ?>
 				<div class="frm_form_field">
 					<label for="frm_req_field_<?php echo esc_attr( $field['id'] ); ?>" class="frm-mb-0">
-						<input type="checkbox" id="frm_req_field_<?php echo esc_attr( $field['id'] ); ?>" class="frm_req_field" name="field_options[required_<?php echo esc_attr( $field['id'] ); ?>]" value="1" <?php echo $display['readonly_required'] ? 'readonly onclick="return false;"' : ''; ?> <?php checked( $field['required'], 1 ); ?> />
+						<input type="checkbox" id="frm_req_field_<?php echo esc_attr( $field['id'] ); ?>" class="frm_req_field" name="field_options[required_<?php echo esc_attr( $field['id'] ); ?>]" value="1" <?php echo $display['readonly_required'] ? 'readonly onclick="return false;"' : ''; ?> <?php checked( ! empty( $field['required'] ) || ! empty( $display['readonly_required'] ) ); ?> />
 						<?php esc_html_e( 'Required', 'formidable' ); ?>
 					</label>
 				</div>


### PR DESCRIPTION
Fixes the customer's issue in https://github.com/Strategy11/formidable-pro/issues/5708

It is possible for the GDPR field to not be required. I can at least replicate this by adding a field, disabling the GDPR setting, save the field, and then enabling it again. Since it is read only you end up with a checkbox that is uncheckable and unchecked.

<img width="232" alt="Screen Shot 2025-03-24 at 10 04 47 AM" src="https://github.com/user-attachments/assets/1860dcc8-d899-4aa5-8802-1b75fde8e5a9" />

This update always sets the checkbox to appear as checked if the `readonly_required` setting is on. When this is on, we expect it to always be checked. I don't see us requiring a readonly disabled checkbox since we would likely just hide the setting in those cases.

I also added a check so it always does the required validation even when unchecked, and the required asterisk will still show even when unchecked.

**Pre-release**
[formidable-6.19.1b.zip](https://github.com/user-attachments/files/19430232/formidable-6.19.1b.zip)
