### PR TITLE
Use less jquery when validating required radios

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -381,8 +381,8 @@ function frmFrontFormJS() {
 				}
 
 				const checkedInputs = requiredField.querySelectorAll( 'input:checked' );
-				checkedInputs.forEach( function( input ) {
-					val = input.value;
+				checkedInputs.forEach( function( checkedInput ) {
+					val = checkedInput.value;
 				} );
 			} );
 		} else if ( field.type === 'file' || fileID ) {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -364,7 +364,7 @@ function frmFrontFormJS() {
 	 * @return {Array} Errors
 	 */
 	function checkRequiredField( field, errors ) {
-		let checkGroup, tempVal, i, placeholder,
+		let tempVal, i, placeholder,
 			val = '',
 			fieldID = '',
 			fileID = field.getAttribute( 'data-frmfile' );
@@ -374,10 +374,17 @@ function frmFrontFormJS() {
 		}
 
 		if ( field.type === 'checkbox' || field.type === 'radio' ) {
-			checkGroup = jQuery( 'input[name="' + field.name + '"]' ).closest( '.frm_required_field' ).find( 'input:checked' );
-			jQuery( checkGroup ).each( function() {
-				val = this.value;
-			});
+			document.querySelectorAll( 'input[name="' + field.name + '"]' ).forEach( function( input ) {
+				const requiredField = input.closest( '.frm_required_field' );
+				if ( ! requiredField ) {
+					return;
+				}
+
+				const checkedInputs = requiredField.querySelectorAll( 'input:checked' );
+				checkedInputs.forEach( function( input ) {
+					val = input.value;
+				} );
+			} );
 		} else if ( field.type === 'file' || fileID ) {
 			if ( typeof fileID === 'undefined' ) {
 				fileID = getFieldId( field, true );


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5002

This update removes another use of `.find()`, `.closest`, and `.each()`.