### PR TITLE
Fix invalid hidden field size input value on load

### DIFF
--- a/classes/helpers/FrmHtmlHelper.php
+++ b/classes/helpers/FrmHtmlHelper.php
@@ -105,9 +105,14 @@ class FrmHtmlHelper {
 				'class' => trim( 'frm-unit-input-control ' . ( $args['input_number_attrs']['class'] ?? '' ) ),
 			)
 		);
+
+		$hidden_value = $args['value'];
+		if ( is_numeric( $hidden_value ) ) {
+			$hidden_value .= $args['default_unit'];
+		}
 		?>
 		<span class="frm-unit-input">
-			<input type="hidden" value="<?php echo esc_attr( $value ); ?>" <?php FrmAppHelper::array_to_html_params( $args['field_attrs'], true ); ?> />
+			<input type="hidden" value="<?php echo esc_attr( $hidden_value ); ?>" <?php FrmAppHelper::array_to_html_params( $args['field_attrs'], true ); ?> />
 			<input <?php FrmAppHelper::array_to_html_params( $input_number_attrs, true ); ?> />
 			<span class="frm-input-group-suffix">
 				<select aria-label="<?php echo esc_attr__( 'Select unit', 'formidable' ); ?>" tabindex="0">


### PR DESCRIPTION
This fixes a bug I'm seeing with the unit dropdowns and the new field options redesign.

On load, I have a field width of 100px. When I save, the hidden input only has "100" as its value, and the units are lost. You can see this in the preview for the password field with a confirmation because it shows the field size setting at the moment. The dropdown still looks like "px", because it reverts to this by default.

https://github.com/user-attachments/assets/a99814a4-43d0-434d-928a-2485f5517340

