### PR TITLE
Stop trigger change when showing field options

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -7308,8 +7308,6 @@ function frmAdminBuildJS() {
 
 		wp.hooks.doAction( 'frmShowedFieldSettings', obj, singleField );
 		maybeAddShortcodesModalTriggerIcon( fieldType, fieldId, singleField );
-
-		singleField.querySelectorAll( '.frm_logic_field_opts' ).forEach( triggerChange );
 	}
 
 	function maybeAddShortcodesModalTriggerIcon( fieldType, fieldId, singleField ) {


### PR DESCRIPTION
This is causing issues with conditional logic setting all being empty. Reverting this change.

I'll need to figure out a better way.