### PR TITLE
Add null check to is valid utf8 function

### DIFF
--- a/classes/helpers/FrmAppHelper.php
+++ b/classes/helpers/FrmAppHelper.php
@@ -5104,11 +5104,16 @@ class FrmAppHelper {
 	 *
 	 * @since 6.24
 	 *
-	 * @param string $string The string to check.
+	 * @param string|null $string The string to check.
 	 *
 	 * @return bool
 	 */
 	public static function is_valid_utf8( $string ) {
+		if ( is_null( $string ) ) {
+			// Return true so we do not attempt to change encoding on a null value.
+			return true;
+		}
+
 		// wp_is_valid_utf8 is added in WP 6.9.
 		if ( function_exists( 'wp_is_valid_utf8' ) ) {
 			return wp_is_valid_utf8( $string );


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3339029727/252954

```
[30-May-2026 20:34:22 UTC] PHP Fatal error: Uncaught TypeError: wp_is_valid_utf8(): Argument #1 ($bytes) must be of type string, null given, called in /var/www/html/wp-content/plugins/formidable/classes/helpers/FrmAppHelper.php on line 5114 and defined in /var/www/html/wp-includes/utf8.php:39
Stack trace:
#0 /var/www/html/wp-content/plugins/formidable/classes/helpers/FrmAppHelper.php(5114): wp_is_valid_utf8(NULL)
#1 /var/www/html/wp-content/plugins/formidable/classes/helpers/FrmXMLHelper.php(1947): FrmAppHelper::is_valid_utf8(NULL)
#2 /var/www/html/wp-content/plugins/formidable/classes/views/xml/forms_xml.php(52): FrmXMLHelper::cdata(NULL)
#3 /var/www/html/wp-content/plugins/formidable/classes/views/xml/xml.php(35): include('/var/www/html/w...')
#4 /var/www/html/wp-content/plugins/formidable/classes/controllers/FrmXMLController.php(571): include('/var/www/html/w...')
#5 /var/www/html/wp-content/plugins/formidable/classes/controllers/FrmXMLController.php(435): FrmXMLController::generate_xml(Array, Array)
#6 /var/www/html/wp-includes/class-wp-hook.php(341): FrmXMLController::export_xml('')
#7 /var/www/html/wp-includes/class-wp-hook.php(365): WP_Hook->apply_filters('', Array)
#8 /var/www/html/wp-includes/plugin.php(522): WP_Hook->do_action(Array)
#9 /var/www/html/wp-admin/admin-ajax.php(192): do_action('wp_ajax_frm_exp...')
```

**Pre-release**
[formidable-6.31.1b.zip](https://github.com/user-attachments/files/28475430/formidable-6.31.1b.zip)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced UTF-8 text validation to gracefully handle null values, improving application stability and preventing potential validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->