### PR TITLE
Add new empty states for forms/entries searches

### DIFF
--- a/classes/helpers/FrmEntriesListHelper.php
+++ b/classes/helpers/FrmEntriesListHelper.php
@@ -208,8 +208,20 @@ class FrmEntriesListHelper extends FrmListHelper {
 			)
 		);
 
-		if ( $s ) {
-			esc_html_e( 'No Entries Found', 'formidable' );
+		if ( $s !== '' ) {
+			$current_url = set_url_scheme(
+				'http://' . FrmAppHelper::get_server_value( 'HTTP_HOST' ) . FrmAppHelper::get_server_value( 'REQUEST_URI' )
+			);
+			$clear_url   = remove_query_arg( 's', $current_url );
+
+			echo '<p>';
+			printf(
+				/* translators: %1$s: Start link HTML, %2$s: End link HTML */
+				esc_html__( 'No entries match your search. %1$sClear search%2$s', 'formidable' ),
+				'<a href="' . esc_url( $clear_url ) . '">',
+				'</a>'
+			);
+			echo '</p>';
 			return;
 		}
 

--- a/classes/helpers/FrmFormsListHelper.php
+++ b/classes/helpers/FrmFormsListHelper.php
@@ -134,6 +134,30 @@ class FrmFormsListHelper extends FrmListHelper {
 	 * @return void
 	 */
 	public function no_items() {
+		$s = self::get_param(
+			array(
+				'param'    => 's',
+				'sanitize' => 'sanitize_text_field',
+			)
+		);
+
+		if ( $s !== '' ) {
+			$current_url = set_url_scheme(
+				'http://' . FrmAppHelper::get_server_value( 'HTTP_HOST' ) . FrmAppHelper::get_server_value( 'REQUEST_URI' )
+			);
+			$clear_url   = remove_query_arg( 's', $current_url );
+
+			echo '<p>';
+			printf(
+				/* translators: %1$s: Start link HTML, %2$s: End link HTML */
+				esc_html__( 'No forms match your search. %1$sClear search%2$s', 'formidable' ),
+				'<a href="' . esc_url( $clear_url ) . '">',
+				'</a>'
+			);
+			echo '</p>';
+			return;
+		}
+
 		if ( $this->status === 'trash' ) {
 			echo '<p>';
 			esc_html_e( 'No forms found in the trash.', 'formidable' );


### PR DESCRIPTION
Razvan requested this.

Now, the empty states for forms/entries will show a special message when there is a search query, with a link to clear the search and reload the page.

**Before**
<img width="1144" height="537" alt="Screenshot 2026-07-16 at 11 48 38 AM" src="https://github.com/user-attachments/assets/4fbe1528-18db-4e96-8ab4-17ecd002aec3" />

<img width="1147" height="181" alt="Screenshot 2026-07-16 at 11 48 24 AM" src="https://github.com/user-attachments/assets/aad81bf0-1c0d-4969-97c6-827b64bc101f" />

**After**
<img width="1148" height="143" alt="Screenshot 2026-07-16 at 11 46 54 AM" src="https://github.com/user-attachments/assets/232e2bc5-89ab-48ad-a5cb-eded03d5634b" />

<img width="1142" height="178" alt="Screenshot 2026-07-16 at 11 47 09 AM" src="https://github.com/user-attachments/assets/8881b360-4717-4eb5-bab3-1dcb0031519f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty search results messaging for entries and forms.
  * Added a “Clear search” link so users can quickly return to the full list.
  * Search-specific messages now display consistently instead of generic empty-state messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->