### PR TITLE
Fix expired modal is not shown for blocked form actions

### DIFF
--- a/classes/controllers/FrmFormActionsController.php
+++ b/classes/controllers/FrmFormActionsController.php
@@ -461,6 +461,10 @@ class FrmFormActionsController {
 		} else {
 			$classes .= ' frm_inactive_action';
 
+			if ( str_contains( $action_control->action_options['classes'], 'frm_show_expired_modal' ) ) {
+				$classes .= ' frm_show_expired_modal';
+			}
+
 			if ( $default_position !== false && ( $allowed_count + $default_position ) < 6 ) {
 				$group_class .= ' frm-default-show';
 			}


### PR DESCRIPTION
The wrong pop-up was showing instead of the renewal one for an expired license with the form actions refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the display of expired and inactive actions. The form management system now consistently applies visual indicators to all inactive actions that have reached their expiration date, ensuring users are clearly notified when actions are no longer available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Strategy11/formidable-forms/pull/3113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->