### PR TITLE
Fix some mago issues

### DIFF
--- a/classes/controllers/FrmStylesController.php
+++ b/classes/controllers/FrmStylesController.php
@@ -1537,6 +1537,9 @@ class FrmStylesController {
 			die();
 		}
 
+		/**
+		 * @var WP_Post|null $post
+		 */
 		$post = get_post( $style_id );
 
 		if ( ! $post || $post->post_type !== self::$post_type ) {

--- a/classes/models/FrmGatedItem.php
+++ b/classes/models/FrmGatedItem.php
@@ -110,14 +110,21 @@ class FrmGatedItem {
 	 * @return string
 	 */
 	protected static function get_permalink_for_gated_item( $post_id ) {
+		/**
+		 * @var WP_Post|null $post
+		 */
 		$post = get_post( $post_id );
 
-		if ( $post && 'private' === $post->post_status ) {
+		if ( ! $post instanceof WP_Post ) {
+			return '';
+		}
+
+		if ( 'private' === $post->post_status ) {
 			$post              = clone $post;
 			$post->post_status = 'publish';
 		}
 
-		return (string) get_permalink( $post );
+		return get_permalink( $post );
 	}
 
 	/**

--- a/tests/phpunit/forms/test_FrmGatedContentAction.php
+++ b/tests/phpunit/forms/test_FrmGatedContentAction.php
@@ -53,7 +53,7 @@ class test_FrmGatedContentAction extends FrmUnitTest {
 		$post    = $this->factory->post->create_and_get(
 			array(
 				'post_status'   => 'publish',
-				'post_password' => 'secret',
+				'post_password' => wp_generate_password( 12 ),
 			)
 		);
 		$grouped = FrmGatedContentAction::get_posts();


### PR DESCRIPTION
Looks like the workflow is mostly failing after some gated content changes.

The `get_permalink` call would potentially get called with `null` because `$post` was only validated in the if condition above.

I haven't tested this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gated content links by safely handling missing or invalid posts.
  * Preserved permalink generation for private posts.
  * Updated password-protected content testing with a generated password for greater reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->