### PR TITLE
Remove beta flag from paypal commerce

### DIFF
--- a/classes/views/frm-form-actions/default_actions.php
+++ b/classes/views/frm-form-actions/default_actions.php
@@ -57,8 +57,6 @@ if ( class_exists( 'FrmPaymentAction' ) ) {
 			// POST data namespace with the PayPal add-on's 'paypal' action, which would make
 			// both action controls save the same submission and create a duplicate action.
 			$this->option_name = 'frm_' . $this->id_base . '_action';
-
-			$this->action_options['is_beta'] = false;
 		}
 	}
 }

--- a/paypal/controllers/FrmPayPalLiteHooksController.php
+++ b/paypal/controllers/FrmPayPalLiteHooksController.php
@@ -50,7 +50,6 @@ class FrmPayPalLiteHooksController {
 			function ( $options ) {
 				// Make actions using the PayPal add-on use the same icon we use in Lite.
 				$options['classes'] = 'frmfont frm_paypal_icon';
-				$options['is_beta'] = true;
 				return $options;
 			}
 		);


### PR DESCRIPTION
Issues have been coming in slower, and we've confirmed live payments work.

So I think this is fine to remove now.

🎉 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the PayPal action option display to use the correct Lite icon styling.
  * Removed an incorrect beta label from the PayPal option so it appears as a standard feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->