### PR TITLE
Limit pages small device message appears in

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1928,6 +1928,13 @@ class FrmFormsController {
 	 * @return void
 	 */
 	public static function include_device_too_small_message() {
+		if ( ! FrmAppHelper::is_formidable_admin() ) {
+			return;
+		}
+		if ( 'frm_logs' !== FrmAppHelper::simple_get( 'post_type', 'sanitize_title' ) ) {
+			return;
+		}
+
 		include FrmAppHelper::plugin_path() . '/classes/views/shared/small-device-message.php';
 	}
 

--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1931,9 +1931,6 @@ class FrmFormsController {
 		if ( ! FrmAppHelper::is_formidable_admin() ) {
 			return;
 		}
-		if ( 'frm_logs' !== FrmAppHelper::simple_get( 'post_type', 'sanitize_title' ) ) {
-			return;
-		}
 
 		include FrmAppHelper::plugin_path() . '/classes/views/shared/small-device-message.php';
 	}

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -9302,7 +9302,7 @@ Responsive Design
 		padding-bottom: 1rem;
 	}
 
-	#posts-filter {
+	.toplevel_page_formidable #posts-filter {
 		display: none;
 	}
 }

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -9302,7 +9302,8 @@ Responsive Design
 		padding-bottom: 1rem;
 	}
 
-	.toplevel_page_formidable #posts-filter {
+	.toplevel_page_formidable #posts-filter,
+	.post-type-frm_display #posts-filter {
 		display: none;
 	}
 }


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5728

### Test procedure
Go to different WP admin pages that are not Formidable pages and confirm the 'More on bigger devices' message does not appear anywhere on the page.