### PR TITLE
Fix false values coming from cache at cache level

### DIFF
--- a/classes/models/FrmDb.php
+++ b/classes/models/FrmDb.php
@@ -256,8 +256,7 @@ class FrmDb {
 	 * @return array
 	 */
 	public static function get_col( $table, $where = array(), $field = 'id', $args = array(), $limit = '' ) {
-		$columns = self::get_var( $table, $where, $field, $args, $limit, 'col' );
-		return is_array( $columns ) ? $columns : array();
+		return self::get_var( $table, $where, $field, $args, $limit, 'col' );
 	}
 
 	/**
@@ -288,8 +287,7 @@ class FrmDb {
 	 * @return array
 	 */
 	public static function get_results( $table, $where = array(), $fields = '*', $args = array() ) {
-		$results = self::get_var( $table, $where, $fields, $args, '', 'results' );
-		return is_array( $results ) ? $results : array();
+		return self::get_var( $table, $where, $fields, $args, '', 'results' );
 	}
 
 	/**
@@ -660,6 +658,9 @@ class FrmDb {
 		$found   = null;
 		$results = wp_cache_get( $cache_key, $group, false, $found );
 		if ( $found !== false || empty( $query ) ) {
+			if ( ! is_array( $results ) && in_array( $type, array( 'get_col', 'get_results' ), true ) ) {
+				return array();
+			}
 			return $results;
 		}
 


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/2996345861/234022

The previous fix didn't really catch everything. Other code calls `check_cache` directly.

**Pre-release**
[formidable-6.22.3b.zip](https://github.com/user-attachments/files/21149412/formidable-6.22.3b.zip)
