### PR TITLE
Prevent duplicate data token attributes when loading multiple forms

### DIFF
--- a/classes/models/FrmAntiSpam.php
+++ b/classes/models/FrmAntiSpam.php
@@ -13,6 +13,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FrmAntiSpam extends FrmValidate {
 
 	/**
+	 * Track when the token filters have been added so they are only added once.
+	 * The callback checks the Anti-Spam setting of the form being rendered, so
+	 * a single callback covers every form on the page. Adding one callback for
+	 * each form would print duplicate data-token attributes.
+	 *
+	 * @since x.x
+	 *
+	 * @var bool
+	 */
+	private static $filters_added = false;
+
+	/**
 	 * @return string
 	 */
 	protected function get_option_key() {
@@ -40,8 +52,14 @@ class FrmAntiSpam extends FrmValidate {
 	 * @return void
 	 */
 	public function init() {
-		add_filter( 'frm_form_attributes', array( $this, 'add_token_to_form' ), 10, 1 );
-		add_filter( 'frm_form_div_attributes', array( $this, 'add_token_to_form' ), 10, 1 );
+		if ( self::$filters_added ) {
+			return;
+		}
+
+		self::$filters_added = true;
+
+		add_filter( 'frm_form_attributes', array( $this, 'add_token_to_form' ), 10, 2 );
+		add_filter( 'frm_form_div_attributes', array( $this, 'add_token_to_form' ), 10, 2 );
 	}
 
 	/**
@@ -160,16 +178,29 @@ class FrmAntiSpam extends FrmValidate {
 	}
 
 	/**
-	 * Add the token field to the form.
+	 * Add the token field to the form if the form has Anti-Spam enabled.
 	 *
 	 * @since 4.11
+	 * @since x.x The $form param was added, and forms without Anti-Spam enabled are now skipped.
 	 *
-	 * @param string $attributes
+	 * @param string      $attributes
+	 * @param object|null $form The form being rendered.
 	 *
 	 * @return string
 	 */
-	public function add_token_to_form( $attributes ) {
-		return $attributes . ( ' data-token="' . esc_attr( $this->get() ) . '"' );
+	public function add_token_to_form( $attributes, $form = null ) {
+		$antispam = $this;
+
+		if ( $form ) {
+			$antispam       = new self( (int) $form->id );
+			$antispam->form = $form;
+		}
+
+		if ( ! $antispam->run_antispam() ) {
+			return $attributes;
+		}
+
+		return $attributes . ( ' data-token="' . esc_attr( $antispam->get() ) . '"' );
 	}
 
 	/**

--- a/tests/phpunit/misc/test_FrmAntiSpam.php
+++ b/tests/phpunit/misc/test_FrmAntiSpam.php
@@ -13,6 +13,48 @@ class test_FrmAntiSpam extends FrmUnitTest {
 		$this->antispam = new FrmAntiSpam( $form_id );
 	}
 
+	public function tearDown(): void {
+		$this->set_private_property( 'FrmAntiSpam', 'filters_added', false );
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers FrmAntiSpam::init
+	 * @covers FrmAntiSpam::add_token_to_form
+	 */
+	public function test_init_only_adds_token_filters_once() {
+		$this->set_private_property( 'FrmAntiSpam', 'filters_added', false );
+		remove_filter( 'frm_run_antispam', '__return_false' );
+
+		$first_form_id  = $this->factory->form->create( array( 'options' => array( 'antispam' => 1 ) ) );
+		$second_form_id = $this->factory->form->create( array( 'options' => array( 'antispam' => 1 ) ) );
+
+		FrmAntiSpam::maybe_init( $first_form_id );
+		FrmAntiSpam::maybe_init( $second_form_id );
+
+		$second_form = FrmForm::getOne( $second_form_id );
+		$this->assertSame( 1, substr_count( apply_filters( 'frm_form_attributes', '', $second_form ), 'data-token=' ) );
+		$this->assertSame( 1, substr_count( apply_filters( 'frm_form_div_attributes', '', $second_form ), 'data-token=' ) );
+	}
+
+	/**
+	 * @covers FrmAntiSpam::add_token_to_form
+	 */
+	public function test_token_is_not_added_to_forms_without_antispam() {
+		$this->set_private_property( 'FrmAntiSpam', 'filters_added', false );
+		remove_filter( 'frm_run_antispam', '__return_false' );
+
+		$antispam_form_id = $this->factory->form->create( array( 'options' => array( 'antispam' => 1 ) ) );
+		FrmAntiSpam::maybe_init( $antispam_form_id );
+
+		$plain_form = FrmForm::getOne( $this->factory->form->create() );
+		$this->assertSame( 0, substr_count( apply_filters( 'frm_form_attributes', '', $plain_form ), 'data-token=' ) );
+		$this->assertSame( 0, substr_count( apply_filters( 'frm_form_div_attributes', '', $plain_form ), 'data-token=' ) );
+
+		$antispam_form = FrmForm::getOne( $antispam_form_id );
+		$this->assertSame( 1, substr_count( apply_filters( 'frm_form_attributes', '', $antispam_form ), 'data-token=' ) );
+	}
+
 	/**
 	 * @covers FrmAntiSpam::get
 	 */


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3408027516/256229

**The issue**
The hooks load for every form, so additional forms loaded on a page include duplicate `data-token` attributes.

**The solution**
The hooks now only load once, and the code that adds the token checks that the current form actually has the JS spam validation setting enabled.

**Things to test**
- That `data-token` only appears once per element. It does appear on both the `div` and the `form`, but that's okay both are required depending on context.
- That `data-token` is not included at all for a form where the setting is disabled.
- That JS spam validation still works as expected.

**Pre-release**
[formidable-6.33.2b.zip](https://github.com/user-attachments/files/30710457/formidable-6.33.2b.zip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anti-spam tokens are now added only to forms with anti-spam protection enabled.
  * Prevented duplicate anti-spam filter registration, improving form processing reliability.

* **Tests**
  * Added coverage to verify correct token behavior and one-time filter registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->