### PR TITLE
Remember entry list sort preference per form

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -1438,9 +1438,9 @@ class FrmAppController {
 			return;
 		}
 
-		$user_id      = get_current_user_id();
-		$order        = FrmAppHelper::get_param( 'order' );
-		$new_sort     = array(
+		$user_id       = get_current_user_id();
+		$order         = FrmAppHelper::get_param( 'order' );
+		$new_sort      = array(
 			'orderby' => $orderby,
 			'order'   => $order,
 		);
@@ -1453,10 +1453,7 @@ class FrmAppController {
 		}
 
 		if ( $new_sort !== $current_sort ) {
-			$new_meta = array(
-				'orderby' => $orderby,
-				'order'   => $order,
-			);
+			$new_meta = $new_sort;
 
 			if ( $is_entry_list && $form_id && is_int( $form_id ) ) {
 				// Index meta by form ID.


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3106941894/239729

Right now user preferences in one form overwrite the user preferences in another form. This doesn't work great when you're trying to sort by a field ID for example, which is unique per form, so sort preferences would always be lost in other forms.

Now new form ID keys are added in the array, so it becomes something like this:
```
array(3) {
  ["orderby"]=>
  string(7) "meta_98"
  ["order"]=>
  string(3) "asc"
  [24]=>
  array(2) {
    ["orderby"]=>
    string(7) "meta_98"
    ["order"]=>
    string(4) "desc"
  }
}
```

This way the old data is still usable in its old format as well.

**Pre-release**
[formidable-6.25.1b.zip](https://github.com/user-attachments/files/22910507/formidable-6.25.1b.zip)
