### PR TITLE
Remove old captcha nonce token JS

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -899,8 +899,6 @@ function frmFrontFormJS() {
 
 				setTimeout(
 					function() {
-						let container, input, previousInput;
-
 						afterFormSubmittedBeforeReplace( object, response );
 
 						replaceContent.replaceWith( response.content );


### PR DESCRIPTION
This should have really been in Pro, and it's only required now if people are opting into the old nonce field which isn't likely.

But it looks like this all happens in PHP anyway. This JS isn't necessary, so we can just remove it.

This also helps move use away from jQuery.

🥳 