### PR TITLE
Fix gated content and custom post type capabilities

### DIFF
--- a/classes/controllers/FrmGatedContentController.php
+++ b/classes/controllers/FrmGatedContentController.php
@@ -160,10 +160,10 @@ class FrmGatedContentController {
 			return;
 		}
 
-		$is_password_protected  = '' !== $post->post_password;
-		$post_type_obj          = get_post_type_object( $post->post_type );
-		$read_private_cap       = $post_type_obj ? $post_type_obj->cap->read_private_posts : 'read_private_posts';
-		$is_restricted_private  = 'private' === $post->post_status && ! current_user_can( $read_private_cap, $post_id );
+		$is_password_protected = '' !== $post->post_password;
+		$post_type_obj         = get_post_type_object( $post->post_type );
+		$read_private_cap      = $post_type_obj ? $post_type_obj->cap->read_private_posts : 'read_private_posts';
+		$is_restricted_private = 'private' === $post->post_status && ! current_user_can( $read_private_cap, $post_id );
 		$access_code_from_url  = FrmAppHelper::simple_get( 'access_code' );
 
 		// Nothing to unlock — post is publicly accessible.

--- a/classes/controllers/FrmGatedContentController.php
+++ b/classes/controllers/FrmGatedContentController.php
@@ -160,8 +160,10 @@ class FrmGatedContentController {
 			return;
 		}
 
-		$is_password_protected = '' !== $post->post_password;
-		$is_restricted_private = 'private' === $post->post_status && ! current_user_can( 'read_private_posts', $post_id );
+		$is_password_protected  = '' !== $post->post_password;
+		$post_type_obj          = get_post_type_object( $post->post_type );
+		$read_private_cap       = $post_type_obj ? $post_type_obj->cap->read_private_posts : 'read_private_posts';
+		$is_restricted_private  = 'private' === $post->post_status && ! current_user_can( $read_private_cap, $post_id );
 		$access_code_from_url  = FrmAppHelper::simple_get( 'access_code' );
 
 		// Nothing to unlock — post is publicly accessible.

--- a/classes/controllers/FrmGatedContentController.php
+++ b/classes/controllers/FrmGatedContentController.php
@@ -228,14 +228,16 @@ class FrmGatedContentController {
 	private static function has_gated_action_for_item( FrmGatedItem $item ): bool {
 		global $wpdb;
 
-		$action_ids = FrmDb::get_col(
-			$wpdb->posts,
-			array(
-				'post_type'    => FrmFormActionsController::$action_post_type,
-				'post_excerpt' => FrmGatedContentAction::$slug,
-				'post_status'  => 'publish',
-			),
-			'ID'
+		// Direct query — FrmDb caches results per-request which would hide newly
+		// created actions until the cache expires. action_contains_item() already
+		// handles per-action caching via transients.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$action_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_excerpt = %s AND post_status = 'publish'",
+				FrmFormActionsController::$action_post_type,
+				FrmGatedContentAction::$slug
+			)
 		);
 
 		foreach ( $action_ids as $action_id ) {

--- a/classes/controllers/FrmGatedContentController.php
+++ b/classes/controllers/FrmGatedContentController.php
@@ -231,10 +231,11 @@ class FrmGatedContentController {
 		// Direct query — FrmDb caches results per-request which would hide newly
 		// created actions until the cache expires. action_contains_item() already
 		// handles per-action caching via transients.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$action_ids = $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_excerpt = %s AND post_status = 'publish'",
+				"SELECT ID FROM %i WHERE post_type = %s AND post_excerpt = %s AND post_status = 'publish'",
+				$wpdb->posts,
 				FrmFormActionsController::$action_post_type,
 				FrmGatedContentAction::$slug
 			)

--- a/classes/controllers/FrmGatedContentController.php
+++ b/classes/controllers/FrmGatedContentController.php
@@ -160,6 +160,19 @@ class FrmGatedContentController {
 			return;
 		}
 
+		$post_item = FrmGatedItem::make(
+			array(
+				'type' => $post->post_type,
+				'id'   => $post_id,
+			)
+		);
+
+		// Only act on posts that are registered in an active gated content action.
+		// Posts unrelated to gated content must not have their access interfered with.
+		if ( ! self::has_gated_action_for_item( $post_item ) ) {
+			return;
+		}
+
 		$is_password_protected = '' !== $post->post_password;
 		$post_type_obj         = get_post_type_object( $post->post_type );
 		$read_private_cap      = $post_type_obj ? $post_type_obj->cap->read_private_posts : 'read_private_posts';
@@ -175,12 +188,6 @@ class FrmGatedContentController {
 			return;
 		}
 
-		$post_item   = FrmGatedItem::make(
-			array(
-				'type' => $post->post_type,
-				'id'   => $post_id,
-			)
-		);
 		$valid_token = FrmGatedTokenHelper::get_valid_token( $post_item );
 
 		if ( $valid_token ) {
@@ -205,6 +212,39 @@ class FrmGatedContentController {
 		if ( $is_restricted_private ) {
 			self::force_404();
 		}
+	}
+
+	/**
+	 * Check whether a content item is registered in at least one active gated content action.
+	 *
+	 * Used by maybe_unlock_post() to avoid interfering with private posts that are unrelated
+	 * to gated content — only items explicitly listed in a published gated content action
+	 * should have their access controlled by this plugin.
+	 *
+	 * @param FrmGatedItem $item Content item to look up.
+	 *
+	 * @return bool True if any published gated content action lists this item.
+	 */
+	private static function has_gated_action_for_item( FrmGatedItem $item ): bool {
+		global $wpdb;
+
+		$action_ids = FrmDb::get_col(
+			$wpdb->posts,
+			array(
+				'post_type'    => FrmFormActionsController::$action_post_type,
+				'post_excerpt' => FrmGatedContentAction::$slug,
+				'post_status'  => 'publish',
+			),
+			'ID'
+		);
+
+		foreach ( $action_ids as $action_id ) {
+			if ( FrmGatedTokenHelper::action_contains_item( (int) $action_id, $item ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/classes/models/FrmGatedContentAction.php
+++ b/classes/models/FrmGatedContentAction.php
@@ -210,6 +210,7 @@ class FrmGatedContentAction extends FrmFormAction {
 		);
 
 		// Initialise empty buckets in get_types() order.
+		/** @var array<string, list<object>> $grouped */
 		$grouped = array_fill_keys( $post_types, array() );
 
 		foreach ( $raw_posts as $post ) {
@@ -218,8 +219,9 @@ class FrmGatedContentAction extends FrmFormAction {
 				continue;
 			}
 
-			if ( isset( $grouped[ $post->post_type ] ) ) {
-				$grouped[ $post->post_type ][] = $post;
+			$post_type = (string) $post->post_type;
+			if ( isset( $grouped[ $post_type ] ) ) {
+				$grouped[ $post_type ][] = $post;
 			}
 		}
 

--- a/classes/models/FrmGatedContentAction.php
+++ b/classes/models/FrmGatedContentAction.php
@@ -177,24 +177,13 @@ class FrmGatedContentAction extends FrmFormAction {
 	}
 
 	/**
-	 * Get posts for the "post" item type selector.
-	 *
-	 * Applies the `frm_gated_content_posts_query` filter so callers can extend
-	 * the post types or change any other WP_Query argument, then narrows the
-	 * result to posts that actually require a token: private posts and
-	 * password-protected posts. Plain published posts are publicly accessible
-	 * and should not appear as selectable gated content items.
-	 *
-	 * @return WP_Post[]
-	 */
-	/**
 	 * Get posts for all post-type-backed gated content item type selectors.
 	 *
-	 * Runs one query covering all enabled post types derived from get_types(), then
-	 * groups the results by type key. Only private and password-protected posts are
-	 * included — plain published posts are publicly accessible and not selectable.
+	 * Runs one query covering all enabled post types, then groups results by type key.
+	 * Only private and password-protected posts are included — plain published posts
+	 * are publicly accessible and should not appear as selectable gated content items.
 	 *
-	 * @return array<string, WP_Post[]> Posts keyed by item type slug (e.g. 'page', 'post').
+	 * @return array<string, object[]> Posts keyed by item type slug (e.g. 'page', 'post').
 	 */
 	public static function get_posts() {
 		$post_types = array();
@@ -209,30 +198,15 @@ class FrmGatedContentAction extends FrmFormAction {
 			return array();
 		}
 
-		/**
-		 * Filter the get_posts() arguments used to build the gated content item selectors.
-		 *
-		 * The filtered list is then narrowed to private and password-protected posts only.
-		 *
-		 * @since 6.33
-		 *
-		 * @param array $query_args get_posts() argument array.
-		 */
-		$query_args = (array) apply_filters(
-			'frm_gated_content_posts_query',
+		$raw_posts = FrmDb::get_results(
+			'posts',
 			array(
-				'post_type'              => $post_types,
-				'post_status'            => array( 'publish', 'private' ),
-				'orderby'                => 'title',
-				'order'                  => 'ASC',
-				'numberposts'            => -1,
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-			)
+				'post_type'   => $post_types,
+				'post_status' => array( 'publish', 'private' ),
+			),
+			'ID, post_title, post_password, post_status, post_type',
+			array( 'order_by' => 'post_title ASC' )
 		);
-
-		$raw_posts = get_posts( $query_args );
-		$raw_posts = is_array( $raw_posts ) ? $raw_posts : array();
 
 		// Initialise empty buckets in get_types() order.
 		$grouped = array_fill_keys( $post_types, array() );
@@ -248,7 +222,6 @@ class FrmGatedContentAction extends FrmFormAction {
 			}
 		}
 
-		/** @var array<string, WP_Post[]> */
 		return $grouped;
 	}
 
@@ -259,7 +232,7 @@ class FrmGatedContentAction extends FrmFormAction {
 	 * jQuery UI autocomplete widget. Each entry has a `value` (post ID string) and
 	 * a `label` (post title).
 	 *
-	 * @param WP_Post[] $posts Posts returned by get_posts().
+	 * @param object[] $posts Posts returned by get_posts().
 	 *
 	 * @return string JSON-encoded array, or an empty string on encoding failure.
 	 */

--- a/classes/models/FrmGatedContentAction.php
+++ b/classes/models/FrmGatedContentAction.php
@@ -183,7 +183,7 @@ class FrmGatedContentAction extends FrmFormAction {
 	 * Only private and password-protected posts are included — plain published posts
 	 * are publicly accessible and should not appear as selectable gated content items.
 	 *
-	 * @return array<string, object[]> Posts keyed by item type slug (e.g. 'page', 'post').
+	 * @return array<string, list<object>> Posts keyed by item type slug (e.g. 'page', 'post').
 	 */
 	public static function get_posts() {
 		$post_types = array();

--- a/classes/models/FrmGatedContentAction.php
+++ b/classes/models/FrmGatedContentAction.php
@@ -209,6 +209,7 @@ class FrmGatedContentAction extends FrmFormAction {
 		);
 
 		// Initialise empty buckets in get_types() order.
+		/** @var array<string, object[]> $grouped */
 		$grouped = array_fill_keys( $post_types, array() );
 
 		foreach ( $raw_posts as $post ) {

--- a/classes/models/FrmGatedContentAction.php
+++ b/classes/models/FrmGatedContentAction.php
@@ -198,6 +198,7 @@ class FrmGatedContentAction extends FrmFormAction {
 			return array();
 		}
 
+		/** @var object[] $raw_posts */
 		$raw_posts = FrmDb::get_results(
 			'posts',
 			array(
@@ -209,7 +210,6 @@ class FrmGatedContentAction extends FrmFormAction {
 		);
 
 		// Initialise empty buckets in get_types() order.
-		/** @var array<string, object[]> $grouped */
 		$grouped = array_fill_keys( $post_types, array() );
 
 		foreach ( $raw_posts as $post ) {

--- a/classes/models/FrmGatedContentAction.php
+++ b/classes/models/FrmGatedContentAction.php
@@ -220,6 +220,7 @@ class FrmGatedContentAction extends FrmFormAction {
 			}
 
 			$post_type = (string) $post->post_type;
+
 			if ( isset( $grouped[ $post_type ] ) ) {
 				$grouped[ $post_type ][] = $post;
 			}

--- a/classes/views/frm-form-actions/_gated_content_item_row.php
+++ b/classes/views/frm-form-actions/_gated_content_item_row.php
@@ -24,7 +24,7 @@
  * @var int          $frm_gc_idx          Zero-based item index. 0 for template rows.
  * @var array        $frm_gc_item         Saved item data. Empty array for template rows.
  * @var array        $frm_gc_types        All registered type configurations.
- * @var array<string, object[]> $frm_gc_posts         Posts grouped by item type key.
+ * @var array<string, list<object>> $frm_gc_posts      Posts grouped by item type key.
  * @var bool                    $frm_gc_use_autocomplete Whether to render autocomplete inputs.
  * @var array<string, string>   $frm_gc_posts_source JSON-encoded autocomplete source per type. Only set when $frm_gc_use_autocomplete.
  * @var string       $frm_gc_wrapper_id   Unique wrapper element ID.

--- a/classes/views/frm-form-actions/_gated_content_item_row.php
+++ b/classes/views/frm-form-actions/_gated_content_item_row.php
@@ -24,7 +24,7 @@
  * @var int          $frm_gc_idx          Zero-based item index. 0 for template rows.
  * @var array        $frm_gc_item         Saved item data. Empty array for template rows.
  * @var array        $frm_gc_types        All registered type configurations.
- * @var array<string, WP_Post[]> $frm_gc_posts        Posts grouped by item type key.
+ * @var array<string, object[]> $frm_gc_posts         Posts grouped by item type key.
  * @var bool                    $frm_gc_use_autocomplete Whether to render autocomplete inputs.
  * @var array<string, string>   $frm_gc_posts_source JSON-encoded autocomplete source per type. Only set when $frm_gc_use_autocomplete.
  * @var string       $frm_gc_wrapper_id   Unique wrapper element ID.

--- a/classes/views/frm-form-actions/_gated_content_settings.php
+++ b/classes/views/frm-form-actions/_gated_content_settings.php
@@ -24,7 +24,7 @@ $frm_gc_types           = FrmGatedContentAction::get_types();
 // gated content actions exist on the same form.
 $frm_gc_wrapper_id = 'frm_gc_settings_' . $this->number;
 
-// array<string, WP_Post[]> — posts grouped by item type key (e.g. 'page', 'post').
+// array<string, object[]> — posts grouped by item type key (e.g. 'page', 'post').
 $frm_gc_posts = FrmGatedContentAction::get_posts();
 
 $frm_gc_total_posts      = array_sum( array_map( 'count', $frm_gc_posts ) );

--- a/classes/views/frm-form-actions/_gated_content_settings.php
+++ b/classes/views/frm-form-actions/_gated_content_settings.php
@@ -24,7 +24,7 @@ $frm_gc_types           = FrmGatedContentAction::get_types();
 // gated content actions exist on the same form.
 $frm_gc_wrapper_id = 'frm_gc_settings_' . $this->number;
 
-// array<string, object[]> — posts grouped by item type key (e.g. 'page', 'post').
+// array<string, list<object>> — posts grouped by item type key (e.g. 'page', 'post').
 $frm_gc_posts = FrmGatedContentAction::get_posts();
 
 $frm_gc_total_posts      = array_sum( array_map( 'count', $frm_gc_posts ) );

--- a/tests/phpunit/forms/test_FrmGatedContentAction.php
+++ b/tests/phpunit/forms/test_FrmGatedContentAction.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * @group gated-content
+ */
+class test_FrmGatedContentAction extends FrmUnitTest {
+
+	// ── get_posts() ───────────────────────────────────────────────────────── //
+
+	/**
+	 * Plain published posts are publicly accessible and must not appear in the
+	 * selector — no token is needed to view them.
+	 *
+	 * @covers FrmGatedContentAction::get_posts
+	 */
+	public function test_get_posts_excludes_plain_published_post() {
+		$post = $this->factory->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		$grouped = FrmGatedContentAction::get_posts();
+
+		$ids = array_column( $grouped['post'] ?? array(), 'ID' );
+		$this->assertNotContains(
+			$post->ID,
+			$ids,
+			'A plain published post must not appear in the gated content item selector.'
+		);
+	}
+
+	/**
+	 * Private posts require a capability check that a token can satisfy — they
+	 * must appear under their post-type key so admins can select them.
+	 *
+	 * @covers FrmGatedContentAction::get_posts
+	 */
+	public function test_get_posts_includes_private_post() {
+		$post = $this->factory->post->create_and_get( array( 'post_status' => 'private' ) );
+
+		$grouped = FrmGatedContentAction::get_posts();
+
+		$this->assertArrayHasKey( 'post', $grouped );
+		$ids = array_column( $grouped['post'], 'ID' );
+		$this->assertContains(
+			$post->ID,
+			$ids,
+			'A private post must appear in the gated content item selector.'
+		);
+	}
+
+	/**
+	 * Password-protected posts are published but block access via a password
+	 * form — a token must be able to bypass that gate, so they must be selectable.
+	 *
+	 * @covers FrmGatedContentAction::get_posts
+	 */
+	public function test_get_posts_includes_password_protected_post() {
+		$post = $this->factory->post->create_and_get(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			)
+		);
+
+		$grouped = FrmGatedContentAction::get_posts();
+
+		$this->assertArrayHasKey( 'post', $grouped );
+		$ids = array_column( $grouped['post'], 'ID' );
+		$this->assertContains(
+			$post->ID,
+			$ids,
+			'A password-protected post must appear in the gated content item selector.'
+		);
+	}
+
+	/**
+	 * Posts and pages must land under the correct type key and not bleed into
+	 * each other's bucket.
+	 *
+	 * @covers FrmGatedContentAction::get_posts
+	 */
+	public function test_get_posts_groups_results_by_post_type() {
+		$post = $this->factory->post->create_and_get( array( 'post_type' => 'post', 'post_status' => 'private' ) );
+		$page = $this->factory->post->create_and_get( array( 'post_type' => 'page', 'post_status' => 'private' ) );
+
+		$grouped = FrmGatedContentAction::get_posts();
+
+		$post_ids = array_column( $grouped['post'] ?? array(), 'ID' );
+		$page_ids = array_column( $grouped['page'] ?? array(), 'ID' );
+
+		$this->assertContains( $post->ID, $post_ids, 'Private post must appear under the "post" key.' );
+		$this->assertNotContains( $post->ID, $page_ids, 'Post must not bleed into the "page" bucket.' );
+		$this->assertContains( $page->ID, $page_ids, 'Private page must appear under the "page" key.' );
+		$this->assertNotContains( $page->ID, $post_ids, 'Page must not bleed into the "post" bucket.' );
+	}
+
+	/**
+	 * Disabled types (frm_file, frm_pdf) are not registered post types — they
+	 * must not appear as keys in the result.
+	 *
+	 * @covers FrmGatedContentAction::get_posts
+	 */
+	public function test_get_posts_omits_disabled_types() {
+		$grouped = FrmGatedContentAction::get_posts();
+
+		$this->assertArrayNotHasKey( 'frm_file', $grouped );
+		$this->assertArrayNotHasKey( 'frm_pdf', $grouped );
+	}
+
+	/**
+	 * When no enabled post types exist, get_posts() must return an empty array
+	 * rather than querying the DB or returning a partial structure.
+	 *
+	 * @covers FrmGatedContentAction::get_posts
+	 */
+	public function test_get_posts_returns_empty_when_no_enabled_types() {
+		add_filter(
+			'frm_gated_content_item_types',
+			static function () {
+				return array(
+					'frm_file' => array(
+						'label'    => 'File',
+						'disabled' => true,
+					),
+				);
+			}
+		);
+
+		$grouped = FrmGatedContentAction::get_posts();
+
+		remove_all_filters( 'frm_gated_content_item_types' );
+
+		$this->assertSame( array(), $grouped, 'get_posts() must return [] when all registered types are disabled.' );
+	}
+}

--- a/tests/phpunit/forms/test_FrmGatedContentAction.php
+++ b/tests/phpunit/forms/test_FrmGatedContentAction.php
@@ -14,11 +14,9 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 	 * @covers FrmGatedContentAction::get_posts
 	 */
 	public function test_get_posts_excludes_plain_published_post() {
-		$post = $this->factory->post->create_and_get( array( 'post_status' => 'publish' ) );
-
+		$post    = $this->factory->post->create_and_get( array( 'post_status' => 'publish' ) );
 		$grouped = FrmGatedContentAction::get_posts();
-
-		$ids = array_column( $grouped['post'] ?? array(), 'ID' );
+		$ids     = array_column( $grouped['post'] ?? array(), 'ID' );
 		$this->assertNotContains(
 			$post->ID,
 			$ids,
@@ -33,8 +31,7 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 	 * @covers FrmGatedContentAction::get_posts
 	 */
 	public function test_get_posts_includes_private_post() {
-		$post = $this->factory->post->create_and_get( array( 'post_status' => 'private' ) );
-
+		$post    = $this->factory->post->create_and_get( array( 'post_status' => 'private' ) );
 		$grouped = FrmGatedContentAction::get_posts();
 
 		$this->assertArrayHasKey( 'post', $grouped );
@@ -78,11 +75,19 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 	 * @covers FrmGatedContentAction::get_posts
 	 */
 	public function test_get_posts_groups_results_by_post_type() {
-		$post = $this->factory->post->create_and_get( array( 'post_type' => 'post', 'post_status' => 'private' ) );
-		$page = $this->factory->post->create_and_get( array( 'post_type' => 'page', 'post_status' => 'private' ) );
-
-		$grouped = FrmGatedContentAction::get_posts();
-
+		$post     = $this->factory->post->create_and_get(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'private',
+			)
+		);
+		$page     = $this->factory->post->create_and_get(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'private',
+			)
+		);
+		$grouped  = FrmGatedContentAction::get_posts();
 		$post_ids = array_column( $grouped['post'] ?? array(), 'ID' );
 		$page_ids = array_column( $grouped['page'] ?? array(), 'ID' );
 

--- a/tests/phpunit/forms/test_FrmGatedContentAction.php
+++ b/tests/phpunit/forms/test_FrmGatedContentAction.php
@@ -15,6 +15,7 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 	 */
 	public function test_get_posts_excludes_plain_published_post() {
 		$post    = $this->factory->post->create_and_get( array( 'post_status' => 'publish' ) );
+		FrmDb::cache_delete_group( 'post' );
 		$grouped = FrmGatedContentAction::get_posts();
 		$ids     = array_column( $grouped['post'] ?? array(), 'ID' );
 		$this->assertNotContains(
@@ -32,6 +33,7 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 	 */
 	public function test_get_posts_includes_private_post() {
 		$post    = $this->factory->post->create_and_get( array( 'post_status' => 'private' ) );
+		FrmDb::cache_delete_group( 'post' );
 		$grouped = FrmGatedContentAction::get_posts();
 
 		$this->assertArrayHasKey( 'post', $grouped );
@@ -56,7 +58,7 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 				'post_password' => 'secret',
 			)
 		);
-
+		FrmDb::cache_delete_group( 'post' );
 		$grouped = FrmGatedContentAction::get_posts();
 
 		$this->assertArrayHasKey( 'post', $grouped );
@@ -87,6 +89,7 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 				'post_status' => 'private',
 			)
 		);
+		FrmDb::cache_delete_group( 'post' );
 		$grouped  = FrmGatedContentAction::get_posts();
 		$post_ids = array_column( $grouped['post'] ?? array(), 'ID' );
 		$page_ids = array_column( $grouped['page'] ?? array(), 'ID' );

--- a/tests/phpunit/forms/test_FrmGatedContentAction.php
+++ b/tests/phpunit/forms/test_FrmGatedContentAction.php
@@ -17,7 +17,7 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 		$post    = $this->factory->post->create_and_get( array( 'post_status' => 'publish' ) );
 		FrmDb::cache_delete_group( 'post' );
 		$grouped = FrmGatedContentAction::get_posts();
-		$ids     = array_column( $grouped['post'] ?? array(), 'ID' );
+		$ids     = array_map( 'intval', array_column( $grouped['post'] ?? array(), 'ID' ) );
 		$this->assertNotContains(
 			$post->ID,
 			$ids,
@@ -37,7 +37,7 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 		$grouped = FrmGatedContentAction::get_posts();
 
 		$this->assertArrayHasKey( 'post', $grouped );
-		$ids = array_column( $grouped['post'], 'ID' );
+		$ids = array_map( 'intval', array_column( $grouped['post'], 'ID' ) );
 		$this->assertContains(
 			$post->ID,
 			$ids,
@@ -62,7 +62,7 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 		$grouped = FrmGatedContentAction::get_posts();
 
 		$this->assertArrayHasKey( 'post', $grouped );
-		$ids = array_column( $grouped['post'], 'ID' );
+		$ids = array_map( 'intval', array_column( $grouped['post'], 'ID' ) );
 		$this->assertContains(
 			$post->ID,
 			$ids,
@@ -91,8 +91,8 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 		);
 		FrmDb::cache_delete_group( 'post' );
 		$grouped  = FrmGatedContentAction::get_posts();
-		$post_ids = array_column( $grouped['post'] ?? array(), 'ID' );
-		$page_ids = array_column( $grouped['page'] ?? array(), 'ID' );
+		$post_ids = array_map( 'intval', array_column( $grouped['post'] ?? array(), 'ID' ) );
+		$page_ids = array_map( 'intval', array_column( $grouped['page'] ?? array(), 'ID' ) );
 
 		$this->assertContains( $post->ID, $post_ids, 'Private post must appear under the "post" key.' );
 		$this->assertNotContains( $post->ID, $page_ids, 'Post must not bleed into the "page" bucket.' );

--- a/tests/phpunit/forms/test_FrmGatedContentAction.php
+++ b/tests/phpunit/forms/test_FrmGatedContentAction.php
@@ -15,7 +15,6 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 	 */
 	public function test_get_posts_excludes_plain_published_post() {
 		$post    = $this->factory->post->create_and_get( array( 'post_status' => 'publish' ) );
-		FrmDb::cache_delete_group( 'post' );
 		$grouped = FrmGatedContentAction::get_posts();
 		$ids     = array_map( 'intval', array_column( $grouped['post'] ?? array(), 'ID' ) );
 		$this->assertNotContains(
@@ -33,7 +32,6 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 	 */
 	public function test_get_posts_includes_private_post() {
 		$post    = $this->factory->post->create_and_get( array( 'post_status' => 'private' ) );
-		FrmDb::cache_delete_group( 'post' );
 		$grouped = FrmGatedContentAction::get_posts();
 
 		$this->assertArrayHasKey( 'post', $grouped );
@@ -52,13 +50,12 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 	 * @covers FrmGatedContentAction::get_posts
 	 */
 	public function test_get_posts_includes_password_protected_post() {
-		$post = $this->factory->post->create_and_get(
+		$post    = $this->factory->post->create_and_get(
 			array(
 				'post_status'   => 'publish',
 				'post_password' => 'secret',
 			)
 		);
-		FrmDb::cache_delete_group( 'post' );
 		$grouped = FrmGatedContentAction::get_posts();
 
 		$this->assertArrayHasKey( 'post', $grouped );
@@ -89,7 +86,6 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 				'post_status' => 'private',
 			)
 		);
-		FrmDb::cache_delete_group( 'post' );
 		$grouped  = FrmGatedContentAction::get_posts();
 		$post_ids = array_map( 'intval', array_column( $grouped['post'] ?? array(), 'ID' ) );
 		$page_ids = array_map( 'intval', array_column( $grouped['page'] ?? array(), 'ID' ) );

--- a/tests/phpunit/misc/test_FrmGatedContentController.php
+++ b/tests/phpunit/misc/test_FrmGatedContentController.php
@@ -144,6 +144,25 @@ class test_FrmGatedContentController extends FrmUnitTest {
 			)
 		);
 
+		// Register the post in a gated content action so the code reaches the cap check.
+		wp_insert_post(
+			array(
+				'post_type'    => 'frm_form_actions',
+				'post_excerpt' => 'gated_content',
+				'post_status'  => 'publish',
+				'post_content' => wp_json_encode(
+					array(
+						'items' => array(
+							array(
+								'type' => $post->post_type,
+								'id'   => $post->ID,
+							),
+						),
+					)
+				),
+			)
+		);
+
 		// Subscriber has read_private_books (the CPT cap) but NOT read_private_posts.
 		$user_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
 		$user    = new WP_User( $user_id );
@@ -151,9 +170,13 @@ class test_FrmGatedContentController extends FrmUnitTest {
 		wp_set_current_user( $user_id );
 
 		// Simulate a singular WP query for this private CPT post.
+		// Both queried_object and queried_object_id must be set: get_queried_object()
+		// returns early when queried_object is set, which skips the code path that
+		// also writes queried_object_id, so get_queried_object_id() would return 0.
 		global $wp_query;
-		$wp_query->is_singular    = true;
-		$wp_query->queried_object = $post;
+		$wp_query->is_singular       = true;
+		$wp_query->queried_object    = $post;
+		$wp_query->queried_object_id = $post->ID;
 
 		FrmGatedContentController::maybe_unlock_post();
 
@@ -163,8 +186,9 @@ class test_FrmGatedContentController extends FrmUnitTest {
 		);
 
 		// Restore query state.
-		$wp_query->is_singular    = false;
-		$wp_query->queried_object = null;
+		$wp_query->is_singular       = false;
+		$wp_query->queried_object    = null;
+		$wp_query->queried_object_id = 0;
 		wp_set_current_user( 0 );
 		unregister_post_type( 'frm_gc_test_book' );
 	}
@@ -186,8 +210,9 @@ class test_FrmGatedContentController extends FrmUnitTest {
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
 
 		global $wp_query;
-		$wp_query->is_singular    = true;
-		$wp_query->queried_object = $post;
+		$wp_query->is_singular       = true;
+		$wp_query->queried_object    = $post;
+		$wp_query->queried_object_id = $post->ID;
 
 		FrmGatedContentController::maybe_unlock_post();
 
@@ -196,8 +221,9 @@ class test_FrmGatedContentController extends FrmUnitTest {
 			'maybe_unlock_post() must not 404 a private post that is not a gated content item.'
 		);
 
-		$wp_query->is_singular    = false;
-		$wp_query->queried_object = null;
+		$wp_query->is_singular       = false;
+		$wp_query->queried_object    = null;
+		$wp_query->queried_object_id = 0;
 		wp_set_current_user( 0 );
 	}
 
@@ -235,8 +261,9 @@ class test_FrmGatedContentController extends FrmUnitTest {
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
 
 		global $wp_query;
-		$wp_query->is_singular    = true;
-		$wp_query->queried_object = $post;
+		$wp_query->is_singular       = true;
+		$wp_query->queried_object    = $post;
+		$wp_query->queried_object_id = $post->ID;
 
 		FrmGatedContentController::maybe_unlock_post();
 
@@ -245,9 +272,10 @@ class test_FrmGatedContentController extends FrmUnitTest {
 			'maybe_unlock_post() must force-404 a gated private post when no valid token exists.'
 		);
 
-		$wp_query->is_404         = false;
-		$wp_query->is_singular    = false;
-		$wp_query->queried_object = null;
+		$wp_query->is_404            = false;
+		$wp_query->is_singular       = false;
+		$wp_query->queried_object    = null;
+		$wp_query->queried_object_id = 0;
 		wp_set_current_user( 0 );
 	}
 

--- a/tests/phpunit/misc/test_FrmGatedContentController.php
+++ b/tests/phpunit/misc/test_FrmGatedContentController.php
@@ -169,6 +169,88 @@ class test_FrmGatedContentController extends FrmUnitTest {
 		unregister_post_type( 'frm_gc_test_book' );
 	}
 
+	/**
+	 * A private post that is not listed in any gated content action must not be force-404'd.
+	 *
+	 * Before the fix, maybe_unlock_post() would call force_404() on any private singular
+	 * post the current user cannot read, even when gated content had nothing to do with it.
+	 * The has_gated_action_for_item() guard must short-circuit before that path.
+	 *
+	 * @covers FrmGatedContentController::maybe_unlock_post
+	 */
+	public function test_maybe_unlock_post_does_not_404_non_gated_private_post() {
+		// No gated content actions exist — this post is unrelated to gated content.
+		$post = $this->factory->post->create_and_get( array( 'post_status' => 'private' ) );
+
+		// Subscriber cannot read private posts.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
+
+		global $wp_query;
+		$wp_query->is_singular    = true;
+		$wp_query->queried_object = $post;
+
+		FrmGatedContentController::maybe_unlock_post();
+
+		$this->assertFalse(
+			is_404(),
+			'maybe_unlock_post() must not 404 a private post that is not a gated content item.'
+		);
+
+		$wp_query->is_singular    = false;
+		$wp_query->queried_object = null;
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * A private post that IS a gated content item must still be force-404'd when no token exists.
+	 *
+	 * Verifies that the has_gated_action_for_item() guard does not accidentally suppress the
+	 * 404 for posts that are legitimately under gated content control.
+	 *
+	 * @covers FrmGatedContentController::maybe_unlock_post
+	 */
+	public function test_maybe_unlock_post_force_404s_gated_private_post_without_token() {
+		$post = $this->factory->post->create_and_get( array( 'post_status' => 'private' ) );
+
+		// Register a gated content action that includes this post.
+		wp_insert_post(
+			array(
+				'post_type'    => 'frm_form_actions',
+				'post_excerpt' => 'gated_content',
+				'post_status'  => 'publish',
+				'post_content' => wp_json_encode(
+					array(
+						'items' => array(
+							array(
+								'type' => $post->post_type,
+								'id'   => $post->ID,
+							),
+						),
+					)
+				),
+			)
+		);
+
+		// Subscriber cannot read private posts and has no token.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
+
+		global $wp_query;
+		$wp_query->is_singular    = true;
+		$wp_query->queried_object = $post;
+
+		FrmGatedContentController::maybe_unlock_post();
+
+		$this->assertTrue(
+			is_404(),
+			'maybe_unlock_post() must force-404 a gated private post when no valid token exists.'
+		);
+
+		$wp_query->is_404         = false;
+		$wp_query->is_singular    = false;
+		$wp_query->queried_object = null;
+		wp_set_current_user( 0 );
+	}
+
 	// ── payment-success event ─────────────────────────────────────────────── //
 
 	/**

--- a/tests/phpunit/misc/test_FrmGatedContentController.php
+++ b/tests/phpunit/misc/test_FrmGatedContentController.php
@@ -95,6 +95,82 @@ class test_FrmGatedContentController extends FrmUnitTest {
 		$this->assertSame( 32, strlen( $raw_token ) );
 	}
 
+	// ── maybe_unlock_post() ─────────────────────────────────────────────────── //
+
+	/**
+	 * Taxonomy archive pages must not be force-404'd.
+	 *
+	 * Before the fix, get_queried_object_id() on an archive returned a term ID which
+	 * get_post() silently resolved to an unrelated post — potentially a private one —
+	 * causing force_404() to fire on a perfectly valid archive page.
+	 *
+	 * @covers FrmGatedContentController::maybe_unlock_post
+	 */
+	public function test_maybe_unlock_post_skips_on_taxonomy_archive() {
+		$cat_id = $this->factory->category->create();
+		$this->set_front_end( get_category_link( $cat_id ) );
+
+		$this->assertFalse( is_singular(), 'Prerequisite: category archive must not be singular.' );
+		$this->assertFalse( is_404(), 'Prerequisite: category archive must not start as a 404.' );
+
+		FrmGatedContentController::maybe_unlock_post();
+
+		$this->assertFalse( is_404(), 'maybe_unlock_post() must not force-404 a taxonomy archive.' );
+	}
+
+	/**
+	 * A user who holds a CPT-specific read-private cap must not be force-404'd.
+	 *
+	 * Before the fix the check always used the built-in `read_private_posts` cap.
+	 * CPTs with a custom capability_type map that abstract name to e.g. `read_private_books`.
+	 * Users who have `read_private_books` but not `read_private_posts` were incorrectly blocked.
+	 *
+	 * @covers FrmGatedContentController::maybe_unlock_post
+	 */
+	public function test_maybe_unlock_post_respects_cpt_read_private_cap() {
+		register_post_type(
+			'frm_gc_test_book',
+			array(
+				'capability_type' => array( 'book', 'books' ),
+				'map_meta_cap'    => true,
+				'public'          => false,
+			)
+		);
+
+		$post = $this->factory->post->create_and_get(
+			array(
+				'post_type'   => 'frm_gc_test_book',
+				'post_status' => 'private',
+			)
+		);
+
+		// Subscriber has read_private_books (the CPT cap) but NOT read_private_posts.
+		$user_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$user    = new WP_User( $user_id );
+		$user->add_cap( 'read_private_books' );
+		wp_set_current_user( $user_id );
+
+		// Simulate a singular WP query for this private CPT post.
+		global $wp_query;
+		$wp_query->is_singular    = true;
+		$wp_query->queried_object = $post;
+
+		FrmGatedContentController::maybe_unlock_post();
+
+		$this->assertFalse(
+			is_404(),
+			'A user with the CPT-specific read_private cap must not be force-404d by maybe_unlock_post().'
+		);
+
+		// Restore query state.
+		$wp_query->is_singular    = false;
+		$wp_query->queried_object = null;
+		wp_set_current_user( 0 );
+		unregister_post_type( 'frm_gc_test_book' );
+	}
+
+	// ── payment-success event ─────────────────────────────────────────────── //
+
 	/**
 	 * A gated content action with only 'create' in its event list must NOT generate
 	 * a token when the payment-success event fires.


### PR DESCRIPTION
Fix #3203 and https://secure.helpscout.net/conversation/3398946279/255863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved private gated-content unlocking to respect content-type-specific “read private” permissions instead of a single hardcoded capability.
  * Prevented incorrect 404 behavior for taxonomy archive pages and for private items not referenced by gated-content actions.
  * Ensured gated private items are properly restricted (including 404 when no valid token exists).
  * Refined gated-content item selection to only surface private and password-protected content where applicable.
* **Tests**
  * Added/expanded PHPUnit coverage for gated-content access edge cases and for correct post selection/grouping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->