### PR TITLE
Stop showing paypal commerce on legacy paypal action

### DIFF
--- a/classes/views/frm-form-actions/_action_icon.php
+++ b/classes/views/frm-form-actions/_action_icon.php
@@ -24,6 +24,9 @@ $single_action_attrs = array_merge(
 		'data-actiontype' => $action_control->id_base,
 	)
 );
+if ( 'paypal' === $action_control->id_base ) {
+	$action_control->name = 'PayPal Commerce';
+}
 ?>
 <li class="frm-card-item frm-card-item--outlined frm-action<?php echo esc_attr( $group_class . ( isset( $data['data-upgrade'] ) ? ' frm-not-installed' : '' ) ); ?>" tabindex="0">
 	<div class="frm-h-stack-xs frm-w-full">

--- a/classes/views/frm-form-actions/_action_icon.php
+++ b/classes/views/frm-form-actions/_action_icon.php
@@ -24,6 +24,7 @@ $single_action_attrs = array_merge(
 		'data-actiontype' => $action_control->id_base,
 	)
 );
+
 if ( 'paypal' === $action_control->id_base ) {
 	$action_control->name = 'PayPal Commerce';
 }

--- a/paypal/controllers/FrmPayPalLiteHooksController.php
+++ b/paypal/controllers/FrmPayPalLiteHooksController.php
@@ -33,13 +33,6 @@ class FrmPayPalLiteHooksController {
 		add_filter( 'frm_add_settings_section', 'FrmPayPalLiteSettingsController::add_settings_section', 99 );
 		add_action( 'frm_update_settings', 'FrmPayPalLiteSettingsController::process_form' );
 
-		add_filter(
-			'frm_paypal_action_name',
-			function () {
-				return 'PayPal Commerce';
-			}
-		);
-
 		add_filter( 'frm_before_save_payment_action', 'FrmPayPalLiteActionsController::before_save_settings', 20, 2 );
 
 		// Hook into after payment type to render Product Name and Product Type fields.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized PayPal action name handling to improve display consistency. The PayPal action is now labeled as "PayPal Commerce" in the user interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Strategy11/formidable-forms/pull/3106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->