### PR TITLE
Denylist spam check improvements

### DIFF
--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -422,6 +422,11 @@ class FrmEntryValidate {
 	 * @param array $errors By reference.
 	 */
 	public static function spam_check( $exclude, $values, &$errors ) {
+		if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
+			// Do not check spam on importing.
+			return;
+		}
+
 		if ( ! empty( $exclude ) || empty( $values['item_meta'] ) || ! empty( $errors ) ) {
 			// only check spam if there are no other errors
 			return;

--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -95,6 +95,8 @@ class FrmSettings {
 
 	public $wp_spam_check;
 
+	public $denylist_check;
+
 	public $disallowed_words;
 
 	public $allowed_words;
@@ -173,6 +175,7 @@ class FrmSettings {
 			'custom_css'                => false,
 			'honeypot'                  => 1,
 			'wp_spam_check'             => 0,
+			'denylist_check'            => 0,
 			'disallowed_words'          => '',
 			'allowed_words'             => '',
 		);

--- a/classes/models/FrmSpamCheckDenylist.php
+++ b/classes/models/FrmSpamCheckDenylist.php
@@ -358,7 +358,7 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 			} elseif ( $this->should_check_this_field( $key, $field_ids_to_check ) ) {
 				$this->add_to_values_to_check( $values_to_check, $value );
 			}
-		}
+		}//end foreach
 
 		if ( isset( $denylist['extract_value'] ) && is_callable( $denylist['extract_value'] ) ) {
 			$values_to_check = call_user_func( $denylist['extract_value'], $values_to_check, $denylist );

--- a/classes/models/FrmSpamCheckDenylist.php
+++ b/classes/models/FrmSpamCheckDenylist.php
@@ -53,15 +53,18 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 	}
 
 	protected function is_enabled() {
+		$frm_settings = FrmAppHelper::get_settings();
+		$is_enabled   = $frm_settings->denylist_check;
+
 		/**
-		 * Allows to disable the denylist check.
+		 * Allows disabling the denylist check.
 		 *
 		 * @since 6.21
 		 *
 		 * @param bool  $is_enabled Whether the denylist check is enabled.
 		 * @param array $values     The entry values.
 		 */
-		return apply_filters( 'frm_check_denylist', true, $this->values );
+		return apply_filters( 'frm_check_denylist', $is_enabled, $this->values );
 	}
 
 	/**

--- a/classes/models/FrmSpamCheckDenylist.php
+++ b/classes/models/FrmSpamCheckDenylist.php
@@ -205,6 +205,9 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 				'skip'             => false,
 			)
 		);
+
+		// Some field types should never be checked.
+		$denylist['skip_field_types'] = array_merge( $denylist['skip_field_types'], array( 'password', 'captcha', 'signature' ) );
 	}
 
 	/**

--- a/classes/models/FrmSpamCheckDenylist.php
+++ b/classes/models/FrmSpamCheckDenylist.php
@@ -197,6 +197,7 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 				'words'            => array(),
 				'is_regex'         => false,
 				'field_types'      => array(),
+				// Add `other` if you want to skip checking Other values of some field types.
 				'skip_field_types' => array(),
 				// Is ignore if `is_regex` is `true`.
 				'compare'          => self::COMPARE_CONTAINS,
@@ -207,7 +208,10 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 		);
 
 		// Some field types should never be checked.
-		$denylist['skip_field_types'] = array_merge( $denylist['skip_field_types'], array( 'password', 'captcha', 'signature' ) );
+		$denylist['skip_field_types'] = array_merge(
+			$denylist['skip_field_types'],
+			array( 'password', 'captcha', 'signature', 'checkbox', 'radio', 'select' )
+		);
 	}
 
 	/**
@@ -341,6 +345,13 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 
 				foreach ( $value as $sub_key => $sub_value ) {
 					if ( $this->should_check_this_field( $sub_key, $field_ids_to_check ) ) {
+						$this->add_to_values_to_check( $values_to_check, $sub_value );
+					}
+				}
+			} elseif ( 'other' === $key ) {
+				if ( ! in_array( 'other', $denylist['skip_field_types'], true ) ) {
+					// This is Other values, loop through this and add sub values.
+					foreach ( $value as $sub_value ) {
 						$this->add_to_values_to_check( $values_to_check, $sub_value );
 					}
 				}

--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -222,6 +222,7 @@ class FrmUsage {
 			'active_captcha',
 			'honeypot',
 			'wp_spam_check',
+			'denylist_check',
 		);
 
 		foreach ( $pass_settings as $setting ) {

--- a/classes/views/frm-settings/captcha/captcha.php
+++ b/classes/views/frm-settings/captcha/captcha.php
@@ -120,6 +120,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 </p>
 
 <p>
+	<label>
+		<input type="checkbox" name="frm_denylist_check" value="1" <?php checked( $frm_settings->denylist_check, 1 ); ?> />
+		<?php esc_html_e( 'Check denylist data to validate for spam', 'formidable' ); ?>
+	</label>
+</p>
+
+<p>
 	<label for="frm-disallowed-words">
 		<?php esc_html_e( 'Custom disallowed words', 'formidable' ); ?>
 		<?php FrmAppHelper::tooltip_icon( __( 'Each word is on one line.', 'formidable' ), array( 'data-container' => 'body' ) ); ?>


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5801

Changes:
- Added a toggle to disable denylist spam check.
- All spam checks now don't run when importing.
- Denylist spam check doesn't check password, captcha, signature, radio, checkbox, select field types. But it still check the Other value of radio, checkbox, select field types. To skip for Other value, add `other` to the `skip_field_types` of denylist.