### PR TITLE
Include item key property when creating a false entry object

### DIFF
--- a/square/controllers/FrmSquareLiteAppController.php
+++ b/square/controllers/FrmSquareLiteAppController.php
@@ -192,10 +192,11 @@ class FrmSquareLiteAppController {
 	 * @return stdClass
 	 */
 	private static function generate_false_entry() {
-		$entry          = new stdClass();
-		$entry->post_id = 0;
-		$entry->id      = 0;
-		$entry->metas   = array();
+		$entry           = new stdClass();
+		$entry->post_id  = 0;
+		$entry->id       = 0;
+		$entry->item_key = '';
+		$entry->metas    = array();
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		foreach ( $_POST as $k => $v ) {

--- a/stripe/models/FrmStrpLiteAuth.php
+++ b/stripe/models/FrmStrpLiteAuth.php
@@ -374,10 +374,11 @@ class FrmStrpLiteAuth {
 	 * @return stdClass
 	 */
 	private static function generate_false_entry() {
-		$entry          = new stdClass();
-		$entry->post_id = 0;
-		$entry->id      = 0;
-		$entry->metas   = array();
+		$entry           = new stdClass();
+		$entry->post_id  = 0;
+		$entry->id       = 0;
+		$entry->item_key = '';
+		$entry->metas    = array();
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		foreach ( $_POST as $k => $v ) {


### PR DESCRIPTION
I noticed this PHP warning when testing Square payments.

> PHP Warning:  Undefined property: stdClass::$item_key in /Users/mikeletellier/Local Sites/dev-site/app/public/wp-content/plugins/formidable-pro/classes/models/FrmProContent.php on line 156