### PR TITLE
Remove references to old blacklist keys WP option

### DIFF
--- a/classes/models/FrmSpamCheckWPDisallowedWords.php
+++ b/classes/models/FrmSpamCheckWPDisallowedWords.php
@@ -31,7 +31,7 @@ class FrmSpamCheckWPDisallowedWords extends FrmSpamCheck {
 		$user_agent = FrmAppHelper::get_server_value( 'HTTP_USER_AGENT' );
 		$user_info  = FrmEntryValidate::get_spam_check_user_info( $values );
 
-		return $this->do_check_wp_disallowed_words(
+		return wp_check_comment_disallowed_list(
 			$user_info['comment_author'],
 			$user_info['comment_author_email'],
 			$user_info['comment_author_url'],
@@ -39,22 +39,6 @@ class FrmSpamCheckWPDisallowedWords extends FrmSpamCheck {
 			$ip,
 			$user_agent
 		);
-	}
-
-	/**
-	 * For WP 5.5 compatibility.
-	 *
-	 * @param string $author
-	 * @param string $email
-	 * @param string $url
-	 * @param string $content
-	 * @param string $ip
-	 * @param string $user_agent
-	 *
-	 * @return bool Return `true` if contains disallowed words.
-	 */
-	private function do_check_wp_disallowed_words( $author, $email, $url, $content, $ip, $user_agent ) {
-		return wp_check_comment_disallowed_list( $author, $email, $url, $content, $ip, $user_agent );
 	}
 
 	protected function is_enabled() {

--- a/classes/models/FrmSpamCheckWPDisallowedWords.php
+++ b/classes/models/FrmSpamCheckWPDisallowedWords.php
@@ -17,7 +17,7 @@ class FrmSpamCheckWPDisallowedWords extends FrmSpamCheck {
 	 * @return bool
 	 */
 	public function check() {
-		$mod_keys = trim( $this->get_disallowed_words() );
+		$mod_keys = trim( get_option( 'disallowed_keys' ) );
 
 		if ( ! $mod_keys ) {
 			return false;
@@ -39,13 +39,6 @@ class FrmSpamCheckWPDisallowedWords extends FrmSpamCheck {
 			$ip,
 			$user_agent
 		);
-	}
-
-	/**
-	 * @return string
-	 */
-	private function get_disallowed_words() {
-		return get_option( 'disallowed_keys' );
 	}
 
 	/**

--- a/classes/models/FrmSpamCheckWPDisallowedWords.php
+++ b/classes/models/FrmSpamCheckWPDisallowedWords.php
@@ -42,20 +42,10 @@ class FrmSpamCheckWPDisallowedWords extends FrmSpamCheck {
 	}
 
 	/**
-	 * For WP 5.5 compatibility.
-	 *
 	 * @return string
 	 */
 	private function get_disallowed_words() {
-		$keys = get_option( 'disallowed_keys' );
-
-		if ( false === $keys ) {
-			// Fallback for WP < 5.5.
-			// phpcs:ignore WordPress.WP.DeprecatedParameterValues.Found
-			return get_option( 'blacklist_keys' );
-		}
-
-		return $keys;
+		return get_option( 'disallowed_keys' );
 	}
 
 	/**
@@ -71,11 +61,7 @@ class FrmSpamCheckWPDisallowedWords extends FrmSpamCheck {
 	 * @return bool Return `true` if contains disallowed words.
 	 */
 	private function do_check_wp_disallowed_words( $author, $email, $url, $content, $ip, $user_agent ) {
-		if ( function_exists( 'wp_check_comment_disallowed_list' ) ) {
-			return wp_check_comment_disallowed_list( $author, $email, $url, $content, $ip, $user_agent );
-		}
-		// phpcs:ignore WordPress.WP.DeprecatedFunctions.wp_blacklist_checkFound
-		return wp_blacklist_check( $author, $email, $url, $content, $ip, $user_agent );
+		return wp_check_comment_disallowed_list( $author, $email, $url, $content, $ip, $user_agent );
 	}
 
 	protected function is_enabled() {

--- a/tests/phpunit/misc/test_FrmSpamCheckWPDisallowedWords.php
+++ b/tests/phpunit/misc/test_FrmSpamCheckWPDisallowedWords.php
@@ -17,14 +17,16 @@ class test_FrmSpamCheckWPDisallowedWords extends FrmUnitTest {
 			'form_id'        => 1,
 		);
 
-		update_option( $this->get_disallowed_option_name(), '' );
+		$option_name = 'disallowed_keys';
+
+		update_option( $option_name, '' );
 		$spam_check = new FrmSpamCheckWPDisallowedWords( $values );
 		$this->assertFalse( $spam_check->is_spam() );
 
 		$blocked   = '23.343.12332';
 		$new_block = $blocked . "\nspamemail@example.com";
-		update_option( $this->get_disallowed_option_name(), $new_block );
-		$this->assertSame( $new_block, get_option( $this->get_disallowed_option_name() ) );
+		update_option( $option_name, $new_block );
+		$this->assertSame( $new_block, get_option( $option_name ) );
 
 		$wp_test = wp_check_comment_disallowed_list(
 			'Author',
@@ -64,14 +66,5 @@ class test_FrmSpamCheckWPDisallowedWords extends FrmUnitTest {
 		$values['item_meta']['25'] = $blocked . '23.343.1233234323';
 		$is_spam                   = FrmAntiSpamController::contains_wp_disallowed_words( $values );
 		$this->assertSame( $is_spam, $spam_msg );
-	}
-
-	/**
-	 * The name of the disallowed list of words was changed in WP 5.5.
-	 *
-	 * @return string
-	 */
-	private function get_disallowed_option_name() {
-		return 'disallowed_keys';
 	}
 }

--- a/tests/phpunit/misc/test_FrmSpamCheckWPDisallowedWords.php
+++ b/tests/phpunit/misc/test_FrmSpamCheckWPDisallowedWords.php
@@ -26,16 +26,24 @@ class test_FrmSpamCheckWPDisallowedWords extends FrmUnitTest {
 		update_option( $this->get_disallowed_option_name(), $new_block );
 		$this->assertSame( $new_block, get_option( $this->get_disallowed_option_name() ) );
 
-		$wp_test = $this->run_private_method(
-			array( $spam_check, 'do_check_wp_disallowed_words' ),
-			array( 'Author', 'author@gmail.com', '', 'No spam here', FrmAppHelper::get_ip_address(), FrmAppHelper::get_server_value( 'HTTP_USER_AGENT' ) )
+		$wp_test = wp_check_comment_disallowed_list(
+			'Author',
+			'author@gmail.com',
+			'',
+			'No spam here',
+			FrmAppHelper::get_ip_address(),
+			FrmAppHelper::get_server_value( 'HTTP_USER_AGENT' )
 		);
 		$this->assertFalse( $wp_test );
 
 		$ip      = FrmAppHelper::get_ip_address();
-		$wp_test = $this->run_private_method(
-			array( $spam_check, 'do_check_wp_disallowed_words' ),
-			array( 'Author', 'author@gmail.com', '', $blocked, $ip, FrmAppHelper::get_server_value( 'HTTP_USER_AGENT' ) )
+		$wp_test = wp_check_comment_disallowed_list(
+			'Author',
+			'author@gmail.com',
+			'',
+			$blocked,
+			$ip,
+			FrmAppHelper::get_server_value( 'HTTP_USER_AGENT' )
 		);
 
 		if ( ! $wp_test ) {

--- a/tests/phpunit/misc/test_FrmSpamCheckWPDisallowedWords.php
+++ b/tests/phpunit/misc/test_FrmSpamCheckWPDisallowedWords.php
@@ -64,8 +64,6 @@ class test_FrmSpamCheckWPDisallowedWords extends FrmUnitTest {
 	 * @return string
 	 */
 	private function get_disallowed_option_name() {
-		$keys = get_option( 'disallowed_keys' );
-		// Fallback for WP < 5.5.
-		return false === $keys ? 'blacklist_keys' : 'disallowed_keys';
+		return 'disallowed_keys';
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized spam detection system to align with current WordPress standards for handling disallowed content. Simplified internal compatibility code by removing legacy fallback mechanisms. Updated related tests to validate proper functionality with the streamlined spam filtering system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->