### PR TITLE
Fix field delete getting called for already deleted field bug

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -4726,7 +4726,7 @@ function frmAdminBuildJS() {
 		const confirmedClick = document.getElementById( 'frm-confirmed-click' );
 
 		// Remove any previous delete field data so delete confirmation does not attempt
-		// to delete a field that was already deleted.
+		// to delete a field that was already deleted or previously attempted and cancelled.
 		confirmedClick?.removeAttribute( 'data-deletefield' );
 
 		jQuery( confirmedClick ).on( 'click', deleteOnConfirm );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5917

The issue is that the `data-deletefield` was never getting removed, so it would also try to remove that field when deleting a field group because it uses the same confirmation button.