### PR TITLE
update e2e tests banner text

### DIFF
--- a/tests/cypress/e2e/Entries/EntriesPageDataValidations.cy.js
+++ b/tests/cypress/e2e/Entries/EntriesPageDataValidations.cy.js
@@ -55,6 +55,7 @@ describe( 'Entries submitted from a form', () => {
 				'Get 60% Off Pro!',
 				'Black Friday Deals',
 				'Cyber Monday Deals',
+				'Get 60% Off Pro'
 			] );
 		} );
 

--- a/tests/cypress/e2e/Forms/formPageDataValidation.cy.js
+++ b/tests/cypress/e2e/Forms/formPageDataValidation.cy.js
@@ -25,6 +25,7 @@ describe( 'Forms page', () => {
 					'upgrading for 60% off during our No Brainer Sale!',
 					'Black Friday Deals',
 					'Cyber Monday Deals',
+					'Anniversary Sale'
 				];
 
 				if ( href && substrings.some( substring => text.includes( substring ) ) ) {
@@ -46,6 +47,7 @@ describe( 'Forms page', () => {
 								'don\'t miss the best deals for cyber monday!',
 								'don\'t miss the giving tuesday flash sale!',
 								'don\'t miss 65% off on the best wordpress form builder!',
+								'upgrading for 60% off before our Anniversary Sale ends!'
 							] ).to.include( headingText );
 						} );
 					} );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test validation for anniversary sale promotional messaging, including "Get 60% Off Pro" variant texts.
  * Expanded test coverage to verify anniversary sale promotion banners and discount messaging are displayed correctly with "60% off" offers tied to anniversary sale end date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->