### PR TITLE
Show placeholders for separate values in conditional logic dropdowns

### DIFF
--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1612,7 +1612,7 @@ function frmAdminBuildJS() {
 	 *
 	 * @param {string} fieldType
 	 */
-	function insertNewFieldByDragging( fieldType ) {		
+	function insertNewFieldByDragging( fieldType ) {
 		if ( shouldStopInsertingField( fieldType ) ) {
 			wp.hooks.doAction( 'frm_stopped_inserting_by_dragging', fieldType );
 			return;
@@ -1667,7 +1667,7 @@ function frmAdminBuildJS() {
 						fieldId,
 						fieldType,
 						form_id: formId,
-					});	
+					});
 				}
 			},
 			error: handleInsertFieldError
@@ -2125,7 +2125,7 @@ function frmAdminBuildJS() {
 						fieldId,
 						fieldType,
 						form_id: formId,
-					});	
+					});
 				}
 			},
 			error: handleInsertFieldError
@@ -2156,7 +2156,7 @@ function frmAdminBuildJS() {
 
 	function insertFormField( fieldType, fieldOptions = {} ) {
 
-		return new Promise( ( resolve ) => {			
+		return new Promise( ( resolve ) => {
 			const formId = thisFormId;
 			let hasBreak = 0;
 

--- a/js/formidable_admin.js
+++ b/js/formidable_admin.js
@@ -1,6 +1,11 @@
 /* exported frm_add_logic_row, frm_remove_tag, frm_show_div, frmCheckAll, frmCheckAllLevel */
 /* eslint-disable jsdoc/require-param, prefer-const, no-redeclare, @wordpress/no-unused-vars-before-return, jsdoc/check-types, jsdoc/check-tag-names, @wordpress/i18n-translator-comments, @wordpress/valid-sprintf, jsdoc/require-returns-description, jsdoc/require-param-type, no-unused-expressions, compat/compat */
 
+/**
+ * WordPress dependencies
+ */
+const { _x } = wp.i18n;
+
 window.FrmFormsConnect = window.FrmFormsConnect || ( function( document, window, $ ) {
 
 	/*global jQuery:false, frm_admin_js, frmGlobal, ajaxurl */
@@ -6080,6 +6085,10 @@ function frmAdminBuildJS() {
 			if ( separateValues ) {
 				labelName = optVals[ i ].name.replace( '[label]', '[value]' );
 				saved = jQuery( 'input[name="' + labelName + '"]' ).val();
+
+				if ( '' === label ) {
+					label = '' !== saved ? saved : _x( 'Untitled', 'dropdown option label', 'formidable' );
+				}
 			}
 
 			if ( hasImageOptions ) {


### PR DESCRIPTION
This PR adds visual indicators for separate values in conditional logic dropdowns when option labels are not present. Previously, when using checkboxes with separate values but no labels (common with image options), users would see blank lines in the conditional logic dropdown with no way to identify which option was which.

### Steps to reproduce
1. Create a form with a checkbox field
2. Add 3-4 options with separate values but no labels (like when using images)
3. Add conditional logic based on this field
4. Notice that the dropdown shows blank lines with no indication of which value corresponds to which option

### Before


### After