### PR TITLE
Fix DeepSource Warnings 

### DIFF
--- a/.github/workflows/mago.yml
+++ b/.github/workflows/mago.yml
@@ -14,11 +14,8 @@ jobs:
       - name: Install dependencies
         run: composer install --dev --prefer-dist --no-progress
 
-      - name: "⚡ Install Mago"
-        uses: nhedger/setup-mago@v1
-
       - name: "✅ Mago Lint"
-        run: mago lint
+        run: ./vendor/bin/mago lint
 
       - name: "🔎 Mago Analyze"
-        run: mago analyze
+        run: ./vendor/bin/mago analyze

--- a/.github/workflows/mago.yml
+++ b/.github/workflows/mago.yml
@@ -15,12 +15,10 @@ jobs:
         run: composer install --dev --prefer-dist --no-progress
 
       - name: "⚡ Install Mago"
-        run: |
-          mkdir -p bin
-          curl --proto '=https' --tlsv1.2 -sSf https://carthage.software/mago.sh | bash -s -- --install-dir=bin
+        uses: nhedger/setup-mago@v1
 
       - name: "✅ Mago Lint"
-        run: ./bin/mago lint
+        run: mago lint
 
       - name: "🔎 Mago Analyze"
-        run: ./bin/mago analyze
+        run: mago analyze

--- a/.github/workflows/mago.yml
+++ b/.github/workflows/mago.yml
@@ -14,8 +14,13 @@ jobs:
       - name: Install dependencies
         run: composer install --dev --prefer-dist --no-progress
 
+      - name: "⚡ Install Mago"
+        run: |
+          mkdir -p bin
+          curl --proto '=https' --tlsv1.2 -sSf https://carthage.software/mago.sh | bash -s -- --install-dir=bin
+
       - name: "✅ Mago Lint"
-        run: ./vendor/bin/mago lint
+        run: ./bin/mago lint
 
       - name: "🔎 Mago Analyze"
-        run: ./vendor/bin/mago analyze
+        run: ./bin/mago analyze

--- a/classes/views/addons/addon.php
+++ b/classes/views/addons/addon.php
@@ -3,6 +3,10 @@
  * Add-Ons addon view.
  *
  * @package Formidable
+ *
+ * @var array  $addon        Single add-on data (slug, title, display_name, excerpt, status, docs, docs_label, is_new, etc.).
+ * @var string $license_type Current license type or empty string.
+ * @var string $pricing      Upgrade URL used for CTAs.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/views/addons/categories.php
+++ b/classes/views/addons/categories.php
@@ -3,6 +3,8 @@
  * Add-Ons categories.
  *
  * @package Formidable
+ *
+ * @var array<string, array{name: string, count: int}> $categories Categories keyed by slug.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/views/addons/index.php
+++ b/classes/views/addons/index.php
@@ -3,6 +3,16 @@
  * Add-Ons Page.
  *
  * @package Formidable
+ *
+ * @var string               $view_path         Absolute path to the views/addons/ directory, with trailing slash.
+ * @var array                $installed_addons  Installed add-on plugins keyed by slug.
+ * @var array<string, array> $addons            Available add-ons keyed by slug.
+ * @var array                $errors            API errors, if any.
+ * @var string               $license_type      Current license type or empty string.
+ * @var string               $request_addon_url URL for requesting a new add-on.
+ * @var array                $pro               Pro add-on entry prepended to $addons.
+ * @var string               $pricing           Upgrade URL used for CTAs.
+ * @var array<string, array> $categories        Add-on categories keyed by slug, each with 'name' and 'count'.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/views/addons/list.php
+++ b/classes/views/addons/list.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * Add-Ons list.
+ *
+ * @package Formidable
+ *
+ * @var array<string, array> $addons            Available add-ons keyed by slug.
+ * @var string               $view_path         Absolute path to the views/addons/ directory, with trailing slash.
+ * @var string               $request_addon_url URL for requesting a new add-on.
+ * @var string               $license_type      Current license type or empty string.
+ * @var string               $pricing           Upgrade URL used for CTAs.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/addons/settings.php
+++ b/classes/views/addons/settings.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Add-Ons license settings.
+ *
+ * @package Formidable
+ *
+ * @var array<string, object> $plugins Installed add-on plugin objects keyed by slug. Each has: is_parent_licence, needs_license, license, option_name, plugin_name.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/applications/header.php
+++ b/classes/views/applications/header.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Applications header.
+ *
+ * @package Formidable
+ *
+ * @var string $title   Header title text.
+ * @var string $context Current applications view context (e.g. 'index').
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/dashboard/templates/counters.php
+++ b/classes/views/dashboard/templates/counters.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Dashboard counters widget.
+ *
+ * @package Formidable
+ *
+ * @var array $template Widget data with a 'counters' array. Each counter has: heading, type, counter, cta and optional items.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/dashboard/templates/entries-list.php
+++ b/classes/views/dashboard/templates/entries-list.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Dashboard entries list widget.
+ *
+ * @package Formidable
+ *
+ * @var array               $template      Widget data with 'widget-heading' string and 'cta' (link, label) array.
+ * @var FrmEntriesListHelper $wp_list_table Prepared entries list table instance (filterable via frm_entries_list_class).
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/dashboard/templates/license-management.php
+++ b/classes/views/dashboard/templates/license-management.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Dashboard license management widget.
+ *
+ * @package Formidable
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/dashboard/templates/notification-banner.php
+++ b/classes/views/dashboard/templates/notification-banner.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Dashboard welcome notification banner.
+ *
+ * @package Formidable
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/dashboard/templates/payment-placeholder.php
+++ b/classes/views/dashboard/templates/payment-placeholder.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Dashboard payment placeholder widget.
+ *
+ * @package Formidable
+ *
+ * @var array $template Widget data with 'counters' and 'placeholder' (copy, cta[link, label, classname]) keys.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/dashboard/templates/widget-placeholder.php
+++ b/classes/views/dashboard/templates/widget-placeholder.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Dashboard widget placeholder.
+ *
+ * @package Formidable
+ *
+ * @var array $template Widget data with 'widget-heading' and 'placeholder' (background, heading, copy, button[link, label, classname]).
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/dashboard/templates/youtube-video.php
+++ b/classes/views/dashboard/templates/youtube-video.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Dashboard YouTube video widget.
+ *
+ * @package Formidable
+ *
+ * @var string $classes  CSS classes for the outer wrapper.
+ * @var array  $template Widget data with 'id' (YouTube video ID).
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-entries/_sidebar-shared-pub.php
+++ b/classes/views/frm-entries/_sidebar-shared-pub.php
@@ -31,7 +31,7 @@ if ( ! isset( $entry ) ) {
 	 * @param string   $text
 	 * @param stdClass $entry
 	 */
-	// Skipcq: PHP-W1020
+	// skipcq: PHP-W1020
 	$additional_timestamp_text = apply_filters( 'frm_additional_timestamp_text', '', $entry );
 
 	printf(

--- a/classes/views/frm-entries/_sidebar-shared-pub.php
+++ b/classes/views/frm-entries/_sidebar-shared-pub.php
@@ -31,7 +31,7 @@ if ( ! isset( $entry ) ) {
 	 * @param string   $text
 	 * @param stdClass $entry
 	 */
-	$additional_timestamp_text = apply_filters( 'frm_additional_timestamp_text', '', $entry );
+	$additional_timestamp_text = apply_filters( 'frm_additional_timestamp_text', '', $entry ); // skipcq: PHP-W1020
 
 	printf(
 		/* translators: %1$s: Entry status, %2$s: <b> open tag, %3$s: The date, %4$s: Possible additional text, %5$s: </b> close tag */

--- a/classes/views/frm-entries/_sidebar-shared-pub.php
+++ b/classes/views/frm-entries/_sidebar-shared-pub.php
@@ -4,7 +4,7 @@
  *
  * @package Formidable
  *
- * @var stdClass      $entry  Entry object (falls back to $record).
+ * @var stdClass|null $entry  Entry object (falls back to $record).
  * @var stdClass|null $record Legacy entry object used when $entry is not set.
  */
 

--- a/classes/views/frm-entries/_sidebar-shared-pub.php
+++ b/classes/views/frm-entries/_sidebar-shared-pub.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Shared entry sidebar publish box.
+ *
+ * @package Formidable
+ *
+ * @var stdClass      $entry  Entry object (falls back to $record).
+ * @var stdClass|null $record Legacy entry object used when $entry is not set.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-entries/_sidebar-shared-pub.php
+++ b/classes/views/frm-entries/_sidebar-shared-pub.php
@@ -31,7 +31,8 @@ if ( ! isset( $entry ) ) {
 	 * @param string   $text
 	 * @param stdClass $entry
 	 */
-	$additional_timestamp_text = apply_filters( 'frm_additional_timestamp_text', '', $entry ); // skipcq: PHP-W1020
+	// Skipcq: PHP-W1020
+	$additional_timestamp_text = apply_filters( 'frm_additional_timestamp_text', '', $entry );
 
 	printf(
 		/* translators: %1$s: Entry status, %2$s: <b> open tag, %3$s: The date, %4$s: Possible additional text, %5$s: </b> close tag */

--- a/classes/views/frm-entries/errors.php
+++ b/classes/views/frm-entries/errors.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Form errors and success message wrapper.
+ *
+ * @package Formidable
+ *
+ * @var stdClass|null $form                    Form object when available.
+ * @var string|null   $message                 Success message HTML.
+ * @var array|null    $errors                  Field errors keyed by field id.
+ * @var string|null   $include_extra_container Optional CSS class for a wrapping container.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-entries/show.php
+++ b/classes/views/frm-entries/show.php
@@ -87,7 +87,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 					 * @param array $show_args The arguments.
 					 * @param array $args      Includes `form`.
 					 */
-					$show_args = apply_filters( 'frm_entries_show_args', $show_args, compact( 'form' ) ); // skipcq: PHP-W1020
+					// Skipcq: PHP-W1020
+					$show_args = apply_filters( 'frm_entries_show_args', $show_args, compact( 'form' ) );
 
 					echo FrmEntriesController::show_entry_shortcode( $show_args ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					?>

--- a/classes/views/frm-entries/show.php
+++ b/classes/views/frm-entries/show.php
@@ -87,7 +87,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					 * @param array $show_args The arguments.
 					 * @param array $args      Includes `form`.
 					 */
-					// Skipcq: PHP-W1020
+					// skipcq: PHP-W1020
 					$show_args = apply_filters( 'frm_entries_show_args', $show_args, compact( 'form' ) );
 
 					echo FrmEntriesController::show_entry_shortcode( $show_args ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/classes/views/frm-entries/show.php
+++ b/classes/views/frm-entries/show.php
@@ -87,7 +87,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					 * @param array $show_args The arguments.
 					 * @param array $args      Includes `form`.
 					 */
-					$show_args = apply_filters( 'frm_entries_show_args', $show_args, compact( 'form' ) );
+					$show_args = apply_filters( 'frm_entries_show_args', $show_args, compact( 'form' ) ); // skipcq: PHP-W1020
 
 					echo FrmEntriesController::show_entry_shortcode( $show_args ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					?>

--- a/classes/views/frm-entries/show.php
+++ b/classes/views/frm-entries/show.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Entry show page.
+ *
+ * @package Formidable
+ *
+ * @var stdClass $form   Form object.
+ * @var stdClass $entry  Entry object.
+ * @var array    $fields Field objects for the entry.
+ * @var int      $id     Entry ID.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-entries/sidebar-shared.php
+++ b/classes/views/frm-entries/sidebar-shared.php
@@ -4,7 +4,7 @@
  *
  * @package Formidable
  *
- * @var int          $id      Entry ID.
+ * @var string       $id      Entry ID.
  * @var stdClass     $entry   Entry object.
  * @var string|null  $browser Browser info string if available.
  * @var array|null   $data    Additional entry meta data (referrer, user_journey, etc.).

--- a/classes/views/frm-entries/sidebar-shared.php
+++ b/classes/views/frm-entries/sidebar-shared.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Shared entry sidebar.
+ *
+ * @package Formidable
+ *
+ * @var int          $id      Entry ID.
+ * @var stdClass     $entry   Entry object.
+ * @var string|null  $browser Browser info string if available.
+ * @var array|null   $data    Additional entry meta data (referrer, user_journey, etc.).
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/ajax-field-placeholder.php
+++ b/classes/views/frm-fields/back-end/ajax-field-placeholder.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Ajax field placeholder in the form builder.
+ *
+ * @package Formidable
+ *
+ * @var object $field_object Field object with 'id', 'type', 'form_id' properties.
+ * @var string $li_classes   Classes for the list item wrapper.
+ * @var array  $display      Display options; 'type' is used.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/automatic-width.php
+++ b/classes/views/frm-fields/back-end/automatic-width.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Automatic width setting for select-like fields.
+ *
+ * @package Formidable
+ *
+ * @var array $field Field data including 'id' and 'size'.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/bulk-options-overlay.php
+++ b/classes/views/frm-fields/back-end/bulk-options-overlay.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Bulk edit options modal.
+ *
+ * @package Formidable
+ *
+ * @var array<string, array> $prepop Preset options groups keyed by label; each may contain a 'class' key.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/default-value-field.php
+++ b/classes/views/frm-fields/back-end/default-value-field.php
@@ -4,10 +4,10 @@
  *
  * @package Formidable
  *
- * @var FrmFieldType $this          Field type handler that included this template.
- * @var array        $field         Field data including 'id' and 'field_key'.
- * @var string       $default_name  HTML name attribute for the input.
- * @var mixed        $default_value Current default value.
+ * @var FrmFieldType     $this          Field type handler that included this template.
+ * @var array            $field         Field data including 'id' and 'field_key'.
+ * @var string           $default_name  HTML name attribute for the input.
+ * @var int|float|string $default_value Current default value.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/views/frm-fields/back-end/default-value-field.php
+++ b/classes/views/frm-fields/back-end/default-value-field.php
@@ -4,9 +4,10 @@
  *
  * @package Formidable
  *
- * @var array  $field         Field data including 'id' and 'field_key'.
- * @var string $default_name  HTML name attribute for the input.
- * @var mixed  $default_value Current default value.
+ * @var FrmFieldType $this          Field type handler that included this template.
+ * @var array        $field         Field data including 'id' and 'field_key'.
+ * @var string       $default_name  HTML name attribute for the input.
+ * @var mixed        $default_value Current default value.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/views/frm-fields/back-end/default-value-field.php
+++ b/classes/views/frm-fields/back-end/default-value-field.php
@@ -7,7 +7,7 @@
  * @var FrmFieldType     $this          Field type handler that included this template.
  * @var array            $field         Field data including 'id' and 'field_key'.
  * @var string           $default_name  HTML name attribute for the input.
- * @var int|float|string $default_value Current default value.
+ * @var float|int|string $default_value Current default value.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/views/frm-fields/back-end/default-value-field.php
+++ b/classes/views/frm-fields/back-end/default-value-field.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Text input for the default value setting.
+ *
+ * @package Formidable
+ *
+ * @var array  $field         Field data including 'id' and 'field_key'.
+ * @var string $default_name  HTML name attribute for the input.
+ * @var mixed  $default_value Current default value.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/default-value-setting.php
+++ b/classes/views/frm-fields/back-end/default-value-setting.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Default value setting in the field settings.
+ *
+ * @package Formidable
+ *
+ * @var array        $field     Field data including 'id', 'default_value', 'dyn_default_value'.
+ * @var FrmFieldType $field_obj Field type handler.
+ * @var array        $display   Display options; may include 'default_value'.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/field-captcha.php
+++ b/classes/views/frm-fields/back-end/field-captcha.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * CAPTCHA field form builder view.
+ *
+ * @package Formidable
+ *
+ * @var string $field_name HTML name attribute for the hidden input.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/field-choices.php
+++ b/classes/views/frm-fields/back-end/field-choices.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Field choices wrapper in the form builder.
+ *
+ * @package Formidable
+ *
+ * @var array $args Arguments including 'field' (with 'post_field', 'id', 'taxonomy' keys).
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/field-choices.php
+++ b/classes/views/frm-fields/back-end/field-choices.php
@@ -4,7 +4,8 @@
  *
  * @package Formidable
  *
- * @var array $args Arguments including 'field' (with 'post_field', 'id', 'taxonomy' keys).
+ * @var FrmFieldType $this Field type handler that included this template.
+ * @var array        $args Arguments including 'field' (with 'post_field', 'id', 'taxonomy' keys).
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/views/frm-fields/back-end/field-credit-card.php
+++ b/classes/views/frm-fields/back-end/field-credit-card.php
@@ -4,7 +4,7 @@
  *
  * @package Formidable
  *
- * @var array|object $field Field data including 'form_id'.
+ * @var array $field Field data including 'form_id'.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/views/frm-fields/back-end/field-credit-card.php
+++ b/classes/views/frm-fields/back-end/field-credit-card.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Credit card field form builder view.
+ *
+ * @package Formidable
+ *
+ * @var array|object $field Field data including 'form_id'.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/field-description.php
+++ b/classes/views/frm-fields/back-end/field-description.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Field description setting in the form builder.
+ *
+ * @package Formidable
+ *
+ * @var array $field Field data including 'id' and 'description'.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/field-hidden.php
+++ b/classes/views/frm-fields/back-end/field-hidden.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Hidden field form builder view.
+ *
+ * @package Formidable
+ *
+ * @var string $html_id    HTML id attribute for the input.
+ * @var string $field_name HTML name attribute for the input.
+ * @var array  $field      Field data including 'default_value'.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/field-html.php
+++ b/classes/views/frm-fields/back-end/field-html.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * HTML field form builder view.
+ *
+ * @package Formidable
+ *
+ * @var array $field Field data including 'description'.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/field-options.php
+++ b/classes/views/frm-fields/back-end/field-options.php
@@ -31,6 +31,7 @@ $field_option_count = is_array( $args['field']['options'] ) ? count( $args['fiel
 			);
 			?>
 		</span>
+		<?php // skipcq: PHP-E1002 ?>
 		<span><?php echo esc_html( $this->get_bulk_edit_string() ); ?></span>
 	</a>
 </span>
@@ -38,7 +39,10 @@ $field_option_count = is_array( $args['field']['options'] ) ? count( $args['fiel
 <?php do_action( 'frm_add_multiple_opts_labels', $args['field'] ); ?>
 
 <ul id="frm_field_<?php echo esc_attr( $args['field']['id'] ); ?>_opts" class="frm_sortable_field_opts frm_clear<?php echo $field_option_count > 10 ? ' frm_field_opts_list' : ''; ?> frm_add_remove" data-key="<?php echo esc_attr( $args['field']['field_key'] ); ?>">
-	<?php $this->show_single_option( $args ); ?>
+	<?php
+	// skipcq: PHP-E1002
+	$this->show_single_option( $args );
+	?>
 </ul>
 
 <?php
@@ -48,6 +52,7 @@ if ( FrmAppHelper::pro_is_connected() && ! is_callable( array( 'FrmProHtmlHelper
 	<div class="frm6 frm_form_field frm_add_opt_container">
 		<a href="javascript:void(0);" data-opttype="single" class="frm-h-stack frm_cb_button frm_add_opt frm6 frm_form_field frm-add-option-legacy" id="frm_add_opt_<?php echo esc_attr( $args['field']['id'] ); ?>">
 			<span><?php FrmAppHelper::icon_by_class( 'frmfont frm_plus1_icon frm_add_tag frm_svg13' ); ?></span>
+			<?php // skipcq: PHP-E1002 ?>
 			<span><?php echo esc_html( $this->get_add_option_string() ); ?></span>
 		</a>
 	</div>

--- a/classes/views/frm-fields/back-end/field-options.php
+++ b/classes/views/frm-fields/back-end/field-options.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Field options settings in the form builder.
+ *
+ * @package Formidable
+ *
+ * @var array $args                  Arguments including 'field' and 'field_obj'.
+ * @var bool  $should_hide_bulk_edit Whether to hide the bulk edit link.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/field-options.php
+++ b/classes/views/frm-fields/back-end/field-options.php
@@ -31,8 +31,12 @@ $field_option_count = is_array( $args['field']['options'] ) ? count( $args['fiel
 			);
 			?>
 		</span>
-		<?php // skipcq: PHP-E1002 ?>
-		<span><?php echo esc_html( $this->get_bulk_edit_string() ); ?></span>
+		<span>
+			<?php
+			// skipcq: PHP-E1002
+			echo esc_html( $this->get_bulk_edit_string() );
+			?>
+		</span>
 	</a>
 </span>
 
@@ -52,8 +56,12 @@ if ( FrmAppHelper::pro_is_connected() && ! is_callable( array( 'FrmProHtmlHelper
 	<div class="frm6 frm_form_field frm_add_opt_container">
 		<a href="javascript:void(0);" data-opttype="single" class="frm-h-stack frm_cb_button frm_add_opt frm6 frm_form_field frm-add-option-legacy" id="frm_add_opt_<?php echo esc_attr( $args['field']['id'] ); ?>">
 			<span><?php FrmAppHelper::icon_by_class( 'frmfont frm_plus1_icon frm_add_tag frm_svg13' ); ?></span>
-			<?php // skipcq: PHP-E1002 ?>
-			<span><?php echo esc_html( $this->get_add_option_string() ); ?></span>
+			<span>
+				<?php
+				// skipcq: PHP-E1002
+				echo esc_html( $this->get_add_option_string() );
+				?>
+			</span>
 		</a>
 	</div>
 <?php } ?>

--- a/classes/views/frm-fields/back-end/field-options.php
+++ b/classes/views/frm-fields/back-end/field-options.php
@@ -4,8 +4,10 @@
  *
  * @package Formidable
  *
- * @var array $args                  Arguments including 'field' and 'field_obj'.
- * @var bool  $should_hide_bulk_edit Whether to hide the bulk edit link.
+ * @var FrmFieldType $this                  Field type handler that included this template.
+ * @var array        $args                  Arguments including 'field' and 'field_obj'.
+ * @var bool         $should_hide_bulk_edit Whether to hide the bulk edit link.
+ * @var string       $option_title          Title attribute for the bulk edit link.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/views/frm-fields/back-end/field-total.php
+++ b/classes/views/frm-fields/back-end/field-total.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Total field form builder view.
+ *
+ * @package Formidable
+ *
+ * @var string $html_id    HTML id attribute for the hidden input.
+ * @var string $field_name HTML name attribute for the hidden input.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/field-total.php
+++ b/classes/views/frm-fields/back-end/field-total.php
@@ -4,8 +4,9 @@
  *
  * @package Formidable
  *
- * @var string $html_id    HTML id attribute for the hidden input.
- * @var string $field_name HTML name attribute for the hidden input.
+ * @var FrmFieldTotal $this       Field type handler that included this template.
+ * @var string       $html_id    HTML id attribute for the hidden input.
+ * @var string       $field_name HTML name attribute for the hidden input.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/views/frm-fields/back-end/field-user-id.php
+++ b/classes/views/frm-fields/back-end/field-user-id.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * User ID field form builder view.
+ *
+ * @package Formidable
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/generate-options-with-ai.php
+++ b/classes/views/frm-fields/back-end/generate-options-with-ai.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Generate options with AI button.
+ *
+ * @package Formidable
+ *
+ * @var array $args       Arguments including 'button_text' and 'show_pill'.
+ * @var array $attributes HTML attributes for the button.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/html-content.php
+++ b/classes/views/frm-fields/back-end/html-content.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * HTML content editor for HTML fields.
+ *
+ * @package Formidable
+ *
+ * @var array $field Field data including 'id' and 'description'.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/inline-modal.php
+++ b/classes/views/frm-fields/back-end/inline-modal.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Inline modal wrapper used inside field settings.
+ *
+ * @package Formidable
+ *
+ * @var array $args Modal arguments: dismiss-icon (bool), show (bool), class (string), id (string), title (string), inside_class (string), callback (callable), args (mixed).
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/input-mask-info.php
+++ b/classes/views/frm-fields/back-end/input-mask-info.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Input mask info panel content.
+ *
+ * @package Formidable
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/layout-classes.php
+++ b/classes/views/frm-fields/back-end/layout-classes.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * CSS layout classes modal content.
+ *
+ * @package Formidable
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/max.php
+++ b/classes/views/frm-fields/back-end/max.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Max characters / rows setting in field settings.
+ *
+ * @package Formidable
+ *
+ * @var array $field                        Field data including 'id', 'type', 'max'.
+ * @var bool  $can_fit_label_in_two_columns Whether the label is short enough for a two-column layout.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/number-range.php
+++ b/classes/views/frm-fields/back-end/number-range.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Number range setting.
+ *
+ * @package Formidable
+ *
+ * @var array $field Field data including 'id', 'field_key', 'minnum', 'maxnum', 'step'.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/pixels-wide.php
+++ b/classes/views/frm-fields/back-end/pixels-wide.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Field size (pixels wide) setting in field settings.
+ *
+ * @package Formidable
+ *
+ * @var array $field       Field data including 'id' and 'size'.
+ * @var bool  $display_max Whether to include the Max Characters input.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/product-options.php
+++ b/classes/views/frm-fields/back-end/product-options.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Product type setting for product fields.
+ *
+ * @package Formidable
+ *
+ * @var array                $field      Field data including 'id' and 'data_type'.
+ * @var array<string, string> $data_types Product type options keyed by type slug.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/product-single-option.php
+++ b/classes/views/frm-fields/back-end/product-single-option.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * Single product option row in field settings.
+ *
+ * @package Formidable
+ *
+ * @var array  $field         Field data including 'id' and 'separate_value'.
+ * @var string $opt_key       Option key.
+ * @var string $opt           Option label.
+ * @var string $field_val     Saved value for the option.
+ * @var string $html_id       HTML id prefix for the row.
+ * @var string $field_name    HTML name attribute for the input.
+ * @var string $default_type  Input type (radio/checkbox).
+ * @var bool   $checked       Whether the option is checked.
+ * @var string $price         Product price for the option.
+ * @var int    $options_count Total number of options.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/quantity-options.php
+++ b/classes/views/frm-fields/back-end/quantity-options.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Quantity field product association setting.
+ *
+ * @package Formidable
+ *
+ * @var array $field Field data including 'id' and 'product_field'.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/radio-field.php
+++ b/classes/views/frm-fields/back-end/radio-field.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Radio field front-end input.
+ *
+ * @package Formidable
+ *
+ * @var array  $field      Field data including 'post_field', 'type', 'options', 'value'.
+ * @var string $field_name HTML name attribute for the radio inputs.
+ * @var string $html_id    HTML id prefix for each radio option.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/settings.php
+++ b/classes/views/frm-fields/back-end/settings.php
@@ -106,7 +106,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php if ( $display['label'] ) { ?>
 		<p class="frm-mt-xs">
 			<label for="frm_name_<?php echo esc_attr( $field['id'] ); ?>">
-				<?php echo esc_html( apply_filters( 'frm_builder_field_label', __( 'Field Label', 'formidable' ), $field ) ); // skipcq: PHP-W1020 ?>
+				<?php
+				// Skipcq: PHP-W1020
+				echo esc_html( apply_filters( 'frm_builder_field_label', __( 'Field Label', 'formidable' ), $field ) );
+				?>
 			</label>
 			<input type="text" name="field_options[name_<?php echo esc_attr( $field['id'] ); ?>]" value="<?php echo esc_attr( $field['name'] ); ?>" id="frm_name_<?php echo esc_attr( $field['id'] ); ?>" data-changeme="field_label_<?php echo esc_attr( $field['id'] ); ?>" />
 		</p>

--- a/classes/views/frm-fields/back-end/settings.php
+++ b/classes/views/frm-fields/back-end/settings.php
@@ -1,4 +1,26 @@
 <?php
+/**
+ * Field settings panel in the form builder.
+ *
+ * @package Formidable
+ *
+ * @var array        $field               Field data.
+ * @var array        $display             Display options for each setting section.
+ * @var array        $values              Form values associated with the field.
+ * @var FrmFieldType $field_obj           Field type handler.
+ * @var string       $type_name           Human-readable field type name.
+ * @var array        $field_types         Available field types this field can switch to.
+ * @var array        $disabled_fields     Field types that are disabled in the type dropdown.
+ * @var array        $default_value_types Default value types available for this field.
+ * @var array        $unique_values_label_atts     Label attributes for the Unique checkbox.
+ * @var array        $read_only_label_atts         Label attributes for the Read Only checkbox.
+ * @var bool         $show_upsell_for_unique_value Whether to show upsell for Unique.
+ * @var bool         $show_upsell_for_read_only    Whether to show upsell for Read Only.
+ * @var bool         $show_upsell_for_before_after_contents Whether to show upsell for before/after contents.
+ * @var bool         $show_upsell_for_autocomplete Whether to show upsell for autocomplete.
+ * @var bool         $show_upsell_for_visibility   Whether to show upsell for visibility.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/settings.php
+++ b/classes/views/frm-fields/back-end/settings.php
@@ -14,11 +14,11 @@
  * @var array        $default_value_types Default value types available for this field.
  * @var array        $unique_values_label_atts     Label attributes for the Unique checkbox.
  * @var array        $read_only_label_atts         Label attributes for the Read Only checkbox.
- * @var bool         $show_upsell_for_unique_value Whether to show upsell for Unique.
- * @var bool         $show_upsell_for_read_only    Whether to show upsell for Read Only.
- * @var bool         $show_upsell_for_before_after_contents Whether to show upsell for before/after contents.
- * @var bool         $show_upsell_for_autocomplete Whether to show upsell for autocomplete.
- * @var bool         $show_upsell_for_visibility   Whether to show upsell for visibility.
+ * @var bool|null    $show_upsell_for_unique_value Whether to show upsell for Unique.
+ * @var bool|null    $show_upsell_for_read_only    Whether to show upsell for Read Only.
+ * @var bool|null    $show_upsell_for_before_after_contents Whether to show upsell for before/after contents.
+ * @var bool|null    $show_upsell_for_autocomplete Whether to show upsell for autocomplete.
+ * @var bool|null    $show_upsell_for_visibility   Whether to show upsell for visibility.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/views/frm-fields/back-end/settings.php
+++ b/classes/views/frm-fields/back-end/settings.php
@@ -106,7 +106,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php if ( $display['label'] ) { ?>
 		<p class="frm-mt-xs">
 			<label for="frm_name_<?php echo esc_attr( $field['id'] ); ?>">
-				<?php echo esc_html( apply_filters( 'frm_builder_field_label', __( 'Field Label', 'formidable' ), $field ) ); ?>
+				<?php echo esc_html( apply_filters( 'frm_builder_field_label', __( 'Field Label', 'formidable' ), $field ) ); // skipcq: PHP-W1020 ?>
 			</label>
 			<input type="text" name="field_options[name_<?php echo esc_attr( $field['id'] ); ?>]" value="<?php echo esc_attr( $field['name'] ); ?>" id="frm_name_<?php echo esc_attr( $field['id'] ); ?>" data-changeme="field_label_<?php echo esc_attr( $field['id'] ); ?>" />
 		</p>
@@ -486,7 +486,7 @@ do_action( 'frm_before_field_options', $field, compact( 'field_obj', 'display', 
 						}
 
 						FrmHtmlHelper::echo_dropdown_option(
-							is_array( $ftype ) ? $ftype['name'] : $ftyp,
+							is_array( $ftype ) ? $ftype['name'] : $ftype,
 							$fkey === $field['type'],
 							$type_option_params
 						);

--- a/classes/views/frm-fields/back-end/settings.php
+++ b/classes/views/frm-fields/back-end/settings.php
@@ -107,7 +107,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<p class="frm-mt-xs">
 			<label for="frm_name_<?php echo esc_attr( $field['id'] ); ?>">
 				<?php
-				// Skipcq: PHP-W1020
+				// skipcq: PHP-W1020
 				echo esc_html( apply_filters( 'frm_builder_field_label', __( 'Field Label', 'formidable' ), $field ) );
 				?>
 			</label>

--- a/classes/views/frm-fields/back-end/smart-values.php
+++ b/classes/views/frm-fields/back-end/smart-values.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Smart values upsell panel.
+ *
+ * @package Formidable
+ *
+ * @var array|string $upgrade_link Arguments or URL used to build the upgrade link.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/textarea-default-value-field.php
+++ b/classes/views/frm-fields/back-end/textarea-default-value-field.php
@@ -6,7 +6,7 @@
  *
  * @var array            $field         Field data including 'id' and 'field_key'.
  * @var string           $default_name  HTML name attribute for the textarea.
- * @var int|float|string $default_value Current default value.
+ * @var float|int|string $default_value Current default value.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/views/frm-fields/back-end/textarea-default-value-field.php
+++ b/classes/views/frm-fields/back-end/textarea-default-value-field.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Textarea input for the default value setting.
+ *
+ * @package Formidable
+ *
+ * @var array  $field         Field data including 'id' and 'field_key'.
+ * @var string $default_name  HTML name attribute for the textarea.
+ * @var mixed  $default_value Current default value.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/back-end/textarea-default-value-field.php
+++ b/classes/views/frm-fields/back-end/textarea-default-value-field.php
@@ -4,9 +4,9 @@
  *
  * @package Formidable
  *
- * @var array  $field         Field data including 'id' and 'field_key'.
- * @var string $default_name  HTML name attribute for the textarea.
- * @var mixed  $default_value Current default value.
+ * @var array            $field         Field data including 'id' and 'field_key'.
+ * @var string           $default_name  HTML name attribute for the textarea.
+ * @var int|float|string $default_value Current default value.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/views/frm-fields/back-end/upsell/ai-upsell-button.php
+++ b/classes/views/frm-fields/back-end/upsell/ai-upsell-button.php
@@ -1,10 +1,15 @@
 <?php
+/**
+ * AI generate options upsell button.
+ *
+ * @package Formidable
+ *
+ * @since x.x
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
-/**
- * @since x.x
- */
 FrmFieldsHelper::render_ai_generate_options_button(
 	array(
 		'show_pill'    => true,

--- a/classes/views/frm-fields/back-end/upsell/ai-upsell-button.php
+++ b/classes/views/frm-fields/back-end/upsell/ai-upsell-button.php
@@ -10,6 +10,7 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }
+
 FrmFieldsHelper::render_ai_generate_options_button(
 	array(
 		'show_pill'    => true,

--- a/classes/views/frm-fields/back-end/value-format.php
+++ b/classes/views/frm-fields/back-end/value-format.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Value format setting.
+ *
+ * @package Formidable
+ *
+ * @var array $field      Field data including 'id' and 'format'.
+ * @var array $attributes HTML attributes for the wrapping paragraph.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/classes/views/frm-fields/single-option.php
+++ b/classes/views/frm-fields/single-option.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Single option row in field settings.
+ *
+ * @package Formidable
+ *
+ * @var array  $field         Field data including 'id', 'separate_value', 'do_not_include_icons'.
+ * @var string $opt_key       Option key.
+ * @var string $opt           Option label.
+ * @var string $field_val     Saved value for the option.
+ * @var string $html_id       HTML id prefix for the row.
+ * @var string $field_name    HTML name attribute for the input.
+ * @var string $default_type  Input type (radio/checkbox/text).
+ * @var bool   $checked       Whether the option is checked.
+ * @var int    $options_count Total number of options.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'You are not allowed to call this page directly.' );
 }

--- a/composer.json
+++ b/composer.json
@@ -41,13 +41,15 @@
 		"friendsofphp/php-cs-fixer": "^3.54",
 		"rector/rector": "^2.3.4",
 		"phpstan/phpstan-strict-rules": "^2.0",
-		"kubawerlos/php-cs-fixer-custom-fixers": "^3.36"
+		"kubawerlos/php-cs-fixer-custom-fixers": "^3.36",
+		"carthage-software/mago": "^1.23"
 	},
 	"config": {
 		"allow-plugins": {
 			"composer/installers": true,
 			"phpstan/extension-installer": true,
-			"dealerdirect/phpcodesniffer-composer-installer": true
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"carthage-software/mago": true
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -41,15 +41,13 @@
 		"friendsofphp/php-cs-fixer": "^3.54",
 		"rector/rector": "^2.3.4",
 		"phpstan/phpstan-strict-rules": "^2.0",
-		"kubawerlos/php-cs-fixer-custom-fixers": "^3.36",
-		"carthage-software/mago": "^1.23"
+		"kubawerlos/php-cs-fixer-custom-fixers": "^3.36"
 	},
 	"config": {
 		"allow-plugins": {
 			"composer/installers": true,
 			"phpstan/extension-installer": true,
-			"dealerdirect/phpcodesniffer-composer-installer": true,
-			"carthage-software/mago": true
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	}
 }

--- a/js/src/admin/admin.js
+++ b/js/src/admin/admin.js
@@ -8084,15 +8084,15 @@ window.frmAdminBuildJS = function() {
 		/*jshint validthis:true */
 		const postField = jQuery( 'select.frm_single_post_field' );
 		postField.css( 'border-color', '' );
-		const $t = this;
-		const v = jQuery( $t ).val();
-		if ( v === '' || v === 'checkbox' ) {
+		const currentField = this;
+		const selectedValue = jQuery( currentField ).val();
+		if ( selectedValue === '' || selectedValue === 'checkbox' ) {
 			return false;
 		}
 		postField.each( function() {
-			if ( jQuery( this ).val() === v && this.name !== $t.name ) {
+			if ( jQuery( this ).val() === selectedValue && this.name !== currentField.name ) {
 				this.style.borderColor = 'red';
-				jQuery( $t ).val( '' );
+				jQuery( currentField ).val( '' );
 				infoModal( frmAdminJs.field_already_used );
 				return false;
 			}
@@ -8101,11 +8101,11 @@ window.frmAdminBuildJS = function() {
 
 	function togglePostContent() {
 		/*jshint validthis:true */
-		const v = jQuery( this ).val();
-		if ( '' === v ) {
+		const selectedValue = jQuery( this ).val();
+		if ( '' === selectedValue ) {
 			jQuery( '.frm_post_content_opt, select.frm_dyncontent_opt' ).hide().val( '' );
 			jQuery( '.frm_dyncontent_opt' ).hide();
-		} else if ( 'post_content' === v ) {
+		} else if ( 'post_content' === selectedValue ) {
 			jQuery( '.frm_post_content_opt' ).show();
 			jQuery( '.frm_dyncontent_opt' ).hide();
 			jQuery( 'select.frm_dyncontent_opt' ).val( '' );
@@ -8117,15 +8117,15 @@ window.frmAdminBuildJS = function() {
 
 	function fillDyncontent() {
 		/*jshint validthis:true */
-		const v = jQuery( this ).val();
+		const selectedValue = jQuery( this ).val();
 		const $dyn = jQuery( document.getElementById( 'frm_dyncontent' ) );
-		if ( '' === v || 'new' === v ) {
+		if ( '' === selectedValue || 'new' === selectedValue ) {
 			$dyn.val( '' );
 			jQuery( '.frm_dyncontent_opt' ).show();
 		} else {
 			jQuery.ajax( {
 				type: 'POST', url: ajaxurl,
-				data: { action: 'frm_display_get_content', id: v, nonce: frmGlobal.nonce },
+				data: { action: 'frm_display_get_content', id: selectedValue, nonce: frmGlobal.nonce },
 				success( val ) {
 					$dyn.val( val );
 					jQuery( '.frm_dyncontent_opt' ).show();
@@ -8436,24 +8436,24 @@ window.frmAdminBuildJS = function() {
 		}
 
 		if ( variable === '[default-html]' || variable === '[default-plain]' ) {
-			let p = 0;
+			let plainText = 0;
 			if ( variable === '[default-plain]' ) {
-				p = 1;
+				plainText = 1;
 			}
 			jQuery.ajax( {
 				type: 'POST', url: ajaxurl,
 				data: {
 					action: 'frm_get_default_html',
 					form_id: jQuery( 'input[name="id"]' ).val(),
-					plain_text: p,
+					plain_text: plainText,
 					nonce: frmGlobal.nonce
 				},
 				elementId,
 				success( msg ) {
 					if ( rich ) {
-						const p = document.createElement( 'p' );
-						p.innerText = msg;
-						send_to_editor( p.innerHTML );
+						const paragraph = document.createElement( 'p' );
+						paragraph.innerText = msg;
+						send_to_editor( paragraph.innerHTML );
 					} else {
 						insertContent( contentBox, msg );
 					}
@@ -8494,13 +8494,13 @@ window.frmAdminBuildJS = function() {
 			document.selection.createRange().text = variable;
 		} else {
 			const obj = contentBox[ 0 ];
-			const e = obj.selectionEnd;
+			const selectionEnd = obj.selectionEnd;
 
-			variable = maybeFormatInsertedContent( contentBox, variable, obj.selectionStart, e );
+			variable = maybeFormatInsertedContent( contentBox, variable, obj.selectionStart, selectionEnd );
 
 			obj.value = obj.value.substr( 0, obj.selectionStart ) + variable + obj.value.substr( obj.selectionEnd, obj.value.length );
 
-			const cursorPos = e + variable.length;
+			const cursorPos = selectionEnd + variable.length;
 
 			maybeRemoveLayoutClasses( obj, variable );
 

--- a/js/src/admin/admin.js
+++ b/js/src/admin/admin.js
@@ -819,7 +819,7 @@ window.frmAdminBuildJS = function() {
 	function clickNewTab() {
 		/*jshint validthis:true */
 		const href = this.getAttribute( 'href' );
-		if ( href === undefined ) {
+		if ( href === null ) {
 			return false;
 		}
 

--- a/js/src/admin/admin.js
+++ b/js/src/admin/admin.js
@@ -7598,7 +7598,7 @@ window.frmAdminBuildJS = function() {
 	 *
 	 * @since x.x
 	 *
-	 * @param {string} baseTitle The base title without any numeric suffix.
+	 * @param {string}   baseTitle      The base title without any numeric suffix.
 	 * @param {string[]} existingTitles Titles currently in use.
 	 * @return {string} The first title not present in existingTitles.
 	 */

--- a/js/src/admin/admin.js
+++ b/js/src/admin/admin.js
@@ -7482,8 +7482,8 @@ window.frmAdminBuildJS = function() {
 		const actionType = targetSettings.querySelector( '.frm_action_name' )?.value;
 		const sourceTitle = targetSettings.querySelector( '.widget-title h4 span:not(.frm-border-icon)' )?.textContent.trim() ?? '';
 		const uniqueTitle = getUniqueActionTitle( sourceTitle.replace( / \(\d+\)$/, '' ), getExistingActionTitles( actionType ) );
-		$action[0].querySelector( '.widget-title h4 span:not(.frm-border-icon)' ).textContent = uniqueTitle;
-		$action[0].querySelector( `input[name$="[${ currentID }][post_title]"]` ).value = uniqueTitle;
+		$action[ 0 ].querySelector( '.widget-title h4 span:not(.frm-border-icon)' ).textContent = uniqueTitle;
+		$action[ 0 ].querySelector( `input[name$="[${ currentID }][post_title]"]` ).value = uniqueTitle;
 
 		$action.find( '.frm_action_id, .frm-btn-group' ).remove();
 		$action.find( `input[name$="[${ currentID }][ID]"]` ).val( '' );
@@ -7589,7 +7589,7 @@ window.frmAdminBuildJS = function() {
 	function getExistingActionTitles( actionType ) {
 		return Array.from(
 			document.querySelectorAll( `.frm_single_${ actionType }_settings .widget-title h4 span:not(.frm-border-icon)` ),
-			( el ) => el.textContent.trim()
+			el => el.textContent.trim()
 		);
 	}
 
@@ -7598,15 +7598,17 @@ window.frmAdminBuildJS = function() {
 	 *
 	 * @since x.x
 	 *
-	 * @param {string}   baseTitle       The base title without any numeric suffix.
-	 * @param {string[]} existingTitles  Titles currently in use.
-	 * @return {string}
+	 * @param {string} baseTitle The base title without any numeric suffix.
+	 * @param {string[]} existingTitles Titles currently in use.
+	 * @return {string} The first title not present in existingTitles.
 	 */
 	function getUniqueActionTitle( baseTitle, existingTitles ) {
 		const taken = new Set( existingTitles );
 		let title = baseTitle;
-		for ( let n = 2; taken.has( title ); n++ ) {
+		let n = 2;
+		while ( taken.has( title ) ) {
 			title = `${ baseTitle } (${ n })`;
+			n++;
 		}
 		return title;
 	}

--- a/js/src/admin/admin.js
+++ b/js/src/admin/admin.js
@@ -818,18 +818,18 @@ window.frmAdminBuildJS = function() {
 
 	function clickNewTab() {
 		/*jshint validthis:true */
-		const t = this.getAttribute( 'href' );
-		if ( t === undefined ) {
+		const href = this.getAttribute( 'href' );
+		if ( href === undefined ) {
 			return false;
 		}
 
-		const c = t.replace( '#', '.' );
+		const classSelector = href.replace( '#', '.' );
 		const $link = jQuery( this );
 
 		$link.closest( 'li' ).addClass( 'frm-tabs active' ).siblings( 'li' ).removeClass( 'frm-tabs active starttab' );
-		$link.closest( 'div' ).children( '.tabs-panel' ).not( t ).not( c ).hide();
+		$link.closest( 'div' ).children( '.tabs-panel' ).not( href ).not( classSelector ).hide();
 
-		const tabContent = document.getElementById( t.replace( '#', '' ) );
+		const tabContent = document.getElementById( href.replace( '#', '' ) );
 		if ( tabContent ) {
 			tabContent.style.display = 'block';
 		}
@@ -843,28 +843,28 @@ window.frmAdminBuildJS = function() {
 
 	function clickTab( link, auto ) {
 		link = jQuery( link );
-		const t = link.attr( 'href' );
-		if ( t === undefined ) {
+		const href = link.attr( 'href' );
+		if ( href === undefined ) {
 			return;
 		}
 
-		const classSelector = t.replace( '#', '.' );
+		const classSelector = href.replace( '#', '.' );
 
 		link.closest( 'li' ).addClass( 'frm-tabs active' ).siblings( 'li' ).removeClass( 'frm-tabs active starttab' );
 		if ( link.closest( 'div' ).find( '.tabs-panel' ).length ) {
-			link.closest( 'div' ).children( '.tabs-panel' ).not( t ).not( classSelector ).hide();
+			link.closest( 'div' ).children( '.tabs-panel' ).not( href ).not( classSelector ).hide();
 		} else if ( document.getElementById( 'form_global_settings' ) !== null ) {
 			/* global settings */
 			const ajax = link.data( 'frmajax' );
 			link.closest( '.frm_wrap' ).find( '.tabs-panel, .hide_with_tabs' ).hide();
 			if ( ajax !== undefined && ajax == '1' ) {
-				loadSettingsTab( t );
+				loadSettingsTab( href );
 			}
 		} else {
 			/* form settings page */
 			jQuery( '#frm-categorydiv .tabs-panel, .hide_with_tabs' ).hide();
 		}
-		jQuery( t ).show();
+		jQuery( href ).show();
 		jQuery( classSelector ).show();
 
 		hideShortcodes();
@@ -880,9 +880,9 @@ window.frmAdminBuildJS = function() {
 		}
 
 		if ( jQuery( '.frm_form_settings' ).length ) {
-			jQuery( '.frm_form_settings' ).attr( 'action', `?page=formidable&frm_action=settings&id=${ jQuery( '.frm_form_settings input[name="id"]' ).val() }&t=${ t.replace( '#', '' ) }` );
+			jQuery( '.frm_form_settings' ).attr( 'action', `?page=formidable&frm_action=settings&id=${ jQuery( '.frm_form_settings input[name="id"]' ).val() }&t=${ href.replace( '#', '' ) }` );
 		} else {
-			jQuery( '.frm_settings_form' ).attr( 'action', `?page=formidable-settings&t=${ t.replace( '#', '' ) }` );
+			jQuery( '.frm_settings_form' ).attr( 'action', `?page=formidable-settings&t=${ href.replace( '#', '' ) }` );
 		}
 	}
 
@@ -2234,7 +2234,7 @@ window.frmAdminBuildJS = function() {
 
 		html = JSON.parse( html );
 		for ( key in html ) {
-			if ( ! Object.prototype.hasOwnProperty.call( html, key ) ) {
+			if ( ! Object.hasOwn( html, key ) ) {
 				continue;
 			}
 			jQuery( `#frm_field_id_${ key }` ).replaceWith( html[ key ] );

--- a/js/src/admin/admin.js
+++ b/js/src/admin/admin.js
@@ -8500,12 +8500,12 @@ window.frmAdminBuildJS = function() {
 
 			obj.value = obj.value.substr( 0, obj.selectionStart ) + variable + obj.value.substr( obj.selectionEnd, obj.value.length );
 
-			const s = e + variable.length;
+			const cursorPos = e + variable.length;
 
 			maybeRemoveLayoutClasses( obj, variable );
 
 			obj.focus();
-			obj.setSelectionRange( s, s );
+			obj.setSelectionRange( cursorPos, cursorPos );
 		}
 		triggerChange( contentBox );
 	}
@@ -9257,21 +9257,21 @@ window.frmAdminBuildJS = function() {
 		/*jshint validthis:true */
 		e.preventDefault();
 
-		let s = false;
+		let status = false;
 		const $exportForms = jQuery( 'input[name="frm_export_forms[]"]' );
 
 		if ( ! jQuery( 'input[name="frm_export_forms[]"]:checked' ).val() ) {
 			$exportForms.closest( '.frm-table-box' ).addClass( 'frm_blank_field' );
-			s = 'stop';
+			status = 'stop';
 		}
 
 		const $exportType = jQuery( 'input[name="type[]"]' );
 		if ( ! jQuery( 'input[name="type[]"]:checked' ).val() && $exportType.attr( 'type' ) === 'checkbox' ) {
 			$exportType.closest( 'p' ).addClass( 'frm_blank_field' );
-			s = 'stop';
+			status = 'stop';
 		}
 
-		if ( s === 'stop' ) {
+		if ( status === 'stop' ) {
 			return false;
 		}
 
@@ -9281,24 +9281,24 @@ window.frmAdminBuildJS = function() {
 
 	function removeExportError() {
 		/*jshint validthis:true */
-		const t = jQuery( this ).closest( '.frm_blank_field' );
-		if ( t === undefined ) {
+		const $blankField = jQuery( this ).closest( '.frm_blank_field' );
+		if ( $blankField === undefined ) {
 			return;
 		}
 
 		const $thisName = this.name;
 		if ( $thisName === 'type[]' && jQuery( 'input[name="type[]"]:checked' ).val() ) {
-			t.removeClass( 'frm_blank_field' );
+			$blankField.removeClass( 'frm_blank_field' );
 		} else if ( $thisName === 'frm_export_forms[]' && jQuery( this ).val() ) {
-			t.removeClass( 'frm_blank_field' );
+			$blankField.removeClass( 'frm_blank_field' );
 		}
 	}
 
 	function checkCSVExtension() {
 		/*jshint validthis:true */
-		const f = jQuery( this ).val();
+		const fileName = jQuery( this ).val();
 		const re = /\.csv$/i;
-		if ( f.match( re ) !== null ) {
+		if ( fileName.match( re ) !== null ) {
 			jQuery( '.show_csv' ).fadeIn();
 		} else {
 			jQuery( '.show_csv' ).fadeOut();
@@ -9334,12 +9334,12 @@ window.frmAdminBuildJS = function() {
 		/*jshint validthis:true */
 		const $dropdown = jQuery( this );
 		const $selected = $dropdown.find( ':selected' );
-		const s = $selected.data( 'support' );
+		const support = $selected.data( 'support' );
 
-		const multiple = s.indexOf( '|' );
+		const multiple = support.indexOf( '|' );
 		jQuery( 'input[name="type[]"]' ).each( function() {
 			this.checked = false;
-			if ( s.includes( this.value ) ) {
+			if ( support.includes( this.value ) ) {
 				this.disabled = false;
 				if ( multiple === -1 ) {
 					this.checked = true;
@@ -9357,9 +9357,9 @@ window.frmAdminBuildJS = function() {
 			jQuery( '.xml_opts' ).show();
 		}
 
-		const c = $selected.data( 'count' );
+		const count = $selected.data( 'count' );
 		const exportField = jQuery( 'input[name="frm_export_forms[]"]' );
-		if ( c === 'single' ) {
+		if ( count === 'single' ) {
 			exportField.prop( 'multiple', false );
 			exportField.prop( 'checked', false );
 		} else {
@@ -9770,9 +9770,9 @@ window.frmAdminBuildJS = function() {
 
 	function removeWPUnload() {
 		window.onbeforeunload = null;
-		const w = jQuery( window );
-		w.off( 'beforeunload.widgets' );
-		w.off( 'beforeunload.edit-post' );
+		const $window = jQuery( window );
+		$window.off( 'beforeunload.widgets' );
+		$window.off( 'beforeunload.edit-post' );
 	}
 
 	function addMultiselectLabelListener() {
@@ -10446,9 +10446,9 @@ window.frmAdminBuildJS = function() {
 
 			// Bootstrap dropdown button
 			jQuery( '.wp-admin' ).on( 'click', function( e ) {
-				const t = jQuery( e.target );
+				const $target = jQuery( e.target );
 				const $openDrop = jQuery( '.dropdown.open' );
-				if ( $openDrop.length && ! t.hasClass( 'dropdown' ) && ! t.closest( '.dropdown' ).length ) {
+				if ( $openDrop.length && ! $target.hasClass( 'dropdown' ) && ! $target.closest( '.dropdown' ).length ) {
 					$openDrop.removeClass( 'open' );
 				}
 			} );

--- a/js/src/admin/admin.js
+++ b/js/src/admin/admin.js
@@ -848,11 +848,11 @@ window.frmAdminBuildJS = function() {
 			return;
 		}
 
-		const c = t.replace( '#', '.' );
+		const classSelector = t.replace( '#', '.' );
 
 		link.closest( 'li' ).addClass( 'frm-tabs active' ).siblings( 'li' ).removeClass( 'frm-tabs active starttab' );
 		if ( link.closest( 'div' ).find( '.tabs-panel' ).length ) {
-			link.closest( 'div' ).children( '.tabs-panel' ).not( t ).not( c ).hide();
+			link.closest( 'div' ).children( '.tabs-panel' ).not( t ).not( classSelector ).hide();
 		} else if ( document.getElementById( 'form_global_settings' ) !== null ) {
 			/* global settings */
 			const ajax = link.data( 'frmajax' );
@@ -865,7 +865,7 @@ window.frmAdminBuildJS = function() {
 			jQuery( '#frm-categorydiv .tabs-panel, .hide_with_tabs' ).hide();
 		}
 		jQuery( t ).show();
-		jQuery( c ).show();
+		jQuery( classSelector ).show();
 
 		hideShortcodes();
 
@@ -1075,18 +1075,18 @@ window.frmAdminBuildJS = function() {
 		$postBodyContent.scrollTop(
 			( _, v ) => {
 				const moved = event.clientY;
-				const h = postBodyContent.offsetHeight;
+				const contentHeight = postBodyContent.offsetHeight;
 				const relativePos = event.clientY - postBodyContent.offsetTop;
-				const y = relativePos - ( h / 2 );
+				const offsetFromCenter = relativePos - ( contentHeight / 2 );
 
-				if ( relativePos > ( h - 50 ) && moved > 5 ) {
+				if ( relativePos > ( contentHeight - 50 ) && moved > 5 ) {
 					// Scrolling down.
-					return v + ( y * 0.1 );
+					return v + ( offsetFromCenter * 0.1 );
 				}
 
 				if ( relativePos < 70 && moved < 130 ) {
 					// Scrolling up.
-					return v - Math.abs( y * 0.1 );
+					return v - Math.abs( offsetFromCenter * 0.1 );
 				}
 
 				return v;
@@ -1974,7 +1974,7 @@ window.frmAdminBuildJS = function() {
 		}
 
 		const isSubmitBtn = draggable.classList.contains( 'edit_field_type_submit' );
-		const containSubmitBtn = ! draggable.classList.contains( 'form_field' ) && !! draggable.querySelector( '.edit_field_type_submit' );
+		const containSubmitBtn = ! draggable.classList.contains( 'form_field' ) && Boolean( draggable.querySelector( '.edit_field_type_submit' ) );
 
 		if ( 'frm-show-fields' === droppable.id ) {
 			const draggableIndex = determineIndexBasedOffOfMousePositionInList( jQuery( droppable ), event.clientY );
@@ -2058,7 +2058,7 @@ window.frmAdminBuildJS = function() {
 	 * @return {boolean} True if the element is the last row.
 	 */
 	function isLastRow( element ) {
-		return element && element.matches( '#frm-show-fields > li:last-child' );
+		return element?.matches( '#frm-show-fields > li:last-child' );
 	}
 
 	// Don't allow a new page break or hidden field in a field group.
@@ -2142,13 +2142,9 @@ window.frmAdminBuildJS = function() {
 			return false;
 		}
 
+		// Do not allow a section inside of a section.
 		const draggableIncludesSection = draggable.classList.contains( 'edit_field_type_divider' ) || draggable.querySelector( '.edit_field_type_divider' );
-		if ( draggableIncludesSection ) {
-			// Do not allow a section inside of a section.
-			return false;
-		}
-
-		return true;
+		return ! draggableIncludesSection;
 	}
 
 	function allowMoveFieldToGroup( draggable, group ) {
@@ -2163,15 +2159,11 @@ window.frmAdminBuildJS = function() {
 			return false;
 		}
 
+		// Do not allow a section or an embed field inside of a section.
 		const draggableIncludesASection = draggable.classList.contains( 'edit_field_type_divider' ) || draggable.querySelector( '.edit_field_type_divider' );
 		const draggableIsEmbedField = draggable.classList.contains( 'edit_field_type_form' );
 		const groupIsInASection = null !== group.closest( '.start_divider' );
-		if ( groupIsInASection && ( draggableIncludesASection || draggableIsEmbedField ) ) {
-			// Do not allow a section or an embed field inside of a section.
-			return false;
-		}
-
-		return true;
+		return ! ( groupIsInASection && ( draggableIncludesASection || draggableIsEmbedField ) );
 	}
 
 	function groupIncludesBreakOrHiddenOrUserId( group ) {
@@ -2242,6 +2234,9 @@ window.frmAdminBuildJS = function() {
 
 		html = JSON.parse( html );
 		for ( key in html ) {
+			if ( ! Object.prototype.hasOwnProperty.call( html, key ) ) {
+				continue;
+			}
 			jQuery( `#frm_field_id_${ key }` ).replaceWith( html[ key ] );
 
 			const newReplacedField = document.getElementById( `frm_field_id_${ key }` );
@@ -3238,17 +3233,17 @@ window.frmAdminBuildJS = function() {
 				continue;
 			}
 
-			const a = document.createElement( 'a' );
-			a.setAttribute( 'href', '#' );
-			a.setAttribute( 'data-code', fields[ i ].fieldId );
-			a.classList.add( 'frm_insert_code' );
-			a.append( span( fields[ i ].fieldName ) );
-			a.append( span( { className: 'frm-text-sm frm-text-grey-500', text: `[${ fields[ i ].fieldId }]` } ) );
+			const anchor = document.createElement( 'a' );
+			anchor.setAttribute( 'href', '#' );
+			anchor.setAttribute( 'data-code', fields[ i ].fieldId );
+			anchor.classList.add( 'frm_insert_code' );
+			anchor.append( span( fields[ i ].fieldName ) );
+			anchor.append( span( { className: 'frm-text-sm frm-text-grey-500', text: `[${ fields[ i ].fieldId }]` } ) );
 
 			const li = document.createElement( 'li' );
 			li.classList.add( `frm-field-list-${ fieldId }` );
 			li.classList.add( `frm-field-list-${ fields[ i ].fieldType }` );
-			li.append( a );
+			li.append( anchor );
 			list.append( li );
 		}
 	}

--- a/phpcs-sniffs/Formidable/Sniffs/Commenting/CommentSpacingSniff.php
+++ b/phpcs-sniffs/Formidable/Sniffs/Commenting/CommentSpacingSniff.php
@@ -84,7 +84,7 @@ class CommentSpacingSniff implements Sniff {
 			&& ! $isSingleWord
 			&& ! $startsWithSpecialWord
 			&& ! $isContinuationComment
-			&& ! preg_match( '/^(end\b|phpcs:|eslint|TODO|FIXME|translators:|e\.g\.|i\.e\.|etc\.|iDeal)/i', $trimmedText );
+			&& ! preg_match( '/^(end\b|phpcs:|skipcq:|eslint|TODO|FIXME|translators:|e\.g\.|i\.e\.|etc\.|iDeal)/i', $trimmedText );
 
 		if ( ! $hasSpaceAfterSlash ) {
 			$fix = $phpcsFile->addFixableError(
@@ -97,7 +97,7 @@ class CommentSpacingSniff implements Sniff {
 				$newText = $trimmedText;
 
 				// Also capitalize if needed (but not for code-like comments, single words, underscore/hyphen words, abbreviations, or continuation comments).
-				if ( preg_match( '/^[a-z]/', $firstChar ) && ! $looksLikeCode && ! $isSingleWord && ! $startsWithSpecialWord && ! $isContinuationComment && ! preg_match( '/^(end\b|phpcs:|eslint|translators:|e\.g\.|i\.e\.|etc\.|iDeal)/i', $trimmedText ) ) {
+				if ( preg_match( '/^[a-z]/', $firstChar ) && ! $looksLikeCode && ! $isSingleWord && ! $startsWithSpecialWord && ! $isContinuationComment && ! preg_match( '/^(end\b|phpcs:|skipcq:|eslint|translators:|e\.g\.|i\.e\.|etc\.|iDeal)/i', $trimmedText ) ) {
 					$newText = ucfirst( $trimmedText );
 				}
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -99,7 +99,6 @@ parameters:
 			message: '#Call to protected method+#'
 			paths:
 				- classes/views/frm-fields/back-end/combo-field/sub-field-options.php
-				- classes/views/frm-fields/back-end/field-options.php
 				- classes/views/frm-fields/back-end/phone/phone-type.php
 				- classes/views/frm-fields/front-end/combo-field/combo-field.php
 		-
@@ -346,7 +345,7 @@ parameters:
 		-
 			message: '#function array_map expects#'
 			paths:
-				- classes/helpers/FrmAppHelper.php  
+				- classes/helpers/FrmAppHelper.php
 				- classes/helpers/FrmHtmlHelper.php
 				- classes/models/FrmEntry.php
 				- classes/models/fields/FrmFieldType.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -326,7 +326,6 @@ parameters:
 				- classes/helpers/FrmFormsHelper.php
 				- classes/helpers/FrmXMLHelper.php
 				- classes/models/FrmEntryValidate.php
-				- classes/views/frm-entries/_sidebar-shared-pub.php
 		- message: '#Possibly invalid array key#'
 		-
 			message: '#should return array<(string|array)> but returns array#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -99,6 +99,7 @@ parameters:
 			message: '#Call to protected method+#'
 			paths:
 				- classes/views/frm-fields/back-end/combo-field/sub-field-options.php
+				- classes/views/frm-fields/back-end/field-options.php
 				- classes/views/frm-fields/back-end/phone/phone-type.php
 				- classes/views/frm-fields/front-end/combo-field/combo-field.php
 		-
@@ -325,6 +326,7 @@ parameters:
 				- classes/helpers/FrmFormsHelper.php
 				- classes/helpers/FrmXMLHelper.php
 				- classes/models/FrmEntryValidate.php
+				- classes/views/frm-entries/_sidebar-shared-pub.php
 		- message: '#Possibly invalid array key#'
 		-
 			message: '#should return array<(string|array)> but returns array#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -99,6 +99,7 @@ parameters:
 			message: '#Call to protected method+#'
 			paths:
 				- classes/views/frm-fields/back-end/combo-field/sub-field-options.php
+				- classes/views/frm-fields/back-end/field-options.php
 				- classes/views/frm-fields/back-end/phone/phone-type.php
 				- classes/views/frm-fields/front-end/combo-field/combo-field.php
 		-

--- a/tests/cypress/e2e/Add-Ons/validateAddOnsPage.cy.js
+++ b/tests/cypress/e2e/Add-Ons/validateAddOnsPage.cy.js
@@ -160,7 +160,7 @@ describe( 'Add-Ons page', () => {
 		} );
 
 		cy.origin( 'https://formidableforms.com', () => {
-			cy.get( 'h1' ).should( 'have.text', 'What is the difference between the Lite (free) and Pro version?' );
+			cy.get( 'h1' ).should( 'contain.text', 'What is the difference between the Lite' );
 		} );
 
 		cy.visit( '/wp-admin/admin.php?page=formidable-addons' );


### PR DESCRIPTION
DeepSource was flagging view templates for undefined variables because those variables are actually passed in from the including controller. This adds PHPDoc headers to document the inherited variables so that DeepSource (and IDEs) can understand the template context.