### PR TITLE
Stop ignoring complexity in entire files

### DIFF
--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -651,7 +651,7 @@ class FrmFormActionsController {
 	 *
 	 * @return void
 	 */
-	public static function trigger_actions( $event, $form, $entry, $type = 'all', $args = array() ) {
+	public static function trigger_actions( $event, $form, $entry, $type = 'all', $args = array() ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		$action_status = array(
 			'post_status' => 'publish',
 		);

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -1341,7 +1341,7 @@ class FrmStylesController {
 	 *
 	 * @return int
 	 */
-	public static function do_accordion_sections( $screen, $context, $data_object ) {
+	public static function do_accordion_sections( $screen, $context, $data_object ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		global $wp_meta_boxes;
 
 		// the symbol id from icons.svg

--- a/classes/controllers/FrmXMLController.php
+++ b/classes/controllers/FrmXMLController.php
@@ -458,7 +458,7 @@ class FrmXMLController {
 	 *
 	 * @return void
 	 */
-	public static function generate_xml( $type, $args = array() ) {
+	public static function generate_xml( $type, $args = array() ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		global $wpdb;
 
 		self::prepare_types_array( $type );

--- a/classes/helpers/FrmCSVExportHelper.php
+++ b/classes/helpers/FrmCSVExportHelper.php
@@ -375,7 +375,7 @@ class FrmCSVExportHelper {
 	 *
 	 * @return void
 	 */
-	private static function csv_headings( &$headings ) {
+	private static function csv_headings( &$headings ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		$fields_by_repeater_id = array();
 		$repeater_ids          = array();
 

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1530,7 +1530,7 @@ class FrmFieldsHelper {
 	 *
 	 * @return string
 	 */
-	public static function get_other_val( $args ) {
+	public static function get_other_val( $args ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		$defaults = array(
 			'opt_key' => 0,
 			'field'   => array(),

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -105,7 +105,7 @@ class FrmFormsHelper {
 	 *
 	 * @return void
 	 */
-	public static function form_switcher( $selected = false ) {
+	public static function form_switcher( $selected = false ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		$where = apply_filters( 'frm_forms_dropdown', array(), '' );
 		$forms = FrmForm::get_published_forms( $where );
 
@@ -414,7 +414,7 @@ class FrmFormsHelper {
 	 *
 	 * @return array
 	 */
-	public static function fill_default_opts( $values, $record, $post_values ) {
+	public static function fill_default_opts( $values, $record, $post_values ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 
 		$defaults = self::get_default_opts();
 

--- a/classes/helpers/FrmListHelper.php
+++ b/classes/helpers/FrmListHelper.php
@@ -956,7 +956,7 @@ class FrmListHelper {
 	 *
 	 * @return void
 	 */
-	public function print_column_headers( $with_id = true ) {
+	public function print_column_headers( $with_id = true ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		list( $columns, $hidden, $sortable, $primary ) = $this->get_column_info();
 
 		$current_url = set_url_scheme( 'http://' . FrmAppHelper::get_server_value( 'HTTP_HOST' ) . FrmAppHelper::get_server_value( 'REQUEST_URI' ) );

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -980,7 +980,7 @@ class FrmXMLHelper {
 	 *
 	 * @return array
 	 */
-	public static function import_xml_views( $views, $imported ) {
+	public static function import_xml_views( $views, $imported ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		$imported['posts'] = array();
 		$form_action_type  = FrmFormActionsController::$action_post_type;
 
@@ -1291,7 +1291,7 @@ class FrmXMLHelper {
 	 * @param stdClass $meta
 	 * @param array    $imported
 	 */
-	private static function populate_postmeta( &$post, $meta, $imported ) {
+	private static function populate_postmeta( &$post, $meta, $imported ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		global $frm_duplicate_ids;
 
 		$m = array(

--- a/classes/models/FrmEntryMeta.php
+++ b/classes/models/FrmEntryMeta.php
@@ -499,7 +499,7 @@ class FrmEntryMeta {
 	 *
 	 * @return void
 	 */
-	private static function get_ids_query( $where, $order_by, $limit, $unique, $args, array &$query ) {
+	private static function get_ids_query( $where, $order_by, $limit, $unique, $args, array &$query ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		global $wpdb;
 		$query[]  = 'SELECT';
 		$defaults = array(

--- a/classes/models/FrmEntryValidate.php
+++ b/classes/models/FrmEntryValidate.php
@@ -238,7 +238,7 @@ class FrmEntryValidate {
 	 *
 	 * @return bool
 	 */
-	private static function option_is_valid( $field, $value, $options ) {
+	private static function option_is_valid( $field, $value, $options ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		if ( '' === $value ) {
 			return true;
 		}
@@ -1090,7 +1090,7 @@ class FrmEntryValidate {
 	 *
 	 * @return array Form IDs.
 	 */
-	private static function get_all_form_ids_and_flatten_meta( &$values ) {
+	private static function get_all_form_ids_and_flatten_meta( &$values ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		$values['name_field_ids'] = array();
 
 		// Blacklist check for File field in the old version doesn't contain `form_id`.

--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -338,7 +338,7 @@ class FrmForm {
 	 *
 	 * @return array
 	 */
-	public static function update_fields( $id, $values ) {
+	public static function update_fields( $id, $values ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 
 		if ( ! isset( $values['item_meta'] ) && ! isset( $values['field_options'] ) ) {
 			return $values;

--- a/classes/models/FrmStyle.php
+++ b/classes/models/FrmStyle.php
@@ -173,7 +173,7 @@ class FrmStyle {
 	 *
 	 * @return void
 	 */
-	private function maybe_sanitize_rgba_value( &$color_val ) {
+	private function maybe_sanitize_rgba_value( &$color_val ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		if ( preg_match( '/(rgb|rgba)\(/', $color_val ) !== 1 ) {
 			return;
 		}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -216,21 +216,6 @@
 			<property name="errorThreshold" value="10" />
 		</properties>
 	</rule>
-	<rule ref="SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh">
-		<exclude-pattern>helpers/FrmFormsHelper.php</exclude-pattern>
-		<exclude-pattern>helpers/FrmListHelper.php</exclude-pattern>
-		<exclude-pattern>helpers/FrmXMLHelper.php</exclude-pattern>
-		<exclude-pattern>models/FrmEntryMeta.php</exclude-pattern>
-		<exclude-pattern>helpers/FrmCSVExportHelper.php</exclude-pattern>
-		<exclude-pattern>helpers/FrmFieldsHelper.php</exclude-pattern>
-		<exclude-pattern>controllers/FrmXMLController.php</exclude-pattern>
-		<exclude-pattern>models/FrmEntryValidate.php</exclude-pattern>
-		<exclude-pattern>models/FrmForm.php</exclude-pattern>
-		<exclude-pattern>models/FrmStyle.php</exclude-pattern>
-		<exclude-pattern>controllers/FrmFormActionsController.php</exclude-pattern>
-		<exclude-pattern>tests/phpunit/base/FrmUnitTest.php</exclude-pattern>
-		<exclude-pattern>controllers/FrmStylesController.php</exclude-pattern>
-	</rule>
 
 	<rule ref="WordPressVIPMinimum">
 		<exclude name="Generic.PHP.NoSilencedErrors.Forbidden" />

--- a/tests/phpunit/base/FrmUnitTest.php
+++ b/tests/phpunit/base/FrmUnitTest.php
@@ -479,7 +479,7 @@ class FrmUnitTest extends WP_UnitTestCase {
 		);
 	}
 
-	public static function generate_xml( $type, $xml_args ) {
+	public static function generate_xml( $type, $xml_args ) { // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
 		// Code copied from FrmXMLController::generate_xml
 		global $wpdb;
 


### PR DESCRIPTION
This update replaces the exclude-pattern code with // phpcs:ignore comments so we're not ignoring the other functions in these large files.