### PR TITLE
Fix Conditional Logic not copied over when duplicating a field

### DIFF
--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -216,13 +216,13 @@ class FrmFieldsController {
 	 * @return int
 	 */
 	private static function get_form_id_from_field_or_form( $field_object, $values ) {
-		$form_id = $field_object->form_id;
+		$form_id = absint( $field_object->form_id );
 
 		if ( isset( $values['form_key'] ) ) {
 			return $values['id'] ?? $form_id;
 		}
 
-		$parent_form_id = FrmDb::get_var( 'frm_forms', array( 'id' => $form_id ), 'parent_form_id' );
+		$parent_form_id = absint( FrmDb::get_var( 'frm_forms', array( 'id' => $form_id ), 'parent_form_id' ) );
 
 		return $parent_form_id ? $parent_form_id : $form_id;
 	}

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -185,7 +185,6 @@ class FrmFieldsController {
 
 		if ( ! isset( $field ) && is_object( $field_object ) ) {
 			$field_object->parent_form_id = self::get_parent_form_id( $field_object, $values );
-
 			$field = FrmFieldsHelper::setup_edit_vars( $field_object );
 		}
 
@@ -218,11 +217,14 @@ class FrmFieldsController {
 	 */
 	private static function get_parent_form_id( $field_object, $values ) {
 		$form_id = $field_object->form_id;
+
 		if ( isset( $values['form_key'] ) ) {
 			return $values['id'] ?? $form_id;
 		}
 
-		return FrmDb::get_var( 'frm_forms', array( 'id' => $form_id ), 'parent_form_id' ) ?? $form_id;
+		$parent_form_id = FrmDb::get_var( 'frm_forms', array( 'id' => $form_id ), 'parent_form_id' );
+
+		return $parent_form_id ? $parent_form_id : $form_id;
 	}
 
 	/**

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -184,8 +184,13 @@ class FrmFieldsController {
 		}
 
 		if ( ! isset( $field ) && is_object( $field_object ) ) {
-			$field_object->parent_form_id = $values['id'] ?? $field_object->form_id;
-			$field                        = FrmFieldsHelper::setup_edit_vars( $field_object );
+			if ( isset( $values['form_key'] ) ) {
+				$field_object->parent_form_id = $values['id'];
+			} else {
+				$parent_form_id               = FrmDb::get_var( 'frm_forms', array( 'id' => $field_object->form_id ), 'parent_form_id' );
+				$field_object->parent_form_id = $parent_form_id ? $parent_form_id : $field_object->form_id;
+			}
+			$field = FrmFieldsHelper::setup_edit_vars( $field_object );
 		}
 
 		/**

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -184,7 +184,7 @@ class FrmFieldsController {
 		}
 
 		if ( ! isset( $field ) && is_object( $field_object ) ) {
-			$field_object->parent_form_id = self::get_parent_form_id( $field_object, $values );
+			$field_object->parent_form_id = self::get_form_id_from_field_or_form( $field_object, $values );
 			$field                        = FrmFieldsHelper::setup_edit_vars( $field_object );
 		}
 
@@ -215,7 +215,7 @@ class FrmFieldsController {
 	 *
 	 * @return int
 	 */
-	private static function get_parent_form_id( $field_object, $values ) {
+	private static function get_form_id_from_field_or_form( $field_object, $values ) {
 		$form_id = $field_object->form_id;
 
 		if ( isset( $values['form_key'] ) ) {

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -185,7 +185,7 @@ class FrmFieldsController {
 
 		if ( ! isset( $field ) && is_object( $field_object ) ) {
 			$field_object->parent_form_id = self::get_parent_form_id( $field_object, $values );
-			$field = FrmFieldsHelper::setup_edit_vars( $field_object );
+			$field                        = FrmFieldsHelper::setup_edit_vars( $field_object );
 		}
 
 		/**

--- a/classes/controllers/FrmFieldsController.php
+++ b/classes/controllers/FrmFieldsController.php
@@ -184,12 +184,8 @@ class FrmFieldsController {
 		}
 
 		if ( ! isset( $field ) && is_object( $field_object ) ) {
-			if ( isset( $values['form_key'] ) ) {
-				$field_object->parent_form_id = $values['id'];
-			} else {
-				$parent_form_id               = FrmDb::get_var( 'frm_forms', array( 'id' => $field_object->form_id ), 'parent_form_id' );
-				$field_object->parent_form_id = $parent_form_id ? $parent_form_id : $field_object->form_id;
-			}
+			$field_object->parent_form_id = self::get_parent_form_id( $field_object, $values );
+
 			$field = FrmFieldsHelper::setup_edit_vars( $field_object );
 		}
 
@@ -208,6 +204,25 @@ class FrmFieldsController {
 		$li_classes .= ' ui-state-default widgets-holder-wrap';
 
 		require FrmAppHelper::plugin_path() . '/classes/views/frm-forms/add_field.php';
+	}
+
+	/**
+	 * Get the parent form id for the field.
+	 *
+	 * @since x.x
+	 *
+	 * @param object $field_object The field object.
+	 * @param array  $values       Either form or field values.
+	 *
+	 * @return int
+	 */
+	private static function get_parent_form_id( $field_object, $values ) {
+		$form_id = $field_object->form_id;
+		if ( isset( $values['form_key'] ) ) {
+			return $values['id'] ?? $form_id;
+		}
+
+		return FrmDb::get_var( 'frm_forms', array( 'id' => $form_id ), 'parent_form_id' ) ?? $form_id;
 	}
 
 	/**


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/6308

## Steps to reproduce

1. Add a field to your form and setup conditional logic on it and save your changes.
2. Duplicate the field and save the form.
3. Confirm that the Conditional logic is copied over to the new field after page is reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parent-form detection when loading individual fields, reducing errors and making field editing and display more reliable—especially for fields lacking an explicit parent reference. This update ensures the correct form relationship is determined from available field or form data, decreasing incorrect form assignments and improving consistency and stability when opening, editing, and displaying field-to-form associations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->