### PR TITLE
Remove redundant validation check

### DIFF
--- a/classes/models/fields/FrmFieldCombo.php
+++ b/classes/models/fields/FrmFieldCombo.php
@@ -435,10 +435,6 @@ class FrmFieldCombo extends FrmFieldType {
 			return $errors;
 		}
 
-		if ( class_exists( 'FrmProFieldsHelper' ) && ! FrmProFieldsHelper::is_field_visible_to_user( $this->field ) ) {
-			return $errors;
-		}
-
 		$blank_msg  = FrmFieldsHelper::get_error_msg( $this->field, 'blank' );
 		$sub_fields = $this->get_processed_sub_fields();
 


### PR DESCRIPTION
This line immediately follows `if ( class_exists( 'FrmProEntryMeta' ) && FrmProEntryMeta::skip_required_validation( $this->field ) ) {`.

But in `FrmProEntryMeta::skip_required_validation`, we have a check for `FrmProEntryMeta::has_invisible_errors` directly inside of `FrmProEntryMeta::skip_required_validation`. There it already checks for `! FrmProFieldsHelper::is_field_visible_to_user( $field );`.

So there's no need for this second check. It's checking what was already checked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Required combo fields are now validated even when hidden from the current user.
  * Existing validation exclusions continue to be respected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->