### PR TITLE
Fix Firefox display issue with input icon containers

### DIFF
--- a/classes/views/frm-fields/back-end/value-format.php
+++ b/classes/views/frm-fields/back-end/value-format.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<label for="frm_format_<?php echo esc_attr( absint( $field['id'] ) ); ?>" class="frm_help" title="<?php esc_attr_e( 'Insert the format you would like to accept. Use a regular expression starting with ^ or an exact format like (999)999-9999.', 'formidable' ); ?>">
 		<?php esc_html_e( 'Format', 'formidable' ); ?>
 	</label>
-	<span class="frm-with-right-icon">
+	<span class="frm-with-right-icon frm-block">
 		<input type="text" class="frm_long_input frm_format_opt" value="<?php echo esc_attr( $field['format'] ); ?>" name="field_options[format_<?php echo absint( $field['id'] ); ?>]" id="frm_format_<?php echo absint( $field['id'] ); ?>" data-fid="<?php echo intval( $field['id'] ); ?>" />
 		<?php
 		FrmAppHelper::icon_by_class(


### PR DESCRIPTION
This PR fixes a Firefox-specific display issue where input icon containers in the custom format field did not render correctly. It affected the appearance and positioning of icons within date input fields when viewed in Firefox.

### Before

<img width="898" height="166" alt="CleanShot 2025-09-30 at 22 30 47@2x" src="https://github.com/user-attachments/assets/73eb4039-59b9-477a-a7ca-ebbaf62539ae" />

### After

<img width="896" height="172" alt="CleanShot 2025-09-30 at 22 31 11@2x" src="https://github.com/user-attachments/assets/620bddbb-db9f-4a53-9735-d3e0660a3016" />
