### PR TITLE
Fix wpml compatibility issue

### DIFF
--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -664,6 +664,22 @@ class FrmFormActionsController {
 
 		return $where;
 	}
+
+	/**
+	 * Prevent WPML from filtering form actions based on the active language.
+	 *
+	 * @since x.x
+	 *
+	 * @param bool|null $null
+	 * @param string    $post_type
+	 * @return bool|null
+	 */
+	public static function prevent_wpml_translations( $null, $post_type ) {
+		if ( 'frm_form_actions' === $post_type ) {
+			return false;
+		}
+		return $null;
+	}
 }
 
 class Frm_Form_Action_Factory {
@@ -692,21 +708,5 @@ class Frm_Form_Action_Factory {
 				$this->actions[ $key ]->_register();
 			}
 		}
-	}
-
-	/**
-	 * Prevent WPML from filtering form actions based on the active language.
-	 *
-	 * @since x.x
-	 *
-	 * @param bool|null $null
-	 * @param string    $post_type
-	 * @return bool|null
-	 */
-	public static function prevent_wpml_translations( $null, $post_type ) {
-		if ( 'frm_form_actions' === $post_type ) {
-			return false;
-		}
-		return $null;
 	}
 }

--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -675,7 +675,7 @@ class FrmFormActionsController {
 	 * @return bool|null
 	 */
 	public static function prevent_wpml_translations( $null, $post_type ) {
-		if ( 'frm_form_actions' === $post_type ) {
+		if ( self::$action_post_type === $post_type ) {
 			return false;
 		}
 		return $null;

--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -693,4 +693,20 @@ class Frm_Form_Action_Factory {
 			}
 		}
 	}
+
+	/**
+	 * Prevent WPML from filtering form actions based on the active language.
+	 *
+	 * @since x.x
+	 *
+	 * @param bool|null $null
+	 * @param string    $post_type
+	 * @return bool|null
+	 */
+	public static function prevent_wpml_translations( $null, $post_type ) {
+		if ( 'frm_form_actions' === $post_type ) {
+			return false;
+		}
+		return $null;
+	}
 }

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -72,6 +72,7 @@ class FrmHooksController {
 		// Form Actions Controller.
 		add_action( 'init', 'FrmFormActionsController::register_post_types', 1 );
 		add_action( 'frm_after_create_entry', 'FrmFormActionsController::trigger_create_actions', 20, 3 );
+		add_filter( 'pre_wpml_is_translated_post_type', 'FrmFormActionsController::prevent_wpml_translations', 10, 2 );
 
 		// Forms Controller.
 		add_action( 'widgets_init', 'FrmFormsController::register_widgets' );


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2885530761/225900

**Pre-release**
[formidable-6.19.1b.zip](https://github.com/user-attachments/files/19540029/formidable-6.19.1b.zip)

This update helps to prevent WPML from filtering our form actions, so they work as expected.