### PR TITLE
Fix issues with inbox items appearing before scheduled

### DIFF
--- a/classes/models/FrmInbox.php
+++ b/classes/models/FrmInbox.php
@@ -52,11 +52,9 @@ class FrmInbox extends FrmFormApi {
 	 */
 	public function get_messages( $filter = false ) {
 		$messages = self::$messages;
-
 		if ( $filter === 'filter' ) {
 			$this->filter_messages( $messages );
 		}
-
 		return $messages;
 	}
 


### PR DESCRIPTION
Based on a conversation in Slack, our inbox items appear up to 3 days early if scheduled ahead of time.