### PR TITLE
Improve isset before not empty sniff

### DIFF
--- a/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/RedundantIssetBeforeNotEmptySniff.php
+++ b/phpcs-sniffs/Formidable/Sniffs/CodeAnalysis/RedundantIssetBeforeNotEmptySniff.php
@@ -107,13 +107,6 @@ class RedundantIssetBeforeNotEmptySniff implements Sniff {
 			return;
 		}
 
-		// For array access, the isset() may be necessary to prevent undefined index warnings.
-		// While empty() technically checks if a variable is set, it can still trigger warnings
-		// in some PHP configurations. Skip array access patterns to be safe.
-		if ( strpos( $issetVarContent, '[' ) !== false ) {
-			return;
-		}
-
 		$fix = $phpcsFile->addFixableError(
 			'Redundant isset() before ! empty(). The empty() function already checks if a variable is set. Use "! empty( %s )" instead.',
 			$stackPtr,

--- a/phpcs-sniffs/Formidable/Sniffs/Security/AddDirectFileAccessCheckSniff.php
+++ b/phpcs-sniffs/Formidable/Sniffs/Security/AddDirectFileAccessCheckSniff.php
@@ -22,7 +22,7 @@ class AddDirectFileAccessCheckSniff implements Sniff {
 	 *
 	 * @var string
 	 */
-	private $accessCheck = "if ( ! defined( 'ABSPATH' ) ) { die( 'You are not allowed to call this page directly.' ); }";
+	private $accessCheck = "if ( ! defined( 'ABSPATH' ) ) { die( 'You are not allowed to call this page directly.' );\n}";
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.


### PR DESCRIPTION
No idea why it has this array check. It's totally inaccurate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection of redundant isset() checks, including patterns with array access
  * Improved formatting of automatically injected security guard code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->