### PR TITLE
Show bulk delete message on payments list page

### DIFF
--- a/stripe/views/lists/list.php
+++ b/stripe/views/lists/list.php
@@ -23,6 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<div class="wrap">
 		<?php
+		require FrmAppHelper::plugin_path() . '/classes/views/shared/errors.php';
+
 		FrmTransLiteListHelper::render_tabs();
 		$wp_list_table->views();
 		?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment list pages now display shared error messages before the tabs and payment table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->