### PR TITLE
Autocomplete does not init for files dropdown for new action

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -651,7 +651,7 @@ function frmAdminBuildJS() {
 						inside.html( html );
 						initiateMultiselect();
 						showInputIcon( '#' + cont.attr( 'id' ) );
-						frmDom.autocomplete.initSelectionAutocomplete( inside );
+						initSelectionAutocomplete( inside );
 						jQuery( b ).trigger( 'frm-action-loaded' );
 
 						/**
@@ -7132,7 +7132,7 @@ function frmAdminBuildJS() {
 		if ( newAction.classList.contains( 'frm_single_on_submit_settings' ) ) {
 			const autocompleteInput = newAction.querySelector( 'input.frm-page-search' );
 			if ( autocompleteInput ) {
-				frmDom.autocomplete.initAutocomplete( 'page', newAction );
+				initSelectionAutocomplete( newAction );
 			}
 		}
 
@@ -7230,7 +7230,7 @@ function frmAdminBuildJS() {
 			showInputIcon( '#frm_form_action_' + actionId );
 
 			initiateMultiselect();
-			frmDom.autocomplete.initAutocomplete( 'page', newAction );
+			initSelectionAutocomplete( newAction );
 
 			if ( widgetTop ) {
 				jQuery( widgetTop ).trigger( 'frm-action-loaded' );
@@ -9203,8 +9203,8 @@ function frmAdminBuildJS() {
 			}
 		});
 	}
-	function initSelectionAutocomplete() {
-		frmDom.autocomplete.initSelectionAutocomplete();
+	function initSelectionAutocomplete( container ) {
+		frmDom.autocomplete.initSelectionAutocomplete( container );
 	}
 
 	function nextInstallStep( thisStep ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -9203,6 +9203,7 @@ function frmAdminBuildJS() {
 			}
 		});
 	}
+
 	function initAutocomplete( container ) {
 		frmDom.autocomplete.initSelectionAutocomplete( container );
 	}

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -651,7 +651,7 @@ function frmAdminBuildJS() {
 						inside.html( html );
 						initiateMultiselect();
 						showInputIcon( '#' + cont.attr( 'id' ) );
-						initSelectionAutocomplete( inside );
+						initAutocomplete( inside );
 						jQuery( b ).trigger( 'frm-action-loaded' );
 
 						/**
@@ -7132,7 +7132,7 @@ function frmAdminBuildJS() {
 		if ( newAction.classList.contains( 'frm_single_on_submit_settings' ) ) {
 			const autocompleteInput = newAction.querySelector( 'input.frm-page-search' );
 			if ( autocompleteInput ) {
-				initSelectionAutocomplete( newAction );
+				initAutocomplete( newAction );
 			}
 		}
 
@@ -7230,7 +7230,7 @@ function frmAdminBuildJS() {
 			showInputIcon( '#frm_form_action_' + actionId );
 
 			initiateMultiselect();
-			initSelectionAutocomplete( newAction );
+			initAutocomplete( newAction );
 
 			if ( widgetTop ) {
 				jQuery( widgetTop ).trigger( 'frm-action-loaded' );
@@ -7697,7 +7697,7 @@ function frmAdminBuildJS() {
 				function( response, optName ) {
 					// The replaced string is declared in FrmProFormActionController::ajax_get_post_menu_order_option() in the pro version.
 					postParentField.querySelector( '.frm_post_parent_opt_wrapper' ).innerHTML = response.replaceAll( 'REPLACETHISNAME', optName );
-					frmDom.autocomplete.initAutocomplete( 'page', postParentField );
+					initAutocomplete( postParentField );
 				}
 			);
 		}
@@ -9203,7 +9203,7 @@ function frmAdminBuildJS() {
 			}
 		});
 	}
-	function initSelectionAutocomplete( container ) {
+	function initAutocomplete( container ) {
 		frmDom.autocomplete.initSelectionAutocomplete( container );
 	}
 
@@ -10145,7 +10145,7 @@ function frmAdminBuildJS() {
 				// Solution install page
 				frmAdminBuild.solutionInit();
 			} else {
-				initSelectionAutocomplete();
+				initAutocomplete();
 
 				jQuery( '[data-frmprint]' ).on( 'click', function() {
 					window.print();
@@ -10623,7 +10623,7 @@ function frmAdminBuildJS() {
 			jQuery( document ).on( 'change', '#form_settings_page input:not(.frm-search-input), #form_settings_page select, #form_settings_page textarea', fieldUpdated );
 
             // Page Selection Autocomplete
-			initSelectionAutocomplete();
+			initAutocomplete();
 
 			jQuery( document ).on( 'frm-action-loaded', onActionLoaded );
 


### PR DESCRIPTION
I was working on a Google Sheets release, but noticed that the autocomplete dropdown was always empty for a new form action.

This update fixes it, and makes some of the calls more consistent.

I added a temporary workaround in the Google Sheets code as well so I could still get a release out https://github.com/Strategy11/formidable-googlespreadsheet/pull/66