### PR TITLE
Update gateway setting toggle logic

### DIFF
--- a/square/js/action.js
+++ b/square/js/action.js
@@ -15,12 +15,18 @@
 		}
 
 		if ( 'recurring' === typeDropdown.value ) {
-			const activeGateway = settings.querySelector( '[name*="[post_content][gateway]"]:checked' )?.value;
+			const activeGateways = Array.from( settings.querySelectorAll( '[name*="[post_content][gateway]"]:checked' ) ).map( function( el ) {
+				return el.value;
+			} );
 
 			settings.querySelectorAll( '.frm_trans_sub_opts' ).forEach(
 				function( subOpts ) {
-					// Check if this setting has a show_* class for the active gateway
-					const hasActiveGatewayClass = subOpts.classList.contains( 'show_' + activeGateway );
+					// Check if this setting has a show_* class for any active gateway
+					const hasActiveGatewayClass = Array.from( subOpts.classList ).some( function( className ) {
+						return activeGateways.some( function( gateway ) {
+							return className === 'show_' + gateway;
+						} );
+					} );
 
 					if ( hasActiveGatewayClass ) {
 						subOpts.classList.remove( 'frm_hidden' );
@@ -34,7 +40,7 @@
 						} );
 
 						if ( hasAnyGatewayClass ) {
-							// Hide if it has a show_* class but not for the active gateway
+							// Hide if it has a show_* class but not for any active gateway
 							subOpts.classList.add( 'frm_hidden' );
 							subOpts.style.display = 'none';
 						} else {

--- a/square/js/action.js
+++ b/square/js/action.js
@@ -8,6 +8,56 @@
 
 	const { __ } = wp.i18n;
 
+	function updateGatewaySettingsVisibility( settings ) {
+		const typeDropdown = settings.querySelector( 'select.frm_trans_type' );
+		if ( ! typeDropdown ) {
+			return;
+		}
+
+		if ( 'recurring' === typeDropdown.value ) {
+			const activeGateway = settings.querySelector( '[name*="[post_content][gateway]"]:checked' )?.value;
+
+			settings.querySelectorAll( '.frm_trans_sub_opts' ).forEach(
+				function( subOpts ) {
+					// Check if this setting has a show_* class for the active gateway
+					const hasActiveGatewayClass = subOpts.classList.contains( 'show_' + activeGateway );
+
+					if ( hasActiveGatewayClass ) {
+						subOpts.classList.remove( 'frm_hidden' );
+						if ( subOpts.classList.contains( 'frm_grid_container' ) ) {
+							subOpts.style.display = 'grid';
+						}
+					} else {
+						// Check if it has any show_* class for a different gateway
+						const hasAnyGatewayClass = Array.from( subOpts.classList ).some( function( className ) {
+							return className.startsWith( 'show_' );
+						} );
+
+						if ( hasAnyGatewayClass ) {
+							// Hide if it has a show_* class but not for the active gateway
+							subOpts.classList.add( 'frm_hidden' );
+							subOpts.style.display = 'none';
+						} else {
+							// Show if it has no show_* class (shared setting)
+							subOpts.classList.remove( 'frm_hidden' );
+							if ( subOpts.classList.contains( 'frm_grid_container' ) ) {
+								subOpts.style.display = 'grid';
+							}
+						}
+					}
+				}
+			);
+			return;
+		}
+
+		settings.querySelectorAll( '.frm_trans_sub_opts' ).forEach(
+			function( subOpts ) {
+				subOpts.classList.add( 'frm_hidden' );
+				subOpts.style.display = 'none';
+			}
+		);
+	}
+
 	function onGatewayToggle( { gateway, settings, checked } ) {
 		if ( 'square' === gateway && checked ) {
 			syncRepeat( settings.get( 0 ) );
@@ -15,14 +65,7 @@
 
 		syncCurrency( gateway, settings.get( 0 ) );
 
-		const typeDropdown = settings.get( 0 ).querySelector( 'select.frm_trans_type' );
-		if ( typeDropdown && 'recurring' !== typeDropdown.value ) {
-			settings.get( 0 ).querySelectorAll( '.frm_trans_sub_opts' ).forEach(
-				function( subOpts ) {
-					subOpts.style.display = 'none';
-				}
-			);
-		}
+		updateGatewaySettingsVisibility( settings.get( 0 ) );
 
 		const captureSetting = settings.get( 0 ).querySelector( '[name*="[post_content][capture]"]' );
 		if ( captureSetting ) {
@@ -30,9 +73,6 @@
 			if ( wrapper ) {
 				if ( 'square' === gateway ) {
 					wrapper.style.display = 'none';
-				} else if ( 'recurring' !== typeDropdown.value ) {
-					// Capture appearing with Stripe selected and recurring selected.
-					wrapper.style.removeProperty( 'display' );
 				}
 			}
 		}
@@ -48,21 +88,15 @@
 		if ( squareGatewayOption?.checked ) {
 			syncRepeat( settings );
 		}
+
+		updateGatewaySettingsVisibility( settings );
 	}
 
 	function onToggleSub() {
 		const target = this;
 		setTimeout( function() {
 			const settings = target.closest( '.frm_form_action_settings' );
-			const squareIsActive = settings.querySelector( '[name*="[post_content][gateway]"][value="square"]' ).checked;
-
-			settings.querySelectorAll( '.frm_trans_sub_opts' ).forEach(
-				function( subOpts ) {
-					if ( subOpts.classList.contains( 'show_stripe' ) && ! subOpts.classList.contains( 'show_square' ) && squareIsActive ) {
-						subOpts.style.display = 'none';
-					}
-				}
-			);
+			updateGatewaySettingsVisibility( settings );
 		}, 0 );
 	}
 
@@ -132,6 +166,7 @@
 		}
 
 		newDropdown.closest( '.frm_trans_sub_opts' )?.classList.add( 'show_square' );
+		newDropdown.closest( '.frm_trans_sub_opts' )?.classList.remove( 'frm_hidden' );
 
 		const stripeLabel = intervalCount.closest( '.frm_trans_sub_opts' )?.querySelector( 'label' );
 		if ( stripeLabel?.textContent.includes( 'Repeat Every' ) ) {


### PR DESCRIPTION
This update should prevent this issue where "Repeat" appears twice.

**The problem**
- Stripe uses "Repeat Interval" / "Repeater Period".
- Square uses "Repeat Cadence".
- The JS to sync which setting is visible misses this case and ends up displaying both the Stripe and Square settings.

**To replicate**
1. Create a payment action. Set it to One Time, Square.
2. Change to Stripe.
3. Change to Recurring.

**When testing**
- We'll want to test with the Stripe add-on active, and inactive, is these may work differently.
- It's also good to test Authorize.Net active and inactive, as the gateways use checkboxes when Authorize.Net is available. While you shouldn't have both Stripe and Square selected (it won't really work), both settings should appear if both gateways are selected.

**Before**

https://github.com/user-attachments/assets/0dbdd0a2-45c5-48eb-9a69-426ff62db173

**After**

https://github.com/user-attachments/assets/41e62151-add3-42f2-9868-e015ffa3a3dc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved payment gateway settings visibility so sub-options consistently show or hide based on transaction type (recurring vs. one-time) and selected gateways.
  * Ensures layout for gateway sub-option groups remains intact when displayed.
  * Fixes cases where repeat-cadence controls could remain hidden after being added, improving UI reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->