### PR TITLE
Split disabling paypal commerce apple pay/google pay

### DIFF
--- a/paypal/controllers/FrmPayPalLiteActionsController.php
+++ b/paypal/controllers/FrmPayPalLiteActionsController.php
@@ -1296,14 +1296,19 @@ class FrmPayPalLiteActionsController extends FrmTransLiteActionsController {
 				break;
 		}
 
-		$components               = array();
-		$include_google_apple_pay = $include_buttons && 'subscription' !== $intent && is_ssl() && self::include_google_pay_apple_pay();
+		$components              = array();
+		$supports_wallet_buttons = $include_buttons && 'subscription' !== $intent && is_ssl() && self::include_google_pay_apple_pay();
+		$include_google_pay      = $supports_wallet_buttons && self::include_google_pay();
+		$include_apple_pay       = $supports_wallet_buttons && self::include_apple_pay();
 
 		if ( $include_buttons ) {
 			$components[] = 'buttons';
 
-			if ( $include_google_apple_pay ) {
+			if ( $include_google_pay ) {
 				$components[] = 'googlepay';
+			}
+
+			if ( $include_apple_pay ) {
 				$components[] = 'applepay';
 			}
 		}
@@ -1343,7 +1348,7 @@ class FrmPayPalLiteActionsController extends FrmTransLiteActionsController {
 
 		wp_register_script( 'paypal-sdk', $sdk_url, array(), null, false );
 
-		if ( $include_google_apple_pay ) {
+		if ( $include_apple_pay ) {
 			wp_register_script( 'apple-pay-sdk', 'https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js', array(), null, false );
 		}
 
@@ -1386,7 +1391,7 @@ class FrmPayPalLiteActionsController extends FrmTransLiteActionsController {
 
 		$dependencies = array( 'paypal-sdk', 'formidable' );
 
-		if ( $include_google_apple_pay ) {
+		if ( $include_apple_pay ) {
 			$dependencies[] = 'apple-pay-sdk';
 		}
 
@@ -1400,7 +1405,7 @@ class FrmPayPalLiteActionsController extends FrmTransLiteActionsController {
 			false
 		);
 
-		if ( $include_google_apple_pay ) {
+		if ( $include_google_pay ) {
 			wp_enqueue_script(
 				'google-pay',
 				'https://pay.google.com/gp/p/js/pay.js',
@@ -1418,7 +1423,9 @@ class FrmPayPalLiteActionsController extends FrmTransLiteActionsController {
 			'style'                    => self::get_style_for_js( $form_id ),
 			'buttonStyle'              => self::get_button_style_for_js( $action ),
 			'imagesUrl'                => FrmPayPalLiteAppHelper::plugin_url() . 'images/',
-			'includeGooglePayApplePay' => $include_google_apple_pay,
+			'includeGooglePay'         => $include_google_pay,
+			'includeApplePay'          => $include_apple_pay,
+			'includeGooglePayApplePay' => $include_google_pay || $include_apple_pay,
 			'mode'                     => FrmPayPalLiteAppHelper::active_mode(),
 		);
 
@@ -1426,6 +1433,11 @@ class FrmPayPalLiteActionsController extends FrmTransLiteActionsController {
 	}
 
 	/**
+	 * Check if the Google Pay and Apple Pay wallet buttons are allowed at all.
+	 *
+	 * This gates both wallets together. To turn off just one of them, use
+	 * frm_paypal_commerce_include_google_pay or frm_paypal_commerce_include_apple_pay instead.
+	 *
 	 * @since 6.31
 	 *
 	 * @return bool
@@ -1437,6 +1449,44 @@ class FrmPayPalLiteActionsController extends FrmTransLiteActionsController {
 		 * @param bool $include_google_pay_apple_pay
 		 */
 		return (bool) apply_filters( 'frm_include_google_pay_apple_pay', true );
+	}
+
+	/**
+	 * Check if the Google Pay wallet button is allowed for PayPal Commerce.
+	 *
+	 * Only called when frm_include_google_pay_apple_pay allows the wallets, so this
+	 * filter turns off Google Pay without affecting Apple Pay.
+	 *
+	 * @since 6.34
+	 *
+	 * @return bool
+	 */
+	private static function include_google_pay() {
+		/**
+		 * @since 6.34
+		 *
+		 * @param bool $include_google_pay
+		 */
+		return (bool) apply_filters( 'frm_paypal_commerce_include_google_pay', true );
+	}
+
+	/**
+	 * Check if the Apple Pay wallet button is allowed for PayPal Commerce.
+	 *
+	 * Only called when frm_include_google_pay_apple_pay allows the wallets, so this
+	 * filter turns off Apple Pay without affecting Google Pay.
+	 *
+	 * @since 6.34
+	 *
+	 * @return bool
+	 */
+	private static function include_apple_pay() {
+		/**
+		 * @since 6.34
+		 *
+		 * @param bool $include_apple_pay
+		 */
+		return (bool) apply_filters( 'frm_paypal_commerce_include_apple_pay', true );
 	}
 
 	/**

--- a/paypal/js/frontend.js
+++ b/paypal/js/frontend.js
@@ -303,19 +303,21 @@
 			return;
 		}
 
-		// Skip (and avoid the SDK wait) when Google Pay / Apple Pay were not enqueued
-		// server-side, e.g. via the frm_include_google_pay_apple_pay filter or non-SSL.
-		if ( ! frmPayPalVars.includeGooglePayApplePay ) {
+		// Skip (and avoid the SDK wait) when neither wallet was enqueued server-side,
+		// e.g. via the frm_include_google_pay_apple_pay filter or non-SSL.
+		if ( ! frmPayPalVars.includeGooglePay && ! frmPayPalVars.includeApplePay ) {
 			return;
 		}
 
 		// Resolve both eligibility checks in parallel so the combined wait is bounded by
 		// the slower of the two, then register them in a fixed order (Google Pay, then
 		// Apple Pay). Registration happens before the selector is built, so they render
-		// together with the other methods.
+		// together with the other methods. A wallet turned off server-side, e.g. via
+		// frm_paypal_commerce_include_google_pay or frm_paypal_commerce_include_apple_pay,
+		// skips its check so it never waits on an SDK that was never enqueued.
 		const [ googlePayEligible, applePayEligible ] = await Promise.all( [
-			resolveGooglePayEligibility(),
-			resolveApplePayEligibility()
+			frmPayPalVars.includeGooglePay ? resolveGooglePayEligibility() : false,
+			frmPayPalVars.includeApplePay ? resolveApplePayEligibility() : false
 		] );
 
 		if ( googlePayEligible ) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Pay and Apple Pay availability can now be configured independently.
  * Wallet eligibility checks and payment options are loaded only for enabled wallets.

* **Bug Fixes**
  * Improved wallet discovery so disabling one payment option no longer prevents the other from being detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->