### PR TITLE
Improve honeypot compatibility with API loaded forms

### DIFF
--- a/classes/models/FrmHoneypot.php
+++ b/classes/models/FrmHoneypot.php
@@ -150,7 +150,40 @@ class FrmHoneypot extends FrmValidate {
 	 * @return bool
 	 */
 	public function should_render_field() {
+		if ( $this->form_is_loaded_by_api() ) {
+			return false;
+		}
 		return $this->is_option_on() && $this->check_honeypot_filter();
+	}
+
+	/**
+	 * Prevent the honeypot from appearing for an API loaded form.
+	 * This is because the footer script is not getting added.
+	 *
+	 * @since x.x
+	 *
+	 * @return bool
+	 */
+	private function form_is_loaded_by_api() {
+		if ( ! class_exists( 'FrmAPIAppController' ) ) {
+			return false;
+		}
+
+		$url = FrmAppHelper::get_server_value( 'REQUEST_URI' );
+		if ( 0 === strpos( $url, '/wp-json/frm/v2/forms/' ) ) {
+			// Prevent the honeypot from appearing for an API loaded form.
+			// This is to prevent conflicts where the script is not working.
+			return true;
+		}
+
+		if ( is_callable( 'FrmProFormState::get_from_request' ) ) {
+			$api = FrmProFormState::get_from_request( 'a', 0 );
+			if ( $api ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
I'm seeing issues when using `[frm-api]` and the `<script>` tag to include an API loaded form, where the honeypot is appearing because it looks like the footer function is never called.

This update effectively disables the honeypot if it detects that the form is loaded from an API.

What do you think @truongwp? There's probably a better fix. I want to keep this contained to this plugin as well for now if possible.