### PR TITLE
Remove redundant listener

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1559,10 +1559,6 @@ function frmFrontFormJS() {
 			);
 		} );
 
-		jQuery( document ).on( 'change', selector, function( event ) {
-			checkFloatLabel( event.target );
-		} );
-
 		runOnLoad = function( firstLoad ) {
 			if ( firstLoad && document.activeElement && -1 !== [ 'INPUT', 'SELECT', 'TEXTAREA' ].indexOf( document.activeElement.tagName ) ) {
 				checkFloatLabel( document.activeElement );


### PR DESCRIPTION
This should be covered by the code immediately above.

```
[ 'focus', 'blur', 'change' ].forEach( function( eventName ) {
	documentOn(
		eventName,
		selector,
		function( event ) {
			checkFloatLabel( event.target );
		},
		true
	);
} );
```