### PR TITLE
Also exclude scannerwork folder from zip

### DIFF
--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -51,6 +51,7 @@ zip -r $zipname $destination \
 	-x "*/.wordpress-org/*" \
 	-x "*/.wp-env.json" \
 	-x "*/.prettierrc" \
+	-x "*/.scannerwork" \
 	-x "*/.jscsrc" \
 	-x "*/.jshintrc" \
 	-x "*/.jshintignore" \


### PR DESCRIPTION
This prevents an empty folder for Sonar Scanner from being included in the release zip.