### PR TITLE
Fix trial period setting using wrong key (paypal)

### DIFF
--- a/paypal/controllers/FrmPayPalLiteAppController.php
+++ b/paypal/controllers/FrmPayPalLiteAppController.php
@@ -626,7 +626,7 @@ class FrmPayPalLiteAppController {
 		$product_name   = self::process_shortcodes_for_action( $action->post_content['product_name'] ?? '', $action );
 		$interval       = $action->post_content['interval'] ?? '';
 		$interval_count = $action->post_content['interval_count'] ?? 1;
-		$trial_period   = $action->post_content['trial_period'] ?? '';
+		$trial_period   = $action->post_content['trial_interval_count'] ?? '';
 		$payment_limit  = $action->post_content['payment_limit'] ?? '';
 		$product_type   = $action->post_content['product_type'] ?? 'SERVICE';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trial period calculation for PayPal subscriptions to ensure the correct value is sent when creating subscription requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Strategy11/formidable-forms/pull/3100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->