### PR TITLE
Reuse verified buyer token if details match hash

### DIFF
--- a/square/controllers/FrmSquareLiteAppController.php
+++ b/square/controllers/FrmSquareLiteAppController.php
@@ -89,6 +89,7 @@ class FrmSquareLiteAppController {
 		wp_send_json_success(
 			array(
 				'verificationDetails' => $verification_details,
+				'hash'                => md5( serialize( $verification_details ) ),
 			)
 		);
 	}

--- a/square/js/frontend.js
+++ b/square/js/frontend.js
@@ -152,7 +152,6 @@
 
 		if ( buyerTokens[ verificationData.data.hash ] ) {
 			// Avoid a second verify buyer request if the verification data has not changed.
-			console.log( 'Re-using ' + buyerTokens[ verificationData.data.hash ] );
 			return buyerTokens[ verificationData.data.hash ];
 		}
 

--- a/square/js/frontend.js
+++ b/square/js/frontend.js
@@ -13,6 +13,8 @@
 
 	let cardGlobal;
 
+	const buyerTokens = {};
+
 	// Track the state of each field in the card form
 	const cardFields = {
 		cardNumber: false,
@@ -148,8 +150,17 @@
 			throw new Error( verificationData.data );
 		}
 
+		if ( buyerTokens[ verificationData.data.hash ] ) {
+			// Avoid a second verify buyer request if the verification data has not changed.
+			console.log( 'Re-using ' + buyerTokens[ verificationData.data.hash ] );
+			return buyerTokens[ verificationData.data.hash ];
+		}
+
 		const verificationDetails = verificationData.data.verificationDetails;
 		const verificationResults = await payments.verifyBuyer( token, verificationDetails );
+
+		buyerTokens[ verificationData.data.hash ] = verificationResults.token;
+
 		return verificationResults.token;
 	}
 


### PR DESCRIPTION
This may help with this related ticket https://secure.helpscout.net/conversation/3025312291/235710

And this related Square issue https://developer.squareup.com/forums/t/verifybuyer-function-locks-up-the-second-time-it-is-called/13218/12

As long as none of the verification data changes, we should be good to re-use the token we had before. Avoiding the duplicate call should prevent the Square error, though I didn't have luck actually triggering the error myself.

**Pre-release**
[formidable-6.23b.zip](https://github.com/user-attachments/files/21621693/formidable-6.23b.zip)
