### PR TITLE
Remove wp_register_style call that is not needed anymore

### DIFF
--- a/classes/views/styles/components/FrmStyleComponent.php
+++ b/classes/views/styles/components/FrmStyleComponent.php
@@ -83,7 +83,6 @@ class FrmStyleComponent {
 		$plugin_url = FrmAppHelper::plugin_url();
 		$version    = FrmAppHelper::plugin_version();
 
-		wp_register_style( self::ASSETS_SLUG, $plugin_url . '/css/admin/style-components.css', array(), $version );
 		wp_register_script( self::ASSETS_SLUG, $plugin_url . '/js/formidable_styles.js', array( 'formidable_admin' ), $version, true );
 	}
 


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/6067