### PR TITLE
Allow links in GDPR agreement text

### DIFF
--- a/classes/views/frm-fields/front-end/gdpr/gdpr-field.php
+++ b/classes/views/frm-fields/front-end/gdpr/gdpr-field.php
@@ -21,7 +21,7 @@ $label_id       = 'frm-gdpr-accept-' . $field_id;
 		<?php echo $checked . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		<?php do_action( 'frm_field_input_html', $field ); ?>
 		/>
-		<?php echo esc_html( $agreement_text ); ?>
+		<?php FrmAppHelper::kses_echo( $agreement_text, array( 'a' ) ); ?>
 	</label>
 </div>
 <?php elseif ( current_user_can( 'frm_edit_forms' ) ) : ?>


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2891604879/226396

It's common to link to Terms and Conditions in a field like our GDPR one.

However, because this was using `esc_html`, links were not working.

**Pre-release**
[formidable-6.19.1b.zip](https://github.com/user-attachments/files/19534949/formidable-6.19.1b.zip)
