### PR TITLE
Bump min pro version in notice

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -376,7 +376,7 @@ class FrmAppController {
 	 */
 	public static function pro_get_started_headline() {
 		self::review_request();
-		FrmAppHelper::min_pro_version_notice( '6.0' );
+		FrmAppHelper::min_pro_version_notice( '6.20' );
 	}
 
 	/**


### PR DESCRIPTION
6.0 is really old and not really compatible, dating back to Feb 2023.

I picked a fairly new version, back from Apr 8.

In reality, people shouldn't be updating Lite and using an old version of Pro.