### PR TITLE
Fix paypal commerce google pay using test environment

### DIFF
--- a/paypal/controllers/FrmPayPalLiteActionsController.php
+++ b/paypal/controllers/FrmPayPalLiteActionsController.php
@@ -1419,6 +1419,7 @@ class FrmPayPalLiteActionsController extends FrmTransLiteActionsController {
 			'buttonStyle'              => self::get_button_style_for_js( $action ),
 			'imagesUrl'                => FrmPayPalLiteAppHelper::plugin_url() . 'images/',
 			'includeGooglePayApplePay' => $include_google_apple_pay,
+			'mode'                     => FrmPayPalLiteAppHelper::active_mode(),
 		);
 
 		wp_localize_script( 'formidable-paypal', 'frmPayPalVars', $paypal_vars );

--- a/paypal/js/frontend.js
+++ b/paypal/js/frontend.js
@@ -920,7 +920,7 @@
 	 */
 	function getGooglePaymentsClient() {
 		return new google.payments.api.PaymentsClient( {
-			environment: 'TEST',
+			environment: frmPayPalVars.mode === 'test' ? 'TEST' : 'PRODUCTION',
 			paymentDataCallbacks: {
 				onPaymentAuthorized
 			}


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3359590190/253804

**Pre-release**
[formidable-6.32.2b.zip](https://github.com/user-attachments/files/29218858/formidable-6.32.2b.zip)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Google Pay to use the correct payment environment (test or production) based on your PayPal plugin configuration, instead of always defaulting to test mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->