### PR TITLE
Drop old deprecated visible/invisible JS global functions

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -2087,28 +2087,6 @@ function frmFrontFormJS() {
 				.replace( /'/g, '&#039;' );
 		},
 
-		/**
-		 * This function was used in old back end code in v2.0.
-		 *
-		 * @param {string} classes
-		 * @return {void}
-		 */
-		invisible: function( classes ) {
-			console.warn( 'DEPRECATED: function frmFrontForm.invisible in v6.16.3' );
-			jQuery( classes ).css( 'visibility', 'hidden' );
-		},
-
-		/**
-		 * This function was used in old back end code in v2.0.
-		 *
-		 * @param {string} classes
-		 * @return {void}
-		 */
-		visible: function( classes ) {
-			console.warn( 'DEPRECATED: function frmFrontForm.visible in v6.16.3' );
-			jQuery( classes ).css( 'visibility', 'visible' );
-		},
-
 		triggerCustomEvent: triggerCustomEvent,
 		documentOn
 	};


### PR DESCRIPTION
Related issue https://github.com/Strategy11/formidable-pro/issues/5002, dropping the last references to `jQuery().css()`.

These have been deprecated for a year, and shouldn't really be used in any custom code.