### PR TITLE
Stop overwriting all inbox items with onboarding message

### DIFF
--- a/classes/controllers/FrmOnboardingWizardController.php
+++ b/classes/controllers/FrmOnboardingWizardController.php
@@ -461,7 +461,7 @@ class FrmOnboardingWizardController {
 	 *
 	 * @since 6.9
 	 *
-	 * @param mixed $inbox_messages The inbox option data.
+	 * @param mixed $inbox_messages The inbox option data. An array of existing inbox messages if there is valid data set in the option.
 	 *
 	 * @return array Configuration for the onboarding wizard slide-in notification.
 	 */


### PR DESCRIPTION
I'm doing some code analysis and it found that `$inbox_messages` is never used.

But it should be if this is used on the `option_frm_inbox` filter, as it overwrites all other messages the way it was written.