### PR TITLE
Fix some phpcs warnings

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -892,7 +892,7 @@ class FrmAddonsController {
 			$link = $site_url . $link;
 		}
 
-		$link       = FrmAppHelper::make_affiliate_url( $link );
+		$link = FrmAppHelper::make_affiliate_url( $link );
 
 		$utm  = array(
 			'campaign' => 'addons',
@@ -1053,7 +1053,6 @@ class FrmAddonsController {
 		if ( $show_form ) {
 			$form     = ob_get_clean();
 			$message  = __( 'Sorry, your site requires FTP authentication. Please download plugins from FormidableForms.com and install them manually.', 'formidable' );
-			$data     = $form;
 			$response = array(
 				'success' => false,
 				'message' => $message,

--- a/classes/controllers/FrmFormTemplatesController.php
+++ b/classes/controllers/FrmFormTemplatesController.php
@@ -566,7 +566,7 @@ class FrmFormTemplatesController {
 				'count' => 0,
 			);
 		}
-		$special_categories['all-items']      = array(
+		$special_categories['all-items'] = array(
 			'name'  => __( 'All Templates', 'formidable' ),
 			'count' => self::get_template_count(),
 		);

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -292,8 +292,7 @@ class FrmStylesController {
 	 */
 	public static function add_tags_to_css( $tag, $handle ) {
 		if ( ( 'formidable' === $handle || 'jquery-theme' === $handle ) && strpos( $tag, ' property=' ) === false ) {
-			$frm_settings = FrmAppHelper::get_settings();
-			$tag          = str_replace( ' type="', ' property="stylesheet" type="', $tag );
+			$tag = str_replace( ' type="', ' property="stylesheet" type="', $tag );
 		}
 
 		return $tag;
@@ -345,7 +344,7 @@ class FrmStylesController {
 		$style_id = self::get_style_id_for_styler();
 
 		if ( ! $style_id ) {
-			$error_args   = array(
+			$error_args = array(
 				'title'      => __( 'No styles', 'formidable' ),
 				'body'       => __( 'You must have a style to use the Visual Styler.', 'formidable' ),
 				'cancel_url' => admin_url( 'admin.php?page=formidable' ),
@@ -363,7 +362,7 @@ class FrmStylesController {
 		$form = FrmForm::getOne( $form_id );
 
 		if ( ! is_object( $form ) ) {
-			$error_args   = array(
+			$error_args = array(
 				'title'      => __( 'No forms', 'formidable' ),
 				'body'       => __( 'You must have a form to use the Visual Styler.', 'formidable' ),
 				'cancel_url' => admin_url( 'admin.php?page=formidable' ),

--- a/classes/controllers/FrmXMLController.php
+++ b/classes/controllers/FrmXMLController.php
@@ -598,7 +598,7 @@ class FrmXMLController {
 			return $parent_slugs;
 		}
 
-		$results      = FrmDb::get_results( 'terms', array( 'term_id' => $parent_term_ids ), 'term_id, slug' );
+		$results = FrmDb::get_results( 'terms', array( 'term_id' => $parent_term_ids ), 'term_id, slug' );
 
 		return wp_list_pluck( $results, 'slug', 'term_id' );
 	}

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -435,7 +435,7 @@ class FrmAppHelper {
 	 * @return bool
 	 */
 	public static function is_formidable_admin() {
-		$page          = self::simple_get( 'page', 'sanitize_title' );
+		$page = self::simple_get( 'page', 'sanitize_title' );
 
 		if ( empty( $page ) ) {
 			return self::is_view_builder_page();

--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -504,7 +504,7 @@ class FrmCSVExportHelper {
 	 */
 	private static function prepare_next_csv_rows( $next_set ) {
 		if ( FrmAppHelper::pro_is_installed() ) {
-			$where    = array(
+			$where = array(
 				'or'             => 1,
 				'id'             => $next_set,
 				'parent_item_id' => $next_set,

--- a/classes/helpers/FrmDashboardHelper.php
+++ b/classes/helpers/FrmDashboardHelper.php
@@ -189,7 +189,7 @@ class FrmDashboardHelper {
 			$buttons = self::get_license_buttons();
 		}
 
-		foreach ( $buttons as $i => $button ) {
+		foreach ( $buttons as $button ) {
 			$add_classes = ! empty( $button['classes'] ) ? ' ' . $button['classes'] : ' frm-button-secondary';
 			?>
 			<a href="<?php echo esc_url( $button['link'] ); ?>" target="_blank"

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -426,7 +426,7 @@ class FrmEntriesHelper {
 			$field_id  = $field['id'];
 			$field_obj = FrmFieldFactory::get_field_object( $field['id'] );
 		} elseif ( is_object( $field ) ) {
-			$field_id  = $field->id;
+			$field_id = $field->id;
 
 			if ( 'hidden' === $field->type && ! empty( $field->field_options['original_type'] ) ) {
 				$field_obj = FrmFieldFactory::get_field_type( $field->field_options['original_type'], $field );

--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -27,7 +27,7 @@ class FrmFormsListHelper extends FrmListHelper {
 	 * @return void
 	 */
 	public function prepare_items() {
-		global $wpdb, $per_page, $mode;
+		global $per_page, $mode;
 
 		$page     = $this->get_pagenum();
 		$per_page = $this->get_items_per_page( 'formidable_page_formidable_per_page' );
@@ -53,7 +53,7 @@ class FrmFormsListHelper extends FrmListHelper {
 
 		FrmAppController::apply_saved_sort_preference( $orderby, $order );
 
-		$start   = self::get_param(
+		$start = self::get_param(
 			array(
 				'param'   => 'start',
 				'default' => ( $page - 1 ) * $per_page,
@@ -237,7 +237,7 @@ class FrmFormsListHelper extends FrmListHelper {
 	 * @return string
 	 */
 	public function single_row( $item, $style = '' ) {
-		global $frm_vars, $mode;
+		global $mode;
 
 		// Set up the hover actions for this user
 		$actions   = array();

--- a/classes/helpers/FrmHtmlHelper.php
+++ b/classes/helpers/FrmHtmlHelper.php
@@ -99,7 +99,7 @@ class FrmHtmlHelper {
 			}
 		}
 
-		$input_number_attrs          = array_merge(
+		$input_number_attrs = array_merge(
 			$args['input_number_attrs'],
 			array(
 				'type'  => ! empty( $selected_unit ) ? 'number' : 'text',

--- a/classes/models/FrmCreateFile.php
+++ b/classes/models/FrmCreateFile.php
@@ -33,12 +33,12 @@ class FrmCreateFile {
 	/**
 	 * @var int
 	 */
-	public $chmod_dir       = 0755;
+	public $chmod_dir = 0755;
 
 	/**
 	 * @var int
 	 */
-	public $chmod_file      = 0644;
+	public $chmod_file = 0644;
 
 	/**
 	 * @var bool

--- a/classes/models/FrmField.php
+++ b/classes/models/FrmField.php
@@ -8,7 +8,7 @@ class FrmField {
 	/**
 	 * @var bool
 	 */
-	public static $use_cache      = true;
+	public static $use_cache = true;
 
 	/**
 	 * @var int

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -978,8 +978,6 @@ class FrmForm {
 	 * @return object count of forms
 	 */
 	public static function get_count() {
-		global $wpdb;
-
 		$cache_key = 'frm_form_counts';
 
 		$counts = wp_cache_get( $cache_key, 'frm_form' );

--- a/classes/models/FrmFormAction.php
+++ b/classes/models/FrmFormAction.php
@@ -660,7 +660,7 @@ class FrmFormAction {
 	 * @return int The filtered limit value.
 	 */
 	public static function get_action_limit( $form_id, $limit = 99 ) {
-		$type  = 'all';
+		$type = 'all';
 		return (int) apply_filters( 'frm_form_action_limit', (int) $limit, compact( 'type', 'form_id' ) );
 	}
 

--- a/classes/models/FrmFormMigrator.php
+++ b/classes/models/FrmFormMigrator.php
@@ -38,7 +38,7 @@ abstract class FrmFormMigrator {
 	/**
 	 * @var array
 	 */
-	protected $fields_map          = array();
+	protected $fields_map = array();
 
 	/**
 	 * @var mixed
@@ -48,7 +48,7 @@ abstract class FrmFormMigrator {
 	/**
 	 * @var array
 	 */
-	protected $current_section     = array();
+	protected $current_section = array();
 
 	/**
 	 * Define required properties.

--- a/classes/models/fields/FrmFieldName.php
+++ b/classes/models/fields/FrmFieldName.php
@@ -281,7 +281,7 @@ class FrmFieldName extends FrmFieldCombo {
 
 		$show_warning = false;
 
-		foreach ( $this->sub_fields as $name => $sub_field ) {
+		foreach ( $this->sub_fields as $sub_field ) {
 			$description = FrmField::get_option( $field, $sub_field['name'] . '_desc' );
 
 			if ( in_array( $description, array( 'First', 'Last' ), true ) ) {

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -841,7 +841,7 @@ DEFAULT_HTML;
 	 * @return array
 	 */
 	public function get_new_field_defaults() {
-		$field        = array(
+		$field = array(
 			'name'          => $this->get_new_field_name(),
 			'description'   => '',
 			'type'          => $this->type,

--- a/classes/views/frm-entries/form.php
+++ b/classes/views/frm-entries/form.php
@@ -80,8 +80,6 @@ if ( ! $only_contain_submit ) {
 	FrmFieldsHelper::show_fields( $fields_to_show, $errors, $form, $form_action );
 }//end if
 
-$frm_settings = FrmAppHelper::get_settings();
-
 if ( FrmAppHelper::is_admin() && ( ! isset( $_GET['action'] ) || 'elementor' !== $_GET['action'] ) ) {
 	?>
 	<div class="frm_form_field form-field">

--- a/classes/views/frm-fields/back-end/settings.php
+++ b/classes/views/frm-fields/back-end/settings.php
@@ -219,7 +219,7 @@ do_action( 'frm_before_field_options', $field, compact( 'field_obj', 'display', 
 						if ( FrmAppHelper::pro_is_connected() && ! is_callable( array( 'FrmProHtmlHelper', 'echo_radio_group' ) ) ) {
 							switch ( $type ) {
 								case 'calc':
-									$default_value_type['data']  = array(
+									$default_value_type['data'] = array(
 										'show'    => '#calc-for-{id}',
 										'disable' => '#default-value-for-{id}',
 									);

--- a/classes/views/frm-form-actions/_action_inside.php
+++ b/classes/views/frm-form-actions/_action_inside.php
@@ -27,7 +27,7 @@ do_action( 'frm_action_settings_before_action_name', $form_action );
 <?php
 
 if ( ! isset( $action_control->action_options['event'] ) ) {
-	$events = 'create';
+	$action_control->action_options['event'] = 'create';
 }
 
 if ( ! is_array( $action_control->action_options['event'] ) ) {

--- a/classes/views/frm-form-actions/_email_settings.php
+++ b/classes/views/frm-form-actions/_email_settings.php
@@ -10,7 +10,6 @@ if ( ! empty( $form_action->post_content['plain_text'] ) ) {
 	$selected_style = 'plain';
 }
 
-$frm_settings  = FrmAppHelper::get_settings();
 $default_style = FrmEmailStylesController::get_default_email_style();
 ?>
 <p class="frm-email-style-container">

--- a/classes/views/frm-settings/email/email-styles.php
+++ b/classes/views/frm-settings/email/email-styles.php
@@ -12,7 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $email_styles   = FrmEmailStylesController::get_email_styles();
-$frm_settings   = FrmAppHelper::get_settings();
 $selected_style = FrmEmailStylesController::get_default_email_style();
 ?>
 <p><?php esc_html_e( 'Customize your email template and sending preferences.', 'formidable' ); ?></p>

--- a/classes/views/summary-emails/base.php
+++ b/classes/views/summary-emails/base.php
@@ -13,7 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
 
-$frm_settings = FrmAppHelper::get_settings();
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/classes/views/xml/posts_xml.php
+++ b/classes/views/xml/posts_xml.php
@@ -116,7 +116,6 @@ foreach ( (array) $terms as $term ) {
 	}
 
 	$frm_inc_tax[] = $term->term_id;
-	$label         = 'category' === $term->taxonomy || 'tag' === $term->taxonomy ? $term->taxonomy : 'term';
 	?>
 	<term><term_id><?php echo esc_html( $term->term_id ); ?></term_id><term_taxonomy><?php echo esc_html( $term->taxonomy ); ?></term_taxonomy><?php
 	if ( ! empty( $parent_slugs[ $term->parent ] ) ) {

--- a/square/controllers/FrmSquareLiteActionsController.php
+++ b/square/controllers/FrmSquareLiteActionsController.php
@@ -545,7 +545,7 @@ class FrmSquareLiteActionsController extends FrmTransLiteActionsController {
 			false
 		);
 
-		$square_vars     = array(
+		$square_vars = array(
 			'formId'     => $form_id,
 			'nonce'      => wp_create_nonce( 'frm_square_ajax' ),
 			'ajax'       => esc_url_raw( FrmAppHelper::get_ajax_url() ),

--- a/stripe/controllers/FrmStrpLiteActionsController.php
+++ b/stripe/controllers/FrmStrpLiteActionsController.php
@@ -317,7 +317,7 @@ class FrmStrpLiteActionsController extends FrmTransLiteActionsController {
 
 		// Gateway is a radio button but it should always be an array in the database for
 		// compatibility with the payments submodule where it is a checkbox.
-		$settings['gateway']  = ! empty( $settings['gateway'] ) ? (array) $settings['gateway'] : array( 'stripe' );
+		$settings['gateway'] = ! empty( $settings['gateway'] ) ? (array) $settings['gateway'] : array( 'stripe' );
 
 		$is_stripe = in_array( 'stripe', $settings['gateway'], true );
 

--- a/stripe/controllers/FrmTransLiteActionsController.php
+++ b/stripe/controllers/FrmTransLiteActionsController.php
@@ -563,7 +563,7 @@ class FrmTransLiteActionsController {
 	 * @return array
 	 */
 	public static function before_save_settings( $settings, $action ) {
-		$settings['gateway']  = ! empty( $settings['gateway'] ) ? (array) $settings['gateway'] : array( 'stripe' );
+		$settings['gateway'] = ! empty( $settings['gateway'] ) ? (array) $settings['gateway'] : array( 'stripe' );
 
 		if ( in_array( 'square', $settings['gateway'] ) ) {
 			$currency = FrmSquareLiteConnectHelper::get_merchant_currency();

--- a/stripe/helpers/FrmStrpLiteConnectHelper.php
+++ b/stripe/helpers/FrmStrpLiteConnectHelper.php
@@ -888,7 +888,7 @@ class FrmStrpLiteConnectHelper {
 	 * @return bool
 	 */
 	public static function update_intent( $intent_id, $data ) {
-		$data    = self::post_with_authenticated_body( 'update_intent', compact( 'intent_id', 'data' ) );
+		$data = self::post_with_authenticated_body( 'update_intent', compact( 'intent_id', 'data' ) );
 		return false !== $data;
 	}
 

--- a/stripe/helpers/FrmTransLiteListHelper.php
+++ b/stripe/helpers/FrmTransLiteListHelper.php
@@ -441,7 +441,6 @@ class FrmTransLiteListHelper extends FrmListHelper {
 	 * @return string
 	 */
 	private function get_user_id_column( $item ) {
-		global $wpdb;
 		$val = FrmDb::get_var( 'frm_items', array( 'id' => $item->item_id ), 'user_id' );
 		return FrmTransLiteAppHelper::get_user_link( $val );
 	}

--- a/stripe/models/FrmStrpLiteAuth.php
+++ b/stripe/models/FrmStrpLiteAuth.php
@@ -817,7 +817,10 @@ class FrmStrpLiteAuth {
 			return false;
 		}
 
-		self::delete_temporary_referer_meta( (int) $row->id );
+		if ( $delete_meta ) {
+			self::delete_temporary_referer_meta( (int) $row->id );
+		}
+
 		return $meta['referer'];
 	}
 

--- a/tests/phpunit/fields/test_FrmFieldValidate.php
+++ b/tests/phpunit/fields/test_FrmFieldValidate.php
@@ -140,8 +140,6 @@ class test_FrmFieldValidate extends FrmUnitTest {
 		$error_fields = array();
 
 		if ( ! empty( $errors ) ) {
-			$error_field_ids = array_keys( $errors );
-
 			foreach ( $fields as $field ) {
 				if ( ! isset( $errors[ 'field' . $field->id ] ) ) {
 					$error_fields[] = $field->type;

--- a/tests/phpunit/forms/test_FrmForm.php
+++ b/tests/phpunit/forms/test_FrmForm.php
@@ -61,7 +61,7 @@ class test_FrmForm extends FrmUnitTest {
 				continue;
 			}
 
-			$id          = FrmForm::destroy( $form->id );
+			FrmForm::destroy( $form->id );
 			$form_exists = FrmForm::getOne( $form->id );
 			$this->assertEmpty( $form_exists, 'Failed to delete form ' . $form->form_key );
 

--- a/tests/phpunit/misc/test_FrmAppHelper.php
+++ b/tests/phpunit/misc/test_FrmAppHelper.php
@@ -530,8 +530,6 @@ class test_FrmAppHelper extends FrmUnitTest {
 	 * @covers FrmAppHelper::get_unique_key
 	 */
 	public function test_get_unique_key() {
-		global $wpdb;
-
 		// Test field keys
 		$table_name = 'frm_fields';
 		$column     = 'field_key';

--- a/tests/phpunit/misc/test_FrmDirectFileAccess.php
+++ b/tests/phpunit/misc/test_FrmDirectFileAccess.php
@@ -20,7 +20,7 @@ class test_FrmDirectFileAccess extends FrmUnitTest {
 		$files_to_ignore   = array( 'set-php-version.php', 'stubs.php', '.php-cs-fixer.php', 'rector.php' );
 		$folders_to_ignore = array( 'tests', 'vendor', 'languages', 'node_modules', 'js', 'phpcs-sniffs' );
 
-		foreach ( $files as $key => $value ) {
+		foreach ( $files as $value ) {
 			$path = realpath( $dir . DIRECTORY_SEPARATOR . $value );
 
 			if ( ! is_dir( $path ) ) {

--- a/tests/phpunit/stripe/FrmStrpLiteUnitTest.php
+++ b/tests/phpunit/stripe/FrmStrpLiteUnitTest.php
@@ -449,7 +449,7 @@ class FrmStrpLiteUnitTest extends FrmUnitTest {
 	 */
 	protected function maybe_create_plan() {
 		$this->get_customer();
-		$plan     = $this->get_plan_options();
+		$plan = $this->get_plan_options();
 		return FrmStrpLiteSubscriptionHelper::maybe_create_plan( $plan );
 	}
 }

--- a/tests/phpunit/styles/test_FrmStylesHelper.php
+++ b/tests/phpunit/styles/test_FrmStylesHelper.php
@@ -124,7 +124,6 @@ class test_FrmStylesHelper extends FrmUnitTest {
 		$default_count                = 0;
 
 		foreach ( $data_for_all_published_forms as $row ) {
-			$form_id = $row->id;
 			$options = $row->options;
 			FrmAppHelper::unserialize_or_decode( $options );
 


### PR DESCRIPTION
- Treats a PHPCS warnings as an error to make sure there are no spaces between the variable name and `=` for single line variable declarations.
- Removes some declarations for unused variables.
- Check `$delete_meta` variable before deleting meta (Like in https://github.com/Strategy11/formidable-stripe/pull/265/files).
- Fixes an `isset` check, where it wasn't setting the right variable. `$events` is never used, but the variable behind the `isset` check is then assumed to be set moving forward.