### PR TITLE
Hide posts filter when showing mobile go back option

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -9301,6 +9301,10 @@ Responsive Design
 	#frm_small_device_message > svg {
 		padding-bottom: 1rem;
 	}
+
+	#posts-filter {
+		display: none;
+	}
 }
 
 /* PRINT */


### PR DESCRIPTION
This fixes the issues I see in https://github.com/Strategy11/formidable-forms/pull/2241#issuecomment-2757943304

There's a `posts-filter` element on the forms list page that was increasing the width of the page. Hiding it fixes the issue.