### PR TITLE
Add filter for honeypot field ID

### DIFF
--- a/classes/models/FrmHoneypot.php
+++ b/classes/models/FrmHoneypot.php
@@ -96,6 +96,15 @@ class FrmHoneypot extends FrmValidate {
 			return;
 		}
 
+		/**
+		 * Allow people to customize the honeypot field ID.
+		 *
+		 * @since x.x
+		 *
+		 * @param int $honeypot_field_id The honeypot field ID.
+		 */
+		$honeypot_field_id = (int) apply_filters( 'frm_honeypot_field_id', $honeypot_field_id );
+
 		$class = class_exists( 'FrmProFormState' ) ? 'FrmProFormState' : 'FrmFormState';
 		$class::set_initial_value( 'honeypot_field_id', $honeypot_field_id );
 


### PR DESCRIPTION
Related ticket https://github.com/Strategy11/formidable-pro/issues/5802

This allows someone to pick a custom honeypot ID, in case the field ID is also loaded on the form.