### PR TITLE
Try to enable submit button on safari autofill

### DIFF
--- a/paypal/js/frontend.js
+++ b/paypal/js/frontend.js
@@ -761,7 +761,6 @@
 	 * @param {Object} data The onBlur event data.
 	 */
 	function onCardFieldsBlur( data ) {
-		alert( 'blur' );
 		if ( selectedMethod === 'card' && data.isFormValid ) {
 			cardFieldsValid = true;
 			enableSubmit();

--- a/paypal/js/frontend.js
+++ b/paypal/js/frontend.js
@@ -718,7 +718,12 @@
 				onError,
 				style: frmPayPalVars.style,
 				inputEvents: {
-					onChange: onCardFieldsChange
+					onChange: onCardFieldsChange,
+					onFocus: function() {
+						// onBlur only triggers if onFocus is defined.
+						// But we don't need to do anything on focus.
+					},
+					onBlur: onCardFieldsBlur
 				}
 			};
 
@@ -746,6 +751,20 @@
 			} else {
 				disableSubmit( thisForm );
 			}
+		}
+	}
+
+	/**
+	 * Handle card field blur events.
+	 * This detects autofilled fields that may not trigger onChange.
+	 *
+	 * @param {Object} data The onBlur event data.
+	 */
+	function onCardFieldsBlur( data ) {
+		alert( 'blur' );
+		if ( selectedMethod === 'card' && data.isFormValid ) {
+			cardFieldsValid = true;
+			enableSubmit();
 		}
 	}
 

--- a/paypal/js/frontend.js
+++ b/paypal/js/frontend.js
@@ -719,7 +719,7 @@
 				style: frmPayPalVars.style,
 				inputEvents: {
 					onChange: onCardFieldsChange,
-					onFocus: function() {
+					onFocus() {
 						// onBlur only triggers if onFocus is defined.
 						// But we don't need to do anything on focus.
 					},


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3363708862/254001

**Pre-release**
[formidable-6.32.2b.zip](https://github.com/user-attachments/files/29255450/formidable-6.32.2b.zip)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PayPal card field validation to properly detect when card inputs are completed. The submit button now enables at the appropriate time, improving support for both manual entry and autofilled card information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->