### PR TITLE
Remove invalid param used in strip_tags call

### DIFF
--- a/css/custom_theme.css.php
+++ b/css/custom_theme.css.php
@@ -7,7 +7,7 @@ if ( ! isset( $saving ) ) {
 	header( 'Content-type: text/css' );
 
 	if ( ! empty( $css ) ) {
-		echo strip_tags( $css, 'all' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo strip_tags( $css ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		FrmStylesController::maybe_hide_sample_form_error_message();
 		die();
 	}


### PR DESCRIPTION
`strip_tags` does not accept an `all` string.

Since this effectively did nothing, and we don't need any HTML tags in our CSS, I'm just removing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS output processing to properly strip all HTML tags from custom theme styles, improving security and ensuring clean CSS content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->