### PR TITLE
Stop using jQuery `.find()` in `formidable.js`

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1871,10 +1871,6 @@ function frmFrontFormJS() {
 		 * @return {void}
 		 */
 		submitFormManual: function( e, object ) {
-			let isPro, errors,
-				invisibleRecaptcha = hasInvisibleRecaptcha( object ),
-				classList = object.className.trim().split( /\s+/gi );
-
 			if ( jQuery( 'body' ).hasClass( 'wp-admin' ) && jQuery( object ).closest( '.frmapi-form' ).length < 1 ) {
 				return;
 			}
@@ -1885,10 +1881,12 @@ function frmFrontFormJS() {
 				return;
 			}
 
-			errors = frmFrontForm.validateFormSubmit( object );
+			const errors = frmFrontForm.validateFormSubmit( object );
 			if ( Object.keys( errors ).length !== 0 ) {
 				return;
 			}
+
+			const invisibleRecaptcha = hasInvisibleRecaptcha( object );
 
 			if ( invisibleRecaptcha ) {
 				showLoadingIndicator( jQuery( object ) );


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5002

This could use more testing.

This update mostly touches code for:

**Tested**
- [x] A honeypot fix in Chrome
- [x] Form error validation (AJAX and JS)
- [x] reCAPTCHA validation
- [x] Disabling / enabling submit buttons and the save draft button
- [x] TinyMCE handling on form submit.
- [x] Required Signature field validation
- [x] Click confirmation (deleting entries from front end)
- [x] Enabling / disabling the save draft button.