### PR TITLE
Only add gateway fields when Stripe gateway is selected

### DIFF
--- a/stripe/controllers/FrmTransLiteActionsController.php
+++ b/stripe/controllers/FrmTransLiteActionsController.php
@@ -596,7 +596,8 @@ class FrmTransLiteActionsController {
 		}
 
 		if ( ! in_array( 'stripe', $settings['gateway'], true ) ) {
-			// We only need a gateway field for Stripe compatibility, so unless Stripe is selected, we can return early.
+			// We only need a gateway field for Stripe add-on compatibility,
+			// so unless Stripe is selected, we can return early.
 			return $settings;
 		}
 

--- a/stripe/controllers/FrmTransLiteActionsController.php
+++ b/stripe/controllers/FrmTransLiteActionsController.php
@@ -595,6 +595,11 @@ class FrmTransLiteActionsController {
 			}
 		}
 
+		if ( ! in_array( 'stripe', $settings['gateway'], true ) ) {
+			// We only need a gateway field for Stripe compatibility, so unless Stripe is selected, we can return early.
+			return $settings;
+		}
+
 		$gateway_field_id = FrmDb::get_var(
 			'frm_fields',
 			array(


### PR DESCRIPTION
This is only added for Stripe add-on compatibility. It isn't necessary for our other gateways, so I'm not adding it anymore for Square or PayPal.