### PR TITLE
Fix submit button when autofilling PayPal card fields

### DIFF
--- a/.github/workflows/oxlint.yml
+++ b/.github/workflows/oxlint.yml
@@ -24,5 +24,8 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Install Oxlint
+        run: npm install oxlint@1.59.0 --no-package-lock
+
       - name: Run Oxlint
         run: ./node_modules/.bin/oxlint . --format unix

--- a/.github/workflows/oxlint.yml
+++ b/.github/workflows/oxlint.yml
@@ -24,8 +24,5 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Install Oxlint
-        run: npm install oxlint@1.59.0 --no-package-lock
-
       - name: Run Oxlint
         run: ./node_modules/.bin/oxlint . --format unix

--- a/paypal/js/frontend.js
+++ b/paypal/js/frontend.js
@@ -719,11 +719,9 @@
 				style: frmPayPalVars.style,
 				inputEvents: {
 					onChange: onCardFieldsChange,
-					// eslint-disable-next-line no-empty, unicorn/no-empty-brace-spaces
-					onFocus() {
-						// This is intentionally left blank, but it should not be deleted.
-						// onFocus is required for onBlur to work.
-					},
+					// This is intentionally left blank, but it should not be deleted. onFocus is required for onBlur to work.
+					// eslint-disable-next-line no-empty
+					onFocus() {},
 					onBlur: onCardFieldsBlur
 				}
 			};
@@ -770,8 +768,7 @@
 					disableSubmit( thisForm );
 				}
 			}
-		} catch ( err ) {
-		}
+		} catch ( err ) {} // eslint-disable-line no-empty
 	}
 
 	/**

--- a/paypal/js/frontend.js
+++ b/paypal/js/frontend.js
@@ -719,7 +719,7 @@
 				style: frmPayPalVars.style,
 				inputEvents: {
 					onChange: onCardFieldsChange,
-					onFocus: function() {
+					onFocus() {
 						// This is intentionally left blank, but it should not be deleted.
 						// onFocus is required for onBlur to work.
 					},

--- a/paypal/js/frontend.js
+++ b/paypal/js/frontend.js
@@ -756,10 +756,8 @@
 
 	/**
 	 * Handle card field blur events.
-	 *
-	 * @param {Object} data The onBlur event data.
 	 */
-	async function onCardFieldsBlur( data ) {
+	async function onCardFieldsBlur() {
 		try {
 			const state = await cardFieldsInstance.getState();
 			cardFieldsValid = state.isFormValid;

--- a/paypal/js/frontend.js
+++ b/paypal/js/frontend.js
@@ -718,7 +718,12 @@
 				onError,
 				style: frmPayPalVars.style,
 				inputEvents: {
-					onChange: onCardFieldsChange
+					onChange: onCardFieldsChange,
+					onFocus: function() {
+						// This is intentionally left blank, but it should not be deleted.
+						// onFocus is required for onBlur to work.
+					},
+					onBlur: onCardFieldsBlur
 				}
 			};
 
@@ -746,6 +751,28 @@
 			} else {
 				disableSubmit( thisForm );
 			}
+		}
+	}
+
+	/**
+	 * Handle card field blur events.
+	 *
+	 * @param {Object} data The onBlur event data.
+	 */
+	async function onCardFieldsBlur( data ) {
+		try {
+			const state = await cardFieldsInstance.getState();
+			cardFieldsValid = state.isFormValid;
+
+			if ( selectedMethod === 'card' ) {
+				if ( cardFieldsValid ) {
+					enableSubmit();
+				} else {
+					disableSubmit( thisForm );
+				}
+			}
+		} catch ( err ) {
+			console.error( 'Failed to get card field state on blur', err );
 		}
 	}
 

--- a/paypal/js/frontend.js
+++ b/paypal/js/frontend.js
@@ -719,6 +719,7 @@
 				style: frmPayPalVars.style,
 				inputEvents: {
 					onChange: onCardFieldsChange,
+					// eslint-disable-next-line no-empty, unicorn/no-empty-brace-spaces
 					onFocus() {
 						// This is intentionally left blank, but it should not be deleted.
 						// onFocus is required for onBlur to work.

--- a/paypal/js/frontend.js
+++ b/paypal/js/frontend.js
@@ -772,7 +772,6 @@
 				}
 			}
 		} catch ( err ) {
-			console.error( 'Failed to get card field state on blur', err );
 		}
 	}
 


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3363708862/254001

**_This currently doesn't fully work, as the PayPal SDK treats the expiry as invalid when auto-filled._**

**Pre-release**
[formidable-6.32.3b.zip](https://github.com/user-attachments/files/29297691/formidable-6.32.3b.zip)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved card payment form behavior when moving focus away from fields.
  * The submit button now updates correctly after a blur event, better reflecting whether card details are valid.
  * Added a small focus-handling change to preserve expected field interaction while entering payment information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->