### PR TITLE
Add mago as composer dependency

### DIFF
--- a/.github/workflows/mago.yml
+++ b/.github/workflows/mago.yml
@@ -15,13 +15,17 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
-          tools: composer:v2
+
+      - name: "🔧 Setup PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
 
       - name: Install dependencies
         run: composer install --dev --prefer-dist --no-progress
 
       - name: "✅ Mago Lint"
-        run: vendor/bin/mago lint
+        run: mago lint
 
       - name: "🔎 Mago Analyze"
-        run: vendor/bin/mago analyze
+        run: mago analyze

--- a/.github/workflows/mago.yml
+++ b/.github/workflows/mago.yml
@@ -14,13 +14,8 @@ jobs:
       - name: Install dependencies
         run: composer install --dev --prefer-dist --no-progress
 
-      - name: "⚡ Install Mago"
-        run: |
-          mkdir -p bin
-          curl --proto '=https' --tlsv1.2 -sSf https://carthage.software/mago.sh | bash -s -- --install-dir=bin --no-verify
-
       - name: "✅ Mago Lint"
-        run: ./bin/mago lint
+        run: vendor/bin/mago lint
 
       - name: "🔎 Mago Analyze"
-        run: ./bin/mago analyze
+        run: vendor/bin/mago analyze

--- a/.github/workflows/mago.yml
+++ b/.github/workflows/mago.yml
@@ -16,11 +16,6 @@ jobs:
         with:
           php-version: '8.1'
 
-      - name: "🔧 Setup PHP"
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.1'
-
       - name: Install dependencies
         run: composer install --dev --prefer-dist --no-progress
 

--- a/.github/workflows/mago.yml
+++ b/.github/workflows/mago.yml
@@ -20,7 +20,7 @@ jobs:
         run: composer install --dev --prefer-dist --no-progress
 
       - name: "✅ Mago Lint"
-        run: mago lint
+        run: vendor/bin/mago lint
 
       - name: "🔎 Mago Analyze"
-        run: mago analyze
+        run: vendor/bin/mago analyze

--- a/.github/workflows/mago.yml
+++ b/.github/workflows/mago.yml
@@ -11,6 +11,11 @@ jobs:
       - name: "📥 Fetching Repository Contents"
         uses: actions/checkout@v4.1.1
 
+      - name: "🔧 Setup PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+
       - name: Install dependencies
         run: composer install --dev --prefer-dist --no-progress
 

--- a/.github/workflows/mago.yml
+++ b/.github/workflows/mago.yml
@@ -15,6 +15,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
+          tools: composer:v2
 
       - name: Install dependencies
         run: composer install --dev --prefer-dist --no-progress

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -14,7 +14,7 @@ jobs:
       - name: "💽  Installing PHP, Composer, CS2PR"
         uses: shivammathur/setup-php@2.30.2
         with:
-          php-version: 8.0
+          php-version: 8.1
           coverage: none
           ini-values: display_errors = on, error_reporting = E_ALL
           tools: composer

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
 		"friendsofphp/php-cs-fixer": "^3.54",
 		"rector/rector": "^2.3.4",
 		"phpstan/phpstan-strict-rules": "^2.0",
-		"kubawerlos/php-cs-fixer-custom-fixers": "^3.36"
+		"kubawerlos/php-cs-fixer-custom-fixers": "^3.36",
+		"carthage-software/mago": "^1.26"
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
Installing composer dependencies seems significantly slower, but the old way is failing now without the `--no-verify` which seems like a bad idea.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code quality and analysis tools to development dependencies
  * Refactored deployment workflow to leverage Composer-managed development binaries for code analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->