### PR TITLE
Fix incorrect column count in CSV export

### DIFF
--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -159,7 +159,7 @@ class FrmCSVExportHelper {
 			array(
 				'item_id'         => $atts['entry_ids'],
 				'field_id'        => 0,
-				'meta_value like' => '{',
+				'meta_value like' => 's:7:"comment";',
 			),
 			array(
 				'group_by' => 'item_id',


### PR DESCRIPTION
The check was catching other false positives, like the `unique_id`.