### PR TITLE
Remove payment cron when all gateways are disconnected

### DIFF
--- a/classes/controllers/FrmAppController.php
+++ b/classes/controllers/FrmAppController.php
@@ -1330,14 +1330,18 @@ class FrmAppController {
 
 	/**
 	 * The payment cron is unscheduled when Formidable is deactivated.
-	 * We need to add it back again on activation if Stripe is configured.
+	 * We need to add it back again on activation if any payment gateway is configured.
 	 *
 	 * @since 6.5
 	 *
 	 * @return void
 	 */
 	private static function maybe_activate_payment_cron() {
-		if ( ! FrmStrpLiteConnectHelper::stripe_connect_is_setup() ) {
+		$stripe_connected = FrmStrpLiteConnectHelper::at_least_one_mode_is_setup();
+		$square_connected = FrmSquareLiteConnectHelper::at_least_one_mode_is_setup();
+		$paypal_connected = FrmPayPalLiteConnectHelper::at_least_one_mode_is_setup();
+
+		if ( ! $stripe_connected && ! $square_connected && ! $paypal_connected ) {
 			return;
 		}
 

--- a/paypal/helpers/FrmPayPalLiteConnectHelper.php
+++ b/paypal/helpers/FrmPayPalLiteConnectHelper.php
@@ -938,6 +938,7 @@ class FrmPayPalLiteConnectHelper {
 	public static function handle_disconnect() {
 		self::disconnect();
 		self::reset_paypal_api_integration();
+		FrmTransLiteAppHelper::trigger_gateway_disconnected_hook( 'paypal', self::get_mode_value_from_post() );
 		wp_send_json_success();
 	}
 

--- a/square/helpers/FrmSquareLiteConnectHelper.php
+++ b/square/helpers/FrmSquareLiteConnectHelper.php
@@ -707,6 +707,7 @@ class FrmSquareLiteConnectHelper {
 	public static function handle_disconnect() {
 		self::disconnect();
 		self::reset_square_api_integration();
+		FrmTransLiteAppHelper::trigger_gateway_disconnected_hook( 'square', self::get_mode_value_from_post() );
 		wp_send_json_success();
 	}
 

--- a/stripe/controllers/FrmTransLiteAppController.php
+++ b/stripe/controllers/FrmTransLiteAppController.php
@@ -45,12 +45,23 @@ class FrmTransLiteAppController {
 	}
 
 	/**
-	 * Remove the cron when the plugin is deactivated.
+	 * Remove the payment cron when all gateways are disconnected.
+	 *
+	 * @since x.x
+	 *
+	 * @param string $gateway 'stripe', 'square', or 'paypal'.
+	 * @param string $mode 'test' or 'live'.
 	 *
 	 * @return void
 	 */
-	public static function remove_cron() {
-		wp_clear_scheduled_hook( 'frm_payment_cron' );
+	public static function maybe_remove_payment_cron( $gateway, $mode ) {
+		$stripe_connected = FrmStrpLiteConnectHelper::at_least_one_mode_is_setup();
+		$square_connected = FrmSquareLiteConnectHelper::at_least_one_mode_is_setup();
+		$paypal_connected = FrmPayPalLiteConnectHelper::at_least_one_mode_is_setup();
+
+		if ( ! $stripe_connected && ! $square_connected && ! $paypal_connected ) {
+			wp_clear_scheduled_hook( 'frm_payment_cron' );
+		}
 	}
 
 	/**
@@ -230,5 +241,17 @@ class FrmTransLiteAppController {
 			.frm_field_box:has(li[data-ftype="gateway"]:only-child) { display: none; }
 			'
 		);
+	}
+
+	/**
+	 * Remove the cron when the plugin is deactivated.
+	 *
+	 * @deprecated x.x
+	 *
+	 * @return void
+	 */
+	public static function remove_cron() {
+		_deprecated_function( __METHOD__, 'x.x' );
+		wp_clear_scheduled_hook( 'frm_payment_cron' );
 	}
 }

--- a/stripe/controllers/FrmTransLiteHooksController.php
+++ b/stripe/controllers/FrmTransLiteHooksController.php
@@ -36,6 +36,8 @@ class FrmTransLiteHooksController {
 	 * @return void
 	 */
 	public static function load_admin_hooks() {
+		add_action( 'frm_disconnected_gateway', 'FrmTransLiteAppController::maybe_remove_payment_cron' );	
+
 		if ( class_exists( 'FrmTransHooksController', false ) ) {
 			add_action( 'frm_pay_show_square_options', 'FrmTransLiteAppController::add_repeat_cadence_value' );
 

--- a/stripe/controllers/FrmTransLiteHooksController.php
+++ b/stripe/controllers/FrmTransLiteHooksController.php
@@ -36,7 +36,7 @@ class FrmTransLiteHooksController {
 	 * @return void
 	 */
 	public static function load_admin_hooks() {
-		add_action( 'frm_disconnected_gateway', 'FrmTransLiteAppController::maybe_remove_payment_cron' );	
+		add_action( 'frm_disconnected_gateway', 'FrmTransLiteAppController::maybe_remove_payment_cron' );
 
 		if ( class_exists( 'FrmTransHooksController', false ) ) {
 			add_action( 'frm_pay_show_square_options', 'FrmTransLiteAppController::add_repeat_cadence_value' );

--- a/stripe/helpers/FrmStrpLiteConnectHelper.php
+++ b/stripe/helpers/FrmStrpLiteConnectHelper.php
@@ -263,7 +263,7 @@ class FrmStrpLiteConnectHelper {
 	private static function handle_disconnect() {
 		self::disconnect();
 		self::reset_stripe_connect_integration();
-		self::maybe_unschedule_crons();
+		FrmTransLiteAppHelper::trigger_gateway_disconnected_hook( 'stripe', self::get_mode_value_from_post() );
 		wp_send_json_success();
 	}
 
@@ -290,26 +290,6 @@ class FrmStrpLiteConnectHelper {
 		return self::post_with_authenticated_body( 'disconnect', $additional_body );
 	}
 
-	/**
-	 * Stop the payment cron once all Stripe connections have been disconnected.
-	 *
-	 * @since 6.5
-	 *
-	 * @return void
-	 */
-	private static function maybe_unschedule_crons() {
-		if ( self::at_least_one_mode_is_setup() ) {
-			// Don't unschedule if a mode is still on.
-			return;
-		}
-
-		$event     = 'frm_payment_cron';
-		$timestamp = wp_next_scheduled( $event );
-
-		if ( false !== $timestamp ) {
-			wp_unschedule_event( $timestamp, $event );
-		}
-	}
 
 	/**
 	 * @since 6.5

--- a/stripe/helpers/FrmStrpLiteConnectHelper.php
+++ b/stripe/helpers/FrmStrpLiteConnectHelper.php
@@ -290,7 +290,6 @@ class FrmStrpLiteConnectHelper {
 		return self::post_with_authenticated_body( 'disconnect', $additional_body );
 	}
 
-
 	/**
 	 * @since 6.5
 	 *

--- a/stripe/helpers/FrmTransLiteAppHelper.php
+++ b/stripe/helpers/FrmTransLiteAppHelper.php
@@ -646,7 +646,7 @@ class FrmTransLiteAppHelper {
 	 * @since x.x
 	 *
 	 * @param string $gateway 'stripe', 'square', or 'paypal'.
-	 * @param string $mode 'test' or 'live'
+	 * @param string $mode 'test' or 'live'.
 	 *
 	 * @return void
 	 */

--- a/stripe/helpers/FrmTransLiteAppHelper.php
+++ b/stripe/helpers/FrmTransLiteAppHelper.php
@@ -641,4 +641,22 @@ class FrmTransLiteAppHelper {
 
 		return $sorted + $gateways;
 	}
+
+	/**
+	 * @since x.x
+	 *
+	 * @param string $gateway 'stripe', 'square', or 'paypal'.
+	 * @param string $mode 'test' or 'live'
+	 *
+	 * @return void
+	 */
+	public static function trigger_gateway_disconnected_hook( $gateway, $mode ) {
+		/**
+		 * @since x.x
+		 *
+		 * @param string $gateway 'stripe', 'square', or 'paypal'.
+		 * @param string $mode 'test' or 'live'.
+		 */
+		do_action( 'frm_disconnected_gateway', $gateway, $mode );
+	}
 }


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3358713219/253763

_**Summary**_
- The `frm_payment_cron` cron is scheduled when the payments tables are created.
- It would only get unscheduled when deactivating Lite, or when disconnecting both Stripe gateways.

**The solution**
- This update adds new hooks for when a payment gateway is disconnected. It checks in this hook if all gateways are disconnected. If they are, the payment cron should automatically get unscheduled (and no longer appear in the WP Control settings).

You can use the WP Crontrol plugin to view your Cron events.

<img width="1063" height="62" alt="Screenshot 2026-06-18 at 4 58 30 PM" src="https://github.com/user-attachments/assets/36af9a0e-fec2-4c02-91ef-2bf32d8bef28" />
