### PR TITLE
Drop label line height styling on styler

### DIFF
--- a/css/admin/style.css
+++ b/css/admin/style.css
@@ -224,15 +224,6 @@ This file is added to the visual styler admin page, accessed from the style tab.
 	min-width: 200px;
 }
 
-/*
-Do not set this for frm_inside_container as it requires a custom line height value.
-Target .frm_primary_label so we avoid other labels like star rating stars.
-Time fields use a div instead of a label, so don't target by the primary label by tag type.
-*/
-#frm_style_preview .frm_form_field:not(.frm_inside_container) > .frm_primary_label {
-	line-height: var(--line-height);
-}
-
 #frm_style_preview .with_frm_style :not(.ui-datepicker-title) > select:not(.flatpickr-monthDropdown-months) {
 	/* Prevent back end styles from shrinking dropdowns. But leave datepicker dropdowns alone. */
 	width: var(--auto-width);


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/5963

This line was added originally was `line-height: normal` along with the comment `Avoid a line-height: 1.4rem rule defined in common.css WordPress admin rules`.

I'm not sure if I see the 1.4rem rule anymore. This seems more consistent if I just drop the CSS.