### PR TITLE
Build style card menus after Pro has registered its filter

### DIFF
--- a/js/admin/style.js
+++ b/js/admin/style.js
@@ -184,9 +184,16 @@
 	 */
 	function initListPage() {
 		document.addEventListener( 'click', handleClickEventsForListPage );
-		// Add a timeout so Pro has a chance to add a filter first.
-		// 0 does not always work in Google Chrome, so use 1.
-		setTimeout( addHamburgerMenusToCards, 1 );
+		// Pro adds its options to these menus with a filter registered from a separate
+		// script file. DOMContentLoaded is the first point at which every enqueued
+		// script has run, so it guarantees the filter is in place. A timeout cannot:
+		// when Pro loses the race the menus are built without Duplicate, Set as
+		// Default and Delete, and a disabled Duplicate upsell is added instead.
+		if ( 'complete' === document.readyState ) {
+			addHamburgerMenusToCards();
+		} else {
+			document.addEventListener( 'DOMContentLoaded', addHamburgerMenusToCards );
+		}
 		initDatepickerSample();
 
 		const enableToggle = document.getElementById( 'frm_enable_styling' );


### PR DESCRIPTION
On the styles list page, a style card's menu sometimes showed a disabled "Duplicate" upsell, with Set as Default and Delete missing entirely, even with Pro active and authorized.

Core builds those menus 1ms after its own script runs, hoping Pro's separate script file has executed and registered its filter by then. When it has not, the menus are built without Pro's options and core adds the upsell to fill the gap. Reproduced on a cold load and not on five warm ones after it.

In this update,
1. The menus are built on DOMContentLoaded rather than after a 1ms timeout, which is the first point at which every enqueued script has run.

Pro's `formidable_pro_style_settings` already declares `formidable_style` as a dependency, so WordPress orders the two scripts correctly and no change is needed on the Pro side.