### PR TITLE
Fix sorting issues

### DIFF
--- a/classes/controllers/FrmUsageController.php
+++ b/classes/controllers/FrmUsageController.php
@@ -106,18 +106,13 @@ class FrmUsageController {
 	 * @return bool
 	 */
 	private static function is_forms_list_page() {
-		if ( ! FrmAppHelper::is_admin_page() ) {
+		if ( ! FrmAppHelper::on_form_listing_page() ) {
 			return false;
 		}
 
-		// Check Trash page.
+		// Exclude Trash page.
 		$form_type = FrmAppHelper::simple_get( 'form_type' );
-		if ( $form_type && 'published' !== $form_type ) {
-			return false;
-		}
-
-		// Check edit or settings page.
-		return ! FrmAppHelper::simple_get( 'frm_action' );
+		return $form_type && 'published' === $form_type;
 	}
 
 	/**

--- a/classes/controllers/FrmUsageController.php
+++ b/classes/controllers/FrmUsageController.php
@@ -106,7 +106,18 @@ class FrmUsageController {
 	 * @return bool
 	 */
 	private static function is_forms_list_page() {
-		return FrmAppHelper::is_admin_list_page();
+		if ( ! FrmAppHelper::is_admin_page() ) {
+			return false;
+		}
+
+		// Check Trash page.
+		$form_type = FrmAppHelper::simple_get( 'form_type' );
+		if ( $form_type && 'published' !== $form_type ) {
+			return false;
+		}
+
+		// Check edit or settings page.
+		return ! FrmAppHelper::simple_get( 'frm_action' );
 	}
 
 	/**

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -340,18 +340,32 @@ class FrmAppHelper {
 	 * @return bool
 	 */
 	public static function is_admin_list_page( $page = 'formidable' ) {
+		if ( 'formidable' === $page ) {
+			return self::on_form_listing_page();
+		}
+
 		if ( ! self::is_admin_page( $page ) ) {
 			return false;
 		}
 
-		// Check Trash page.
-		$form_type = self::simple_get( 'form_type' );
-		if ( $form_type && 'published' !== $form_type ) {
-			return false;
+		if ( 'formidable-entries' === $page ) {
+			$action = self::simple_get( 'frm_action' );
+			if ( ! $action || in_array( $action, self::get_entries_listing_page_form_actions(), true ) ) {
+				return true;
+			}
 		}
 
 		// Check edit or settings page.
 		return ! self::simple_get( 'frm_action' );
+	}
+
+	/**
+	 * @since x.x
+	 *
+	 * @return array<string>
+	 */
+	private static function get_entries_listing_page_form_actions() {
+		return array( 'list', 'destroy' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5722

This function was all messed up. It was copied from the usage controller, but that has a different context.

1. It was checking for the trash page and returning false, so sorting on the trash page was not possible.
2. It was missing the delete action.

I also fixed the usage controller logic, so it doesn't miss the delete action either.