### PR TITLE
Add ranking fields to denylist skip list

### DIFF
--- a/classes/models/FrmSpamCheckDenylist.php
+++ b/classes/models/FrmSpamCheckDenylist.php
@@ -231,7 +231,7 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 		// Some field types should never be checked.
 		$denylist['skip_field_types'] = array_merge(
 			$denylist['skip_field_types'],
-			array( 'password', 'captcha', 'signature', 'checkbox', 'radio', 'select', 'ranking', 'likert' )
+			array( 'password', 'captcha', 'signature', 'checkbox', 'radio', 'select', 'ranking' )
 		);
 	}
 


### PR DESCRIPTION
It looks like ranking fields were causing form validation issues.

I think we should probably ignore ranking fields as well since they're similar to the other skipped field types (radio, checkbox, select).