### PR TITLE
Avoid showing sales banner to user without the proper role

### DIFF
--- a/classes/models/FrmSalesApi.php
+++ b/classes/models/FrmSalesApi.php
@@ -244,12 +244,12 @@ class FrmSalesApi extends FrmFormApi {
 	 * @return bool
 	 */
 	public static function maybe_show_banner() {
-		if ( ! isset( self::$instance ) ) {
-			self::$instance = new FrmSalesApi();
-		}
-
 		if ( ! current_user_can( 'frm_change_settings' ) ) {
 			return false;
+		}
+
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new FrmSalesApi();
 		}
 
 		$sale = self::$instance->get_best_sale();

--- a/classes/models/FrmSalesApi.php
+++ b/classes/models/FrmSalesApi.php
@@ -248,6 +248,10 @@ class FrmSalesApi extends FrmFormApi {
 			self::$instance = new FrmSalesApi();
 		}
 
+		if ( ! current_user_can( 'frm_change_settings' ) ) {
+			return false;
+		}
+
 		$sale = self::$instance->get_best_sale();
 		if ( ! $sale || ! is_array( $sale ) ) {
 			return false;


### PR DESCRIPTION
This is to prevent it from appearing for users who can't really act on the sale.