### PR TITLE
New sniff to enforce using the Lite textdomain for translations

### DIFF
--- a/phpcs-sniffs/Formidable/Sniffs/Translations/UseSharedTranslationDomainSniff.php
+++ b/phpcs-sniffs/Formidable/Sniffs/Translations/UseSharedTranslationDomainSniff.php
@@ -56,7 +56,7 @@ class UseSharedTranslationDomainSniff implements Sniff {
 	 *
 	 * @var array<string, bool>|null
 	 */
-	private static $potStrings = null;
+	private static $potStrings;
 
 	/**
 	 * Translation functions to check.
@@ -312,9 +312,7 @@ class UseSharedTranslationDomainSniff implements Sniff {
 		$string = str_replace( '\\n', "\n", $string );
 		$string = str_replace( '\\t', "\t", $string );
 		$string = str_replace( '\\"', '"', $string );
-		$string = str_replace( '\\\\', '\\', $string );
-
-		return $string;
+		return str_replace( '\\\\', '\\', $string );
 	}
 
 	/**


### PR DESCRIPTION
This shouldn't do anything really in this repo, but in other repositories it can help us remove string translations that are already handled in Lite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new code quality check to enforce consistent translation text domain usage, automatically aligning domains with shared standards and offering automatic fixes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->