### PR TITLE
Get all form actions for usage tracking

### DIFF
--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -627,6 +627,8 @@ class FrmUsage {
 
 			$offset += $limit;
 			unset( $saved_actions );
+
+			gc_collect_cycles();
 		} while ( count( $actions ) >= $offset );
 
 		return $actions;

--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -603,17 +603,23 @@ class FrmUsage {
 	 * @return array
 	 */
 	private function actions() {
-		$actions = array();
-		$offset  = 0;
-		$limit   = 100;
+		$actions        = array();
+		$offset         = 0;
+		$limit          = 100;
+		$limit_plus_one = $limit + 1;
 
 		do {
 			$args          = array(
 				'post_type'   => FrmFormActionsController::$action_post_type,
-				'numberposts' => $limit,
+				'numberposts' => $limit_plus_one,
 				'offset'      => $offset,
 			);
 			$saved_actions = get_posts( $args );
+
+			$has_more = count( $saved_actions ) === $limit_plus_one;
+			if ( $has_more ) {
+				array_pop( $saved_actions );
+			}
 
 			foreach ( $saved_actions as $action ) {
 				$actions[] = array(
@@ -627,11 +633,10 @@ class FrmUsage {
 
 			$offset += $limit;
 
-			$saved_actions_remain = ! empty( $saved_actions );
 			unset( $saved_actions );
 
 			gc_collect_cycles();
-		} while ( $saved_actions_remain );
+		} while ( $has_more );
 
 		return $actions;
 	}

--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -603,22 +603,31 @@ class FrmUsage {
 	 * @return array
 	 */
 	private function actions() {
-		$args = array(
-			'post_type'   => FrmFormActionsController::$action_post_type,
-			'numberposts' => 100,
-		);
+		$actions = array();
+		$offset  = 0;
+		$limit   = 100;
 
-		$actions       = array();
-		$saved_actions = FrmDb::check_cache( json_encode( $args ), 'frm_actions', $args, 'get_posts' );
-
-		foreach ( $saved_actions as $action ) {
-			$actions[] = array(
-				'form_id'  => $action->menu_order,
-				'type'     => $action->post_excerpt,
-				'status'   => $action->post_status,
-				'settings' => FrmAppHelper::maybe_json_decode( $action->post_content ),
+		do {
+			$args          = array(
+				'post_type'   => FrmFormActionsController::$action_post_type,
+				'numberposts' => $limit,
+				'offset'      => $offset,
 			);
-		}
+			$saved_actions = get_posts( $args );
+
+			foreach ( $saved_actions as $action ) {
+				$actions[] = array(
+					'form_id'  => $action->menu_order,
+					'type'     => $action->post_excerpt,
+					'status'   => $action->post_status,
+					'settings' => FrmAppHelper::maybe_json_decode( $action->post_content ),
+				);
+				unset( $action );
+			}
+
+			$offset += $limit;
+			unset( $saved_actions );
+		} while ( count( $actions ) >= $offset );
 
 		return $actions;
 	}

--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -626,10 +626,12 @@ class FrmUsage {
 			}
 
 			$offset += $limit;
+
+			$saved_actions_remain = ! empty( $saved_actions );
 			unset( $saved_actions );
 
 			gc_collect_cycles();
-		} while ( count( $actions ) >= $offset );
+		} while ( $saved_actions_remain );
 
 		return $actions;
 	}

--- a/classes/models/FrmUsage.php
+++ b/classes/models/FrmUsage.php
@@ -615,9 +615,10 @@ class FrmUsage {
 				'offset'      => $offset,
 			);
 			$saved_actions = get_posts( $args );
+			$has_more      = count( $saved_actions ) === $limit_plus_one;
 
-			$has_more = count( $saved_actions ) === $limit_plus_one;
 			if ( $has_more ) {
+				// Pop off the last item as it is only queried to determine if there are more results.
 				array_pop( $saved_actions );
 			}
 


### PR DESCRIPTION
It looks like our usage tracking would only send data for 100 form actions. This update uses batches to pull all form actions, 100 at a time.

This is memory sensitive, so I added some `unset` code and a call to `gc_collect_cycles`. I also removed our caching layer here, as I think it would just add to memory in most cases since this query isn't really happening in any other code. Without the extra logic, the query is significantly faster as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Usage snapshots now capture all available actions, including installations with more than 100 actions.
  * Improved reliability when loading large sets of usage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->