### PR TITLE
Exclude vscode folder from zips

### DIFF
--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -48,6 +48,7 @@ zip -r $zipname $destination \
 	-x "*/.gitignore" \
 	-x "*/.windsurf/*" \
 	-x "*/.devin/*" \
+	-x "*/.vscode/*" \
 	-x "*/.jshintignore" \
 	-x "*/.php-cs-fixer.cache" \
 	-x "*/.php-cs-fixer.php" \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin archives now exclude Visual Studio Code configuration files, resulting in cleaner packaged plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->