### PR TITLE
Add exception for post field setting when validation options

### DIFF
--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -232,6 +232,10 @@ class FrmEntryValidate {
 			return true;
 		}
 
+		if ( ! empty( $field->field_options['post_field'] ) ) {
+			return true;
+		}
+
 		$value = (array) $value;
 
 		foreach ( $value as $current_value ) {


### PR DESCRIPTION
This should already be fine because of the `options_are_dynamic_based_on_hook` check, but for some reason it's still an issue in this ticket https://secure.helpscout.net/conversation/2943441570/230308

This extra check should help.