### PR TITLE
Use "found" parameter in wp_cache_get

### DIFF
--- a/classes/models/FrmDb.php
+++ b/classes/models/FrmDb.php
@@ -656,8 +656,9 @@ class FrmDb {
 	 * @return mixed $results The cache or query results
 	 */
 	public static function check_cache( $cache_key, $group = '', $query = '', $type = 'get_var', $time = 300 ) {
-		$results = wp_cache_get( $cache_key, $group );
-		if ( ! FrmAppHelper::is_empty_value( $results, false ) || empty( $query ) ) {
+		$found = null;
+		$results = wp_cache_get( $cache_key, $group, false, $found );
+		if ( $found !== false || empty( $query ) ) {
 			return $results;
 		}
 


### PR DESCRIPTION
I've seen views that make heavy use of frm-stats where this returns hundreds of empty arrays that don't get cached, because the current check which won't cache empty arrays.