### PR TITLE
Deprecate trans lite function that should not exist

### DIFF
--- a/stripe/controllers/FrmTransLiteSubscriptionsController.php
+++ b/stripe/controllers/FrmTransLiteSubscriptionsController.php
@@ -154,6 +154,8 @@ class FrmTransLiteSubscriptionsController extends FrmTransLiteCRUDController {
 	}
 
 	/**
+	 * @deprecated x.x
+	 *
 	 * @return string|null
 	 */
 	public static function list_subscriptions_shortcode() {


### PR DESCRIPTION
This was copied over from Stripe incorrectly.

It references a view that doesn't exist.