### PR TITLE
Add frm_builder_after_field_label hook

### DIFF
--- a/classes/models/fields/FrmFieldType.php
+++ b/classes/models/fields/FrmFieldType.php
@@ -307,6 +307,21 @@ DEFAULT_HTML;
 			<span class="frm-sub-label frm-collapsed-label">
 				<?php esc_html_e( '(Collapsed)', 'formidable' ); ?>
 			</span>
+			<?php
+			/**
+			 * Fires at the end of a field's label in the form builder.
+			 *
+			 * Use this to add a marker beside the field name, the way the
+			 * required indicator above does. Anything echoed here lands inside
+			 * the label, so keep it inline and decorative.
+			 *
+			 * @since x.x
+			 *
+			 * @param array $field The field settings, as prepared by
+			 *                     FrmFieldsHelper::setup_edit_vars().
+			 */
+			do_action( 'frm_builder_after_field_label', $field );
+			?>
 		</label>
 		<?php
 		// phpcs:enable Generic.WhiteSpace.ScopeIndent


### PR DESCRIPTION
Add this hook to show the tooltip icon after the label inside the form builder. Without this hook, the field tooltip add-on uses JS to show the icon there.

Related PR: https://github.com/Strategy11/formidable-field-tooltips/pull/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an extension point that allows custom content to appear after field labels in the form builder.
  * Provides field configuration details to support tailored label-related enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->