### PR TITLE
add filter that will extended the form field container html attribues…

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -64,12 +64,13 @@ class FrmFieldsController {
 		FrmAppHelper::permission_check( 'frm_edit_forms' );
 		check_ajax_referer( 'frm_ajax', 'nonce' );
 
-		$field_type = FrmAppHelper::get_post_param( 'field_type', '', 'sanitize_text_field' );
-		$form_id    = FrmAppHelper::get_post_param( 'form_id', 0, 'absint' );
+		$field_type    = FrmAppHelper::get_post_param( 'field_type', '', 'sanitize_text_field' );
+		$form_id       = FrmAppHelper::get_post_param( 'form_id', 0, 'absint' );
+		$field_options = FrmAppHelper::get_post_param( 'field_options', array(), 'wp_kses_post' );
 
 		do_action( 'frm_before_create_field', $field_type, $form_id );
 
-		$field = self::include_new_field( $field_type, $form_id );
+		$field = self::include_new_field( $field_type, $form_id, $field_options );
 
 		// this hook will allow for multiple fields to be added at once
 		do_action( 'frm_after_field_created', $field, $form_id );
@@ -82,11 +83,16 @@ class FrmFieldsController {
 	 *
 	 * @param string $field_type
 	 * @param int    $form_id
+	 * @param array  $field_options
 	 *
 	 * @return array|false
 	 */
-	public static function include_new_field( $field_type, $form_id ) {
+	public static function include_new_field( $field_type, $form_id, $field_options = array() ) {
 		$field_values = FrmFieldsHelper::setup_new_vars( $field_type, $form_id );
+
+		if ( ! empty( $field_options ) ) {
+			$field_values['field_options'] = array_merge( $field_values['field_options'], $field_options );
+		}
 
 		// When a new field is added to the form, flag it as draft and hide it from the front-end.
 		$field_values['field_options']['draft'] = 1;
@@ -181,6 +187,17 @@ class FrmFieldsController {
 			$field_object->parent_form_id = isset( $values['id'] ) ? $values['id'] : $field_object->form_id;
 			$field                        = FrmFieldsHelper::setup_edit_vars( $field_object );
 		}
+
+		/**
+		 * Filter for adding extra attributes to the field container.
+		 *
+		 * @since x.x
+		 *
+		 * @param array $extra_field_attributes
+		 * @param array $field
+		 * @param array $display
+		 */
+		$extra_field_attributes = apply_filters( 'frm_field_container_extra_attributes', '', $field, $display );
 
 		$li_classes  = self::get_classes_for_builder_field( $field, $display, $field_obj );
 		$li_classes .= ' ui-state-default widgets-holder-wrap';
@@ -313,6 +330,10 @@ class FrmFieldsController {
 
 		if ( ! isset( $field['read_only'] ) ) {
 			$field['read_only'] = false;
+		}
+
+		if ( ! isset( $field['range_field'] ) ) {
+			$field['range_field'] = false;
 		}
 
 		$field_selection_data = self::maybe_define_field_selection_data();

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -124,7 +124,6 @@ class FrmStylesController {
 		self::load_pro_hooks();
 
 		$version = FrmAppHelper::plugin_version();
-		wp_enqueue_script( 'jquery-ui-datepicker' );
 
 		if ( FrmAppHelper::is_style_editor_page( 'edit' ) ) {
 			wp_enqueue_style( 'wp-color-picker' );
@@ -541,7 +540,7 @@ class FrmStylesController {
 		$version         = FrmAppHelper::plugin_version();
 		$js_dependencies = array( 'wp-i18n', 'wp-hooks', 'formidable_dom' );
 
-		if ( FrmAppHelper::pro_is_installed() ) {
+		if ( FrmAppHelper::pro_is_installed() && is_callable( 'FrmProAppHelper', 'use_jquery_datepicker' ) && FrmProAppHelper::use_jquery_datepicker() ) {
 			$js_dependencies[] = 'jquery-ui-datepicker';
 		}
 

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -367,6 +367,7 @@ DEFAULT_HTML;
 			'readonly_required' => false,
 			'unique'            => false,
 			'read_only'         => false,
+			'range_field'       => false,
 			'description'       => true,
 			'options'           => true,
 			'label_position'    => true,

--- a/classes/views/frm-fields/back-end/settings.php
+++ b/classes/views/frm-fields/back-end/settings.php
@@ -112,7 +112,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</div>
 				<?php
 			}
-
 			do_action( 'frm_field_options_form_top', $field, $display, $values );
 			?>
 		</div>
@@ -426,7 +425,7 @@ do_action( 'frm_before_field_options', $field, compact( 'field_obj', 'display', 
 
 				if ( $display['unique'] ) {
 					?>
-					<p class="frm_unique_details<?php echo esc_attr( $field['id'] . ( $field['unique'] ? '' : ' frm_hidden' ) ); ?>">
+					<p class="frm_unique_details<?php echo esc_attr( $field['id'] . ( $field['unique'] ? '' : ' frm_hidden' ) ); ?> <?php echo 'time' === $field['type'] ? 'frm-has-linked-date-field' : ''; ?>">
 						<label for="field_options_unique_msg_<?php echo esc_attr( $field['id'] ); ?>">
 							<?php esc_html_e( 'Unique', 'formidable' ); ?>
 						</label>

--- a/classes/views/frm-forms/add_field.php
+++ b/classes/views/frm-forms/add_field.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
 ?>
-<li id="frm_field_id_<?php echo esc_attr( $field['id'] ); ?>" class="<?php echo esc_attr( $li_classes ); ?>" data-fid="<?php echo esc_attr( $field['id'] ); ?>" data-formid="<?php echo esc_attr( 'divider' === $field['type'] && isset( $field['form_select'] ) ? $field['form_select'] : $field['form_id'] ); ?>" data-ftype="<?php echo esc_attr( $display['type'] ); ?>" data-type="<?php echo esc_attr( $field['type'] ); ?>">
+<li id="frm_field_id_<?php echo esc_attr( $field['id'] ); ?>" class="<?php echo esc_attr( $li_classes ); ?>" data-fid="<?php echo esc_attr( $field['id'] ); ?>" data-formid="<?php echo esc_attr( 'divider' === $field['type'] && isset( $field['form_select'] ) ? $field['form_select'] : $field['form_id'] ); ?>" data-ftype="<?php echo esc_attr( $display['type'] ); ?>" data-type="<?php echo esc_attr( $field['type'] ); ?>" <?php echo esc_attr( $extra_field_attributes ); ?>>
 <?php
 if ( $field['type'] === 'divider' ) {
 	$icon_class = empty( $field['form_select'] ) ? 'frm-form-title-style' : 'frm_repeat_icon';

--- a/css/admin/frm_admin_global.css
+++ b/css/admin/frm_admin_global.css
@@ -21,3 +21,7 @@
 #adminmenu .frm-orange-text {
 	color: #F47449;
 }
+.frm-form-field-option-disabled {
+	opacity: 0.5;
+	pointer-events: none;
+}

--- a/js/admin/settings.js
+++ b/js/admin/settings.js
@@ -13,6 +13,11 @@
 		if ( 'frm_currency' === e.target.id) {
 			syncCurrencyOptions( e.target );
 		}
+
+		if ( 'frm_datepicker_library' === e.target.id ) {
+			toggleDatepickerJqueryRangeSupportNoteOnChange( e );
+		}
+
 	}
 
 	function handleKeyDownEvent( e ) {
@@ -45,6 +50,23 @@
 			e.preventDefault(); // Prevent automatic browser scroll when space is pressed.
 			e.target.click();
 		}
+	}
+
+	/**
+	 * Toggle the jQuery range support note based on the datepicker library selection.
+	 * @param {Event} event
+	 * @return {void}
+	 */
+	function toggleDatepickerJqueryRangeSupportNoteOnChange( event ) {
+		const datepickerLibrary      = event.target.value;
+		const jqueryRangeSupportNote = document.getElementById( 'frm_datepicker_jquery_range_support_note' );
+
+		if ( 'jquery' === datepickerLibrary ) {
+			jqueryRangeSupportNote.classList.remove( 'frm_hidden' );
+			return;
+		}
+
+		jqueryRangeSupportNote.classList.add( 'frm_hidden' );
 	}
 
 	addEventListeners();

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -1446,6 +1446,11 @@
 	 * @returns {void}
 	 */
 	function initDatepickerSample() {
+		// If flatpickr is defined, then is a recent version of Pro which handles the datepicker preview as it's a PRO feature.
+		if ( 'undefined' !== typeof flatpickr ) {
+			return;
+		}
+
 		const $sample = jQuery( '#datepicker_sample' );
 		if ( $sample.length && 'function' === typeof $sample.datepicker ) {
 			$sample.datepicker({ changeMonth: true, changeYear: true });


### PR DESCRIPTION
…, add js filter that will get fired after a field is successfully added in the form build, export 2 js functions that are related to inserting a new field and deleting it from form builder in order to reuse these in other plugins, toggle a jQuery notice if jQuery is selected as library from general settings