### PR TITLE
New sniff to flip ternaries that use compare value on the right side …

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -2355,7 +2355,7 @@ class FrmFormsController {
 				array(
 					'parent' => 'frm-forms',
 					'id'     => 'edit_form_' . $form_id,
-					'title'  => empty( $name ) ? FrmFormsHelper::get_no_title_text() : $name,
+					'title'  => $name ? $name : FrmFormsHelper::get_no_title_text(),
 					'href'   => FrmForm::get_edit_link( $form_id ),
 				)
 			);

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -473,7 +473,7 @@ class FrmFieldsHelper {
 		);
 
 		$msg = FrmField::get_option( $field, $error );
-		$msg = empty( $msg ) ? $defaults[ $error ]['part'] : $msg;
+		$msg = $msg ? $msg : $defaults[ $error ]['part'];
 		$msg = do_shortcode( $msg );
 
 		return self::maybe_replace_substrings_with_field_name( $msg, $error, $field );

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -194,7 +194,7 @@ class FrmXMLHelper {
 				array(
 					'slug'        => (string) $t->term_slug,
 					'description' => (string) $t->term_description,
-					'parent'      => empty( $parent ) ? 0 : $parent,
+					'parent'      => $parent ? $parent : 0,
 				)
 			);
 
@@ -2385,7 +2385,7 @@ class FrmXMLHelper {
 			}
 
 			if ( $reply_to || $reply_to_name ) {
-				$new_notification2['post_content']['from'] = ( empty( $reply_to_name ) ? '[sitename]' : $reply_to_name ) . ' <' . ( empty( $reply_to ) ? '[admin_email]' : $reply_to ) . '>'; // phpcs:ignore SlevomatCodingStandard.Files.LineLength.LineTooLong
+				$new_notification2['post_content']['from'] = ( $reply_to_name ? $reply_to_name : '[sitename]' ) . ' <' . ( $reply_to ? $reply_to : '[admin_email]' ) . '>'; // phpcs:ignore SlevomatCodingStandard.Files.LineLength.LineTooLong
 			}
 
 			$notifications[] = $new_notification2;

--- a/classes/models/fields/FrmFieldCheckbox.php
+++ b/classes/models/fields/FrmFieldCheckbox.php
@@ -87,7 +87,7 @@ class FrmFieldCheckbox extends FrmFieldType {
 		$form_id = $this->get_field_column( 'form_id' );
 
 		return array(
-			'align' => FrmStylesController::get_style_val( 'check_align', ( empty( $form_id ) ? 'default' : $form_id ) ),
+			'align' => FrmStylesController::get_style_val( 'check_align', ( $form_id ? $form_id : 'default' ) ),
 		);
 	}
 

--- a/classes/models/fields/FrmFieldRadio.php
+++ b/classes/models/fields/FrmFieldRadio.php
@@ -78,7 +78,7 @@ class FrmFieldRadio extends FrmFieldType {
 		$form_id = $this->get_field_column( 'form_id' );
 
 		return array(
-			'align' => FrmStylesController::get_style_val( 'radio_align', ( empty( $form_id ) ? 'default' : $form_id ) ),
+			'align' => FrmStylesController::get_style_val( 'radio_align', ( $form_id ? $form_id : 'default' ) ),
 		);
 	}
 

--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -367,7 +367,7 @@ DEFAULT_HTML;
 	 * @return string
 	 */
 	protected function html_name( $name = '' ) {
-		$prefix = empty( $name ) ? 'item_meta' : $name;
+		$prefix = $name ? $name : 'item_meta';
 		return $prefix . '[' . $this->get_field_column( 'id' ) . ']';
 	}
 

--- a/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/SimplifyEmptyTernarySniff.php
+++ b/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/SimplifyEmptyTernarySniff.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Sniff to simplify empty() ternaries with function parameters.
+ *
+ * @package Formidable\Sniffs\CodeAnalysis
+ */
+
+namespace Formidable\Sniffs\CodeAnalysis;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Detects empty($param) ? default : $param and converts to $param ? $param : default.
+ *
+ * Bad:
+ * $prefix = empty( $name ) ? 'item_meta' : $name;
+ *
+ * Good:
+ * $prefix = $name ? $name : 'item_meta';
+ *
+ * This works because function parameters are always set, so empty() is redundant.
+ */
+class SimplifyEmptyTernarySniff implements Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array( T_EMPTY );
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// Find the opening parenthesis after empty.
+		$openParen = $phpcsFile->findNext( T_WHITESPACE, $stackPtr + 1, null, true );
+
+		if ( false === $openParen || $tokens[ $openParen ]['code'] !== T_OPEN_PARENTHESIS ) {
+			return;
+		}
+
+		// Find the closing parenthesis.
+		if ( ! isset( $tokens[ $openParen ]['parenthesis_closer'] ) ) {
+			return;
+		}
+
+		$closeParen = $tokens[ $openParen ]['parenthesis_closer'];
+
+		// Get the variable inside empty().
+		$varToken = $phpcsFile->findNext( T_WHITESPACE, $openParen + 1, $closeParen, true );
+
+		if ( false === $varToken || $tokens[ $varToken ]['code'] !== T_VARIABLE ) {
+			return;
+		}
+
+		$variableName = $tokens[ $varToken ]['content'];
+
+		// Check if there's only the variable inside empty() (no array access, etc.).
+		$nextInParen = $phpcsFile->findNext( T_WHITESPACE, $varToken + 1, $closeParen, true );
+
+		if ( false !== $nextInParen ) {
+			// There's something else inside empty(), skip.
+			return;
+		}
+
+		// Find the ternary operator after empty().
+		$ternaryOp = $phpcsFile->findNext( T_WHITESPACE, $closeParen + 1, null, true );
+
+		if ( false === $ternaryOp || $tokens[ $ternaryOp ]['code'] !== T_INLINE_THEN ) {
+			return;
+		}
+
+		// Find the colon.
+		$colonOp = $phpcsFile->findNext( T_INLINE_ELSE, $ternaryOp + 1 );
+
+		if ( false === $colonOp ) {
+			return;
+		}
+
+		// Get the "then" part (between ? and :).
+		$thenStart = $phpcsFile->findNext( T_WHITESPACE, $ternaryOp + 1, $colonOp, true );
+
+		if ( false === $thenStart ) {
+			return;
+		}
+
+		// Find the end of the ternary (semicolon or other terminator).
+		$ternaryEnd = $phpcsFile->findNext( array( T_SEMICOLON, T_COMMA, T_CLOSE_PARENTHESIS, T_CLOSE_SQUARE_BRACKET ), $colonOp + 1 );
+
+		if ( false === $ternaryEnd ) {
+			return;
+		}
+
+		// Get the "else" part (between : and end).
+		$elseStart = $phpcsFile->findNext( T_WHITESPACE, $colonOp + 1, $ternaryEnd, true );
+
+		if ( false === $elseStart ) {
+			return;
+		}
+
+		// Check if the else part is just the same variable.
+		if ( $tokens[ $elseStart ]['code'] !== T_VARIABLE || $tokens[ $elseStart ]['content'] !== $variableName ) {
+			return;
+		}
+
+		// Check there's nothing else in the else part.
+		$nextInElse = $phpcsFile->findNext( T_WHITESPACE, $elseStart + 1, $ternaryEnd, true );
+
+		if ( false !== $nextInElse ) {
+			// There's something else in the else part, skip.
+			return;
+		}
+
+		// Get the default value (the "then" part).
+		$defaultValue = $phpcsFile->getTokensAsString( $thenStart, $colonOp - $thenStart );
+		$defaultValue = trim( $defaultValue );
+
+		$fix = $phpcsFile->addFixableError(
+			'Simplify empty( %s ) ? %s : %s to %s ? %s : %s.',
+			$stackPtr,
+			'SimplifyEmptyTernary',
+			array( $variableName, $defaultValue, $variableName, $variableName, $variableName, $defaultValue )
+		);
+
+		if ( true === $fix ) {
+			$phpcsFile->fixer->beginChangeset();
+
+			// Remove everything from empty to the end of the ternary.
+			for ( $i = $stackPtr; $i < $ternaryEnd; $i++ ) {
+				$phpcsFile->fixer->replaceToken( $i, '' );
+			}
+
+			// Add the new simplified ternary.
+			$phpcsFile->fixer->addContentBefore( $ternaryEnd, $variableName . ' ? ' . $variableName . ' : ' . $defaultValue );
+
+			$phpcsFile->fixer->endChangeset();
+		}
+	}
+}

--- a/phpcs-sniffs/Formidable/ruleset.xml
+++ b/phpcs-sniffs/Formidable/ruleset.xml
@@ -32,6 +32,7 @@
 	<rule ref="Formidable.CodeAnalysis.PreferKsesEcho" />
 	<rule ref="Formidable.CodeAnalysis.MoveVariableBelowEarlyReturn" />
 	<rule ref="Formidable.CodeAnalysis.PreferEscHtmlE" />
+	<rule ref="Formidable.CodeAnalysis.SimplifyEmptyTernary" />
 	<rule ref="Formidable.CodeAnalysis.StrictComparisonForIntFunctions" />
 	<rule ref="Formidable.CodeAnalysis.FlipNegativeTernary" />
 	<rule ref="Formidable.CodeAnalysis.FlipIfToEarlyReturn" />


### PR DESCRIPTION
…of the colon in an empty check

This sniff prefers `A ? A : B` over `! A ? : B : A` ternary logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated conditional logic patterns across form and field components to improve code consistency and maintainability.

* **Chores**
  * Extended code quality analysis tooling with a new automated rule to validate and simplify conditional expressions in development workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->