### PR TITLE
Try to cut back on calls to get option

### DIFF
--- a/classes/models/FrmFormApi.php
+++ b/classes/models/FrmFormApi.php
@@ -301,13 +301,16 @@ class FrmFormApi {
 			return false;
 		}
 
-		$is_expired  = empty( $cache['timeout'] ) || time() > $cache['timeout'];
-		$for_current = isset( $cache['version'] ) && $cache['version'] === FrmAppHelper::plugin_version();
+		$is_expired = empty( $cache['timeout'] ) || time() > $cache['timeout'];
+
+		if ( ! $is_expired && isset( $cache['version'] ) && $cache['version'] !== FrmAppHelper::plugin_version() ) {
+			$is_expired = true;
+		}
 
 		// Avoid old cached data, unless we're currently trying to query for new data.
 		// The call to $this->is_running likely triggers a database query, so only call if if we're expired.
 		// (Rather than the other way around, which is less efficient).
-		if ( ( $is_expired || ! $for_current ) && ! $this->is_running() ) {
+		if ( $is_expired && ! $this->is_running() ) {
 			return false;
 		}
 


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3168224965/244001

- Ensures that the license check is part of the "all options" data to avoid extra db calls.
- Avoids `get_option` checks for the request lock when the cached data is not expired.

**Pre-release**
[formidable-6.26.1b.zip](https://github.com/user-attachments/files/24132496/formidable-6.26.1b.zip)
