### PR TITLE
Extend sales api cache timeout

### DIFF
--- a/classes/models/FrmSalesApi.php
+++ b/classes/models/FrmSalesApi.php
@@ -70,6 +70,22 @@ class FrmSalesApi extends FrmFormApi {
 	}
 
 	/**
+	 * If the last check was a rate limit, we'll need to check again sooner.
+	 *
+	 * @since 6.25.1
+	 *
+	 * @param array $addons
+	 *
+	 * @return string
+	 */
+	protected function get_cache_timeout( $addons ) {
+		if ( isset( $addons['response_code'] ) && 429 === $addons['response_code'] ) {
+			return '+1 hour';
+		}
+		return $this->cache_timeout;
+	}
+
+	/**
 	 * @since 6.17
 	 *
 	 * @return void

--- a/classes/models/FrmSalesApi.php
+++ b/classes/models/FrmSalesApi.php
@@ -72,7 +72,7 @@ class FrmSalesApi extends FrmFormApi {
 	/**
 	 * If the last check was a rate limit, we'll need to check again sooner.
 	 *
-	 * @since 6.25.1
+	 * @since x.x
 	 *
 	 * @param array $addons
 	 *


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API resilience and application stability by implementing intelligent cache timeout adjustments. When the external API service experiences rate limiting, the system automatically extends the cache duration to gracefully handle the situation, reducing failed requests and maintaining consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->