### PR TITLE
Fix issues with renaming a style with no ID

### DIFF
--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -651,6 +651,7 @@ class FrmStylesController {
 			// A new or duplicated style has no ID yet, so the Rename modal updates the post_title input
 			// instead of calling an endpoint. Prefer that posted title over $_GET['style_name'] when present.
 			$posted_title = '';
+
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing
 			if ( isset( $_POST['frm_style_setting']['post_title'] ) ) {
 				// The nonce is verified in FrmStylesController::save_style before this renders.

--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -648,7 +648,17 @@ class FrmStylesController {
 		}//end switch
 
 		if ( in_array( $view, array( 'duplicate', 'new_style' ), true ) ) {
-			$style->post_title = FrmAppHelper::simple_get( 'style_name' );
+			// A new or duplicated style has no ID yet, so the Rename modal updates the post_title input
+			// instead of calling an endpoint. Prefer that posted title over $_GET['style_name'] when present.
+			$posted_title = '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			if ( isset( $_POST['frm_style_setting']['post_title'] ) ) {
+				// The nonce is verified in FrmStylesController::save_style before this renders.
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing
+				$posted_title = sanitize_text_field( wp_unslash( $_POST['frm_style_setting']['post_title'] ) );
+			}
+
+			$style->post_title = '' !== $posted_title ? $posted_title : FrmAppHelper::simple_get( 'style_name' );
 			$style->menu_order = 0;
 		}
 

--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -874,6 +874,24 @@
 			return;
 		}
 
+		if ( ! styleId || '0' === String( styleId ) ) {
+			// A new or duplicated style has no ID yet, so there is nothing to rename on the server.
+			// Update the post_title input (which overrides $_GET['style_name'] on save) and the
+			// visible style name instead of calling the rename_style endpoint.
+			const postTitleInput = document.querySelector( 'input[name="frm_style_setting[post_title]"]' );
+			if ( postTitleInput ) {
+				postTitleInput.value = newStyleName;
+			}
+
+			const styleNameElement = document.getElementById( 'frm_style_name' );
+			if ( styleNameElement ) {
+				styleNameElement.textContent = newStyleName;
+			}
+
+			success( __( 'Style has been renamed successfully', 'formidable' ) );
+			return;
+		}
+
 		const formData = new FormData();
 		formData.append( 'style_id', styleId );
 		formData.append( 'style_name', newStyleName );


### PR DESCRIPTION
A style has no ID when it's new and hasn't been saved yet, or when you're duplicating a style.

**Before**
It would make a rename request with an empty `style_id`.

<img width="686" height="368" alt="Screen Shot 2026-06-02 at 9 53 10 AM" src="https://github.com/user-attachments/assets/ed95d2d6-22ce-4d37-9860-818f86a10cc0" />

Resulting in a `Invalid route` error.
<img width="561" height="162" alt="Screen Shot 2026-06-02 at 9 53 34 AM" src="https://github.com/user-attachments/assets/cc342c03-b0e4-4c3d-ba4f-7613c90754d1" />

https://github.com/user-attachments/assets/203dc046-ef64-4637-b168-236023e9797b

**After**

https://github.com/user-attachments/assets/2df7cb7c-c6de-42a1-90c2-c691aa559979


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved style naming workflow when creating new styles or duplicating existing ones.
  * Optimized style renaming to process locally when appropriate, reducing unnecessary server requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->