### PR TITLE
Revert black text is used for errors

### DIFF
--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -367,7 +367,7 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 .<?php echo esc_html( $style_class ); ?> .frm_error,
 .<?php echo esc_html( $style_class ); ?> .frm_limit_error{
 	font-weight:<?php echo esc_html( $weight . $important ); ?>;
-	color:<?php echo esc_html( $text_color_error . $important ); ?>;
+	color:<?php echo esc_html( $border_color_error . $important ); ?>;
 }
 
 .<?php echo esc_html( $style_class ); ?> .frm_error_style{


### PR DESCRIPTION
This changed during the Quick Settings update https://github.com/Strategy11/formidable-forms/commit/30c73f1b33ec772f649a804c9194e0cb950e81e8

But it's wrong. I figured this was intentional or something, but talking to Razvan, it sounds like this is just a bug.

- `$text_color_error` is intended for the input text color (inside of the input). By default this is a shade of gray.
- We want our errors to be red by default, and we want it to match the red error colour of the borders. It should still be using `$border_color_error`, which was intentionally set that way.

<img width="198" height="106" alt="Screen Shot 2025-12-04 at 4 10 11 PM" src="https://github.com/user-attachments/assets/6b84752c-dbd6-4fa1-b07a-d69827674e39" />
