### PR TITLE
Add htaccess file

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,45 @@
+# Only allow direct access to specific Web-available files.
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Order Deny,Allow
+	Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>
+
+# Allow all JavaScript files
+<FilesMatch "\.(js)$">
+	<IfModule !mod_authz_core.c>
+		Allow from all
+	</IfModule>
+	
+	<IfModule mod_authz_core.c>
+		Require all granted
+	</IfModule>
+</FilesMatch>
+
+# Allow all CSS files
+<FilesMatch "\.(css)$">
+	<IfModule !mod_authz_core.c>
+		Allow from all
+	</IfModule>
+	
+	<IfModule mod_authz_core.c>
+		Require all granted
+	</IfModule>
+</FilesMatch>
+
+# Allow all image files
+<FilesMatch "\.(png|jpg|jpeg|gif|svg|webp|ico)$">
+	<IfModule !mod_authz_core.c>
+		Allow from all
+	</IfModule>
+	
+	<IfModule mod_authz_core.c>
+		Require all granted
+	</IfModule>
+</FilesMatch>


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3143339284

**Pre-release**
[formidable-6.25.2b.zip](https://github.com/user-attachments/files/23612715/formidable-6.25.2b.zip)

**This update only applies to Apache servers**

When trying to access a file like `/wp-content/plugins/formidable/readme.txt`, you should see a 403 error.

**When testing**, we mostly want to confirm that nothing is broken. I tried to allow all JS, CSS, and all image files. It's possible there's another asset I missed.

<img width="374" height="114" alt="Screen Shot 2025-11-18 at 3 42 52 PM" src="https://github.com/user-attachments/assets/ad4e2ab5-f384-48eb-a237-53af6f9911ed" />
