### PR TITLE
Fix import issue with conditonal logic

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1599,6 +1599,9 @@ class FrmFieldsHelper {
 			$replace_with[] = 'field_id="' . $new . '"';
 			$replace[]      = 'field_id=\"' . $old . '\"';
 			$replace_with[] = 'field_id=\"' . $new . '\"';
+			// This covers conditional logic.
+			$replace[]      = '_field":"' . $old . '","';
+			$replace_with[] = '_field":"' . $new . '","';
 			unset( $old, $new );
 		}//end foreach
 		if ( is_array( $val ) ) {


### PR DESCRIPTION
I noticed that quiz outcomes weren't importing properly. The fields were all unmapped.

This update adds another substring that should be safe to replace when importing data, that could possibly catch other similar issues - not just conditional logic.