### PR TITLE
Fix stripe issue when using old versions of Pro

### DIFF
--- a/stripe/controllers/FrmStrpLiteActionsController.php
+++ b/stripe/controllers/FrmStrpLiteActionsController.php
@@ -23,7 +23,7 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 			// Fallback to Stripe Lite if we do not know the form.
 			// This way we do not display the default credit card field
 			// when Pro is not up to version 6.21.
-			return 'FrmStrpLiteActionsController::show_card';
+			return self::class . '::show_card';
 		}
 
 		$form_id = is_object( $field ) ? $field->form_id : $field['form_id'];


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3025504009/235727

This update falls back to the `show_card` function so it works like it did before the Square Lite update.