### PR TITLE
Style settings improvements (fix scoping issues on duplicate and when…

### DIFF
--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -631,8 +631,8 @@ class FrmStylesController {
 				// The single style custom CSS is nested under the old style's scope. Re-scope it to the
 				// new style's scope so it unnests correctly for display and re-nests correctly on save.
 				if ( ! empty( $style->post_content['single_style_custom_css'] ) ) {
-					$css_scope_helper = new FrmCssScopeHelper();
-					$unnested_css     = $css_scope_helper->unnest( $style->post_content['single_style_custom_css'], 'frm_style_' . $style->post_name );
+					$css_scope_helper                               = new FrmCssScopeHelper();
+					$unnested_css                                   = $css_scope_helper->unnest( $style->post_content['single_style_custom_css'], 'frm_style_' . $style->post_name );
 					$style->post_content['single_style_custom_css'] = $css_scope_helper->nest( $unnested_css, 'frm_style_' . $new_name );
 				}
 
@@ -645,7 +645,7 @@ class FrmStylesController {
 				$style            = $frm_style->get_new();
 				$style->post_name = self::get_new_style_post_name( $style->post_name );
 				break;
-		}
+		}//end switch
 
 		if ( in_array( $view, array( 'duplicate', 'new_style' ), true ) ) {
 			$style->post_title = FrmAppHelper::simple_get( 'style_name' );

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -632,7 +632,7 @@ class FrmStylesController {
 				// new style's scope so it unnests correctly for display and re-nests correctly on save.
 				if ( ! empty( $style->post_content['single_style_custom_css'] ) ) {
 					$css_scope_helper                               = new FrmCssScopeHelper();
-					$unnested_css                                   = $css_scope_helper->unnest( $style->post_content['single_style_custom_css'], 'frm_style_' . $style->post_name );
+					$unnested_css                                   = $css_scope_helper->unnest( $style->post_content['single_style_custom_css'], 'frm_style_' . $style->post_name ); // phpcs:ignore SlevomatCodingStandard.Files.LineLength.LineTooLong
 					$style->post_content['single_style_custom_css'] = $css_scope_helper->nest( $unnested_css, 'frm_style_' . $new_name );
 				}
 

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -624,15 +624,26 @@ class FrmStylesController {
 				break;
 
 			case 'duplicate':
-				$style            = clone $active_style;
-				$new_style        = $frm_style->get_new();
+				$style     = clone $active_style;
+				$new_style = $frm_style->get_new();
+				$new_name  = self::get_new_style_post_name( $new_style->post_name );
+
+				// The single style custom CSS is nested under the old style's scope. Re-scope it to the
+				// new style's scope so it unnests correctly for display and re-nests correctly on save.
+				if ( ! empty( $style->post_content['single_style_custom_css'] ) ) {
+					$css_scope_helper = new FrmCssScopeHelper();
+					$unnested_css     = $css_scope_helper->unnest( $style->post_content['single_style_custom_css'], 'frm_style_' . $style->post_name );
+					$style->post_content['single_style_custom_css'] = $css_scope_helper->nest( $unnested_css, 'frm_style_' . $new_name );
+				}
+
 				$style->ID        = $new_style->ID;
-				$style->post_name = $new_style->post_name;
-				unset( $new_style );
+				$style->post_name = $new_name;
+				unset( $new_style, $new_name );
 				break;
 
 			case 'new_style':
-				$style = $frm_style->get_new();
+				$style            = $frm_style->get_new();
+				$style->post_name = self::get_new_style_post_name( $style->post_name );
 				break;
 		}
 
@@ -660,6 +671,25 @@ class FrmStylesController {
 		$notes                    = $preview_helper->get_notes_for_styler_preview();
 
 		include $style_views_path . 'show.php';
+	}
+
+	/**
+	 * Derive the temporary post_name (CSS scope slug) for a new or duplicated style from the chosen
+	 * style name so the displayed scope matches the slug WordPress will store on save.
+	 *
+	 * Falls back to the auto-generated key when no style name was provided so the scope is never empty.
+	 *
+	 * @since x.x
+	 *
+	 * @param string $fallback The auto-generated post_name to use when no style name is chosen.
+	 *
+	 * @return string
+	 */
+	private static function get_new_style_post_name( $fallback ) {
+		$style_name = FrmAppHelper::simple_get( 'style_name' );
+		$slug       = $style_name ? sanitize_title( $style_name ) : '';
+
+		return $slug ? $slug : $fallback;
 	}
 
 	/**

--- a/classes/models/FrmStyle.php
+++ b/classes/models/FrmStyle.php
@@ -119,16 +119,18 @@ class FrmStyle {
 			$new_instance['post_content']['custom_css'] = $custom_css;
 			unset( $custom_css );
 
-			if ( ! empty( $new_instance['post_content']['single_style_custom_css'] ) ) {
-				$css_scope = 'frm_style_' . $new_instance['post_name'];
-				$new_instance['post_content']['single_style_custom_css'] = $css_scope_helper->nest( $new_instance['post_content']['single_style_custom_css'], $css_scope );
-			}
-
 			$new_instance['post_type']   = FrmStylesController::$post_type;
 			$new_instance['post_status'] = 'publish';
 
 			if ( ! $id ) {
-				$new_instance['post_name'] = $new_instance['post_title'];
+				// For a new style (including a duplicate), the post_name is derived from the title.
+				// Sanitize it here so the CSS scope below matches the slug WordPress will store.
+				$new_instance['post_name'] = sanitize_title( $new_instance['post_title'] );
+			}
+
+			if ( ! empty( $new_instance['post_content']['single_style_custom_css'] ) ) {
+				$css_scope = 'frm_style_' . $new_instance['post_name'];
+				$new_instance['post_content']['single_style_custom_css'] = $css_scope_helper->nest( $new_instance['post_content']['single_style_custom_css'], $css_scope );
 			}
 
 			$default_settings = $this->get_defaults();

--- a/classes/models/FrmStyle.php
+++ b/classes/models/FrmStyle.php
@@ -124,8 +124,10 @@ class FrmStyle {
 
 			if ( ! $id ) {
 				// For a new style (including a duplicate), the post_name is derived from the title.
-				// Sanitize it here so the CSS scope below matches the slug WordPress will store.
-				$new_instance['post_name'] = sanitize_title( $new_instance['post_title'] );
+				// Resolve slug uniqueness up front (WordPress appends -2, -3, etc. to duplicate slugs)
+				// so the CSS scope below matches the slug WordPress will actually store.
+				$slug                      = sanitize_title( $new_instance['post_title'] );
+				$new_instance['post_name'] = wp_unique_post_slug( $slug, 0, $new_instance['post_status'], $new_instance['post_type'], 0 );
 			}
 
 			if ( ! empty( $new_instance['post_content']['single_style_custom_css'] ) ) {


### PR DESCRIPTION
… renaming, use a more accurate style class name based on the name in the input

Fixes https://github.com/Strategy11/formidable-pro/issues/6157

The custom CSS is saved with the style name prefixed. The automatic scoping is there to prevent conflicts and unnested in the settings so it is more user friendly.

On duplicate, it would use the old style name.

In this update, the unnested/nesting happens when the style name changes appropriately.

**In addition**
- The "Style Class" would previously show a random string, and then change on save based on the style name setting. Now, since the style name is initially typed in a modal, the style class on load is based on that string so it's closer to what it will be on submit. If the style name is already in use, it will end up with `-2`, `-3`, appended to it.

https://github.com/user-attachments/assets/ab7a632f-4266-435a-af39-b3d15752fb6e
