### PR TITLE
Fix duplicate legacy paypal action created on create

### DIFF
--- a/classes/views/frm-form-actions/default_actions.php
+++ b/classes/views/frm-form-actions/default_actions.php
@@ -52,6 +52,12 @@ if ( class_exists( 'FrmPaymentAction' ) ) {
 			$this->id_base = 'paypal-legacy';
 			$this->name    = 'PayPal (Legacy)';
 
+			// FrmPaymentAction sets option_name to 'frm_paypal_action' using its 'paypal'
+			// id_base. Recompute it from the new id_base so this action does not share the
+			// POST data namespace with the PayPal add-on's 'paypal' action, which would make
+			// both action controls save the same submission and create a duplicate action.
+			$this->option_name = 'frm_' . $this->id_base . '_action';
+
 			$this->action_options['is_beta'] = false;
 		}
 	}


### PR DESCRIPTION
I'm noticing this bug with the new payment action changes.

When I create a legacy PayPal action and save, it would create a second legacy PayPal action.

It looks like changing option name here as well fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed namespace collision between legacy PayPal actions and PayPal add-on actions, ensuring each maintains its own separate option storage and preventing data conflicts between the two payment systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->