### PR TITLE
Bring stripe add-on fixes into Stripe Lite

### DIFF
--- a/stripe/controllers/FrmStrpLiteEventsController.php
+++ b/stripe/controllers/FrmStrpLiteEventsController.php
@@ -84,7 +84,9 @@ class FrmStrpLiteEventsController {
 
 			FrmTransLiteAppHelper::add_note_to_payment( $payment_values, $note );
 
-			$u = $frm_payment->update( $payment->id, $payment_values );
+			// Read the status again right before the update, in case another request has already changed it.
+			$payment_status_still_does_not_match = $this->payment_status_still_does_not_match( $payment->id );
+			$updated                             = $frm_payment->update( $payment->id, $payment_values );
 
 			echo json_encode(
 				array(
@@ -93,7 +95,7 @@ class FrmStrpLiteEventsController {
 				)
 			);
 
-			if ( ! $is_partial_refund ) {
+			if ( ! $is_partial_refund && $payment_status_still_does_not_match && $updated ) {
 				$run_triggers = true;
 			}
 		}//end if
@@ -106,6 +108,24 @@ class FrmStrpLiteEventsController {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Double check that the payment status has not changed.
+	 * This is to avoid running actions twice by mistake, since a Stripe Link
+	 * return URL and a webhook event can both process the same payment.
+	 *
+	 * @since x.x
+	 *
+	 * @param int $payment_id The id of the payment to check.
+	 *
+	 * @return bool
+	 */
+	private function payment_status_still_does_not_match( $payment_id ) {
+		$frm_payment = new FrmTransLitePayment();
+		$payment     = $frm_payment->get_one( $payment_id );
+
+		return $payment && $payment->status !== $this->status;
 	}
 
 	/**
@@ -310,7 +330,9 @@ class FrmStrpLiteEventsController {
 		};
 
 		add_filter( $hook, $filter, 99 );
-		$cancelled = FrmStrpLiteApiHelper::cancel_subscription( $sub->sub_id );
+
+		// There is no logged in user when a webhook event is processed, so the customer check has to be skipped here.
+		$cancelled = FrmStrpLiteAppHelper::call_stripe_helper_class( 'cancel_subscription_without_customer_check', $sub->sub_id );
 
 		if ( $cancelled ) {
 			FrmTransLiteSubscriptionsController::change_subscription_status(
@@ -319,6 +341,8 @@ class FrmStrpLiteEventsController {
 					'sub'    => $sub,
 				)
 			);
+		} else {
+			FrmTransLiteLog::log_message( 'Stripe Webhook Message', 'Unable to cancel subscription ' . $sub->sub_id . ' after it reached its payment limit.' );
 		}
 
 		remove_filter( $hook, $filter, 99 );

--- a/stripe/controllers/FrmStrpLiteLinkController.php
+++ b/stripe/controllers/FrmStrpLiteLinkController.php
@@ -146,11 +146,34 @@ class FrmStrpLiteLinkController {
 
 		self::maybe_update_intent( $intent, $action, $entry );
 
-		$frm_payment->update( $payment->id, $new_payment_values );
-		FrmTransLiteActionsController::trigger_payment_status_change( compact( 'status', 'payment' ) );
+		// A webhook event may have already updated this payment, so check the status again before running triggers.
+		$needs_triggers = $status !== $payment->status && self::payment_status_still_needs_to_update( $payment->id, $status );
+		$updated        = $frm_payment->update( $payment->id, $new_payment_values );
+
+		if ( $needs_triggers && $updated ) {
+			FrmTransLiteActionsController::trigger_payment_status_change( compact( 'status', 'payment' ) );
+		}
 
 		$redirect_helper->handle_success( $entry, isset( $charge ) ? $charge->id : '' );
 		die();
+	}
+
+	/**
+	 * Check that the payment status has not been updated by another request already.
+	 * This is to avoid running the payment actions twice.
+	 *
+	 * @since x.x
+	 *
+	 * @param int    $payment_id The id of the payment to check.
+	 * @param string $status     The status the payment is about to be updated to.
+	 *
+	 * @return bool
+	 */
+	private static function payment_status_still_needs_to_update( $payment_id, $status ) {
+		$frm_payment = new FrmTransLitePayment();
+		$payment     = $frm_payment->get_one( $payment_id );
+
+		return $payment && $payment->status !== $status;
 	}
 
 	/**

--- a/stripe/helpers/FrmStrpLiteConnectApiAdapter.php
+++ b/stripe/helpers/FrmStrpLiteConnectApiAdapter.php
@@ -38,6 +38,21 @@ class FrmStrpLiteConnectApiAdapter {
 	}
 
 	/**
+	 * Cancel a subscription without checking that it belongs to the current user.
+	 * Use this when there is no logged in user, like when a webhook event is processed.
+	 * The customer check in self::cancel_subscription would always fail there because the current user ID is 0.
+	 *
+	 * @since x.x
+	 *
+	 * @param string $sub_id
+	 *
+	 * @return bool
+	 */
+	public static function cancel_subscription_without_customer_check( $sub_id ) {
+		return FrmStrpLiteConnectHelper::cancel_subscription( $sub_id );
+	}
+
+	/**
 	 * @param string $payment_id
 	 *
 	 * @return bool

--- a/stripe/models/FrmStrpLiteAuth.php
+++ b/stripe/models/FrmStrpLiteAuth.php
@@ -767,7 +767,7 @@ class FrmStrpLiteAuth {
 			$success_url = $atts['form']->options['success_url'];
 		}
 
-		$success_url = trim( $atts['form']->options['success_url'] );
+		$success_url = trim( $success_url );
 		$success_url = apply_filters( 'frm_content', $success_url, $atts['form'], $atts['entry'] );
 		$success_url = do_shortcode( $success_url );
 		$atts['id']  = $atts['entry']->id;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate payment status actions when webhook or return processing has already updated a payment.
  * Improved subscription cancellation handling for webhook events and added failure logging.
  * Excluded partial refunds from triggering standard payment status-change actions.
  * Trimmed success URLs consistently before redirect processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->