### PR TITLE
New sniff to prefer ! empty ternaries

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -203,7 +203,7 @@ class FrmAppHelper {
 
 		$query_args = wp_parse_args( $parsed['query'] );
 
-		return empty( $query_args['utm_medium'] ) ? '' : $query_args['utm_medium'];
+		return ! empty( $query_args['utm_medium'] ) ? $query_args['utm_medium'] : '';
 	}
 
 	/**

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -854,7 +854,7 @@ class FrmFieldsHelper {
 			esc_html__( 'Options are dynamically created from your %1$s%2$s: %3$s%4$s', 'formidable' ),
 			'<a href="' . esc_url( admin_url( 'edit-tags.php?taxonomy=' . $tax->name ) ) . '" target="_blank">',
 			esc_html__( 'taxonomy', 'formidable' ),
-			empty( $tax->labels->name ) ? esc_html__( 'Categories', 'formidable' ) : $tax->labels->name,
+			! empty( $tax->labels->name ) ? $tax->labels->name : esc_html__( 'Categories', 'formidable' ),
 			'</a>'
 		);
 	}

--- a/classes/helpers/FrmFormsHelper.php
+++ b/classes/helpers/FrmFormsHelper.php
@@ -208,7 +208,7 @@ class FrmFormsHelper {
 					}
 
 					$url       = isset( $base ) ? add_query_arg( $args, $base ) : add_query_arg( $args );
-					$form_name = empty( $form->name ) ? self::get_no_title_text() : $form->name;
+					$form_name = ! empty( $form->name ) ? $form->name : self::get_no_title_text();
 					?>
 					<li class="frm-dropdown-form">
 						<a href="<?php echo esc_url( $url ); ?>" tabindex="-1" class="frm-justify-between">

--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -1684,7 +1684,7 @@ class FrmXMLHelper {
 
 		if ( $primary_form ) {
 			$primary_form = FrmForm::getOne( $primary_form );
-			$form_id      = empty( $primary_form->parent_form_id ) ? $primary_form->id : $primary_form->parent_form_id;
+			$form_id      = ! empty( $primary_form->parent_form_id ) ? $primary_form->parent_form_id : $primary_form->id;
 			$message     .= '<li><a href="' . esc_url( FrmForm::get_edit_link( $form_id ) ) . '">' . esc_html__( 'Go to imported form', 'formidable' ) . '</a></li>';
 		}
 	}
@@ -2327,7 +2327,7 @@ class FrmXMLHelper {
 
 		// Set from
 		if ( ! empty( $atts['reply_to'] ) || ! empty( $atts['reply_to_name'] ) ) {
-			$new_notification['post_content']['from'] = ( empty( $atts['reply_to_name'] ) ? '[sitename]' : $atts['reply_to_name'] ) . ' <' . ( empty( $atts['reply_to'] ) ? '[admin_email]' : $atts['reply_to'] ) . '>'; // phpcs:ignore SlevomatCodingStandard.Files.LineLength.LineTooLong
+			$new_notification['post_content']['from'] = ( ! empty( $atts['reply_to_name'] ) ? $atts['reply_to_name'] : '[sitename]' ) . ' <' . ( ! empty( $atts['reply_to'] ) ? $atts['reply_to'] : '[admin_email]' ) . '>'; // phpcs:ignore SlevomatCodingStandard.Files.LineLength.LineTooLong
 		}
 	}
 

--- a/classes/views/styles/components/FrmSliderStyleComponent.php
+++ b/classes/views/styles/components/FrmSliderStyleComponent.php
@@ -73,7 +73,7 @@ class FrmSliderStyleComponent extends FrmStyleComponent {
 	 * @return void
 	 */
 	private function init_defaults() {
-		$this->data['max_value'] = empty( $this->data['max_value'] ) ? 100 : $this->data['max_value'];
+		$this->data['max_value'] = ! empty( $this->data['max_value'] ) ? $this->data['max_value'] : 100;
 	}
 
 	/**
@@ -91,8 +91,8 @@ class FrmSliderStyleComponent extends FrmStyleComponent {
 
 		$values = $this->get_values();
 		$top    = $values[0];
-		$bottom = empty( $values[2] ) ? $values[0] : $values[2];
-		$left   = empty( $values[3] ) ? $values[1] : $values[3];
+		$bottom = ! empty( $values[2] ) ? $values[2] : $values[0];
+		$left   = ! empty( $values[3] ) ? $values[3] : $values[1];
 		$right  = $values[1];
 
 		$this->data['vertical'] = array(

--- a/classes/widgets/FrmShowForm.php
+++ b/classes/widgets/FrmShowForm.php
@@ -17,7 +17,7 @@ class FrmShowForm extends WP_Widget {
 	 * @return void
 	 */
 	public function widget( $args, $instance ) {
-		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'], $instance, $this->id_base );
+		$title = apply_filters( 'widget_title', ! empty( $instance['title'] ) ? $instance['title'] : '', $instance, $this->id_base );
 
 		FrmAppHelper::kses_echo( $args['before_widget'], 'all' );
 

--- a/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/PreferNotEmptyTernarySniff.php
+++ b/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/PreferNotEmptyTernarySniff.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ * Formidable_Sniffs_CodeAnalysis_PreferNotEmptyTernarySniff
+ *
+ * Detects ternary expressions using `empty( A ) ? B : A` and converts them
+ * to the preferred form `! empty( A ) ? A : B`.
+ *
+ * @package Formidable\Sniffs
+ */
+
+namespace Formidable\Sniffs\CodeAnalysis;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Prefers `! empty( A ) ? A : B` over `empty( A ) ? B : A`.
+ *
+ * Bad:
+ * empty( $var ) ? $default : $var
+ *
+ * Good:
+ * ! empty( $var ) ? $var : $default
+ */
+class PreferNotEmptyTernarySniff implements Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array( T_EMPTY );
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// Check if this empty() is NOT preceded by a negation (!).
+		$prevToken = $phpcsFile->findPrevious( T_WHITESPACE, $stackPtr - 1, null, true );
+
+		if ( false !== $prevToken && $tokens[ $prevToken ]['code'] === T_BOOLEAN_NOT ) {
+			// This is ! empty(), not what we're looking for.
+			return;
+		}
+
+		// Find the opening parenthesis after empty.
+		$openParen = $phpcsFile->findNext( T_WHITESPACE, $stackPtr + 1, null, true );
+
+		if ( false === $openParen || $tokens[ $openParen ]['code'] !== T_OPEN_PARENTHESIS ) {
+			return;
+		}
+
+		if ( ! isset( $tokens[ $openParen ]['parenthesis_closer'] ) ) {
+			return;
+		}
+
+		$closeParen = $tokens[ $openParen ]['parenthesis_closer'];
+
+		// Get the content inside empty() - this is "A".
+		$emptyContent = $this->getTokensContentNormalized( $phpcsFile, $openParen + 1, $closeParen - 1 );
+
+		if ( empty( $emptyContent['content'] ) ) {
+			return;
+		}
+
+		// Find the ternary operator (?) after the empty().
+		$ternaryOperator = $phpcsFile->findNext( T_WHITESPACE, $closeParen + 1, null, true );
+
+		if ( false === $ternaryOperator || $tokens[ $ternaryOperator ]['code'] !== T_INLINE_THEN ) {
+			return;
+		}
+
+		// Find the colon (:) for the else part.
+		$colonOperator = $this->findTernaryColon( $phpcsFile, $ternaryOperator + 1 );
+
+		if ( false === $colonOperator ) {
+			return;
+		}
+
+		// Get the "then" part (B in: empty(A) ? B : A).
+		$thenContent = $this->getTokensContentNormalized( $phpcsFile, $ternaryOperator + 1, $colonOperator - 1 );
+
+		if ( empty( $thenContent['content'] ) ) {
+			return;
+		}
+
+		// Find the end of the ternary expression.
+		$ternaryEnd = $this->findTernaryEnd( $phpcsFile, $colonOperator + 1 );
+
+		if ( false === $ternaryEnd ) {
+			return;
+		}
+
+		// Get the "else" part (A in: empty(A) ? B : A).
+		$elseContent = $this->getTokensContentNormalized( $phpcsFile, $colonOperator + 1, $ternaryEnd );
+
+		if ( empty( $elseContent['content'] ) ) {
+			return;
+		}
+
+		// Check if the else part matches the empty() argument.
+		if ( $elseContent['content'] !== $emptyContent['content'] ) {
+			return;
+		}
+
+		// We have a match: empty( A ) ? B : A
+		// Should become: ! empty( A ) ? A : B
+		$fix = $phpcsFile->addFixableError(
+			'Prefer "! empty( %s ) ? %s : %s" over "empty( %s ) ? %s : %s".',
+			$stackPtr,
+			'Found',
+			array(
+				$emptyContent['content'],
+				$emptyContent['content'],
+				$thenContent['content'],
+				$emptyContent['content'],
+				$thenContent['content'],
+				$elseContent['content'],
+			)
+		);
+
+		if ( true === $fix ) {
+			$this->applyFix(
+				$phpcsFile,
+				$stackPtr,
+				$closeParen,
+				$ternaryOperator,
+				$colonOperator,
+				$ternaryEnd,
+				$emptyContent,
+				$thenContent
+			);
+		}
+	}
+
+	/**
+	 * Find the colon operator for a ternary, handling nested ternaries.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $start     Start position to search from.
+	 *
+	 * @return false|int
+	 */
+	private function findTernaryColon( File $phpcsFile, $start ) {
+		$tokens     = $phpcsFile->getTokens();
+		$depth      = 0;
+		$parenDepth = 0;
+
+		for ( $i = $start; $i < count( $tokens ); $i++ ) {
+			$code = $tokens[ $i ]['code'];
+
+			// Track parentheses.
+			if ( $code === T_OPEN_PARENTHESIS ) {
+				++$parenDepth;
+				continue;
+			}
+
+			if ( $code === T_CLOSE_PARENTHESIS ) {
+				--$parenDepth;
+				continue;
+			}
+
+			// Only process at the same parenthesis level.
+			if ( $parenDepth > 0 ) {
+				continue;
+			}
+
+			// Track nested ternaries.
+			if ( $code === T_INLINE_THEN ) {
+				++$depth;
+				continue;
+			}
+
+			if ( $code === T_INLINE_ELSE ) {
+				if ( $depth > 0 ) {
+					--$depth;
+					continue;
+				}
+
+				return $i;
+			}
+
+			// Stop at statement terminators.
+			if ( in_array( $code, array( T_SEMICOLON, T_CLOSE_TAG, T_COMMA ), true ) ) {
+				return false;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Find the end of a ternary expression.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $start     Start position to search from.
+	 *
+	 * @return false|int
+	 */
+	private function findTernaryEnd( File $phpcsFile, $start ) {
+		$tokens     = $phpcsFile->getTokens();
+		$parenDepth = 0;
+		$end        = false;
+
+		for ( $i = $start; $i < count( $tokens ); $i++ ) {
+			$code = $tokens[ $i ]['code'];
+
+			// Track parentheses.
+			if ( $code === T_OPEN_PARENTHESIS ) {
+				++$parenDepth;
+				continue;
+			}
+
+			if ( $code === T_CLOSE_PARENTHESIS ) {
+				if ( $parenDepth > 0 ) {
+					--$parenDepth;
+					continue;
+				}
+
+				// This closes the containing expression.
+				return $end;
+			}
+
+			// Only process at the same parenthesis level.
+			if ( $parenDepth > 0 ) {
+				if ( $tokens[ $i ]['code'] !== T_WHITESPACE ) {
+					$end = $i;
+				}
+				continue;
+			}
+
+			// Stop at statement terminators or operators that end the ternary.
+			if ( in_array( $code, array( T_SEMICOLON, T_CLOSE_TAG, T_COMMA, T_INLINE_THEN, T_INLINE_ELSE ), true ) ) {
+				return $end;
+			}
+
+			if ( $tokens[ $i ]['code'] !== T_WHITESPACE ) {
+				$end = $i;
+			}
+		}
+
+		return $end;
+	}
+
+	/**
+	 * Get the content of tokens between two positions, normalized (no extra whitespace).
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $start     Start position.
+	 * @param int  $end       End position.
+	 *
+	 * @return array Array with 'content', 'start', 'end', 'raw' keys.
+	 */
+	private function getTokensContentNormalized( File $phpcsFile, $start, $end ) {
+		$tokens  = $phpcsFile->getTokens();
+		$content = '';
+		$raw     = '';
+		$first   = null;
+		$last    = null;
+
+		for ( $i = $start; $i <= $end; $i++ ) {
+			$raw .= $tokens[ $i ]['content'];
+
+			if ( $tokens[ $i ]['code'] === T_WHITESPACE ) {
+				continue;
+			}
+
+			if ( null === $first ) {
+				$first = $i;
+			}
+
+			$last     = $i;
+			$content .= $tokens[ $i ]['content'];
+		}
+
+		return array(
+			'content' => $content,
+			'start'   => $first,
+			'end'     => $last,
+			'raw'     => trim( $raw ),
+		);
+	}
+
+	/**
+	 * Apply the fix to convert empty(A) ? B : A to ! empty(A) ? A : B.
+	 *
+	 * @param File  $phpcsFile       The file being scanned.
+	 * @param int   $emptyToken      Position of empty keyword.
+	 * @param int   $closeParen      Position of closing paren after empty.
+	 * @param int   $ternaryOperator Position of ?.
+	 * @param int   $colonOperator   Position of :.
+	 * @param int   $ternaryEnd      Position of end of ternary.
+	 * @param array $emptyContent    The A content.
+	 * @param array $thenContent     The B content.
+	 *
+	 * @return void
+	 */
+	private function applyFix( File $phpcsFile, $emptyToken, $closeParen, $ternaryOperator, $colonOperator, $ternaryEnd, $emptyContent, $thenContent ) {
+		$tokens = $phpcsFile->getTokens();
+		$fixer  = $phpcsFile->fixer;
+
+		$fixer->beginChangeset();
+
+		// Add "! " before empty.
+		$fixer->addContentBefore( $emptyToken, '! ' );
+
+		// Replace the "then" part (B) with A.
+		$thenStart = $phpcsFile->findNext( T_WHITESPACE, $ternaryOperator + 1, $colonOperator, true );
+		$thenEnd   = $phpcsFile->findPrevious( T_WHITESPACE, $colonOperator - 1, $ternaryOperator, true );
+
+		if ( false !== $thenStart && false !== $thenEnd ) {
+			// Clear the then part.
+			for ( $i = $thenStart; $i <= $thenEnd; $i++ ) {
+				$fixer->replaceToken( $i, '' );
+			}
+			// Add A in place of B.
+			$fixer->addContent( $thenStart - 1, ' ' . $emptyContent['raw'] . ' ' );
+		}
+
+		// Replace the "else" part (A) with B.
+		// $ternaryEnd is the last token of the else expression (before semicolon/terminator).
+		$elseStart = $phpcsFile->findNext( T_WHITESPACE, $colonOperator + 1, $ternaryEnd + 1, true );
+
+		if ( false !== $elseStart ) {
+			// Clear the else part (from elseStart to ternaryEnd inclusive).
+			for ( $i = $elseStart; $i <= $ternaryEnd; $i++ ) {
+				$fixer->replaceToken( $i, '' );
+			}
+			// Add B in place of A.
+			$fixer->addContent( $elseStart - 1, ' ' . $thenContent['raw'] );
+		}
+
+		$fixer->endChangeset();
+	}
+}

--- a/phpcs-sniffs/Formidable/ruleset.xml
+++ b/phpcs-sniffs/Formidable/ruleset.xml
@@ -44,6 +44,7 @@
 	<rule ref="Formidable.CodeAnalysis.PreferArrayKeyExists" />
 	<rule ref="Formidable.CodeAnalysis.PreferNegationOverEmptyForFunctionCall" />
 	<rule ref="Formidable.CodeAnalysis.PreferEmptyArrayComparison" />
+	<rule ref="Formidable.CodeAnalysis.PreferNotEmptyTernary" />
 	<rule ref="Formidable.CodeAnalysis.StrictComparisonForIntFunctions" />
 	<rule ref="Formidable.CodeAnalysis.MoveSimpleCheckBeforeExpensiveCall" />
 	<rule ref="Formidable.CodeAnalysis.MoveVariableBelowEarlyReturn" />

--- a/stripe/helpers/FrmStrpLiteConnectHelper.php
+++ b/stripe/helpers/FrmStrpLiteConnectHelper.php
@@ -706,7 +706,7 @@ class FrmStrpLiteConnectHelper {
 			return ! empty( self::$latest_error_from_stripe_connect ) ? self::$latest_error_from_stripe_connect : false;
 		}
 
-		return empty( $data->customer_id ) ? false : $data->customer_id;
+		return ! empty( $data->customer_id ) ? $data->customer_id : false;
 	}
 
 	/**

--- a/stripe/helpers/FrmStrpLiteSubscriptionHelper.php
+++ b/stripe/helpers/FrmStrpLiteSubscriptionHelper.php
@@ -127,7 +127,7 @@ class FrmStrpLiteSubscriptionHelper {
 			'interval'       => $settings['interval'],
 			'interval_count' => $settings['interval_count'],
 			'currency'       => $settings['currency'],
-			'name'           => empty( $settings['description'] ) ? $default_description : $settings['description'],
+			'name'           => ! empty( $settings['description'] ) ? $settings['description'] : $default_description,
 		);
 
 		if ( ! empty( $settings['trial_interval_count'] ) ) {


### PR DESCRIPTION
This update prefers `! empty( A ) ? A : B` over `empty( A ) ? B : A` which feels backwards since `A ? A : B` reads a lot better and `! empty` is really a double negative / positive check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized conditional logic across multiple helper classes for consistency and code quality.

* **Chores**
  * Added a new code style rule to enforce consistent ternary operator patterns in the codebase.
  * Updated code analysis ruleset to include the new style rule.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->