### PR TITLE
Switch field ids in field descriptions

### DIFF
--- a/classes/models/FrmForm.php
+++ b/classes/models/FrmForm.php
@@ -166,6 +166,8 @@ class FrmForm {
 	 * Switches field ID in fields.
 	 *
 	 * @since 5.3
+	 * @since x.x The description column is checked too, so a field id in a description survives a
+	 *            duplicate or import when the field it points at is created afterwards.
 	 *
 	 * @param int $form_id Form ID.
 	 *
@@ -175,7 +177,7 @@ class FrmForm {
 		global $wpdb;
 
 		// Keys of fields that you want to check to replace field ID.
-		$keys     = array( 'default_value', 'field_options' );
+		$keys     = array( 'default_value', 'description', 'field_options' );
 		$sql_cols = 'fi.id';
 
 		foreach ( $keys as $key ) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicated or imported forms so field references within descriptions are updated correctly.
  * Ensured description content continues pointing to the corresponding newly created fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->