### PR TITLE
Stop showing new for pricing fields section when pro is installed

### DIFF
--- a/classes/views/frm-forms/add_field_links.php
+++ b/classes/views/frm-forms/add_field_links.php
@@ -100,7 +100,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 								<h3 class="frm-with-line">
 									<span><?php echo esc_html( $section_labels[ $section ] ?? ucwords( $section ) ); ?></span>
 									<span style="padding-left: 0;">
-										<?php FrmAppHelper::show_pill_text(); ?>
+										<?php
+										if ( ! FrmAppHelper::pro_is_installed() ) {
+											FrmAppHelper::show_pill_text();
+										}
+										?>
 									</span>
 								</h3>
 								<ul class="field_type_list frm_grid_container">


### PR DESCRIPTION
Nothing is really new for Pro users, aside from the image options for product fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conditional rendering of instructional text in form field UI to display only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->