### PR TITLE
Stop using jQuery when changing window scroll positions

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1672,6 +1672,7 @@ function frmFrontFormJS() {
 			return;
 		}
 
+		/* eslint-disable compat/compat */
 		const startTime = performance.now();
 		const step      = ( currentTime ) => {
 			const progress = Math.min( ( currentTime - startTime ) / duration, 1 );
@@ -1681,6 +1682,7 @@ function frmFrontFormJS() {
 			}
 		};
 		requestAnimationFrame( step );
+		/* eslint-enable compat/compat */
 	}
 
 	return {

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1656,6 +1656,28 @@ function frmFrontFormJS() {
 		return uniqueKey + '-' + timestamp;
 	}
 
+	/**
+	 * Animates the scroll position of the document.
+	 *
+	 * @since x.x
+	 *
+	 * @param {number} start
+	 * @param {number} end
+	 * @param {number} duration
+	 * @return {void}
+	 */
+	function animateScroll( start, end, duration ) {
+		const startTime = performance.now();
+		const step      = ( currentTime ) => {
+			const progress = Math.min( ( currentTime - startTime ) / duration, 1 );
+			document.documentElement.scrollTop = start + ( end - start ) * progress;
+			if ( progress < 1 ) {
+				requestAnimationFrame( step );
+			}
+		};
+		requestAnimationFrame( step );
+	}
+
 	return {
 		init: function() {
 			jQuery( document ).off( 'submit.formidable', '.frm-show-form' );
@@ -1948,9 +1970,9 @@ function frmFrontFormJS() {
 				if ( newPos > screenBottom || newPos < screenTop ) {
 					// Not in view
 					if ( typeof animate === 'undefined' ) {
-						jQuery( window ).scrollTop( newPos );
+						document.documentElement.scrollTop = newPos;
 					} else {
-						jQuery( 'html,body' ).animate({ scrollTop: newPos }, 500 );
+						animateScroll( screenTop, newPos, 500 );
 					}
 					return false;
 				}

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1667,6 +1667,11 @@ function frmFrontFormJS() {
 	 * @return {void}
 	 */
 	function animateScroll( start, end, duration ) {
+		if ( ! window.hasOwnProperty( 'performance' ) || ! window.hasOwnProperty( 'requestAnimationFrame' ) ) {
+			document.documentElement.scrollTop = end;
+			return;
+		}
+
 		const startTime = performance.now();
 		const step      = ( currentTime ) => {
 			const progress = Math.min( ( currentTime - startTime ) / duration, 1 );


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5002

This drops some more complicated jQuery, removing `.scrollTop`, and `.animate`.