### PR TITLE
Improve accessibility for file uploads and form messages

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -3870,6 +3870,8 @@ class FrmAppHelper {
 			'id'                   => __( 'ID', 'formidable' ),
 			'no_results'           => __( 'No results match', 'formidable' ),
 			'file_spam'            => __( 'That file looks like Spam.', 'formidable' ),
+			'uploading'            => __( 'Uploading', 'formidable' ),
+			'file_uploaded'        => __( 'File uploaded:', 'formidable' ),
 			'calc_error'           => __( 'There is an error in the calculation in the field with key', 'formidable' ),
 			'empty_fields'         => __( 'Please complete the preceding required fields before uploading a file.', 'formidable' ),
 			'focus_first_error'    => self::should_focus_first_error(),

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -325,7 +325,7 @@ class FrmFormsHelper {
 		}
 
 		$message = do_shortcode( $message );
-		return '<div class="' . esc_attr( $atts['class'] ) . '" role="status">' . $message . '</div>';
+		return '<div class="' . esc_attr( $atts['class'] ) . '" role="status" tabindex="-1">' . $message . '</div>';
 	}
 
 	/**

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -1065,9 +1065,27 @@ function frmFrontFormJS() {
 		const formCompleted = tempDiv.querySelector( '.frm_message' );
 		if ( formCompleted ) {
 			jQuery( document ).trigger( 'frmFormComplete', [ object, response ] );
+			// Focus success message for screen reader accessibility
+			object.closest( '.frm_forms' )?.parentNode?.querySelector( '.frm_message' )?.focus();
 		} else {
 			jQuery( document ).trigger( 'frmPageChanged', [ object, response ] );
+			focusPageHeading( object );
 		}
+	}
+
+	/**
+	 * Focus first heading after multi-page navigation for screen reader accessibility.
+	 *
+	 * @since x.x
+	 *
+	 * @param {HTMLElement} object The form element.
+	 * @return {void}
+	 */
+	function focusPageHeading( object ) {
+		const container = object.closest( '.frm_forms' );
+		const heading = container?.parentNode?.querySelector( '.frm_page_num_active h2, .frm_page_num_active h3, .frm_rootline_title' );
+		heading?.setAttribute( 'tabindex', '-1' );
+		heading?.focus();
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/6098

This PR improves accessibility for Formidable forms in a few key places.

It makes file upload controls clearer for screen reader users, provides better feedback during uploads, and keeps keyboard focus in a predictable place when files are removed. It also improves the experience after submitting a form by moving focus to the success message, and helps multi‑page forms by moving focus to the new step after navigation.

### Add-ons Changes

- https://github.com/Strategy11/formidable-pro/pull/6165