### PR TITLE
Fix paypal commerce test mode checkbox not working when paypal addon is active

### DIFF
--- a/paypal/controllers/FrmPayPalLiteHooksController.php
+++ b/paypal/controllers/FrmPayPalLiteHooksController.php
@@ -32,6 +32,11 @@ class FrmPayPalLiteHooksController {
 		// These are called explicitly below the Lite PayPal settings.
 		add_filter( 'frm_add_settings_section', 'FrmPayPalLiteSettingsController::add_settings_section', 99 );
 		add_action( 'frm_update_settings', 'FrmPayPalLiteSettingsController::process_form' );
+		// Hook with high priority to sync test_mode after add-on saves
+		add_action( 'frm_update_settings', 'FrmPayPalLiteSettingsController::sync_test_mode_after_addon', 999 );
+
+		// Hook into update_option to preserve test_mode when add-on saves
+		add_action( 'update_option_frm_paypal_options', 'FrmPayPalLiteSettingsController::preserve_test_mode_on_update', 10, 2 );
 
 		add_filter( 'frm_before_save_payment_action', 'FrmPayPalLiteActionsController::before_save_settings', 20, 2 );
 

--- a/paypal/controllers/FrmPayPalLiteHooksController.php
+++ b/paypal/controllers/FrmPayPalLiteHooksController.php
@@ -32,8 +32,6 @@ class FrmPayPalLiteHooksController {
 		// These are called explicitly below the Lite PayPal settings.
 		add_filter( 'frm_add_settings_section', 'FrmPayPalLiteSettingsController::add_settings_section', 99 );
 		add_action( 'frm_update_settings', 'FrmPayPalLiteSettingsController::process_form' );
-		// Hook with high priority to sync test_mode after add-on saves
-		add_action( 'frm_update_settings', 'FrmPayPalLiteSettingsController::sync_test_mode_after_addon', 999 );
 
 		// Hook into update_option to preserve test_mode when add-on saves
 		add_action( 'update_option_frm_paypal_options', 'FrmPayPalLiteSettingsController::preserve_test_mode_on_update', 10, 2 );

--- a/paypal/controllers/FrmPayPalLiteSettingsController.php
+++ b/paypal/controllers/FrmPayPalLiteSettingsController.php
@@ -71,10 +71,12 @@ class FrmPayPalLiteSettingsController {
 		}
 
 		// If old value had test_mode but new value doesn't, preserve it
-		if ( isset( $old_value->test_mode ) && ! isset( $new_value->test_mode ) ) {
-			$new_value->test_mode = $old_value->test_mode;
-			// Update the option with the preserved test_mode
-			update_option( 'frm_paypal_options', $new_value );
+		if ( ! isset( $old_value->test_mode ) || isset( $new_value->test_mode ) ) {
+			return;
 		}
+
+		$new_value->test_mode = $old_value->test_mode;
+		// Update the option with the preserved test_mode
+		update_option( 'frm_paypal_options', $new_value );
 	}
 }

--- a/paypal/controllers/FrmPayPalLiteSettingsController.php
+++ b/paypal/controllers/FrmPayPalLiteSettingsController.php
@@ -55,4 +55,52 @@ class FrmPayPalLiteSettingsController {
 		$settings->update( $_POST );
 		$settings->store();
 	}
+
+	/**
+	 * Sync test_mode after PayPal add-on saves its settings.
+	 * This runs with high priority to ensure it runs after the add-on's process_form.
+	 *
+	 * @param array $params
+	 *
+	 * @return void
+	 */
+	public static function sync_test_mode_after_addon( $params ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( ! isset( $_POST['frm_paypal_test_mode'] ) ) {
+			return;
+		}
+
+		$test_mode = absint( $_POST['frm_paypal_test_mode'] );
+		$options = get_option( 'frm_paypal_options' );
+
+		if ( ! is_object( $options ) ) {
+			$options = new stdClass();
+		}
+
+		// Preserve test_mode which the add-on's update() method doesn't handle
+		$options->test_mode = $test_mode;
+		update_option( 'frm_paypal_options', $options );
+	}
+
+	/**
+	 * Preserve test_mode when the PayPal add-on updates frm_paypal_options.
+	 * This hooks into update_option to ensure test_mode isn't lost.
+	 *
+	 * @param mixed $old_value The old option value.
+	 * @param mixed $new_value The new option value.
+	 *
+	 * @return void
+	 */
+	public static function preserve_test_mode_on_update( $old_value, $new_value ) {
+		if ( ! is_object( $old_value ) || ! is_object( $new_value ) ) {
+			return;
+		}
+
+		// If old value had test_mode but new value doesn't, preserve it
+		if ( isset( $old_value->test_mode ) && ! isset( $new_value->test_mode ) ) {
+			$new_value->test_mode = $old_value->test_mode;
+			// Update the option with the preserved test_mode
+			update_option( 'frm_paypal_options', $new_value );
+		}
+	}
 }

--- a/paypal/controllers/FrmPayPalLiteSettingsController.php
+++ b/paypal/controllers/FrmPayPalLiteSettingsController.php
@@ -57,32 +57,6 @@ class FrmPayPalLiteSettingsController {
 	}
 
 	/**
-	 * Sync test_mode after PayPal add-on saves its settings.
-	 * This runs with high priority to ensure it runs after the add-on's process_form.
-	 *
-	 * @param array $params
-	 *
-	 * @return void
-	 */
-	public static function sync_test_mode_after_addon( $params ) {
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		if ( ! isset( $_POST['frm_paypal_test_mode'] ) ) {
-			return;
-		}
-
-		$test_mode = absint( $_POST['frm_paypal_test_mode'] );
-		$options = get_option( 'frm_paypal_options' );
-
-		if ( ! is_object( $options ) ) {
-			$options = new stdClass();
-		}
-
-		// Preserve test_mode which the add-on's update() method doesn't handle
-		$options->test_mode = $test_mode;
-		update_option( 'frm_paypal_options', $options );
-	}
-
-	/**
 	 * Preserve test_mode when the PayPal add-on updates frm_paypal_options.
 	 * This hooks into update_option to ensure test_mode isn't lost.
 	 *

--- a/paypal/models/FrmPayPalLiteSettings.php
+++ b/paypal/models/FrmPayPalLiteSettings.php
@@ -65,6 +65,8 @@ class FrmPayPalLiteSettings {
 	public function get_options() {
 		$settings = get_option( 'frm_' . $this->param() . '_options' );
 
+		error_log( 'PayPal Lite get_options: raw settings = ' . print_r( $settings, true ) );
+
 		if ( is_object( $settings ) ) {
 			$this->set_default_options( $settings );
 		} elseif ( $settings ) {
@@ -74,6 +76,8 @@ class FrmPayPalLiteSettings {
 			$this->set_default_options( true );
 			$this->store();
 		}
+
+		error_log( 'PayPal Lite get_options: final test_mode = ' . $this->settings->test_mode );
 
 		return $this->settings;
 	}
@@ -85,14 +89,15 @@ class FrmPayPalLiteSettings {
 	 */
 	public function update( $params ) {
 		$settings = $this->default_options();
+		$param    = $this->param();
 
 		foreach ( $settings as $setting => $default ) {
-			if ( isset( $params[ 'frm_' . $this->param() . '_' . $setting ] ) ) {
-				$this->settings->{$setting} = sanitize_text_field( $params[ 'frm_' . $this->param() . '_' . $setting ] );
+			if ( isset( $params[ 'frm_' . $param . '_' . $setting ] ) ) {
+				$this->settings->{$setting} = sanitize_text_field( $params[ 'frm_' . $param . '_' . $setting ] );
 			}
 		}
 
-		$this->settings->test_mode = isset( $params[ 'frm_' . $this->param() . '_test_mode' ] ) ? absint( $params[ 'frm_' . $this->param() . '_test_mode' ] ) : 0;
+		$this->settings->test_mode = isset( $params[ 'frm_' . $param . '_test_mode' ] ) ? absint( $params[ 'frm_' . $param . '_test_mode' ] ) : 0;
 	}
 
 	/**

--- a/paypal/models/FrmPayPalLiteSettings.php
+++ b/paypal/models/FrmPayPalLiteSettings.php
@@ -65,8 +65,6 @@ class FrmPayPalLiteSettings {
 	public function get_options() {
 		$settings = get_option( 'frm_' . $this->param() . '_options' );
 
-		error_log( 'PayPal Lite get_options: raw settings = ' . print_r( $settings, true ) );
-
 		if ( is_object( $settings ) ) {
 			$this->set_default_options( $settings );
 		} elseif ( $settings ) {
@@ -76,8 +74,6 @@ class FrmPayPalLiteSettings {
 			$this->set_default_options( true );
 			$this->store();
 		}
-
-		error_log( 'PayPal Lite get_options: final test_mode = ' . $this->settings->test_mode );
 
 		return $this->settings;
 	}

--- a/paypal/views/settings/connect-settings-container.php
+++ b/paypal/views/settings/connect-settings-container.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</td>
 		<td>
 			<label>
+				<input type="hidden" name="frm_paypal_test_mode" value="0" />
 				<input type="checkbox" name="frm_paypal_test_mode" id="frm_paypal_test_mode" value="1" <?php checked( $settings->settings->test_mode, 1 ); ?> />
 				<?php esc_html_e( 'Use the PayPal test mode', 'formidable' ); ?>
 			</label>


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3359590190/253804

**Pre-release**
[formidable-6.32.1b.zip](https://github.com/user-attachments/files/29097372/formidable-6.32.1b.zip)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the PayPal add-on's test mode setting could be lost when updating PayPal configuration. Test mode preference is now properly preserved during settings updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->