### PR TITLE
Fix issue 5751

### DIFF
--- a/classes/helpers/FrmEntriesListHelper.php
+++ b/classes/helpers/FrmEntriesListHelper.php
@@ -95,9 +95,8 @@ class FrmEntriesListHelper extends FrmListHelper {
 				'param'   => 'orderby',
 				'default' => 'id',
 			)
-		);		
-
-		$order = self::get_param(
+		);
+		$order   = self::get_param(
 			array(
 				'param'   => 'order',
 				'default' => 'DESC',

--- a/classes/helpers/FrmEntriesListHelper.php
+++ b/classes/helpers/FrmEntriesListHelper.php
@@ -95,12 +95,7 @@ class FrmEntriesListHelper extends FrmListHelper {
 				'param'   => 'orderby',
 				'default' => 'id',
 			)
-		);
-
-		if ( strpos( $orderby, 'meta' ) !== false ) {
-			$order_field_type = FrmField::get_type( str_replace( 'meta_', '', $orderby ) );
-			$orderby         .= in_array( $order_field_type, array( 'number', 'scale', 'star' ) ) ? '+0' : '';
-		}
+		);		
 
 		$order = self::get_param(
 			array(
@@ -110,6 +105,14 @@ class FrmEntriesListHelper extends FrmListHelper {
 		);
 
 		FrmAppController::apply_saved_sort_preference( $orderby, $order );
+
+		if ( strpos( $orderby, 'meta' ) !== false ) {
+			$order_field_type = FrmField::get_type( str_replace( 'meta_', '', $orderby ) );
+
+			if ( in_array( $order_field_type, array( 'number', 'scale', 'star' ), true ) ) {
+				$orderby .= '+0';
+			}
+		}
 
 		return FrmDb::esc_order( $orderby . ' ' . $order );
 	}


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5751

This broke with the QoL update. This code that adds the `+0` is important, but get overwritten when `FrmAppController::apply_saved_sort_preference` is called.

I moved this after so it still happens.