### PR TITLE
Stop excluding htaccess file from zips

### DIFF
--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -33,13 +33,25 @@ fi
 # Generate the plugin zip file.
 status "Creating archive..."
 zip -r $zipname $destination \
-	-x "*/.*" \
+	-x "*/.DS_Store" \
+	-x "*/.babelrc" \
+	-x "*/.browserslistrc" \
+	-x "*/.editorconfig" \
+	-x "*/.eslintignore" \
+	-x "*/.eslintrc.json" \
 	-x "*/.git/*" \
+	-x "*/.gitattributes" \
 	-x "*/.github/*" \
-	-x "*/.phpunit.result.cache" \
-	-x "*/.php-cs-fixer.yml" \
+	-x "*/.gitignore" \
+	-x "*/.jshintignore" \
 	-x "*/.php-cs-fixer.cache" \
+	-x "*/.php-cs-fixer.php" \
+	-x "*/.phpunit.result.cache" \
+	-x "*/.stylelintrc.json" \
+	-x "*/.wordpress-org/*" \
 	-x "*/.wp-env.json" \
+	-x "*/.jshintrc" \
+	-x "*/.jshintignore" \
 	-x "*/bin/*" \
 	-x "*/scss/*" \
 	-x "*/css/*.css.map" \


### PR DESCRIPTION
This was using a `*/.*` rule and needs to be replaced by a list of all of the dotfiles instead.