### PR TITLE
Revert change in the order of Checkbox's checked attribute to fix unit test in Pro

### DIFF
--- a/classes/views/frm-fields/front-end/checkbox-field.php
+++ b/classes/views/frm-fields/front-end/checkbox-field.php
@@ -79,8 +79,8 @@ if ( isset( $field['post_field'] ) && $field['post_field'] === 'post_category' )
 
 		?><input type="checkbox" name="<?php echo esc_attr( $field_name ); ?>[<?php echo esc_attr( $other_opt ? $opt_key : '' ); ?>]" id="<?php echo esc_attr( $html_id ); ?>-<?php echo esc_attr( $opt_key ); ?>" value="<?php echo esc_attr( $field_val ); ?>"<?php
 
-		do_action( 'frm_field_input_html', $field );
 		echo $checked . ' '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		do_action( 'frm_field_input_html', $field );
 
 		if ( $should_echo_disabled_att ) {
 			echo 'disabled="disabled" data-max-reached="1" ';


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This update fixed a unit test that is failing in Lite in the Choice Limit update branch: https://github.com/Strategy11/formidable-pro/pull/6005