### PR TITLE
Fix single row style setting not working as expected

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -982,7 +982,11 @@ DEFAULT_HTML;
 		if ( 'inline' === $align ) {
 			$align = 'horizontal_radio';
 		} elseif ( 'block' === $align ) {
-			$align = 'vertical_radio';
+			$check_align = FrmStylesController::get_style_val( 'check_align', $this->field['form_id'] );
+			// Check needed to fix issue #6035
+			if ( 'block' === $check_align ) {
+				$align = 'vertical_radio';
+			}
 		}
 	}
 

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -984,7 +984,7 @@ DEFAULT_HTML;
 		} elseif ( 'block' === $align ) {
 			$check_align = FrmStylesController::get_style_val( 'check_align', $this->field['form_id'] );
 			// Check needed to fix issue #6035
-			if ( 'block' === $check_align ) {
+			if ( 'inline' !== $check_align ) {
 				$align = 'vertical_radio';
 			}
 		}

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -982,7 +982,7 @@ DEFAULT_HTML;
 		if ( 'inline' === $align ) {
 			$align = 'horizontal_radio';
 		} elseif ( 'block' === $align ) {
-			$check_align = FrmStylesController::get_style_val( 'check_align', $this->field['form_id'] );
+			$check_align = $this->field ? FrmStylesController::get_style_val( 'check_align', $this->field['form_id'] ) : '';
 			// Check needed to fix issue #6035
 			if ( 'inline' !== $check_align ) {
 				$align = 'vertical_radio';


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/6035
Related PR: https://github.com/Strategy11/formidable-pro/pull/6057
### Test steps
1. Add Checkbox and Radio fields  to a form.
2. Go to the Styles tab and set the alignment setting to 'Single row' as in the screenshot below
3. Preview the form and confirm that the field choices are displayed in a Single row.

<img width="512" height="384" alt="image" src="https://github.com/user-attachments/assets/581e2424-1764-4d9d-8cd7-8538b79914ee" />