### PR TITLE
Prevent fatal error when no action control object is returned

### DIFF
--- a/classes/models/FrmFormAction.php
+++ b/classes/models/FrmFormAction.php
@@ -540,6 +540,9 @@ class FrmFormAction {
 		}
 
 		if ( 'all' !== $type ) {
+			if ( is_array( $action_controls ) ) {
+				return array();
+			}
 			return $action_controls->get_all( $form_id, $atts );
 		}
 


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3009409187/234771

**Pre-release**
[formidable-6.22.4b.zip](https://github.com/user-attachments/files/21413432/formidable-6.22.4b.zip)
