### PR TITLE
Make new sniffs better at negating conditions

### DIFF
--- a/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/FlipForeachIfToContinueSniff.php
+++ b/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/FlipForeachIfToContinueSniff.php
@@ -246,6 +246,7 @@ class FlipForeachIfToContinueSniff implements Sniff {
 
 		// Try to flip comparison operators.
 		$flipped = $this->flipComparisonOperator( $condition );
+
 		if ( $flipped !== false ) {
 			return $flipped;
 		}
@@ -265,7 +266,7 @@ class FlipForeachIfToContinueSniff implements Sniff {
 	 *
 	 * @param string $condition The condition to flip.
 	 *
-	 * @return string|false The flipped condition, or false if not a simple comparison.
+	 * @return false|string The flipped condition, or false if not a simple comparison.
 	 */
 	private function flipComparisonOperator( $condition ) {
 		// Map of operators to their opposites.
@@ -283,6 +284,7 @@ class FlipForeachIfToContinueSniff implements Sniff {
 		// Check for each operator (check longer ones first).
 		foreach ( $operatorMap as $op => $opposite ) {
 			$pos = strpos( $condition, $op );
+
 			if ( $pos !== false ) {
 				// Make sure this is a simple comparison (no && or ||).
 				if ( strpos( $condition, '&&' ) !== false || strpos( $condition, '||' ) !== false ) {

--- a/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/FlipIfToEarlyReturnSniff.php
+++ b/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/FlipIfToEarlyReturnSniff.php
@@ -254,6 +254,7 @@ class FlipIfToEarlyReturnSniff implements Sniff {
 
 		// Try to flip comparison operators.
 		$flipped = $this->flipComparisonOperator( $condition );
+
 		if ( $flipped !== false ) {
 			return $flipped;
 		}
@@ -273,7 +274,7 @@ class FlipIfToEarlyReturnSniff implements Sniff {
 	 *
 	 * @param string $condition The condition to flip.
 	 *
-	 * @return string|false The flipped condition, or false if not a simple comparison.
+	 * @return false|string The flipped condition, or false if not a simple comparison.
 	 */
 	private function flipComparisonOperator( $condition ) {
 		// Map of operators to their opposites.
@@ -291,6 +292,7 @@ class FlipIfToEarlyReturnSniff implements Sniff {
 		// Check for each operator (check longer ones first).
 		foreach ( $operatorMap as $op => $opposite ) {
 			$pos = strpos( $condition, $op );
+
 			if ( $pos !== false ) {
 				// Make sure this is a simple comparison (no && or ||).
 				if ( strpos( $condition, '&&' ) !== false || strpos( $condition, '||' ) !== false ) {


### PR DESCRIPTION
The code in Pro was being refactored funnily. `0 !== strpos` would become `! 0 !== strpos` instead of `0 === strpos`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced code analysis sniffs with improved condition handling and operator transformation logic in early return and foreach analyses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->