### PR TITLE
Update flip sniffs to handle object properties better

### DIFF
--- a/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/FlipForeachIfToContinueSniff.php
+++ b/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/FlipForeachIfToContinueSniff.php
@@ -269,7 +269,7 @@ class FlipForeachIfToContinueSniff implements Sniff {
 	 * @return false|string The flipped condition, or false if not a simple comparison.
 	 */
 	private function flipComparisonOperator( $condition ) {
-		// Map of operators to their opposites.
+		// Map of operators to their opposites (check longer ones first).
 		$operatorMap = array(
 			'!==' => '===',
 			'===' => '!==',
@@ -277,22 +277,72 @@ class FlipForeachIfToContinueSniff implements Sniff {
 			'=='  => '!=',
 			'>='  => '<',
 			'<='  => '>',
-			'>'   => '<=',
-			'<'   => '>=',
 		);
+
+		// Make sure this is a simple comparison (no && or ||).
+		if ( strpos( $condition, '&&' ) !== false || strpos( $condition, '||' ) !== false ) {
+			return false;
+		}
 
 		// Check for each operator (check longer ones first).
 		foreach ( $operatorMap as $op => $opposite ) {
 			$pos = strpos( $condition, $op );
 
-			if ( $pos !== false ) {
-				// Make sure this is a simple comparison (no && or ||).
-				if ( strpos( $condition, '&&' ) !== false || strpos( $condition, '||' ) !== false ) {
-					return false;
-				}
-
+			if ( false !== $pos ) {
 				return substr( $condition, 0, $pos ) . $opposite . substr( $condition, $pos + strlen( $op ) );
 			}
+		}
+
+		// Handle single < and > separately to avoid matching -> or =>.
+		$pos = $this->findComparisonOperator( $condition, '>' );
+
+		if ( false !== $pos ) {
+			return substr( $condition, 0, $pos ) . '<=' . substr( $condition, $pos + 1 );
+		}
+
+		$pos = $this->findComparisonOperator( $condition, '<' );
+
+		if ( false !== $pos ) {
+			return substr( $condition, 0, $pos ) . '>=' . substr( $condition, $pos + 1 );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Find a single comparison operator (< or >) that is not part of -> or =>.
+	 *
+	 * @param string $condition The condition string.
+	 * @param string $operator  The operator to find (< or >).
+	 *
+	 * @return false|int The position of the operator, or false if not found.
+	 */
+	private function findComparisonOperator( $condition, $operator ) {
+		$pos = 0;
+
+		while ( ( $pos = strpos( $condition, $operator, $pos ) ) !== false ) {
+			// Check character before to avoid matching -> or =>.
+			if ( $pos > 0 ) {
+				$charBefore = $condition[ $pos - 1 ];
+
+				// Skip if this is part of ->, =>, <=, >=, or a multi-char comparison.
+				if ( $charBefore === '-' || $charBefore === '=' || $charBefore === '<' || $charBefore === '>' || $charBefore === '!' ) {
+					++$pos;
+					continue;
+				}
+			}
+
+			// Check character after to avoid matching <=, >=, =>.
+			if ( $pos < strlen( $condition ) - 1 ) {
+				$charAfter = $condition[ $pos + 1 ];
+
+				if ( $charAfter === '=' || $charAfter === '>' ) {
+					++$pos;
+					continue;
+				}
+			}
+
+			return $pos;
 		}
 
 		return false;

--- a/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/FlipIfToEarlyReturnSniff.php
+++ b/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/FlipIfToEarlyReturnSniff.php
@@ -322,7 +322,7 @@ class FlipIfToEarlyReturnSniff implements Sniff {
 	 * @return false|string The flipped condition, or false if not a simple comparison.
 	 */
 	private function flipComparisonOperator( $condition ) {
-		// Map of operators to their opposites.
+		// Map of operators to their opposites (check longer ones first).
 		$operatorMap = array(
 			'!==' => '===',
 			'===' => '!==',
@@ -330,22 +330,72 @@ class FlipIfToEarlyReturnSniff implements Sniff {
 			'=='  => '!=',
 			'>='  => '<',
 			'<='  => '>',
-			'>'   => '<=',
-			'<'   => '>=',
 		);
+
+		// Make sure this is a simple comparison (no && or ||).
+		if ( strpos( $condition, '&&' ) !== false || strpos( $condition, '||' ) !== false ) {
+			return false;
+		}
 
 		// Check for each operator (check longer ones first).
 		foreach ( $operatorMap as $op => $opposite ) {
 			$pos = strpos( $condition, $op );
 
-			if ( $pos !== false ) {
-				// Make sure this is a simple comparison (no && or ||).
-				if ( strpos( $condition, '&&' ) !== false || strpos( $condition, '||' ) !== false ) {
-					return false;
-				}
-
+			if ( false !== $pos ) {
 				return substr( $condition, 0, $pos ) . $opposite . substr( $condition, $pos + strlen( $op ) );
 			}
+		}
+
+		// Handle single < and > separately to avoid matching -> or =>.
+		$pos = $this->findComparisonOperator( $condition, '>' );
+
+		if ( false !== $pos ) {
+			return substr( $condition, 0, $pos ) . '<=' . substr( $condition, $pos + 1 );
+		}
+
+		$pos = $this->findComparisonOperator( $condition, '<' );
+
+		if ( false !== $pos ) {
+			return substr( $condition, 0, $pos ) . '>=' . substr( $condition, $pos + 1 );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Find a single comparison operator (< or >) that is not part of -> or =>.
+	 *
+	 * @param string $condition The condition string.
+	 * @param string $operator  The operator to find (< or >).
+	 *
+	 * @return false|int The position of the operator, or false if not found.
+	 */
+	private function findComparisonOperator( $condition, $operator ) {
+		$pos = 0;
+
+		while ( ( $pos = strpos( $condition, $operator, $pos ) ) !== false ) {
+			// Check character before to avoid matching -> or =>.
+			if ( $pos > 0 ) {
+				$charBefore = $condition[ $pos - 1 ];
+
+				// Skip if this is part of ->, =>, <=, >=, or a multi-char comparison.
+				if ( $charBefore === '-' || $charBefore === '=' || $charBefore === '<' || $charBefore === '>' || $charBefore === '!' ) {
+					++$pos;
+					continue;
+				}
+			}
+
+			// Check character after to avoid matching <=, >=, =>.
+			if ( $pos < strlen( $condition ) - 1 ) {
+				$charAfter = $condition[ $pos + 1 ];
+
+				if ( $charAfter === '=' || $charAfter === '>' ) {
+					++$pos;
+					continue;
+				}
+			}
+
+			return $pos;
 		}
 
 		return false;

--- a/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/FlipLargeIfSmallElseSniff.php
+++ b/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/FlipLargeIfSmallElseSniff.php
@@ -366,7 +366,7 @@ class FlipLargeIfSmallElseSniff implements Sniff {
 	 * @return false|string The flipped condition, or false if not a simple comparison.
 	 */
 	private function flipComparisonOperator( $condition ) {
-		// Map of operators to their opposites.
+		// Map of operators to their opposites (check longer ones first).
 		$operatorMap = array(
 			'!==' => '===',
 			'===' => '!==',
@@ -374,27 +374,72 @@ class FlipLargeIfSmallElseSniff implements Sniff {
 			'=='  => '!=',
 			'>='  => '<',
 			'<='  => '>',
-			'>'   => '<=',
-			'<'   => '>=',
 		);
+
+		// Make sure this is a simple comparison (no && or ||).
+		if ( strpos( $condition, '&&' ) !== false || strpos( $condition, '||' ) !== false ) {
+			return false;
+		}
 
 		// Check for each operator (check longer ones first).
 		foreach ( $operatorMap as $op => $opposite ) {
 			$pos = strpos( $condition, $op );
 
-			if ( $pos !== false ) {
-				// Make sure this is a simple comparison (no && or ||).
-				if ( strpos( $condition, '&&' ) !== false || strpos( $condition, '||' ) !== false ) {
-					return false;
-				}
-
-				// Skip if this is part of -> (object operator).
-				if ( $op === '>' && $pos > 0 && $condition[ $pos - 1 ] === '-' ) {
-					continue;
-				}
-
+			if ( false !== $pos ) {
 				return substr( $condition, 0, $pos ) . $opposite . substr( $condition, $pos + strlen( $op ) );
 			}
+		}
+
+		// Handle single < and > separately to avoid matching -> or =>.
+		$pos = $this->findComparisonOperator( $condition, '>' );
+
+		if ( false !== $pos ) {
+			return substr( $condition, 0, $pos ) . '<=' . substr( $condition, $pos + 1 );
+		}
+
+		$pos = $this->findComparisonOperator( $condition, '<' );
+
+		if ( false !== $pos ) {
+			return substr( $condition, 0, $pos ) . '>=' . substr( $condition, $pos + 1 );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Find a single comparison operator (< or >) that is not part of -> or =>.
+	 *
+	 * @param string $condition The condition string.
+	 * @param string $operator  The operator to find (< or >).
+	 *
+	 * @return false|int The position of the operator, or false if not found.
+	 */
+	private function findComparisonOperator( $condition, $operator ) {
+		$pos = 0;
+
+		while ( ( $pos = strpos( $condition, $operator, $pos ) ) !== false ) {
+			// Check character before to avoid matching -> or =>.
+			if ( $pos > 0 ) {
+				$charBefore = $condition[ $pos - 1 ];
+
+				// Skip if this is part of ->, =>, <=, >=, or a multi-char comparison.
+				if ( $charBefore === '-' || $charBefore === '=' || $charBefore === '<' || $charBefore === '>' || $charBefore === '!' ) {
+					++$pos;
+					continue;
+				}
+			}
+
+			// Check character after to avoid matching <=, >=, =>.
+			if ( $pos < strlen( $condition ) - 1 ) {
+				$charAfter = $condition[ $pos + 1 ];
+
+				if ( $charAfter === '=' || $charAfter === '>' ) {
+					++$pos;
+					continue;
+				}
+			}
+
+			return $pos;
 		}
 
 		return false;

--- a/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/FlipLoopIfElseToContinueSniff.php
+++ b/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/FlipLoopIfElseToContinueSniff.php
@@ -381,6 +381,7 @@ class FlipLoopIfElseToContinueSniff implements Sniff {
 	 * @return false|string
 	 */
 	private function flipComparisonOperator( $condition ) {
+		// Map of operators to their opposites (check longer ones first).
 		$operatorMap = array(
 			'!==' => '===',
 			'===' => '!==',
@@ -388,25 +389,72 @@ class FlipLoopIfElseToContinueSniff implements Sniff {
 			'=='  => '!=',
 			'>='  => '<',
 			'<='  => '>',
-			'>'   => '<=',
-			'<'   => '>=',
 		);
 
+		// Make sure this is a simple comparison (no && or ||).
+		if ( strpos( $condition, '&&' ) !== false || strpos( $condition, '||' ) !== false ) {
+			return false;
+		}
+
+		// Check for each operator (check longer ones first).
 		foreach ( $operatorMap as $op => $opposite ) {
 			$pos = strpos( $condition, $op );
 
-			if ( $pos !== false ) {
-				if ( strpos( $condition, '&&' ) !== false || strpos( $condition, '||' ) !== false ) {
-					return false;
-				}
-
-				// Skip if this is part of -> (object operator).
-				if ( $op === '>' && $pos > 0 && $condition[ $pos - 1 ] === '-' ) {
-					continue;
-				}
-
+			if ( false !== $pos ) {
 				return substr( $condition, 0, $pos ) . $opposite . substr( $condition, $pos + strlen( $op ) );
 			}
+		}
+
+		// Handle single < and > separately to avoid matching -> or =>.
+		$pos = $this->findComparisonOperator( $condition, '>' );
+
+		if ( false !== $pos ) {
+			return substr( $condition, 0, $pos ) . '<=' . substr( $condition, $pos + 1 );
+		}
+
+		$pos = $this->findComparisonOperator( $condition, '<' );
+
+		if ( false !== $pos ) {
+			return substr( $condition, 0, $pos ) . '>=' . substr( $condition, $pos + 1 );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Find a single comparison operator (< or >) that is not part of -> or =>.
+	 *
+	 * @param string $condition The condition string.
+	 * @param string $operator  The operator to find (< or >).
+	 *
+	 * @return false|int The position of the operator, or false if not found.
+	 */
+	private function findComparisonOperator( $condition, $operator ) {
+		$pos = 0;
+
+		while ( ( $pos = strpos( $condition, $operator, $pos ) ) !== false ) {
+			// Check character before to avoid matching -> or =>.
+			if ( $pos > 0 ) {
+				$charBefore = $condition[ $pos - 1 ];
+
+				// Skip if this is part of ->, =>, <=, >=, or a multi-char comparison.
+				if ( $charBefore === '-' || $charBefore === '=' || $charBefore === '<' || $charBefore === '>' || $charBefore === '!' ) {
+					++$pos;
+					continue;
+				}
+			}
+
+			// Check character after to avoid matching <=, >=, =>.
+			if ( $pos < strlen( $condition ) - 1 ) {
+				$charAfter = $condition[ $pos + 1 ];
+
+				if ( $charAfter === '=' || $charAfter === '>' ) {
+					++$pos;
+					continue;
+				}
+			}
+
+			return $pos;
 		}
 
 		return false;


### PR DESCRIPTION
Some conditions would change to something like `if ( empty( $body - <= success ) ) {`, which is totally invalid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of code analysis suggestions by fixing false positives when detecting and flipping comparison operators in conditional statements.

* **Refactor**
  * Enhanced internal logic for handling comparison operators to be more robust and avoid misinterpreting edge cases with similar-looking operators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->