### PR TITLE
Adjust stripe link label styles

### DIFF
--- a/stripe/controllers/FrmStrpLiteActionsController.php
+++ b/stripe/controllers/FrmStrpLiteActionsController.php
@@ -538,9 +538,11 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 				'backgroundColor' => $settings['bg_color_active'],
 			),
 			'.Label'              => array(
-				'color'      => $settings['label_color'],
-				'fontSize'   => $settings['font_size'],
-				'fontWeight' => $settings['weight'],
+				'color'        => $settings['label_color'],
+				'fontSize'     => $settings['font_size'],
+				'fontWeight'   => $settings['weight'],
+				'padding'      => $settings['label_padding'],
+				'marginBottom' => 0,
 			),
 			'.Error'              => array(
 				'color' => $settings['border_color_error'],
@@ -549,6 +551,17 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 		if ( isset( $settings['field_shape_type'] ) && 'circle' === $settings['field_shape_type'] ) {
 			$rules['.Input']['borderRadius'] = '30px';
 		}
+
+		/*
+		 * Filters the appearance rules for Stripe elements.
+		 *
+		 * @since x.x
+		 *
+		 * @param array $rules
+		 * @param array $settings
+		 * @param mixed $form_id
+		 */
+		$rules = apply_filters( 'frm_stripe_appearance_rules', $rules, $settings, $form_id );
 		return $rules;
 	}
 

--- a/stripe/controllers/FrmStrpLiteActionsController.php
+++ b/stripe/controllers/FrmStrpLiteActionsController.php
@@ -559,9 +559,8 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 		 *
 		 * @param array $rules
 		 * @param array $settings
-		 * @param mixed $form_id
 		 */
-		$rules = apply_filters( 'frm_stripe_appearance_rules', $rules, $settings, $form_id );
+		$rules = apply_filters( 'frm_stripe_appearance_rules', $rules, $settings );
 		return $rules;
 	}
 


### PR DESCRIPTION
Fabio brought this up in Slack https://strategy11.slack.com/archives/CJFQ599V5/p1745604846742759

This update tries to make the Stripe Link label styling more consistent.

I'm also introducing a `frm_stripe_appearance_rules` filter to make it easier to get things perfect.

Example snippet.

```
add_filter(
	'frm_stripe_appearance_rules',
	function ( $rules ) {
		$rules['.Label']['lineHeight'] = 1;
		return $rules;
	}
);
```