### PR TITLE
Make unread inbox count checks more consistent

### DIFF
--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -879,7 +879,7 @@ class FrmEntriesHelper {
 		}
 
 		$inbox       = new FrmInbox();
-		$inbox_count = count( $inbox->unread() );
+		$inbox_count = $inbox->get_unread_count();
 
 		if ( ! $inbox_count ) {
 			return 0;

--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -315,7 +315,7 @@ class FrmInbox extends FrmFormApi {
 	 * @return string
 	 */
 	public function unread_html( $filtered = true ) {
-		$count = count( $this->unread() );
+		$count = $this->get_unread_count();
 		if ( ! $count ) {
 			return '';
 		}
@@ -332,6 +332,17 @@ class FrmInbox extends FrmFormApi {
 		 * @param string $html
 		 */
 		return (string) apply_filters( 'frm_inbox_badge', $html );
+	}
+
+	/**
+	 * Get unread inbox count.
+	 *
+	 * @since x.x
+	 *
+	 * @return int
+	 */
+	public function get_unread_count() {
+		return count( $this->unread() );
 	}
 
 	/**


### PR DESCRIPTION
This way it's all happening in one place. It's easier for testing and will be easier if we end up changing the count when there isn't a  new inbox item (ie. for sales).