### PR TITLE
Update JS validation to always remove errors when valid regardless of…

### DIFF
--- a/js/formidable.js
+++ b/js/formidable.js
@@ -282,9 +282,12 @@ function frmFrontFormJS() {
 			maybeAddHttpsToUrl( field );
 		}
 		const form = field.closest( 'form' );
-		if ( form && hasClass( form, 'frm_js_validate' ) ) {
-			validateField( field );
+		if ( ! form ) {
+			return;
 		}
+
+		// Removing stale errors is universal. Adding errors only happens when JS validation is enabled.
+		validateField( field, hasClass( form, 'frm_js_validate' ) );
 	}
 
 	/**
@@ -301,11 +304,16 @@ function frmFrontFormJS() {
 	/**
 	 * Validate a field with JS.
 	 *
+	 * Removing stale errors is universal. Adding errors only happens when JS validation is enabled.
+	 *
+	 * @since x.x Added the `addErrors` parameter.
+	 *
 	 * @param {HTMLElement} field
+	 * @param {boolean}     addErrors Whether to add new errors. Defaults to `true`.
 	 *
 	 * @return {void}
 	 */
-	function validateField( field ) {
+	function validateField( field, addErrors = true ) {
 		let errors;
 		let key;
 
@@ -325,11 +333,18 @@ function frmFrontFormJS() {
 			validateFieldValue( field, errors, false );
 		}
 
-		removeFieldError( fieldContainer );
-		if ( Object.keys( errors ).length > 0 ) {
-			for ( key in errors ) {
-				addFieldError( fieldContainer, key, errors );
+		const hasErrors = Object.keys( errors ).length > 0;
+
+		if ( addErrors ) {
+			removeFieldError( fieldContainer );
+			if ( hasErrors ) {
+				for ( key in errors ) {
+					addFieldError( fieldContainer, key, errors );
+				}
 			}
+		} else if ( ! hasErrors ) {
+			// JS validation is off, so only remove existing errors once the field passes validation.
+			removeFieldError( fieldContainer );
 		}
 	}
 


### PR DESCRIPTION
… validation setting

**That this update changes**
With this update, JS validation does not need to be enabled in order for field errors to disappear on change events.

**Where this update might break**
I'd mostly look out for JS errors in the console. Validating all fields always might introduce an error somewhere in our validation logic. I don't think it's likely though as I'm not aware of any issues with our JS validation setting throwing errors. If there are, these are good to catch anyway.

It also wouldn't hurt to test with JS validation on as well.

**To replicate**
1. Ensure the form does not have JS validation enabled.
2. Submit the form in a case where errors would appear (like required field validation).
3. Update the field.

Previously, the error would remain. Now, it disappears.

**Before**

https://github.com/user-attachments/assets/5609ba52-84d6-4c2f-8c92-f8f28cf2b962

**After**

https://github.com/user-attachments/assets/399d6e3b-7196-46fa-b5ea-c717bc2037f0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved URL field error handling to ensure stale validation errors are properly cleared even when JavaScript validation is disabled, while preventing new validation errors from appearing unless validation is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->