### PR TITLE
Add https instead of http to URLs missing a protocol

### DIFF
--- a/classes/models/fields/FrmFieldUrl.php
+++ b/classes/models/fields/FrmFieldUrl.php
@@ -68,7 +68,7 @@ class FrmFieldUrl extends FrmFieldType {
 			$value = '';
 		} else {
 			$value = esc_url_raw( $value );
-			$value = preg_match( '/^(https?|ftps?|mailto|news|feed|telnet):/is', $value ) ? $value : 'http://' . $value;
+			$value = preg_match( '/^(https?|ftps?|mailto|news|feed|telnet):/is', $value ) ? $value : 'https://' . $value;
 		}
 
 		FrmEntriesHelper::set_posted_value( $this->field, $value, $args );

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -270,7 +270,7 @@ function frmFrontFormJS() {
 	 */
 	function maybeValidateChange( field ) {
 		if ( field.type === 'url' ) {
-			maybeAddHttpToUrl( field );
+			maybeAddHttpsToUrl( field );
 		}
 		const form = field.closest( 'form' );
 		if ( form && hasClass( form, 'frm_js_validate' ) ) {
@@ -281,11 +281,11 @@ function frmFrontFormJS() {
 	/**
 	 * @param {HTMLElement} field
 	 */
-	function maybeAddHttpToUrl( field ) {
+	function maybeAddHttpsToUrl( field ) {
 		const url = field.value;
 		const matches = url.match( /^(https?|ftps?|mailto|news|feed|telnet):/ );
 		if ( field.value !== '' && matches === null ) {
-			field.value = 'http://' + url;
+			field.value = 'https://' + url;
 		}
 	}
 


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3014270403/235068

Related feature request https://fr.strategy11.com/formidable/2021/04/30/add-option-for-https-instead-of-http-in-url-fields/

**Pre-release**
[formidable-6.22.4b.zip](https://github.com/user-attachments/files/21434245/formidable-6.22.4b.zip)
