### PR TITLE
Fix undefined array key warning in maybe_add_utm_license

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -173,7 +173,7 @@ class FrmAppHelper {
 	 * @return array
 	 */
 	private static function maybe_add_utm_license( $query_args ) {
-		if ( 'pro' === $query_args['utm_medium'] && is_callable( 'FrmProAddonsController::get_readable_license_type' ) ) {
+		if ( isset( $query_args['utm_medium'] ) && 'pro' === $query_args['utm_medium'] && is_callable( 'FrmProAddonsController::get_readable_license_type' ) ) {
 			$query_args['utm_license'] = strtolower( FrmProAddonsController::get_readable_license_type() );
 		}
 


### PR DESCRIPTION
Fixes an undefined array key warning when `utm_medium` is not present in the query args.

## Demo

<img width="3454" height="1792" alt="CleanShot 2025-11-26 at 17 08 51@2x" src="https://github.com/user-attachments/assets/7bea4153-1fb3-4ad7-bf22-486b2c81b525" />

<img width="3456" height="1770" alt="CleanShot 2025-11-26 at 17 09 02@2x" src="https://github.com/user-attachments/assets/b4131683-eb5a-4bfa-99d0-8d87bb2f62f0" />
