### PR TITLE
Exclude tests/phpunit from DeepSource PHP analysis

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -23,7 +23,16 @@ exclude_patterns = [
   "js/formidable-web-components.js",
   "js/frm_testing_mode.js",
   "js/welcome-tour.js",
-  "eslint-rules/**"
+  "eslint-rules/**",
+  # PHPUnit tests: the PHP analyzer cannot resolve PHPUnit\Framework\TestCase
+  # (it lives under the excluded vendor/**), so every assert*() call in these files
+  # is reported as "Call to an undefined method". PHPStan and Psalm are green on the
+  # same files only because both load stubs.php explicitly, which DeepSource has no
+  # equivalent setting for. test_patterns below is not enough: it relaxes the style
+  # and security categories but still reports bug-risk issues like undefined methods.
+  # Mirrors phpstan.neon's excludePaths (*/tests/*) and phpcs.xml's tests/phpunit/*
+  # rule exclusions.
+  "tests/phpunit/**"
 ]
 
 # 2. Test Patterns


### PR DESCRIPTION
## The problem

`DeepSource: PHP` goes red on any PR that adds or edits a PHPUnit test file, regardless of what the PR does. The analyzer cannot resolve `PHPUnit\Framework\TestCase` — it lives under the already-excluded `vendor/**` — so **every `assert*()` call in a test file is reported as "Call to an undefined method"**.

Measured on #3242, which is red right now: **56 findings, 55 of them of exactly this shape.**

| File | Findings |
|---|---|
| `tests/phpunit/styles/test_FrmStyle.php` | 33 |
| `tests/phpunit/misc/test_FrmCreateFile.php` | 15 |
| `tests/phpunit/styles/test_FrmStylesController.php` | 5 |
| `tests/phpunit/database/test_FrmMigrate.php` | 2 |
| `classes/models/FrmStyle.php` | 1 |

Sample: `Call to an undefined method test_FrmStyle::assertNotEmpty()`, `…::assertSame()`, `…::assertTrue()`, `…::assertCount()`, and `Call to an undefined static method FrmUnitTest::tearDown()`.

It is not limited to *new* test files. #3256 merely edits `tests/phpunit/fields/test_FrmFieldValidate.php` — a file that already carried assertions on `master` — and draws the same class of finding.

## Why `test_patterns` doesn't already handle it

`.deepsource.toml` already lists these paths under `test_patterns`, so this looks like it should be solved. It isn't: `test_patterns` relaxes the **style and security** categories but still reports **bug-risk** issues, and "undefined method" is bug-risk. `exclude_patterns` is the only setting that stops them.

## Why these are definitely artifacts, not defects

- `stubs.php` declares `WP_UnitTestCase extends WP_UnitTestCase_Base extends PHPUnit\Framework\TestCase`, and **both `phpstan.neon` and `psalm.xml` load `stubs.php` explicitly**. That is precisely why PHPStan and Psalm are green on the same files DeepSource calls broken. DeepSource has no equivalent stub-path setting.
- The **PHPUnit matrix passes** on both PHP 7.4 and PHP 8. A suite cannot pass while calling undefined methods.

## Why exclusion is the right fix rather than a workaround

Every other analyzer in this repo already treats these files this way:

- `phpstan.neon` → `excludePaths: */tests/*`
- `phpcs.xml` → a list of rule exclusions scoped to `tests/phpunit/*`

This change brings DeepSource in line with them. Since the analyzer cannot resolve the base class, its findings on this directory are 100% false positives, so nothing of value is being given up.

Scoped deliberately to `tests/phpunit/**` rather than `**/tests/**`, so the **JavaScript** analyzer keeps covering `tests/cypress` — it currently passes there and this shouldn't touch it. `test_patterns` and both `[[analyzers]]` blocks are unchanged; TOML validated.

## What this does and does not fix

It removes the recurring red. It is **not** cosmetic: the noise has real cost — this failure class has been re-diagnosed on #3242 across roughly a dozen separate triage passes, and it has trained everyone to read `DeepSource: PHP` as "probably nothing," which is exactly how a genuine finding gets waved through. #3234 merged with 6 open DeepSource threads and #3235 with 9, both on test files.

The one remaining finding on #3242 is a real (if arguable) one in product code — `Use of insecure md5() function found` in `classes/models/FrmStyle.php`, where the hash is an opaque cache-busting key rather than a credential. That belongs to #3242 and is deliberately left out of this PR.

Requesting a look from @Crabcyborg since this is a repo-wide CI policy change rather than a fix to my own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code analysis settings to exclude PHPUnit test files from DeepSource scanning.
  * Prevented incorrect undefined-method warnings for PHPUnit assertions in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->