### PR TITLE
Include frm_payment_status_ hooks when triggering payment status change

### DIFF
--- a/stripe/controllers/FrmTransLiteActionsController.php
+++ b/stripe/controllers/FrmTransLiteActionsController.php
@@ -224,6 +224,10 @@ class FrmTransLiteActionsController {
 		$atts['trigger'] = str_replace( '_', '-', $atts['trigger'] );
 
 		/**
+		 * Trigger various hooks including frm_payment_status_complete.
+		 *
+		 * @since x.x This was included in the payments submodule, but not included in Lite until x.x.
+		 *
 		 * @param array $atts
 		 */
 		do_action( 'frm_payment_status_' . $atts['trigger'], $atts );


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3106934212/239728

This hook is never called in Lite. For consistency, and to give people more flexibility, this is now called in Lite as well.