### PR TITLE
Fix denylist spam check warnings for nested field values (Ranking)

### DIFF
--- a/classes/models/FrmSpamCheckDenylist.php
+++ b/classes/models/FrmSpamCheckDenylist.php
@@ -424,7 +424,7 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 	 * @return void
 	 */
 	protected function add_to_values_to_check( &$values_to_check, $value ) {
-		$values_to_check[] = is_array( $value ) ? implode( ' ', $value ) : $value;
+		$values_to_check[] = is_array( $value ) ? FrmAppHelper::safe_implode( ' ', $value ) : $value;
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-surveys/issues/342

This PR fixes repeated PHP warnings triggered when editing an entry with a Ranking field. The spam denylist checker attempted to `implode()` field values that can include nested arrays, causing “Array to string conversion” warnings.  
It now uses the existing `FrmAppHelper::safe_implode()` helper to safely flatten arrays before imploding, preserving existing behavior for normal field values while preventing warnings for nested data.