### PR TITLE
Prevent fatal error when getting data for blacklist check

### DIFF
--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -879,7 +879,9 @@ class FrmEntryValidate {
 						$values['name_field_ids'][] = $subsubindex;
 					}
 
-					$values['item_meta'][ $subsubindex ][] = $subsubvalue;
+					if ( is_array( $values['item_meta'][ $subsubindex ] ) ) {
+						$values['item_meta'][ $subsubindex ][] = $subsubvalue;
+					}
 				}
 			}//end foreach
 


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2903104466/227288

> PHP Fatal error:  Uncaught Error: [] operator not supported for strings