### PR TITLE
Fix square styling error when using multiple fonts in font family sty…

### DIFF
--- a/square/controllers/FrmSquareLiteActionsController.php
+++ b/square/controllers/FrmSquareLiteActionsController.php
@@ -567,7 +567,6 @@ class FrmSquareLiteActionsController extends FrmTransLiteActionsController {
 				'backgroundColor' => $settings['bg_color'],
 				'fontWeight'      => $settings['field_weight'],
 			),
-			// How does input placeholder work??
 			'input::placeholder'        => array(
 				'color' => $settings['text_color_disabled'],
 			),


### PR DESCRIPTION
…le setting

> Uncaught (in promise) InvalidStylesError: One or more style selectors and/or CSS properties are invalid
  Invalid style value 'Tahoma,Arial' for property 'fontFamily'.