### PR TITLE
new sniff to remove whitspace from start of functions

### DIFF
--- a/phpcs-sniffs/Formidable/Sniffs/WhiteSpace/NoBlankLineAfterFunctionOpenSniff.php
+++ b/phpcs-sniffs/Formidable/Sniffs/WhiteSpace/NoBlankLineAfterFunctionOpenSniff.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Formidable_Sniffs_WhiteSpace_NoBlankLineAfterFunctionOpenSniff
+ *
+ * Ensures there is no blank line immediately after the opening brace of a function/method.
+ *
+ * @package Formidable\Sniffs
+ */
+
+namespace Formidable\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Ensures there is no blank line immediately after the opening brace of a function/method.
+ *
+ * Bad:
+ * function example() {
+ *
+ *     do_something();
+ * }
+ *
+ * Good:
+ * function example() {
+ *     do_something();
+ * }
+ */
+class NoBlankLineAfterFunctionOpenSniff implements Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array( T_FUNCTION, T_CLOSURE );
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// Make sure this function has a scope (curly braces).
+		if ( ! isset( $tokens[ $stackPtr ]['scope_opener'] ) ) {
+			return;
+		}
+
+		$scopeOpener = $tokens[ $stackPtr ]['scope_opener'];
+		$scopeCloser = $tokens[ $stackPtr ]['scope_closer'];
+
+		// Find the first non-whitespace token after the opening brace.
+		$firstContent = $phpcsFile->findNext( T_WHITESPACE, $scopeOpener + 1, $scopeCloser, true );
+
+		if ( false === $firstContent ) {
+			// Empty function body.
+			return;
+		}
+
+		$openerLine  = $tokens[ $scopeOpener ]['line'];
+		$contentLine = $tokens[ $firstContent ]['line'];
+
+		// Check if there's a blank line between the opener and first content.
+		// A blank line means the content is more than 1 line after the opener.
+		if ( $contentLine <= $openerLine + 1 ) {
+			// No blank line, content is on the next line or same line.
+			return;
+		}
+
+		$fix = $phpcsFile->addFixableError(
+			'No blank line should follow the opening brace of a function.',
+			$scopeOpener,
+			'BlankLineAfterFunctionOpen'
+		);
+
+		if ( true === $fix ) {
+			$phpcsFile->fixer->beginChangeset();
+
+			// Find the whitespace token right after the opener that contains the blank line.
+			$nextToken = $scopeOpener + 1;
+
+			if ( $tokens[ $nextToken ]['code'] === T_WHITESPACE ) {
+				$content      = $tokens[ $nextToken ]['content'];
+				$newlineCount = substr_count( $content, "\n" );
+
+				if ( $newlineCount >= 2 ) {
+					// Multiple newlines - reduce to single newline + indentation.
+					$lastNewline = strrpos( $content, "\n" );
+					$indent      = substr( $content, $lastNewline + 1 );
+					$phpcsFile->fixer->replaceToken( $nextToken, "\n" . $indent );
+				} elseif ( $newlineCount === 1 ) {
+					// Single newline here, but there might be another whitespace token creating the blank.
+					// Check if the next token is also whitespace with a newline.
+					$afterNext = $nextToken + 1;
+
+					if ( $afterNext < $firstContent && $tokens[ $afterNext ]['code'] === T_WHITESPACE ) {
+						// Remove this extra whitespace token.
+						$phpcsFile->fixer->replaceToken( $afterNext, '' );
+					}
+				}
+			}
+
+			$phpcsFile->fixer->endChangeset();
+		}
+	}
+}

--- a/phpcs-sniffs/Formidable/ruleset.xml
+++ b/phpcs-sniffs/Formidable/ruleset.xml
@@ -10,6 +10,7 @@
 	<rule ref="Formidable.WhiteSpace.NoBlankLineInShortIf" />
 	<rule ref="Formidable.WhiteSpace.NoBlankLineAfterLoopOpen" />
 	<rule ref="Formidable.WhiteSpace.NoBlankLineAfterIfOpen" />
+	<rule ref="Formidable.WhiteSpace.NoBlankLineAfterFunctionOpen" />
 	<rule ref="Formidable.WhiteSpace.NoBlankLineBeforeCloseBrace" />
 
 	<!-- Code Analysis -->


### PR DESCRIPTION
I thought I had this already.

Either way, it seems to have been applied in Lite because there are no issues in this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced a new coding standard rule that prevents blank lines from appearing immediately after function and closure opening braces. The rule is now available in the Formidable PHP standards and includes automatic fixing capabilities to help maintain consistent code formatting across your projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->