### PR TITLE
Treat strict in array WP phpcs rule as error

### DIFF
--- a/classes/controllers/FrmEntriesController.php
+++ b/classes/controllers/FrmEntriesController.php
@@ -390,6 +390,7 @@ class FrmEntriesController {
 		$save            = false;
 
 		foreach ( (array) $frm_vars['prev_hidden_cols'] as $prev_hidden ) {
+			// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 			if ( empty( $prev_hidden ) || in_array( $prev_hidden, $meta_value ) ) {
 				// Don't add blank cols or process included cols.
 				continue;

--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -2308,7 +2308,7 @@ class FrmAppHelper {
 
 		$can = self::current_user_can( $needed_role );
 
-		if ( $can || in_array( $needed_role, array( '-1', 'loggedout' ) ) ) {
+		if ( $can || in_array( $needed_role, array( '-1', 'loggedout' ), true ) ) {
 			return $can;
 		}
 
@@ -2447,6 +2447,7 @@ class FrmAppHelper {
 
 		$current = is_null( $current ) ? '' : htmlspecialchars_decode( trim( $current ) );
 
+		// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 		return ( is_array( $values ) && in_array( $current, $values ) ) || ( ! is_array( $values ) && $values == $current );
 	}
 
@@ -3565,7 +3566,7 @@ class FrmAppHelper {
 			$frm_action = 'reports';
 		}
 
-		if ( empty( $action ) || ( ! empty( $frm_action ) && in_array( $frm_action, $action ) ) ) {
+		if ( empty( $action ) || ( ! empty( $frm_action ) && in_array( $frm_action, $action, true ) ) ) {
 			echo ' class="current_page"';
 		}
 	}

--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -577,6 +577,7 @@ class FrmEntriesHelper {
 
 			// Multi-select dropdown.
 			if ( is_array( $value ) ) {
+				// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 				$o_key = array_search( $field->options[ $other_key ], $value );
 
 				if ( $o_key !== false ) {

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -698,6 +698,7 @@ class FrmFieldsHelper {
 
 			$field_name = $base_name . ( $default_type === 'checkbox' ? '[' . $opt_key . ']' : '' );
 
+			// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 			$checked = ( isset( $field['default_value'] ) && ( ( ! is_array( $field['default_value'] ) && $field['default_value'] == $field_val ) || ( is_array( $field['default_value'] ) && in_array( $field_val, $field['default_value'] ) ) ) );
 
 			// If this is an "Other" option, get the HTML for it.
@@ -952,9 +953,11 @@ class FrmFieldsHelper {
 				$m = array_intersect( $hide_opt, $observed_value );
 				$m = $m !== array();
 			} else {
+				// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 				$m = in_array( $hide_opt, $observed_value );
 			}
 		} elseif ( $cond === '!=' ) {
+			// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 			$m = ! in_array( $hide_opt, $observed_value );
 		} elseif ( $cond === '>' ) {
 			$min = min( $observed_value );
@@ -1587,6 +1590,7 @@ class FrmFieldsHelper {
 
 				// Multi-select dropdowns - key is not preserved
 				if ( is_array( $field['value'] ) ) {
+					// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 					$o_key = array_search( $temp_val, $field['value'] );
 
 					if ( isset( $field['value'][ $o_key ] ) ) {

--- a/classes/helpers/FrmFormMigratorsHelper.php
+++ b/classes/helpers/FrmFormMigratorsHelper.php
@@ -15,6 +15,7 @@ class FrmFormMigratorsHelper {
 		if ( $dismissed === null ) {
 			$dismissed = get_option( 'frm_dismissed' );
 		}
+		// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 		return ! empty( $dismissed ) && in_array( $form['class'], $dismissed );
 	}
 

--- a/classes/helpers/FrmListHelper.php
+++ b/classes/helpers/FrmListHelper.php
@@ -976,6 +976,7 @@ class FrmListHelper {
 			$aria_sort_attr = '';
 			$order_text     = '';
 
+			// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 			if ( in_array( $column_key, $hidden ) ) {
 				$class[] = 'hidden';
 			}
@@ -1229,6 +1230,7 @@ class FrmListHelper {
 				$classes .= ' has-row-actions column-primary';
 			}
 
+			// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 			if ( in_array( $column_name, $hidden ) ) {
 				$classes .= ' hidden';
 			}

--- a/classes/helpers/FrmStylesPreviewHelper.php
+++ b/classes/helpers/FrmStylesPreviewHelper.php
@@ -322,7 +322,7 @@ class FrmStylesPreviewHelper {
 		$styles->remove( 'edit' );
 
 		$wp_admin_dependencies = $styles->registered['wp-admin']->deps;
-		$edit_key              = array_search( 'edit', $wp_admin_dependencies );
+		$edit_key              = array_search( 'edit', $wp_admin_dependencies, true );
 
 		if ( false === $edit_key ) {
 			return;
@@ -389,7 +389,8 @@ class FrmStylesPreviewHelper {
 	 */
 	private static function remove_wp_admin_dependency( $styles, $key ) {
 		$dependencies = $styles->registered['wp-admin']->deps;
-		$index        = array_search( $key, $dependencies );
+		// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+		$index = array_search( $key, $dependencies );
 
 		if ( false === $index ) {
 			return;

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -2052,9 +2052,11 @@ class FrmXMLHelper {
 
 		// Do a str_replace with each item to set the new IDs
 		foreach ( $post_content as $key => $setting ) {
+			// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 			if ( ! is_array( $setting ) && in_array( $key, $basic_fields ) ) {
 				// Replace old IDs with new IDs
 				$post_content[ $key ] = str_replace( $old, $new, $setting );
+			// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 			} elseif ( is_array( $setting ) && in_array( $key, $array_fields ) ) {
 				foreach ( $setting as $k => $val ) {
 					// Replace old IDs with new IDs

--- a/classes/models/FrmAddon.php
+++ b/classes/models/FrmAddon.php
@@ -416,7 +416,7 @@ class FrmAddon {
 			}
 
 			foreach ( $roles as $role => $details ) {
-				if ( in_array( $role, $cap_roles ) ) {
+				if ( in_array( $role, $cap_roles, true ) ) {
 					$wp_roles->add_cap( $role, $cap );
 				} else {
 					$wp_roles->remove_cap( $role, $cap );

--- a/classes/models/FrmDb.php
+++ b/classes/models/FrmDb.php
@@ -93,7 +93,8 @@ class FrmDb {
 		}
 
 		foreach ( $args as $key => $value ) {
-			$where         .= empty( $where ) ? $base_where : $condition;
+			$where .= empty( $where ) ? $base_where : $condition;
+			// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 			$array_inc_null = ( ! is_numeric( $key ) && is_array( $value ) && in_array( null, $value ) );
 
 			if ( is_numeric( $key ) || $array_inc_null ) {

--- a/classes/models/FrmEntry.php
+++ b/classes/models/FrmEntry.php
@@ -1145,6 +1145,7 @@ class FrmEntry {
 
 		global $frm_vars;
 
+		// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 		if ( isset( $frm_vars['saved_entries'] ) && is_array( $frm_vars['saved_entries'] ) && in_array( (int) $id, $frm_vars['saved_entries'] ) ) {
 			$update = false;
 		}

--- a/classes/models/FrmEntryMeta.php
+++ b/classes/models/FrmEntryMeta.php
@@ -154,6 +154,7 @@ class FrmEntryMeta {
 
 			self::get_value_to_save( compact( 'field', 'field_id', 'entry_id' ), $meta_value );
 
+			// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 			if ( $previous_field_ids && in_array( $field_id, $previous_field_ids ) ) {
 
 				if ( $meta_value === array() || ( ! is_array( $meta_value ) && trim( $meta_value ) === '' ) ) {

--- a/classes/models/FrmEntryValues.php
+++ b/classes/models/FrmEntryValues.php
@@ -336,6 +336,7 @@ class FrmEntryValues {
 	 * @return bool
 	 */
 	protected function is_field_in_array( $field, $array ) {
+		// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 		return in_array( $field->id, $array ) || in_array( (string) $field->field_key, $array, true );
 	}
 

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -267,7 +267,7 @@ class FrmForm {
 		$new_values = self::set_update_options( array(), $values, array( 'form_id' => $id ) );
 
 		foreach ( $values as $value_key => $value ) {
-			if ( $value_key && in_array( $value_key, $form_fields ) ) {
+			if ( $value_key && in_array( $value_key, $form_fields, true ) ) {
 				$new_values[ $value_key ] = $value;
 			}
 		}
@@ -357,6 +357,7 @@ class FrmForm {
 		$existing_keys = array_keys( $values['item_meta'] );
 
 		foreach ( $all_fields as $fid ) {
+			// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 			if ( ! in_array( $fid->id, $existing_keys ) && ( isset( $values['frm_fields_submitted'] ) && in_array( $fid->id, $values['frm_fields_submitted'] ) ) || isset( $values['options'] ) ) {
 				$values['item_meta'][ $fid->id ] = '';
 			}

--- a/classes/models/FrmFormAction.php
+++ b/classes/models/FrmFormAction.php
@@ -233,7 +233,7 @@ class FrmFormAction {
 			$group = $this->id_base;
 		} else {
 			foreach ( $groups as $name => $check_group ) {
-				if ( isset( $check_group['actions'] ) && in_array( $this->id_base, $check_group['actions'] ) ) {
+				if ( isset( $check_group['actions'] ) && in_array( $this->id_base, $check_group['actions'], true ) ) {
 					$group = $name;
 					break;
 				}

--- a/classes/models/FrmFormMigrator.php
+++ b/classes/models/FrmFormMigrator.php
@@ -608,10 +608,12 @@ abstract class FrmFormMigrator {
 		$imported    = $this->get_tracked_import();
 		$new_form_id = 0;
 
+		// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 		if ( ! isset( $imported[ $this->slug ] ) || ! in_array( $source_id, $imported[ $this->slug ] ) ) {
 			return $new_form_id;
 		}
 
+		// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 		$new_form_id = array_search( $source_id, array_reverse( $imported[ $this->slug ], true ) );
 
 		if ( $new_form_id && ! FrmForm::get_key_by_id( $new_form_id ) ) {

--- a/classes/models/FrmSettings.php
+++ b/classes/models/FrmSettings.php
@@ -618,7 +618,7 @@ class FrmSettings {
 			}
 
 			foreach ( $roles as $role => $details ) {
-				if ( in_array( $role, $this->$frm_role ) ) {
+				if ( in_array( $role, $this->$frm_role, true ) ) {
 					$wp_roles->add_cap( $role, $frm_role );
 				} else {
 					$wp_roles->remove_cap( $role, $frm_role );

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -1872,6 +1872,7 @@ DEFAULT_HTML;
 	 * @return array
 	 */
 	protected function get_multi_opts_for_import( $value ) {
+		// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 		if ( ! $this->field || ! $value || in_array( $value, (array) $this->field->options ) ) {
 			return $value;
 		}

--- a/classes/views/frm-form-actions/_action_inside.php
+++ b/classes/views/frm-form-actions/_action_inside.php
@@ -53,7 +53,7 @@ if ( count( $action_control->action_options['event'] ) === 1 || $action_control-
 
 	foreach ( $action_control->action_options['event'] as $event ) {
 		?>
-		<option value="<?php echo esc_attr( $event ); ?>" <?php echo in_array( $event, (array) $form_action->post_content['event'] ) ? ' selected="selected"' : ''; ?> ><?php echo esc_html( $event_labels[ $event ] ?? $event ); ?></option>
+		<option value="<?php echo esc_attr( $event ); ?>" <?php echo in_array( $event, (array) $form_action->post_content['event'], true ) ? ' selected="selected"' : ''; ?> ><?php echo esc_html( $event_labels[ $event ] ?? $event ); ?></option>
 <?php } ?>
 		</select>
 	</p>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -275,6 +275,10 @@
 		<severity>8</severity>
 		<type>error</type>
 	</rule>
+	<rule ref="WordPress.PHP.StrictInArray.MissingTrueStrict">
+		<severity>8</severity>
+		<type>error</type>
+	</rule>
 
 	<!-- Custom Formidable sniffs -->
 	<rule ref="Formidable.WhiteSpace.BlankLineAfterClosingBrace" />

--- a/stripe/helpers/FrmTransLiteListHelper.php
+++ b/stripe/helpers/FrmTransLiteListHelper.php
@@ -365,7 +365,7 @@ class FrmTransLiteListHelper extends FrmListHelper {
 	private function get_row_classes( $atts ) {
 		$class = 'column-' . $atts['column_name'];
 
-		if ( in_array( $atts['column_name'], $atts['hidden'] ) ) {
+		if ( in_array( $atts['column_name'], $atts['hidden'], true ) ) {
 			$class .= ' frm_hidden';
 		}
 
@@ -485,7 +485,8 @@ class FrmTransLiteListHelper extends FrmListHelper {
 	 * @return string
 	 */
 	private function get_item_id_column( $item ) {
-		$entry_id         = (int) $item->item_id;
+		$entry_id = (int) $item->item_id;
+		// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 		$entry_is_deleted = ! in_array( $entry_id, $this->valid_entry_ids );
 
 		if ( $entry_is_deleted ) {


### PR DESCRIPTION
I fixed a few more of the violations, and left a few I was less sure about. I put ignore comments for those so the rest of the files are still covered.