### PR TITLE
Ignore no-jquery errors with inline comments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -165,7 +165,14 @@
 				"no-jquery/no-prop": "error",
 				"no-jquery/no-filter": "error",
 				"no-jquery/no-data": "error",
-				"no-jquery/no-parents": "error"
+				"no-jquery/no-parents": "error",
+				"no-jquery/no-val": "error",
+				"no-jquery/no-serialize": "error",
+				"no-jquery/no-class": "error",
+				"no-jquery/no-closest": "error",
+				"no-jquery/no-ajax": "error",
+				"no-jquery/no-fade": "error",
+				"no-jquery/no-is": "error"
 			}
 		}
 	]

--- a/js/formidable.js
+++ b/js/formidable.js
@@ -417,7 +417,7 @@ function frmFrontFormJS() {
 				return errors;
 			}
 
-			val = jQuery( field ).val();
+			val = jQuery( field ).val(); // eslint-disable-line no-jquery/no-val
 
 			if ( val === null ) {
 				val = '';
@@ -851,7 +851,7 @@ function frmFrontFormJS() {
 		const fieldsets = object.querySelectorAll( '.frm_form_field' );
 		fieldsets.forEach( field => field.classList.add( 'frm_doing_ajax' ) );
 
-		data = jQuery( object ).serialize() + '&action=frm_entries_' + action + '&nonce=' + frm_js.nonce; // eslint-disable-line camelcase
+		data = jQuery( object ).serialize() + '&action=frm_entries_' + action + '&nonce=' + frm_js.nonce; // eslint-disable-line no-jquery/no-serialize, camelcase
 		shouldTriggerEvent = object.classList.contains( 'frm_trigger_event_on_submit' );
 
 		const doRedirect = response => {
@@ -923,7 +923,7 @@ function frmFrontFormJS() {
 				const formIdInput = object.querySelector( 'input[name="form_id"]' );
 				formID = formIdInput ? formIdInput.value : '';
 				response.content = response.content.replace( / frm_pro_form /g, ' frm_pro_form frm_no_hide ' );
-				replaceContent = jQuery( object ).closest( '.frm_forms' );
+				replaceContent = jQuery( object ).closest( '.frm_forms' ); // eslint-disable-line no-jquery/no-closest
 				removeAddedScripts( replaceContent, formID );
 				delay = maybeSlideOut( replaceContent, response.content );
 
@@ -964,8 +964,8 @@ function frmFrontFormJS() {
 					$fieldCont = fieldContEl ? jQuery( fieldContEl ) : jQuery();
 
 					if ( $fieldCont.length ) {
-						if ( ! $fieldCont.is( ':visible' ) ) {
-							inCollapsedSection = $fieldCont.closest( '.frm_toggle_container' );
+						if ( ! $fieldCont.is( ':visible' ) ) { // eslint-disable-line no-jquery/no-is
+							inCollapsedSection = $fieldCont.closest( '.frm_toggle_container' ); // eslint-disable-line no-jquery/no-closest
 							if ( inCollapsedSection.length ) {
 								frmTrigger = inCollapsedSection.prev();
 								if ( ! frmTrigger.hasClass( 'frm_trigger' ) ) {
@@ -976,7 +976,7 @@ function frmFrontFormJS() {
 							}
 						}
 
-						if ( $fieldCont.is( ':visible' ) ) {
+						if ( $fieldCont.is( ':visible' ) ) { // eslint-disable-line no-jquery/no-is
 							addFieldError( $fieldCont, key, response.errors );
 							contSubmit = false;
 						}
@@ -1056,7 +1056,7 @@ function frmFrontFormJS() {
 			ajaxParams.error = error;
 		}
 
-		jQuery.ajax( ajaxParams );
+		jQuery.ajax( ajaxParams ); // eslint-disable-line no-jquery/no-ajax
 	}
 
 	function afterFormSubmitted( object, response ) {
@@ -1290,7 +1290,7 @@ function frmFrontFormJS() {
 	}
 
 	function showLoadingIndicator( $object ) {
-		if ( ! $object.hasClass( 'frm_loading_form' ) && ! $object.hasClass( 'frm_loading_prev' ) ) {
+		if ( ! $object.hasClass( 'frm_loading_form' ) && ! $object.hasClass( 'frm_loading_prev' ) ) { // eslint-disable-line no-jquery/no-class
 			addLoadingClass( $object );
 			$object.trigger( 'frmStartFormLoading' );
 		}
@@ -1299,7 +1299,7 @@ function frmFrontFormJS() {
 	function addLoadingClass( $object ) {
 		const loadingClass = isGoingToPrevPage( $object ) ? 'frm_loading_prev' : 'frm_loading_form';
 
-		$object.addClass( loadingClass );
+		$object.addClass( loadingClass ); // eslint-disable-line no-jquery/no-class
 	}
 
 	function isGoingToPrevPage( $object ) {
@@ -1332,7 +1332,7 @@ function frmFrontFormJS() {
 		const fileval = fileInput ? fileInput.value : '';
 		if ( fileval !== '' ) {
 			setTimeout( function() {
-				jQuery( loading ).fadeIn( 'slow' );
+				jQuery( loading ).fadeIn( 'slow' ); // eslint-disable-line no-jquery/no-fade
 			}, 2000 );
 		}
 	}


### PR DESCRIPTION
This should help detect most new uses of jQuery that we want to block and it makes it easier to find which code needs to update.