### PR TITLE
Add new phpcs warning as error

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -270,6 +270,10 @@
 		<severity>8</severity>
 		<type>error</type>
 	</rule>
+	<rule ref="Generic.Formatting.MultipleStatementAlignment.IncorrectWarning">
+		<severity>8</severity>
+		<type>error</type>
+	</rule>
 
 	<!-- Custom Formidable sniffs -->
 	<rule ref="Formidable.WhiteSpace.BlankLineAfterClosingBrace" />


### PR DESCRIPTION
This is applied in https://github.com/Strategy11/formidable-forms/pull/2676/files but it looks like I must've reverted these changes in this file instead of committing them.