### PR TITLE
Only editors should be allowed to preview

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -389,6 +389,7 @@ class FrmFormsController {
 	 * @return string|null
 	 */
 	public static function page_preview() {
+		FrmAppHelper::permission_check( 'frm_edit_forms' );
 		$params = FrmForm::list_page_params();
 		if ( ! $params['form'] ) {
 			return null;
@@ -415,6 +416,7 @@ class FrmFormsController {
 	 * @return void
 	 */
 	public static function preview() {
+		FrmAppHelper::permission_check( 'frm_edit_forms' );
 		do_action( 'frm_wp' );
 		FrmAppHelper::set_current_screen_and_hook_suffix();
 


### PR DESCRIPTION
Given that:
* on the creation of a new site, Formidable creates a form called 'contact-form' that is active
* the form has an Email Notification action set to send to [site_admin]
* the form does not have any strong spam mitigation enabled
* the preview page is not restricted in any way

This results in a situation where any unauthenticated user can go to `/wp-admin/admin-ajax.php?action=frm_forms_preview&form=contact-form` and spam the site admin's email without any authentication, whether or not the default example form has been published on any page.

The solution proposed here is to limit the Preview function to people who have `frm_edit_forms` access since it's clear from the interface that the only way you should normally be able to access the Preview is to do so from the Editor.