### PR TITLE
Add trim check when checking for valid option match

### DIFF
--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -254,6 +254,11 @@ class FrmEntryValidate {
 					break;
 				}
 
+				$match = $current_value === trim( $option_value );
+				if ( $match ) {
+					break;
+				}
+
 				if ( is_numeric( $current_value ) ) {
 					$match = (int) $current_value === (int) $option_value;
 					if ( $match ) {

--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -265,7 +265,7 @@ class FrmEntryValidate {
 						break;
 					}
 				}
-			}
+			}//end foreach
 
 			if ( ! $match ) {
 				return self::options_are_dynamic_based_on_hook( $field, $value );


### PR DESCRIPTION
Related Slack comment https://strategy11.slack.com/archives/C799A2R61/p1747926380511749?thread_ts=1747901832.697259&cid=C799A2R61

If I have spaces at the end of my options in my database, it throws errors because the value getting sent is trimmed and the options are not.