### PR TITLE
Add additional eslint rules for no jQuery in front end js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -150,5 +150,23 @@
 		"react/jsx-no-target-blank": "off",
 		"comma-dangle": "off",
 		"arrow-parens": ["error", "as-needed"]
-	}
+	},
+	"overrides": [
+		{
+			"files": ["js/formidable.js"],
+			"rules": {
+				"no-jquery/no-find": "error",
+				"no-jquery/no-visibility": "error",
+				"no-jquery/no-slide": "error",
+				"no-jquery/no-css": "error",
+				"no-jquery/no-each": "error",
+				"no-jquery/no-append-html": "error",
+				"no-jquery/no-animate": "error",
+				"no-jquery/no-prop": "error",
+				"no-jquery/no-filter": "error",
+				"no-jquery/no-data": "error",
+				"no-jquery/no-parents": "error"
+			}
+		}
+	]
 }


### PR DESCRIPTION
This is to help make sure that none of these jQuery functions are reintroduced in our `formidable.js` file.