### PR TITLE
use regular current user can function

### DIFF
--- a/classes/models/FrmSpamCheckDenylist.php
+++ b/classes/models/FrmSpamCheckDenylist.php
@@ -96,7 +96,7 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 			),
 			array(
 				'file'             => FrmAppHelper::plugin_path() . '/denylist/splorp-wp-comment.txt',
-				'skip'             => FrmAppHelper::current_user_can( 'frm_create_entries' ),
+				'skip'             => current_user_can( 'frm_create_entries' ),
 				'skip_field_types' => array( 'file' ),
 			),
 			array(


### PR DESCRIPTION
The other functions works but it has extra logic that isn't required for hard coded capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated denylist checks to use the standard WordPress permission check, improving access handling for authorized users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->