### PR TITLE
Stop running square triggers a second time when payments submodule is…

### DIFF
--- a/square/controllers/FrmSquareLiteActionsController.php
+++ b/square/controllers/FrmSquareLiteActionsController.php
@@ -116,8 +116,7 @@ class FrmSquareLiteActionsController extends FrmTransLiteActionsController {
 		if ( 'recurring' === $action->post_content['type'] ) {
 			$charge = self::trigger_recurring_payment( $payment_args );
 		} else {
-			$charge                   = self::trigger_one_time_payment( $payment_args );
-			$response['run_triggers'] = true;
+			$charge = self::trigger_one_time_payment( $payment_args );
 		}
 
 		if ( $charge === true ) {


### PR DESCRIPTION
… active

The `run_triggers` logic is only in the Stripe / Authorize.Net add-ons. If one was active, notifications would trigger twice.

Related ticket https://secure.helpscout.net/conversation/3121612193/240624

**Pre-release**
[formidable-6.25.1b.zip](https://github.com/user-attachments/files/23234636/formidable-6.25.1b.zip)
