### PR TITLE
Pro issue 6020 email style tracking

### DIFF
--- a/classes/controllers/FrmEmailStylesController.php
+++ b/classes/controllers/FrmEmailStylesController.php
@@ -307,6 +307,8 @@ class FrmEmailStylesController {
 			self::get_content_type_header( $email_style ),
 		);
 
+		FrmUsageController::update_flows_data( 'send_test_email', $email_style );
+
 		$result = wp_mail( $valid_emails, $subject, $content, $headers );
 		if ( $result ) {
 			wp_send_json_success( __( 'Test email sent successfully!', 'formidable' ) );

--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -223,6 +223,7 @@ class FrmUsage {
 			'honeypot',
 			'wp_spam_check',
 			'denylist_check',
+			'email_style',
 		);
 
 		foreach ( $pass_settings as $setting ) {


### PR DESCRIPTION
This PR adds this data to the snapshot:
- 'email_style' in 'settings'.
- Number of times send test email is used for each style, this is in the `flows` table:
```
'send_test_email' => array(
    'classic' => 2,
    'modern'  => 5,
    ...
)
```

Related issue: https://github.com/Strategy11/formidable-pro/issues/6020