### PR TITLE
Validate serialized data that appears to be broken

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2203,7 +2203,7 @@ class FrmAppHelper {
 	 * @since 2.0
 	 */
 	public static function use_wpautop( $content ) {
-		if ( apply_filters( 'frm_use_wpautop', true ) && ! is_array( $content ) ) {
+		if ( apply_filters( 'frm_use_wpautop', true ) && is_string( $content ) ) {
 			$content = wpautop( str_replace( '<br>', '<br />', $content ) );
 		}
 

--- a/classes/helpers/FrmSerializedStringParserHelper.php
+++ b/classes/helpers/FrmSerializedStringParserHelper.php
@@ -59,11 +59,7 @@ class FrmSerializedStringParserHelper {
 	 * @return bool
 	 */
 	private function serialized_value_is_valid( $value ) {
-		if ( ! is_string( $value ) ) {
-			return true;
-		}
-
-		return strpos( $value, ';s:' ) === false;
+		return ! is_string( $value ) || strpos( $value, ';s:' ) === false;
 	}
 
 	/**

--- a/classes/helpers/FrmSerializedStringParserHelper.php
+++ b/classes/helpers/FrmSerializedStringParserHelper.php
@@ -43,7 +43,7 @@ class FrmSerializedStringParserHelper {
 	public function parse( $string ) {
 		$unserialized_data = $this->do_parse( new FrmStringReaderHelper( $string ) );
 
-		if ( $this->serialized_string_is_invalid( $string ) ) {
+		if ( is_array( $unserialized_data ) && $this->serialized_string_is_invalid( $string ) ) {
 			return array_filter( $unserialized_data, array( $this, 'serialized_value_is_valid' ) );
 		}
 

--- a/classes/helpers/FrmSerializedStringParserHelper.php
+++ b/classes/helpers/FrmSerializedStringParserHelper.php
@@ -41,7 +41,32 @@ class FrmSerializedStringParserHelper {
 	 * @return mixed
 	 */
 	public function parse( $string ) {
+		if ( $this->serialized_string_is_invalid( $string ) ) {
+			return array();
+		}
+
 		return $this->do_parse( new FrmStringReaderHelper( $string ) );
+	}
+
+	/**
+	 * @since x.x
+	 *
+	 * @param string $string
+	 * @return bool
+	 */
+	private function serialized_string_is_invalid( $string ) {
+		$invalid_substrings = array(
+			';s:10:"a"',
+			';s:"',
+		);
+
+		foreach ( $invalid_substrings as $invalid ) {
+			if ( strpos( $string, $invalid ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/classes/helpers/FrmSerializedStringParserHelper.php
+++ b/classes/helpers/FrmSerializedStringParserHelper.php
@@ -41,11 +41,39 @@ class FrmSerializedStringParserHelper {
 	 * @return mixed
 	 */
 	public function parse( $string ) {
+		$unserialized_data = $this->do_parse( new FrmStringReaderHelper( $string ) );
+
 		if ( $this->serialized_string_is_invalid( $string ) ) {
-			return array();
+			return array_filter( $unserialized_data, array( $this, 'serialized_value_is_valid' ) );
 		}
 
-		return $this->do_parse( new FrmStringReaderHelper( $string ) );
+		return $unserialized_data;
+	}
+
+	/**
+	 * Check if an unserialized value is valid.
+	 *
+	 * @since x.x
+	 *
+	 * @param mixed $value
+	 * @return bool
+	 */
+	private function serialized_value_is_valid( $value ) {
+		if ( ! is_string( $value ) ) {
+			return true;
+		}
+
+		$invalid_substrings = array(
+			';s:',
+		);
+
+		foreach ( $invalid_substrings as $invalid ) {
+			if ( strpos( $value, $invalid ) !== false ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/classes/helpers/FrmSerializedStringParserHelper.php
+++ b/classes/helpers/FrmSerializedStringParserHelper.php
@@ -56,8 +56,8 @@ class FrmSerializedStringParserHelper {
 	 */
 	private function serialized_string_is_invalid( $string ) {
 		$invalid_substrings = array(
-			';s:10:"a"',
-			';s:"',
+			';s:10:\"a"',
+			';s:";',
 		);
 
 		foreach ( $invalid_substrings as $invalid ) {

--- a/classes/helpers/FrmSerializedStringParserHelper.php
+++ b/classes/helpers/FrmSerializedStringParserHelper.php
@@ -63,17 +63,7 @@ class FrmSerializedStringParserHelper {
 			return true;
 		}
 
-		$invalid_substrings = array(
-			';s:',
-		);
-
-		foreach ( $invalid_substrings as $invalid ) {
-			if ( strpos( $value, $invalid ) !== false ) {
-				return false;
-			}
-		}
-
-		return true;
+		return strpos( $value, ';s:' ) === false;
 	}
 
 	/**


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2881045066/225606

The serialized data just isn't valid, and the parsing is getting it partially right but it's problematic.

This update filters the data if it looks invalid, and only uses what appears to be valid.

This update checks for 2 substrings that appear in the customer's data. When using `unserialize`, I just get back `false`.

There's also a small deprectred messaged fix for if your form `description` is `null` as well. I'm seeing this because I inserted the row into the DB manually and didn't add a value.

**Pre-release**
[formidable-6.19.1b.zip](https://github.com/user-attachments/files/19435518/formidable-6.19.1b.zip)

**_Tested and confirmed by Dimitris_**