### PR TITLE
Fix new pill styling on payment field

### DIFF
--- a/css/frm_admin.css
+++ b/css/frm_admin.css
@@ -7823,7 +7823,7 @@ ul.frm_two_col {
 	opacity: .5;
 }
 
-#frm-insert-fields li span {
+#frm-insert-fields li span:not(.frm-new-pill) {
 	vertical-align: middle;
 	white-space: nowrap;
 	overflow: hidden;


### PR DESCRIPTION
This update just prevents this from being 100% width.

<img width="340" alt="Advanced Fields" src="https://github.com/user-attachments/assets/edf1cefd-556c-4a60-ab57-89c71b7dfb13" />
