### PR TITLE
Add more checks that style settings are set

### DIFF
--- a/classes/models/FrmStyle.php
+++ b/classes/models/FrmStyle.php
@@ -682,12 +682,21 @@ class FrmStyle {
 		}
 
 		if ( ! isset( $settings['submit_hover_bg_color'] ) && isset( $settings['submit_bg_color'] ) ) {
-			$settings['submit_hover_bg_color']     = $settings['submit_bg_color'];
-			$settings['submit_hover_color']        = $settings['submit_text_color'];
+			$settings['submit_hover_bg_color'] = $settings['submit_bg_color'];
+		}
+		if ( ! isset( $settings['submit_hover_color'] ) && isset( $settings['submit_text_color'] ) ) {
+			$settings['submit_hover_color'] = $settings['submit_text_color'];
+		}
+		if ( ! isset( $settings['submit_hover_border_color'] ) && isset( $settings['submit_border_color'] ) ) {
 			$settings['submit_hover_border_color'] = $settings['submit_border_color'];
-
-			$settings['submit_active_bg_color']     = $settings['submit_bg_color'];
-			$settings['submit_active_color']        = $settings['submit_text_color'];
+		}
+		if ( ! isset( $settings['submit_active_bg_color'] ) && isset( $settings['submit_bg_color'] ) ) {
+			$settings['submit_active_bg_color'] = $settings['submit_bg_color'];
+		}
+		if ( ! isset( $settings['submit_active_color'] ) && isset( $settings['submit_text_color'] ) ) {
+			$settings['submit_active_color'] = $settings['submit_text_color'];
+		}
+		if ( ! isset( $settings['submit_active_border_color'] ) && isset( $settings['submit_border_color'] ) ) {
 			$settings['submit_active_border_color'] = $settings['submit_border_color'];
 		}
 

--- a/classes/models/FrmStyle.php
+++ b/classes/models/FrmStyle.php
@@ -684,18 +684,23 @@ class FrmStyle {
 		if ( ! isset( $settings['submit_hover_bg_color'] ) && isset( $settings['submit_bg_color'] ) ) {
 			$settings['submit_hover_bg_color'] = $settings['submit_bg_color'];
 		}
+
 		if ( ! isset( $settings['submit_hover_color'] ) && isset( $settings['submit_text_color'] ) ) {
 			$settings['submit_hover_color'] = $settings['submit_text_color'];
 		}
+
 		if ( ! isset( $settings['submit_hover_border_color'] ) && isset( $settings['submit_border_color'] ) ) {
 			$settings['submit_hover_border_color'] = $settings['submit_border_color'];
 		}
+
 		if ( ! isset( $settings['submit_active_bg_color'] ) && isset( $settings['submit_bg_color'] ) ) {
 			$settings['submit_active_bg_color'] = $settings['submit_bg_color'];
 		}
+
 		if ( ! isset( $settings['submit_active_color'] ) && isset( $settings['submit_text_color'] ) ) {
 			$settings['submit_active_color'] = $settings['submit_text_color'];
 		}
+
 		if ( ! isset( $settings['submit_active_border_color'] ) && isset( $settings['submit_border_color'] ) ) {
 			$settings['submit_active_border_color'] = $settings['submit_border_color'];
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Submit button hover and active states now preserve any custom colors you’ve already set.
  * Missing hover/active colors are filled in from the main button colors only when needed, helping avoid unexpected style overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->