### PR TITLE
Fix currency format stays selected

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5437,12 +5437,17 @@ function frmAdminBuildJS() {
 			}
 		}
 
-		formatElement.querySelectorAll( 'option' ).forEach(
-			option => {
-				if ( option.selected && option.classList.contains( 'frm_show_upgrade' ) ) {
-					formatElement.value = 'none';
-				}
-			}
+		setTimeout(
+			function() {
+				formatElement.querySelectorAll( 'option' ).forEach(
+					option => {
+						if ( option.selected && option.classList.contains( 'frm_show_upgrade' ) ) {
+							formatElement.value = 'none';
+						}
+					}
+				);
+			},
+			0
 		);
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5438,7 +5438,7 @@ function frmAdminBuildJS() {
 		}
 
 		setTimeout(
-			function() {
+			() => {
 				formatElement.querySelectorAll( 'option' ).forEach(
 					option => {
 						if ( option.selected && option.classList.contains( 'frm_show_upgrade' ) ) {

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -6827,6 +6827,10 @@ function frmAdminBuildJS() {
 			}
 			link = link.replace( /(content=)[a-z_-]+/ig, '$1' + content );
 			button.setAttribute( 'href', link );
+
+			if ( element.nodeName === 'OPTION' && 'SELECT' === element.parentElement?.nodeName ) {
+				element.parentElement.value = 'none';
+			}
 		}
 	}
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -5436,6 +5436,14 @@ function frmAdminBuildJS() {
 				formatInput.setAttribute( 'value', '' );
 			}
 		}
+
+		formatElement.querySelectorAll( 'option' ).forEach(
+			option => {
+				if ( option.selected && option.classList.contains( 'frm_show_upgrade' ) ) {
+					formatElement.value = 'none';
+				}
+			}
+		);
 	}
 
 	/**
@@ -6827,10 +6835,6 @@ function frmAdminBuildJS() {
 			}
 			link = link.replace( /(content=)[a-z_-]+/ig, '$1' + content );
 			button.setAttribute( 'href', link );
-
-			if ( element.nodeName === 'OPTION' && 'SELECT' === element.parentElement?.nodeName ) {
-				element.parentElement.value = 'none';
-			}
 		}
 	}
 


### PR DESCRIPTION
This fixes an issue I was seeing, where "Currency"/"Number" would stay selected after the format options were selected and the upgrade modal was shown.