### PR TITLE
Allow localization of hCaptcha and Turnstile widgets content

### DIFF
--- a/classes/models/fields/FrmFieldCaptcha.php
+++ b/classes/models/fields/FrmFieldCaptcha.php
@@ -132,9 +132,9 @@ class FrmFieldCaptcha extends FrmFieldType {
 		 * @since x.x
 		 *
 		 * @param string $lang
-		 * @return string
+		 * @param array $field
 		 */
-		return apply_filters( 'frm_captcha_lang', get_bloginfo( 'language' ) );
+		return apply_filters( 'frm_captcha_lang', get_bloginfo( 'language' ), $this->field );
 	}
 
 	/**


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/5996

### Test steps

1. Configure a Turnstile Captcha settings in Formidable > Global Settings
2. Create a form, add a captcha field to it.
3. Change the site language
4. Publish the form into a page
5. Preview the form
6. Confirm that the Captcha messages are localized
<img width="757" height="310" alt="image" src="https://github.com/user-attachments/assets/8388f5e7-41a7-4cfe-930f-efcef9d538cf" />

Note: This fix is supposed to cover hCaptcha too but it seems something might be off from their end as the captcha's content is not translated. https://docs.hcaptcha.com/languages/