### PR TITLE
Get oxlint workflow passing

### DIFF
--- a/.github/workflows/oxlint.yml
+++ b/.github/workflows/oxlint.yml
@@ -28,4 +28,4 @@ jobs:
         run: npm install oxlint@^1.51.0 --no-package-lock
 
       - name: Run Oxlint
-        run: ./node_modules/.bin/oxlint .
+        run: ./node_modules/.bin/oxlint . --format unix --max-diagnostics 1000

--- a/.github/workflows/oxlint.yml
+++ b/.github/workflows/oxlint.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: "22"
 
       - name: Install Oxlint
-        run: npm install oxlint@^1.51.0 --no-package-lock
+        run: npm install oxlint@1.59.0 --no-package-lock
 
       - name: Run Oxlint
         run: ./node_modules/.bin/oxlint . --format unix

--- a/.github/workflows/oxlint.yml
+++ b/.github/workflows/oxlint.yml
@@ -28,4 +28,4 @@ jobs:
         run: npm install oxlint@^1.51.0 --no-package-lock
 
       - name: Run Oxlint
-        run: ./node_modules/.bin/oxlint . --format unix --max-diagnostics 1000
+        run: ./node_modules/.bin/oxlint . --format unix

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -103,6 +103,8 @@
 		"react/jsx-props-no-spreading": "off",
 		"react/no-array-index-key": "off",
 		"react/no-multi-comp": "off",
+		"react/no-class-component": "off",
+		"react/naming-convention-use-state": "off",
 		"react/react-in-jsx-scope": "off",
 		"react/self-closing-comp": "off",
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,7 +4,7 @@
 	"categories": {
 		"correctness": "error",
 		"suspicious": "error",
-		"pedantic": "error",
+		"pedantic": "off",
 		"perf": "error",
 		"style": "error",
 		"restriction": "error"
@@ -103,6 +103,8 @@
 		"react/jsx-props-no-spreading": "off",
 		"react/no-array-index-key": "off",
 		"react/no-multi-comp": "off",
+		"react/prefer-function-component": "off",
+		"react/hook-use-state": "off",
 		"react/react-in-jsx-scope": "off",
 		"react/self-closing-comp": "off",
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -103,8 +103,6 @@
 		"react/jsx-props-no-spreading": "off",
 		"react/no-array-index-key": "off",
 		"react/no-multi-comp": "off",
-		"react/no-class-component": "off",
-		"react/naming-convention-use-state": "off",
 		"react/react-in-jsx-scope": "off",
 		"react/self-closing-comp": "off",
 


### PR DESCRIPTION
I think these rules are new. Either way I'm not too concerned about enforcing a lot of React rules since we're only using it for blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Linter workflow updated to use a newer linter version and produce Unix-formatted diagnostics for more consistent output.

* **Style**
  * Several strict linting rules relaxed: pedantic checks disabled and select React-specific rules turned off to reduce blocking style errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->