### PR TITLE
Drop onblur logic from formidable.js

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1760,12 +1760,6 @@ function frmFrontFormJS() {
 			jQuery( document ).off( 'submit.formidable', '.frm-show-form' );
 			jQuery( document ).on( 'submit.formidable', '.frm-show-form', frmFrontForm.submitForm );
 
-			document.querySelectorAll( '.frm-show-form input[onblur], .frm-show-form textarea[onblur]' ).forEach( function( field ) {
-				if ( field.value === '' ) {
-					jQuery( field ).trigger( 'blur' );
-				}
-			} );
-
 			jQuery( document ).on( 'change', '.frm-show-form input[name^="item_meta"], .frm-show-form select[name^="item_meta"], .frm-show-form textarea[name^="item_meta"]', frmFrontForm.fieldValueChanged );
 
 			jQuery( document ).on( 'change', '.frm_verify[id^=field_]', onHoneypotFieldChange );


### PR DESCRIPTION
Working on replacing jQuery with vanilla JS, I'm noticing that this logic doesn't seem to be required for anything, or documented anywhere.

I can trace it going back to 10+ years ago.

I don't think it's relevant anymore.