### PR TITLE
Stop loading `font_icons.css` in Elementor by using the custom widget icon class only

### DIFF
--- a/classes/widgets/FrmElementorWidget.php
+++ b/classes/widgets/FrmElementorWidget.php
@@ -21,8 +21,6 @@ if ( class_exists( '\Elementor\Widget_Base' ) ) {
 		}
 
 		/**
-		 * Returns the Elementor widget icon.
-		 *
 		 * @return string
 		 */
 		public function get_icon() {


### PR DESCRIPTION
This PR updates the Elementor widget `get_icon()` value to return only `frm_logo_icon`.

### Demo

<img width="1132" height="1238" alt="CleanShot 2026-01-08 at 20 24 32@2x" src="https://github.com/user-attachments/assets/eef1f70f-97c3-4120-8f11-7ff52fd4ac2b" />
