### PR TITLE
Fix spam check issue with backslashes

### DIFF
--- a/classes/models/FrmSpamCheckDenylist.php
+++ b/classes/models/FrmSpamCheckDenylist.php
@@ -268,6 +268,7 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 		}
 
 		$values_str = strtolower( $this->convert_values_to_string( $values_to_check ) );
+
 		return strpos( $values_str, $line ) !== false;
 	}
 
@@ -278,7 +279,8 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 	 * @return string
 	 */
 	protected function convert_values_to_string( $values ) {
-		return FrmAppHelper::maybe_json_encode( $values );
+		// Unslash so strings like /joomla/ are not stuck as \/joomla\/.
+		return wp_unslash( FrmAppHelper::maybe_json_encode( $values ) );
 	}
 
 	/**

--- a/classes/models/FrmSpamCheckDenylist.php
+++ b/classes/models/FrmSpamCheckDenylist.php
@@ -279,8 +279,8 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 	 * @return string
 	 */
 	protected function convert_values_to_string( $values ) {
-		// Unslash so strings like /joomla/ are not stuck as \/joomla\/.
-		return wp_unslash( FrmAppHelper::maybe_json_encode( $values ) );
+		// Unslash the forward slashes so strings like /joomla/ are not stuck as \/joomla\/.
+		return str_replace( '\\/', '/', FrmAppHelper::maybe_json_encode( $values ) );
 	}
 
 	/**


### PR DESCRIPTION
I noticed that some strings in our `splorp-wp-comment.txt` file were not throwing spam errors.

This is because of the `maybe_json_encode` call, which changes the array into JSON, where the slashes are escaped.

As a basic PHP example:
```
var_dump( json_encode( [ 'key' => '/joomla/' ] ) );
```

Outputs
```
string(20) "{"key":"\/joomla\/"}" 
```

**Before**
`/joomla/` would not trigger a denylist error.

**After**
<img width="542" height="367" alt="Screen Shot 2025-07-30 at 3 46 56 PM" src="https://github.com/user-attachments/assets/cb6a00e8-c629-4809-aed6-c0f9e709f73c" />
