### PR TITLE
Fix can't deactivate plugin when popup has limited height

### DIFF
--- a/css/admin/deactivation-feedback.css
+++ b/css/admin/deactivation-feedback.css
@@ -1,5 +1,7 @@
 #frm-deactivation-modal {
 	--padding: 24px;
+
+	overflow-y: auto;
 }
 .frm_screen_reader {
 	border: 0;


### PR DESCRIPTION
User shared a screenshot:
<img width="1500" height="500" alt="image" src="https://github.com/user-attachments/assets/f8b9ccba-9321-4b82-aec5-072582082b46" />
