### PR TITLE
Add form builder check before loading stripe scripts

### DIFF
--- a/stripe/controllers/FrmTransLiteActionsController.php
+++ b/stripe/controllers/FrmTransLiteActionsController.php
@@ -473,6 +473,12 @@ class FrmTransLiteActionsController {
 			return $values;
 		}
 
+		if ( FrmAppHelper::is_form_builder_page() ) {
+			// The hooks this uses can get called in the form builder and settings pages.
+			// But we do not need the script in this case.
+			return $values;
+		}
+
 		// This is also called from the frm_enqueue_form_scripts hook.
 		// With this here, the value of frm_stripe_vars.settings[0].fields is -1
 		// This is because the amount value is processed and a shortcode is not found in '000'.


### PR DESCRIPTION
Prevents this doing it wrong message I see in the form builder and settings pages.

> Function WP_Scripts::add was called incorrectly. The script with the handle "formidable-stripe" was enqueued with dependencies that are not registered: formidablepro.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gateway field display issues when editing forms in the form builder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->