### PR TITLE
Fix honeypot field shows in audience identification popup

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -3222,10 +3222,6 @@ class FrmFormsController {
 			// load formidable js
 			wp_enqueue_script( 'formidable' );
 		}
-
-		if ( ! FrmAppHelper::is_admin() ) {
-			FrmHoneypot::maybe_print_honeypot_js();
-		}
 	}
 
 	/**

--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -81,6 +81,7 @@ class FrmHooksController {
 		add_filter( 'frm_replace_content_shortcodes', 'FrmFormsController::replace_content_shortcodes', 20, 3 );
 		add_action( 'admin_bar_init', 'FrmFormsController::admin_bar_css' );
 		add_action( 'wp_footer', 'FrmFormsController::footer_js', 1, 0 );
+		add_action( 'wp_footer', 'FrmHoneypot::maybe_print_honeypot_js', 99 );
 
 		add_action( 'wp_scheduled_delete', 'FrmForm::scheduled_delete' );
 

--- a/classes/models/FrmHoneypot.php
+++ b/classes/models/FrmHoneypot.php
@@ -86,7 +86,7 @@ class FrmHoneypot extends FrmValidate {
 
 	/**
 	 * @param int $form_id Form ID.
-	 * 
+	 *
 	 * @return void
 	 */
 	public static function maybe_render_field( $form_id ) {
@@ -121,7 +121,7 @@ class FrmHoneypot extends FrmValidate {
 	 * @since 6.21
 	 */
 	public static function maybe_print_honeypot_js() {
-		if ( ! self::is_enabled() ) {
+		if ( FrmAppHelper::is_admin() || ! self::is_enabled() ) {
 			return;
 		}
 


### PR DESCRIPTION
Mike reported this via Slack.

To replicate it locally:
- Install this plugin https://github.com/Strategy11/s11-audience-identification.
- Create a form, set the form key to `s11-audience-identification`.
- Log in using an account that isn't admin.
- View the frontend, you will see the honeypot field show in the form in the popup.

The problem is that the script to hide the honeypot field is called before the audience identification form.