### PR TITLE
More accessible captcha labels

### DIFF
--- a/classes/models/fields/FrmFieldCaptcha.php
+++ b/classes/models/fields/FrmFieldCaptcha.php
@@ -72,7 +72,11 @@ class FrmFieldCaptcha extends FrmFieldType {
 	}
 
 	/**
-	 * Replace the "for" attribute for captcha field so it matches the response ID.
+	 * Modify the captcha field label so it is not orphaned.
+	 *
+	 * The label is omitted when the label position is set to "none".
+	 * When the label is visible it is rendered as a <span> instead of a <label>,
+	 * since the captcha response input is inside an iframe and cannot be referenced.
 	 *
 	 * @param array  $args
 	 * @param string $html
@@ -80,8 +84,17 @@ class FrmFieldCaptcha extends FrmFieldType {
 	 * @return string
 	 */
 	protected function before_replace_html_shortcodes( $args, $html ) {
-		$settings = FrmCaptchaFactory::get_settings_object();
-		return str_replace( ' for="field_[key]"', ' for="' . esc_attr( $settings->token_field ) . '"', $html );
+		if ( 'none' === FrmField::get_option( $this->field, 'label' ) ) {
+			// Fully strip the label for a CAPTCHA if it is set to hidden.
+			return preg_replace( '~\s*<label\b[^>]*for="field_\[key\]"[^>]*>.*?</label>\s*~s', '', $html );
+		}
+
+		// Convert a CAPTCHA label to a span to prevent an orphaned label issue in WAVE.
+		return preg_replace(
+			'~<label\b([^>]*?)\s*for="field_\[key\]"([^>]*?)>(.*?)</label>~s',
+			'<span$1$2>$3</span>',
+			$html
+		);
 	}
 
 	/**


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3386866379/255259

Fixes this WAVE issue.

The CAPTCHA inputs are always in an iframe, so a label can't actually direct to any inputs.

<img width="214" height="81" alt="Screenshot 2026-07-16 at 1 58 21 PM" src="https://github.com/user-attachments/assets/6d1b7a08-a194-4ae4-85bb-8296142664cd" />

In this update,
1. If the label position is set to "None" (the default value), the label is removed altogether.
2. If the label position is not set to "None", the label element is converted to a span tag.