### PR TITLE
Stop showing hidden inputs when using opt option in input shortcode

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1172,6 +1172,15 @@ DEFAULT_HTML;
 		return $hidden;
 	}
 
+	/**
+	 * When opt=2 for example is used in the [input] shortcode, only print a single hidden input.
+	 *
+	 * @since x.x
+	 *
+	 * @param array      $args
+	 * @param int|string $opt
+	 * @return string
+	 */
 	private function include_hidden_values_for_single_opt( $args, $opt ) {
 		$hidden         = '';
 		$selected_value = isset( $args['field_value'] ) ? $args['field_value'] : $this->field['value'];
@@ -1198,7 +1207,7 @@ DEFAULT_HTML;
 		return $hidden;
 	}
 	
-		/**
+	/**
 	 * When the field is read only, does it need it include hidden fields?
 	 * Checkboxes and dropdowns need this
 	 */

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1068,10 +1068,10 @@ DEFAULT_HTML;
 			return;
 		}
 
-		if ( ! isset( $shortcode_atts['opt'] ) ) {
-			$hidden = $this->maybe_include_hidden_values( $args );
+		if ( isset( $shortcode_atts['opt'] ) ) {
+			$hidden = $this->include_hidden_values_for_single_opt( $args, $shortcode_atts['opt'] );
 		} else {
-			$hidden = '';
+			$hidden = $this->maybe_include_hidden_values( $args );
 		}
 
 		$field      = $this->field;
@@ -1172,7 +1172,33 @@ DEFAULT_HTML;
 		return $hidden;
 	}
 
-	/**
+	private function include_hidden_values_for_single_opt( $args, $opt ) {
+		$hidden         = '';
+		$selected_value = isset( $args['field_value'] ) ? $args['field_value'] : $this->field['value'];
+
+		if ( ! is_array( $selected_value ) ) {
+			return $hidden;
+		}
+
+		$options = array_values( $this->field['options'] );
+		if ( ! isset( $options[ $opt ] ) ) {
+			return $hidden;
+		}
+
+		$option = $options[ $opt ];
+		if ( is_array( $option ) ) {
+			$option = $option['value'];
+		}
+
+		if ( in_array( $option, $selected_value, true ) ) {
+			$args['field_value'] = array( $option );
+			$hidden              = $this->maybe_include_hidden_values( $args );
+		}
+
+		return $hidden;
+	}
+	
+		/**
 	 * When the field is read only, does it need it include hidden fields?
 	 * Checkboxes and dropdowns need this
 	 */

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1068,7 +1068,7 @@ DEFAULT_HTML;
 			return;
 		}
 
-		if ( ! isset( $shortcode_atts['opt'] ) || ! is_numeric( $shortcode_atts['opt'] ) ) {
+		if ( ! isset( $shortcode_atts['opt'] ) ) {
 			$hidden = $this->maybe_include_hidden_values( $args );
 		} else {
 			$hidden = '';

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1068,7 +1068,11 @@ DEFAULT_HTML;
 			return;
 		}
 
-		$hidden = $this->maybe_include_hidden_values( $args );
+		if ( ! isset( $shortcode_atts['opt'] ) ) {
+			$hidden = $this->maybe_include_hidden_values( $args );
+		} else {
+			$hidden = '';
+		}
 
 		$field      = $this->field;
 		$html_id    = $args['html_id'];

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1068,7 +1068,7 @@ DEFAULT_HTML;
 			return;
 		}
 
-		if ( ! isset( $shortcode_atts['opt'] ) ) {
+		if ( ! isset( $shortcode_atts['opt'] ) || ! is_numeric( $shortcode_atts['opt'] ) ) {
 			$hidden = $this->maybe_include_hidden_values( $args );
 		} else {
 			$hidden = '';

--- a/classes/views/frm-fields/front-end/checkbox-field.php
+++ b/classes/views/frm-fields/front-end/checkbox-field.php
@@ -16,8 +16,9 @@ if ( isset( $field['post_field'] ) && $field['post_field'] === 'post_category' )
 	do_action( 'frm_after_checkbox', compact( 'field', 'field_name', 'type' ) );
 } elseif ( $field['options'] ) {
 	$option_index = 0;
+
 	foreach ( $field['options'] as $opt_key => $opt ) {
-		if ( isset( $shortcode_atts ) && isset( $shortcode_atts['opt'] ) && ( $shortcode_atts['opt'] !== $opt_key ) ) {
+		if ( isset( $shortcode_atts ) && isset( $shortcode_atts['opt'] ) && $shortcode_atts['opt'] !== $opt_key ) {
 			continue;
 		}
 
@@ -69,13 +70,13 @@ if ( isset( $field['post_field'] ) && $field['post_field'] === 'post_category' )
 		do_action( 'frm_field_input_html', $field );
 
 		if ( 0 === $option_index && FrmField::is_required( $field ) ) {
-	echo ' aria-required="true" ';
+			echo ' aria-required="true" ';
 		}
 
 		?> /><?php
 
 		if ( ! isset( $shortcode_atts ) || ! isset( $shortcode_atts['label'] ) || $shortcode_atts['label'] ) {
-	echo ' ' . FrmAppHelper::kses( $label, 'all' ) . '</label>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo ' ' . FrmAppHelper::kses( $label, 'all' ) . '</label>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
 		$other_args = array(


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2957477608/231494

The issue is that it would print out all of these hidden inputs when using `opt=2`, etc, which it shouldn't be doing. There were a TON of `undefined` strings getting sent, that broke validation.

**Pre-release**
[formidable-6.21.2b.zip](https://github.com/user-attachments/files/20573969/formidable-6.21.2b.zip)
