### PR TITLE
Add proceed anyway to small device message

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -1507,4 +1507,17 @@ class FrmAppController {
 		wp_safe_redirect( admin_url( 'admin.php?page=formidable' ) );
 		exit;
 	}
+
+	/**
+	 * Handles the small screen proceed action.
+	 *
+	 * @since x.x
+	 *
+	 * @return void
+	 */
+	public static function small_screen_proceed() {
+		FrmAppHelper::permission_check( 'frm_view_forms' );
+		update_user_option( get_current_user_id(), 'frm_ignore_small_screen_warning', true );
+		wp_send_json_success();
+	}
 }

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -301,6 +301,8 @@ class FrmHooksController {
 
 		// Reviews.
 		add_action( 'wp_ajax_frm_dismiss_review', 'FrmAppController::dismiss_review' );
+
+		add_action( 'wp_ajax_frm_small_screen_proceed', 'FrmAppController::small_screen_proceed' );
 	}
 
 	/**

--- a/classes/views/shared/small-device-message.php
+++ b/classes/views/shared/small-device-message.php
@@ -9,12 +9,16 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
+
+if ( ! get_user_option( 'frm_ignore_small_screen_warning', get_current_user_id() ) ) {
 ?>
 <div id="frm_small_device_message_container">
 	<div id="frm_small_device_message">
 		<svg xmlns="http://www.w3.org/2000/svg" width="32" height="49" fill="none"><rect width="30" height="47" x="1" y="1" fill="#F5FAFF" stroke="#4199FD" stroke-width="2" rx="3"/><rect width="8" height="2" x="12" y="5" fill="#C0DDFE" rx="1"/><path stroke="#80BBFE" stroke-width="1.5" d="M23 33c0-3.314-2.91-6-6.5-6S10 29.686 10 33"/><circle cx="10.5" cy="20.5" r="1" fill="#80BBFE" stroke="#80BBFE"/><circle cx="21.5" cy="20.5" r="1" fill="#80BBFE" stroke="#80BBFE"/></svg>
 		<b><?php esc_html_e( 'More on bigger devices', 'formidable' ); ?></b>
 		<p><?php esc_html_e( 'For the best experience, we recommend using Formidable Forms on larger devices such as a desktop or tablet.', 'formidable' ); ?></p>
-		<a href="<?php echo esc_url( admin_url() ); ?>" class="frm-button-primary"><?php esc_html_e( 'Go back', 'formidable' ); ?></a>
+		<div><a href="<?php echo esc_url( admin_url() ); ?>" class="frm-button-primary"><?php esc_html_e( 'Go Back', 'formidable' ); ?></a>&nbsp;&nbsp;&nbsp;&nbsp;<a id="frm_small_screen_proceed_button" href="#" class="frm-button-secondary"><?php esc_html_e( 'Proceed Anyway', 'formidable' ); ?></a></div>
 	</div>
 </div>
+<?php
+}

--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -9302,8 +9302,8 @@ Responsive Design
 		padding-bottom: 1rem;
 	}
 
-	.toplevel_page_formidable #posts-filter,
-	.post-type-frm_display #posts-filter {
+	.toplevel_page_formidable:has(#frm_small_device_message_container) #posts-filter,
+	.post-type-frm_display:has(#frm_small_device_message_container) #posts-filter {
 		display: none;
 	}
 }

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -10639,6 +10639,14 @@ function frmAdminBuildJS() {
 					maybeAddSaveAndDragIcons( fieldId );
 				});
 			});
+
+			const smallScreenProceedButton = document.getElementById( 'frm_small_screen_proceed_button' );
+			if ( smallScreenProceedButton ) {
+				onClickPreventDefault( smallScreenProceedButton, () => {
+					document.getElementById( 'frm_small_device_message_container' )?.remove();
+					doJsonPost( 'small_screen_proceed', new FormData() );
+				});
+			}
 		},
 
 		buildInit: function() {


### PR DESCRIPTION
Related comment https://github.com/Strategy11/formidable-pro/issues/4076#issuecomment-2790657289

Updated design https://www.figma.com/design/DQbZMgeNmJWkxOWYfHjDZX/Formidable-System?node-id=316-1642

This update adds a "Proceed Anyway" button to the small device message, instead of blocking their access to the pages. I save this as a user pref so it isn't shown again.

<img width="398" alt="Screen Shot 2025-04-10 at 9 58 18 AM" src="https://github.com/user-attachments/assets/6575146f-3001-419c-99a8-356bea4e1071" />
