### PR TITLE
Try to stop awaiting on apple pay button click

### DIFF
--- a/paypal/js/frontend.js
+++ b/paypal/js/frontend.js
@@ -40,6 +40,9 @@
 	/** Cached Apple Pay config from paypal.Applepay().config(). */
 	let applePayConfig = null;
 
+	/** Cached Apple Pay SDK instance (reused for validateMerchant and confirmOrder). */
+	let applePayInstance = null;
+
 	/** Cached payment amount for Apple Pay (must be available synchronously in click handler). */
 	let cachedAmount = '0.00';
 
@@ -946,7 +949,8 @@
 
 		// Use paypal.Applepay().config() as the definitive eligibility check (per PayPal multiparty docs).
 		try {
-			applePayConfig = await paypal.Applepay().config();
+			applePayInstance = paypal.Applepay();
+			applePayConfig = await applePayInstance.config();
 
 			if ( ! applePayConfig || ! applePayConfig.isEligible ) {
 				return 'PayPal reports Apple Pay is not eligible for this merchant/domain';
@@ -1021,10 +1025,9 @@
 		};
 
 		const session = new ApplePaySession( 4, paymentRequest );
-		const applepay = paypal.Applepay();
 
 		session.onvalidatemerchant = event => {
-			applepay.validateMerchant( {
+			applePayInstance.validateMerchant( {
 				validationUrl: event.validationURL,
 				displayName: document.title || 'Payment'
 			} )
@@ -1037,10 +1040,16 @@
 				} );
 		};
 
+		session.onpaymentmethodselected = () => {
+			session.completePaymentMethodSelection( {
+				newTotal: paymentRequest.total,
+			} );
+		};
+
 		session.onpaymentauthorized = event => {
 			createOrderForApplePay()
 				.then( orderId => {
-					return applepay.confirmOrder( {
+					return applePayInstance.confirmOrder( {
 						orderId,
 						token: event.payment.token,
 						billingContact: event.payment.billingContact

--- a/paypal/js/frontend.js
+++ b/paypal/js/frontend.js
@@ -40,6 +40,9 @@
 	/** Cached Apple Pay config from paypal.Applepay().config(). */
 	let applePayConfig = null;
 
+	/** Cached payment amount for Apple Pay (must be available synchronously in click handler). */
+	let cachedAmount = '0.00';
+
 	// ---- Constants ----
 
 	/**
@@ -180,6 +183,14 @@
 			renderMessages();
 			jQuery( document ).on( 'frmFieldChanged', priceChanged );
 			checkPriceFieldsOnLoad();
+		}
+
+		// 8. Pre-fetch the amount for Apple Pay so it is available synchronously in the click handler.
+		if ( paymentMethods.has( 'apple_pay' ) ) {
+			refreshCachedAmount();
+			if ( ! paymentMethods.has( 'paylater' ) ) {
+				jQuery( document ).on( 'frmFieldChanged', refreshCachedAmountOnFieldChange );
+			}
 		}
 	}
 
@@ -985,29 +996,16 @@
 
 	/**
 	 * Handle click on the Apple Pay button.
-	 * Fetches the price asynchronously, then creates an ApplePaySession and processes the payment via PayPal.
+	 *
+	 * ApplePaySession MUST be created and begun synchronously inside the click
+	 * handler. Any async work (like fetching the price) before session.begin()
+	 * causes the user-gesture activation to expire, leaving the payment sheet
+	 * visible but non-interactive.
 	 */
-	async function onApplePayButtonClick() {
+	function onApplePayButtonClick() {
 		if ( ! applePayConfig ) {
 			console.error( 'Apple Pay config not available' );
 			return;
-		}
-
-		let amount = '0.00';
-
-		// Try to fetch the actual price from the server.
-		try {
-			amount = await new Promise( ( resolve, reject ) => {
-				getPrice( result => {
-					if ( result?.data?.amount ) {
-						resolve( String( result.data.amount ) );
-					} else {
-						reject( new Error( 'No amount' ) );
-					}
-				} );
-			} );
-		} catch ( e ) {
-			// Fall back to form total if we can't get the price from server.
 		}
 
 		const paymentRequest = {
@@ -1018,11 +1016,10 @@
 			total: {
 				label: document.title || 'Payment',
 				type: 'final',
-				amount,
+				amount: cachedAmount,
 			},
 		};
 
-		// ApplePaySession MUST be created synchronously inside the click handler.
 		const session = new ApplePaySession( 4, paymentRequest );
 		const applepay = paypal.Applepay();
 
@@ -1777,12 +1774,45 @@
 			.then( response => response.json() )
 			.then( function( result ) {
 				if ( result.success && result.data?.amount ) {
+					cachedAmount = String( result.data.amount );
 					callback( result );
 				}
 			} )
 			.catch( function( err ) {
 				console.error( 'Failed to get PayPal amount', err );
 			} );
+	}
+
+	/**
+	 * Refresh the cached amount for Apple Pay.
+	 */
+	function refreshCachedAmount() {
+		getPrice( function() {} );
+	}
+
+	/**
+	 * Refresh the cached amount when a price-related field changes.
+	 *
+	 * @param {Event}       _       jQuery event.
+	 * @param {HTMLElement} field   The changed field element.
+	 * @param {string}      fieldId The changed field ID.
+	 */
+	function refreshCachedAmountOnFieldChange( _, field, fieldId ) {
+		const price = getPriceFields();
+		let run = price.includes( fieldId ) || price.includes( field.id );
+
+		if ( ! run ) {
+			for ( let i = 0; i < price.length; i++ ) {
+				if ( field.id.indexOf( price[ i ] ) === 0 ) {
+					run = true;
+					break;
+				}
+			}
+		}
+
+		if ( run ) {
+			refreshCachedAmount();
+		}
 	}
 
 	/**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Faster, more reliable Apple Pay checkout via amount caching and prefetching for quicker payment session start.
  * Totals and line-item amounts now stay synchronized throughout the Apple Pay sheet, reflecting recent price-affecting changes.
  * Reduced checkout interruptions when price updates occur, with better handling around alternate payment options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Strategy11/formidable-forms/pull/3102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->