### PR TITLE
Small css changes

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -495,6 +495,7 @@ legend.frm_hidden{
 	opacity: 1;
 	transition: opacity 0.3s ease-in;
 }
+/* End floating label */
 
 .with_frm_style .frm_description,
 .with_frm_style .frm_pro_max_limit_desc{


### PR DESCRIPTION
**Some changes**
- Fixes a double semi-colon
- Drops references to `:-moz-placeholder` and `:-ms-input-placeholder` which shouldn't be necessary with `::placeholder` set.