### PR TITLE
Consistently set 11 as the max column count for entries list

### DIFF
--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -407,12 +407,11 @@ class FrmEntriesController {
 		global $frm_vars;
 		$i = isset( $frm_vars['cols'] ) ? count( $frm_vars['cols'] ) : 0;
 
+		$max_columns = 11;
+
 		if ( ! empty( $hidden ) ) {
-			$result      = $hidden;
-			$i           = $i - count( $result );
-			$max_columns = 11;
-		} else {
-			$max_columns = 8;
+			$result = $hidden;
+			$i      = $i - count( $result );
 		}
 
 		if ( $i <= $max_columns ) {


### PR DESCRIPTION
Using 8 it would always hide the ID column, including on the list of all entries, which I look for first.