### PR TITLE
Update serialized string parser to prevent null array keys

### DIFF
--- a/classes/helpers/FrmSerializedStringParserHelper.php
+++ b/classes/helpers/FrmSerializedStringParserHelper.php
@@ -138,7 +138,7 @@ class FrmSerializedStringParserHelper {
 			$array_key   = $this->do_parse( $string );
 			$array_value = $this->do_parse( $string );
 
-			if ( ! is_array( $array_key ) ) {
+			if ( ! is_array( $array_key ) && null !== $array_key ) {
 				$val[ $array_key ] = $array_value;
 			}
 		}


### PR DESCRIPTION
I believe it's trying to parse an invalid string. This update ignores a `null` array key since that isn't valid.

> PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead in .../formidable/classes/helpers/FrmSerializedStringParserHelper.php on line 142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of parsed serialized keys by skipping entries with invalid or null keys, preventing unexpected values from being added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->