### PR TITLE
Add more stub files to zip plugin exclusions

### DIFF
--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -99,6 +99,8 @@ zip -r $zipname $destination \
 	-x "*/*.stubs.php" \
 	-x "*/stubs.php" \
 	-x "*/stubs" \
+	-x "*/stubs-mcp-adapter" \
+	-x "*/stubs-wp-rest-controller" \
 	-x "*/readme.md" \
 	-x "*/README.md" \
 	-x "*/tests/*" \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated ZIP archives now exclude internal stub directories, resulting in cleaner package contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->