### PR TITLE
Add missing disabled submit button styles to Lite

### DIFF
--- a/css/_single_theme.css.php
+++ b/css/_single_theme.css.php
@@ -315,6 +315,12 @@ if ( '' === $field_height || 'auto' === $field_height ) {
 			max-width:var(--submit-width)<?php echo esc_html( $important ); ?>;
 		<?php } ?>
 }
+.<?php echo esc_html( $style_class ); ?> input[type=submit][disabled],
+.<?php echo esc_html( $style_class ); ?> .frm_submit input[type=button][disabled],
+.<?php echo esc_html( $style_class ); ?> .frm_submit button[disabled] {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
 		<?php
 	}//end if
 }//end if


### PR DESCRIPTION
I noticed that disabled submit buttons don't appear disabled when Pro is inactive.

This fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual feedback for disabled buttons with reduced opacity and "not-allowed" cursor styling applied across all disabled form submit controls and buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->