### PR TITLE
Fix "After Payment" setting not imported for Payment actions

### DIFF
--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1847,7 +1847,7 @@ class FrmFieldsHelper {
 
 			$val[ $k ] = str_replace( $replace, $replace_with, $v );
 			unset( $k, $v );
-		}
+		}//end foreach
 
 		return $val;
 	}

--- a/classes/helpers/FrmFieldsHelper.php
+++ b/classes/helpers/FrmFieldsHelper.php
@@ -1826,11 +1826,21 @@ class FrmFieldsHelper {
 
 		foreach ( $val as $k => $v ) {
 			if ( ! is_string( $v ) ) {
+				if ( is_array( $v ) ) {
+					$val[ $k ] = self::switch_field_ids( $v );
+					unset( $k, $v );
+				}
 				continue;
 			}
 
 			if ( 'custom_html' === $k ) {
 				$val[ $k ] = self::switch_ids_except_strings( $replace, $replace_with, array( '[if description]', '[description]', '[/if description]' ), $v );
+				unset( $k, $v );
+				continue;
+			}
+
+			if ( isset( $frm_duplicate_ids[ $v ] ) ) {
+				$val[ $k ] = $frm_duplicate_ids[ $v ];
 				unset( $k, $v );
 				continue;
 			}

--- a/classes/models/FrmFormAction.php
+++ b/classes/models/FrmFormAction.php
@@ -402,6 +402,8 @@ class FrmFormAction {
 				foreach ( $switch[ $key ] as $subkey ) {
 					$action->post_content[ $key ] = $this->duplicate_array_walk( $action->post_content[ $key ], $subkey, $val );
 				}
+			} elseif ( is_array( $val ) ) {
+				$action->post_content[ $key ] = FrmFieldsHelper::switch_field_ids( $val );
 			}
 
 			unset( $key, $val );


### PR DESCRIPTION
Fix https://github.com/Strategy11/formidable-pro/issues/6377

### Test steps
1. Create a Payment form
2. Go to the Payment Action and add "After Payment" updates mapping fields as needed for test
3. Export the form and import it back.
4. Go to the Payment Action and confirm that the "After Payment" field mappings are imported successfully.
<img width="1284" height="452" alt="image" src="https://github.com/user-attachments/assets/a7661b8b-321c-4213-8a3f-cceb8c9e1cc5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Form duplication now correctly updates nested and array-valued field entries so duplicated forms keep proper field references.
  * Duplicate-ID mappings are applied earlier in the duplication process to ensure accurate field ID replacement for complex form configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->