### PR TITLE
Add object check to usage data cleanup

### DIFF
--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -202,6 +202,11 @@ class FrmUsage {
 				continue;
 			}
 
+			if ( is_object( $value ) ) {
+				$value = '{{object}}';
+				continue;
+			}
+
 			if ( is_array( $value ) ) {
 				$this->clean_before_send( $value );
 				continue;


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3230717395/247593

> str_contains(): Argument #1 must be string, stdClass given

**Pre-release**
[formidable-6.28.1b.zip](https://github.com/user-attachments/files/25347689/formidable-6.28.1b.zip)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data handling to properly detect and sanitize object values during processing, preventing potential issues with object traversal and expansion. Objects are now safely replaced with a placeholder to ensure clean data output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->