### PR TITLE
Fix AI popup appearing when pressing Enter in field labels

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -2730,7 +2730,7 @@ class FrmFieldsHelper {
 	public static function render_ai_generate_options_button( $args, $should_hide_bulk_edit = false ) {
 		$attributes = array(
 			'type'  => 'button',
-			'class' => self::get_ai_generate_options_button_class()
+			'class' => self::get_ai_generate_options_button_class(),
 		);
 
 		if ( ! empty( $should_hide_bulk_edit ) ) {


### PR DESCRIPTION
Fixed an issue where the "Generate options with AI are not available" popup would unexpectedly appear when pressing Enter after typing a field label in the form builder.

### Issue

Fixes https://github.com/Strategy11/formidable-pro/issues/6125 