### PR TITLE
Add js validate class on square form submit

### DIFF
--- a/square/js/frontend.js
+++ b/square/js/frontend.js
@@ -254,6 +254,8 @@
 
 		async function handlePaymentMethodSubmission( event, card ) {
 			try {
+				thisForm.classList.add( 'frm_js_validate' );
+
 				if ( ! validateFormSubmit( thisForm ) ) {
 					return;
 				}


### PR DESCRIPTION
We do this for Stripe. This should help to prevent issues with verifying the Square buyer when fields are not filled in.