### PR TITLE
Keep cellspacing for now

### DIFF
--- a/classes/models/FrmTableHTMLGenerator.php
+++ b/classes/models/FrmTableHTMLGenerator.php
@@ -258,7 +258,7 @@ class FrmTableHTMLGenerator {
 	 * @return string
 	 */
 	public function generate_table_header() {
-		return '<table ' . $this->table_style . '><tbody>' . "\r\n";
+		return '<table cellspacing="0"' . $this->table_style . '><tbody>' . "\r\n";
 	}
 
 	/**

--- a/tests/phpunit/entries/test_FrmShowEntryShortcode.php
+++ b/tests/phpunit/entries/test_FrmShowEntryShortcode.php
@@ -784,7 +784,7 @@ class test_FrmShowEntryShortcode extends FrmUnitTest {
 			return '';
 		}
 
-		$header = '<table ';
+		$header = '<table cellspacing="0" ';
 
 		if ( ! isset( $atts['inline_style'] ) || $atts['inline_style'] == true ) {
 			$defaults     = $this->get_defaults();


### PR DESCRIPTION
Even though this is deprecated, it still appears to work everywhere.

I think we might want to replace this with new CSS, not just remove it, so I'm putting it back for now.