### PR TITLE
Remove old backward compatibility code

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -4677,14 +4677,6 @@ class FrmAppHelper {
 	public static function copy_for_lite_license() {
 		$message = __( 'You\'re using Formidable Forms Lite - no license needed. Enjoy!', 'formidable' ) . ' 🙂';
 
-		if ( is_callable( 'FrmProAddonsController::get_readable_license_type' ) && ! class_exists( 'FrmProDashboardController' ) ) {
-			// Manage PRO versions without PRO dashboard functionality.
-			$license_type = FrmProAddonsController::get_readable_license_type();
-			if ( 'lite' !== strtolower( $license_type ) ) {
-				$message = 'Formidable Pro ' . $license_type;
-			}
-		}
-
 		return apply_filters( 'frm_license_type_text', $message );
 	}
 


### PR DESCRIPTION
This fallback message is pretty incomplete, and shouldn't really come up anymore since the dashboard has been around since v6.8, back from Jan 25, 2024.