### PR TITLE
Exclude several api files from zips

### DIFF
--- a/bin/zip-plugin.sh
+++ b/bin/zip-plugin.sh
@@ -104,6 +104,19 @@ zip -r $zipname $destination \
 	-x "*/readme.md" \
 	-x "*/README.md" \
 	-x "*/tests/*" \
+	-x "formidable-api/lib/vendor/*/docs/*" \
+	-x "formidable-api/lib/vendor/*/generator/*" \
+	-x "formidable-api/lib/vendor/*/skill/*" \
+	-x "formidable-api/lib/vendor/*/CHANGELOG.md" \
+	-x "formidable-api/lib/vendor/*/CLAUDE.md" \
+	-x "formidable-api/lib/vendor/*/CONTRIBUTING.md" \
+	-x "formidable-api/lib/vendor/*/README-INITIAL.md" \
+	-x "formidable-api/lib/vendor/*/.nvmrc" \
+	-x "formidable-api/lib/vendor/*/.prettierignore" \
+	-x "formidable-api/lib/vendor/*/.prettierrc.js" \
+	-x "formidable-api/lib/vendor/*/.wp-env.json" \
+	-x "formidable-api/lib/vendor/*/phpcs.xml.dist" \
+	-x "formidable-api/lib/vendor/*/phpstan.neon.dist" \
 	-x "$source/vendor/*" \
 	-x "$source/formidable-payments/vendor/*" \
 	-x "*/temp.xml" \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin archives now exclude unnecessary vendor documentation, tooling, configuration, changelog, and metadata files.
  * Reduced archive contents help produce cleaner, more focused plugin packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->