### PR TITLE
Switch to string match to avoid possible false positive matches

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -1817,7 +1817,7 @@ class FrmAppHelper {
 	 *
 	 * @since 1.07.10
 	 *
-	 * @param string $value The value to compare.
+	 * @param int|string $value The value to compare.
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
I changed this recently, but I'm concerned that casting to int can cause funny matches (since something like `12abc` converts to `12`).