### PR TITLE
Fix PHP notice related to script registering in Styles settings

### DIFF
--- a/classes/controllers/FrmFormsController.php
+++ b/classes/controllers/FrmFormsController.php
@@ -3423,9 +3423,13 @@ class FrmFormsController {
 	}
 
 	/**
+	 * Register the formidable script so it is available as a dependency for other scripts.
+	 *
+	 * @since x.x
+	 *
 	 * @return void
 	 */
-	public static function front_head() {
+	public static function register_formidable_script() {
 		$version = FrmAppHelper::plugin_version();
 		$suffix  = FrmAppHelper::js_suffix();
 
@@ -3434,6 +3438,13 @@ class FrmFormsController {
 		} else {
 			wp_register_script( 'formidable', FrmAppHelper::plugin_url() . "/js/formidable{$suffix}.js", array( 'jquery' ), $version, true );
 		}
+	}
+
+	/**
+	 * @return void
+	 */
+	public static function front_head() {
+		self::register_formidable_script();
 
 		add_filter( 'script_loader_tag', 'FrmFormsController::defer_script_loading', 10, 2 );
 

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -127,6 +127,8 @@ class FrmStylesController {
 		}
 
 		FrmStyleComponent::register_assets();
+		FrmFormsController::register_formidable_script();
+		self::register_style_script();
 		self::load_pro_hooks();
 
 		$version = FrmAppHelper::plugin_version();
@@ -568,13 +570,14 @@ class FrmStylesController {
 	}
 
 	/**
-	 * Register and enqueue styles and scripts for the style tab page.
+	 * Register the formidable_style script early so it is available as a dependency
+	 * for other scripts enqueued on admin_enqueue_scripts (e.g. formidable-pro).
 	 *
-	 * @since 6.0
+	 * @since x.x
 	 *
 	 * @return void
 	 */
-	private static function setup_styles_and_scripts_for_styler() {
+	public static function register_style_script() {
 		$plugin_url      = FrmAppHelper::plugin_url();
 		$version         = FrmAppHelper::plugin_version();
 		$js_dependencies = array( 'wp-i18n', 'wp-hooks', 'formidable_dom' );
@@ -585,6 +588,17 @@ class FrmStylesController {
 
 		wp_register_script( 'formidable_style', $plugin_url . '/js/admin/style.js', $js_dependencies, $version );
 		wp_register_style( 'formidable_style', $plugin_url . '/css/admin/style.css', array(), $version );
+	}
+
+	/**
+	 * Register and enqueue styles and scripts for the style tab page.
+	 *
+	 * @since 6.0
+	 *
+	 * @return void
+	 */
+	private static function setup_styles_and_scripts_for_styler() {
+		self::register_style_script();
 		wp_print_styles( 'formidable_style' );
 
 		wp_print_styles( 'formidable' );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/6338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal script and style registration logic in the form controller system, optimizing how dependencies are initialized for the form builder and Visual Styler components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Strategy11/formidable-forms/pull/3103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->