### PR TITLE
Make get col and get result functions always return array

### DIFF
--- a/classes/models/FrmDb.php
+++ b/classes/models/FrmDb.php
@@ -253,10 +253,11 @@ class FrmDb {
 	 * @param array  $args
 	 * @param string $limit
 	 *
-	 * @return mixed
+	 * @return array
 	 */
 	public static function get_col( $table, $where = array(), $field = 'id', $args = array(), $limit = '' ) {
-		return self::get_var( $table, $where, $field, $args, $limit, 'col' );
+		$columns = self::get_var( $table, $where, $field, $args, $limit, 'col' );
+		return is_array( $columns ) ? $columns : array();
 	}
 
 	/**
@@ -271,7 +272,6 @@ class FrmDb {
 	 */
 	public static function get_row( $table, $where = array(), $fields = '*', $args = array() ) {
 		$args['limit'] = 1;
-
 		return self::get_var( $table, $where, $fields, $args, '', 'row' );
 	}
 
@@ -285,10 +285,11 @@ class FrmDb {
 	 * @param string $fields
 	 * @param array  $args
 	 *
-	 * @return mixed
+	 * @return array
 	 */
 	public static function get_results( $table, $where = array(), $fields = '*', $args = array() ) {
-		return self::get_var( $table, $where, $fields, $args, '', 'results' );
+		$results = self::get_var( $table, $where, $fields, $args, '', 'results' );
+		return is_array( $results ) ? $results : array();
 	}
 
 	/**


### PR DESCRIPTION
This is in case the cache is doing something weird.

A lot of code expects these to be arrays, so it's best that we just always return arrays.