### PR TITLE
Make css valid check more type safe

### DIFF
--- a/classes/helpers/FrmStylesHelper.php
+++ b/classes/helpers/FrmStylesHelper.php
@@ -470,10 +470,18 @@ class FrmStylesHelper {
 	 *
 	 * @since 6.20
 	 *
-	 * @param string $var
+	 * @param mixed $var
 	 * @return bool
 	 */
 	private static function css_value_is_valid( $var ) {
+		if ( is_numeric( $var ) ) {
+			return true;
+		}
+
+		if ( ! is_string( $var ) ) {
+			return false;
+		}
+
 		// None of these substrings should be present in any CSS value.
 		$invalid_substrings = array(
 			'function(',


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3016541817/235193

In case `$var` is something unexpected, like an array, we can skip it.