### PR TITLE
Check classes input exists before setting value

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -2236,7 +2236,11 @@ function frmAdminBuildJS() {
 		fieldClasses = fieldClasses.replace( 'frm_first', '' );
 		if ( ! newField.className.includes( fieldClasses ) ) {
 			newField.className += ' ' + fieldClasses;
-			document.getElementById( 'frm_classes_' + newField.dataset.fid ).value = fieldClasses;
+
+			const classesInput = document.getElementById( 'frm_classes_' + newField.dataset.fid );
+			if ( classesInput ) {
+				classesInput.value = fieldClasses;
+			}
 		}
 	}
 


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2911273467/227892

> Javascript Message: Uncaught TypeError: Cannot set properties of null (setting \’value\’) – URL: https://mywebsite.com/wp-content/plugins/formidable/js/formidable_admin.js?ver=6.20 – Line: 2239

No clue how to replicate this since any field allowed in a field group supports layout classes.

**Pre-release**
[formidable-6.21b.zip](https://github.com/user-attachments/files/19794945/formidable-6.21b.zip)
