### PR TITLE
Remove unneeded stripe function call

### DIFF
--- a/stripe/helpers/FrmStrpLiteSubscriptionHelper.php
+++ b/stripe/helpers/FrmStrpLiteSubscriptionHelper.php
@@ -147,7 +147,6 @@ class FrmStrpLiteSubscriptionHelper {
 	 * @return mixed
 	 */
 	public static function maybe_create_plan( $plan ) {
-		FrmStrpLiteAppHelper::call_stripe_helper_class( 'initialize_api' );
 		return FrmStrpLiteAppHelper::call_stripe_helper_class( 'maybe_create_plan', $plan );
 	}
 


### PR DESCRIPTION
This is a legacy line from copying from the add-on. There's no need to initialize an API first with Stripe Connect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined subscription plan creation by removing a redundant setup step.
  * Plan creation continues to be handled through the Stripe integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->