### PR TITLE
Allow more HTML in GDPR agreement text

### DIFF
--- a/classes/views/frm-fields/front-end/gdpr/gdpr-field.php
+++ b/classes/views/frm-fields/front-end/gdpr/gdpr-field.php
@@ -21,7 +21,7 @@ $label_id       = 'frm-gdpr-accept-' . $field_id;
 		<?php echo $checked . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		<?php do_action( 'frm_field_input_html', $field ); ?>
 		/>
-		<?php FrmAppHelper::kses_echo( $agreement_text, array( 'a', 'b', 'br', 'div', 'i', 'p', 'span', 'strong' ) ); ?>
+		<?php FrmAppHelper::kses_echo( $agreement_text, array( 'a', 'b', 'br', 'div', 'em', 'i', 'p', 'span', 'strong' ) ); ?>
 	</label>
 </div>
 <?php elseif ( current_user_can( 'frm_edit_forms' ) ) : ?>


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5938

We added support for anchor tags in https://github.com/Strategy11/formidable-forms/pull/2288/, but now we're seeing a ticket requesting additional tags like `span`.

This update goes through our safe tags and allows the ones that make sense in an agreement text context.