### PR TITLE
Fix archive page show 404 because of the gated content

### DIFF
--- a/classes/controllers/FrmGatedContentController.php
+++ b/classes/controllers/FrmGatedContentController.php
@@ -144,6 +144,10 @@ class FrmGatedContentController {
 	 * @return void
 	 */
 	public static function maybe_unlock_post() {
+		if ( ! is_singular() ) {
+			return;
+		}
+
 		$post_id = get_queried_object_id();
 
 		if ( ! $post_id ) {


### PR DESCRIPTION
This fixes https://secure.helpscout.net/conversation/3388018170/255310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gated content unlocking now runs only on individual post or page views.
  * Prevented access-code checks, redirects, and restricted-content handling from affecting archive, listing, and other non-singular pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->