### PR TITLE
Load star SVG differently to prevent a phpcs:ignore comment

### DIFF
--- a/classes/helpers/FrmAddonsHelper.php
+++ b/classes/helpers/FrmAddonsHelper.php
@@ -290,13 +290,12 @@ class FrmAddonsHelper {
 	 * @return void
 	 */
 	public static function show_five_star_rating( $color = 'black' ) {
-		$icon = file_get_contents( FrmAppHelper::plugin_path() . '/images/star.svg' );
 		// phpcs:disable Generic.WhiteSpace.ScopeIndent
 		?>
 		<span style="color: <?php echo esc_attr( $color ); ?>;">
 			<?php
 			for ( $i = 0; $i < 5; $i++ ) {
-				echo $icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				readfile( FrmAppHelper::plugin_path() . '/images/star.svg' );
 			}
 			?>
 		</span>


### PR DESCRIPTION
I'm trying to cut back on `phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped` comments that we don't really need.

This might be slightly less efficient, but there's no need to micro-optimize on this views upsell page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized how star ratings are displayed internally.

---

**Note:** This release contains primarily internal optimizations with no new user-facing features or visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->