### PR TITLE
Import nulls without fatal errors

### DIFF
--- a/classes/helpers/FrmXMLHelper.php
+++ b/classes/helpers/FrmXMLHelper.php
@@ -620,8 +620,35 @@ class FrmXMLHelper {
 			'form_id'       => (int) $form_id,
 			'required'      => (int) $field->required,
 			'options'       => FrmAppHelper::maybe_json_decode( (string) $field->options ),
-			'field_options' => FrmAppHelper::maybe_json_decode( (string) $field->field_options ),
+			'field_options' => self::fill_field_options( $field ),
 		);
+	}
+
+	/**
+	 * Reads a field's options out of the file as an array.
+	 *
+	 * Field options are a settings map, and every step of the import reads them
+	 * as one. A file whose value there cannot be read, because it is empty or
+	 * was written by something other than an export, used to end the whole
+	 * import with a fatal error on the first field it reached. An empty set of
+	 * options is recoverable, since the defaults for the field type fill the
+	 * gaps, so prefer that over stopping.
+	 *
+	 * Unserialize is tried as well as JSON so options written by an older
+	 * version are still read rather than thrown away.
+	 *
+	 * @since x.x
+	 *
+	 * @param object $field Field element from the file.
+	 *
+	 * @return array
+	 */
+	private static function fill_field_options( $field ) {
+		$options = (string) $field->field_options;
+
+		FrmAppHelper::unserialize_or_decode( $options );
+
+		return is_array( $options ) ? $options : array();
 	}
 
 	/**

--- a/tests/phpunit/xml/test_FrmXMLHelper.php
+++ b/tests/phpunit/xml/test_FrmXMLHelper.php
@@ -170,4 +170,66 @@ class test_FrmXMLHelper extends FrmUnitTest {
 		$this->assertSame( '<![CDATA[HelloÁWorld]]>', FrmXMLHelper::cdata( "Hello\xC1World" ) ); // \xC1 is the Á character.
 		$this->assertSame( '<![CDATA[é]]>', FrmXMLHelper::cdata( "\xE9" ) ); // \xE9 is the é character.
 	}
+
+	/**
+	 * Field options are a settings map, and every step of an import reads them as
+	 * one. A file whose value there cannot be read used to end the whole import
+	 * with a fatal error on the first field it reached, so anything unreadable
+	 * becomes an empty set of options and the field type's defaults fill the gaps.
+	 *
+	 * @covers FrmXMLHelper::fill_field_options
+	 *
+	 * @dataProvider unreadable_field_options_provider
+	 *
+	 * @param string $stored Value as it appears in the file.
+	 *
+	 * @return void
+	 */
+	public function test_fill_field_options_always_returns_an_array( $stored ) {
+		$field   = new SimpleXMLElement( '<field><field_options>' . $stored . '</field_options></field>' );
+		$options = $this->run_private_method( array( 'FrmXMLHelper', 'fill_field_options' ), array( $field ) );
+
+		$this->assertIsArray( $options, "Options stored as '{$stored}' should be read as an array." );
+	}
+
+	/**
+	 * @return void array<string>>
+	 */
+	public function unreadable_field_options_provider(): \Iterator {
+		yield 'serialized null' => array( 'N;' );
+		yield 'empty' => array( '' );
+		yield 'not json' => array( 'not json' );
+		yield 'a bare number' => array( '0' );
+	}
+
+	/**
+	 * Options written by an older version are serialized rather than JSON, so
+	 * they are read rather than thrown away for not being JSON.
+	 *
+	 * @covers FrmXMLHelper::fill_field_options
+	 *
+	 * @return void
+	 */
+	public function test_fill_field_options_reads_serialized_options() {
+		$serialized = 'a:2:{s:10:"start_year";s:4:"1990";s:8:"end_year";s:4:"2050";}';
+		$field      = new SimpleXMLElement( '<field><field_options>' . $serialized . '</field_options></field>' );
+		$options    = $this->run_private_method( array( 'FrmXMLHelper', 'fill_field_options' ), array( $field ) );
+
+		$this->assertSame( '1990', $options['start_year'], 'Serialized options should survive the import.' );
+		$this->assertSame( '2050', $options['end_year'], 'Serialized options should survive the import.' );
+	}
+
+	/**
+	 * JSON options, which is what an export writes today.
+	 *
+	 * @covers FrmXMLHelper::fill_field_options
+	 *
+	 * @return void
+	 */
+	public function test_fill_field_options_reads_json_options() {
+		$field   = new SimpleXMLElement( '<field><field_options>{"start_year":"1990"}</field_options></field>' );
+		$options = $this->run_private_method( array( 'FrmXMLHelper', 'fill_field_options' ), array( $field ) );
+
+		$this->assertSame( '1990', $options['start_year'], 'JSON options should be read as an array.' );
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved field XML imports to correctly read legacy serialized and JSON field options.
  * Invalid, empty, or unreadable field options are now safely converted to an empty array.

* **Tests**
  * Added coverage for serialized, JSON, invalid, empty, null, and numeric field option values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->