### PR TITLE
Use a different action name, put it in the right place, and add a check that var is set

### DIFF
--- a/classes/views/frm-forms/add_field_links.php
+++ b/classes/views/frm-forms/add_field_links.php
@@ -235,7 +235,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				 *
 				 * @param stdClass $form The form object.
 				 */
-				do_action( 'frm_extra_form_builder_tabs_content', $form );
+				do_action( 'frm_extra_form_instruction_tabs_content', $form );
 				?>
 			</div>
 		</div>

--- a/classes/views/frm-forms/add_field_links.php
+++ b/classes/views/frm-forms/add_field_links.php
@@ -224,19 +224,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 							</form>
 						</div>
 					</div>
+					<?php
+					if ( isset( $form ) ) {
+						/**
+						 * Hook in so people can include additional tab content.
+						 * Used along with frm_extra_form_instruction_tabs which is used to
+						 * include the tabs.
+						 *
+						 * @since x.x
+						 *
+						 * @param stdClass $form The form object.
+						 */
+						do_action( 'frm_extra_form_instruction_tabs_content', $form );
+					}
+					?>
 				</div>
-				<?php
-				/**
-				 * Hook in so people can include additional tab content.
-				 * Used along with frm_extra_form_instruction_tabs which is used to
-				 * include the tabs.
-				 *
-				 * @since x.x
-				 *
-				 * @param stdClass $form The form object.
-				 */
-				do_action( 'frm_extra_form_instruction_tabs_content', $form );
-				?>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Meant to base this on the other hook. I still don't like the name that was being used after making some changes.

It was also still in the wrong place.

Snippet example:
```
add_action(
	'frm_extra_form_instruction_tabs',
	function () {
	?>
		<li>
			<a href="#custom-tab">
				Custom Tab
			</a>
		</li>
	<?php
	}
);

add_action(
	'frm_extra_form_instruction_tabs_content',
	function () {
		?>
			<div>
				<div id="custom-tab" class="tabs-panel">
					Custom tab content
				</div>
			</div>
		<?php
	}
);
```