### PR TITLE
Remove api feature checks

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -1511,12 +1511,6 @@ class FrmFormsController {
 			unset( $sections['buttons'] );
 		}
 
-		foreach ( array( 'landing', 'chat', 'abandonment' ) as $feature ) {
-			if ( ! FrmAppHelper::show_new_feature( $feature ) ) {
-				unset( $sections[ $feature ] );
-			}
-		}
-
 		$sections = apply_filters( 'frm_add_form_settings_section', $sections, $values );
 
 		foreach ( $sections as $key => $section ) {

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -4229,15 +4229,6 @@ class FrmAppHelper {
 	/**
 	 * @since 5.0.16
 	 *
-	 * @return bool
-	 */
-	public static function show_landing_pages() {
-		return self::show_new_feature( 'landing' );
-	}
-
-	/**
-	 * @since 5.0.16
-	 *
 	 * @return array
 	 */
 	public static function get_landing_page_upgrade_data_params( $medium = 'landing' ) {
@@ -4660,5 +4651,16 @@ class FrmAppHelper {
 			return seems_utf8( $string );
 		}
 		return false;
+	}
+
+	/**
+	 * @since 5.0.16
+	 * @deprecated x.x
+	 *
+	 * @return bool
+	 */
+	public static function show_landing_pages() {
+		_deprecated_function( __METHOD__, 'x.x' );
+		return true;
 	}
 }

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -718,7 +718,7 @@ class FrmEntriesHelper {
 			'icon'  => 'frm_icon_font frm_email_icon',
 		);
 
-		if ( ! function_exists( 'frm_pdfs_autoloader' ) && FrmAppHelper::show_new_feature( 'pdfs' ) ) {
+		if ( ! function_exists( 'frm_pdfs_autoloader' ) ) {
 			$actions['frm_download_pdf'] = array(
 				'url'   => '#',
 				'label' => __( 'Download as PDF', 'formidable' ),

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -252,10 +252,6 @@ class FrmField {
 			unset( $fields['ranking'] );
 		}
 
-		if ( ! FrmAppHelper::show_new_feature( 'ai' ) ) {
-			unset( $fields['ai'] );
-		}
-
 		// Since the signature field may be in a different section, don't show it twice.
 		$lite_fields = self::field_selection();
 		if ( isset( $lite_fields['signature'] ) ) {

--- a/classes/views/frm-forms/_publish_box.php
+++ b/classes/views/frm-forms/_publish_box.php
@@ -33,21 +33,17 @@ $preview_link = FrmFormsHelper::get_direct_link( $values['form_key'] );
 						<?php esc_html_e( 'In Theme', 'formidable' ); ?>
 					</a>
 				</li>
-				<?php if ( FrmAppHelper::show_new_feature( 'test-mode' ) ) { ?>
-					<li>
-						<a href="<?php echo esc_url( $preview_link ); ?>&testmode=1" target="_blank">
-							<?php
-							esc_html_e( 'In Test Mode', 'formidable' );
-							FrmAppHelper::show_pill_text();
-							?>
-						</a>
-					</li>
-				<?php } ?>
-				<?php if ( FrmAppHelper::show_landing_pages() ) { ?>
-					<li>
-						<?php FrmFormsController::landing_page_preview_option(); ?>
-					</li>
-				<?php } ?>
+				<li>
+					<a href="<?php echo esc_url( $preview_link ); ?>&testmode=1" target="_blank">
+						<?php
+						esc_html_e( 'In Test Mode', 'formidable' );
+						FrmAppHelper::show_pill_text();
+						?>
+					</a>
+				</li>
+				<li>
+					<?php FrmFormsController::landing_page_preview_option(); ?>
+				</li>
 			</ul>
 		</div>
 		<?php


### PR DESCRIPTION
These checks are really only necessary for handling old caches.

We shouldn't need any of these anymore, and removing them should help with performance.