### PR TITLE
Fix denylist performance issue when there are no strings to check

### DIFF
--- a/classes/models/FrmSpamCheckDenylist.php
+++ b/classes/models/FrmSpamCheckDenylist.php
@@ -180,6 +180,11 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 			$this->fill_default_denylist_data( $denylist );
 			$denylist['allowed_words'] = $allowed_words;
 
+			if ( ! $this->add_values_to_check( $denylist ) ) {
+				// Nothing in this submission needs to be checked against this denylist.
+				continue;
+			}
+
 			if ( ! empty( $denylist['words'] ) ) {
 				foreach ( $denylist['words'] as $word ) {
 					if ( $this->single_line_check_values( $word, $denylist ) ) {
@@ -232,6 +237,37 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 	}
 
 	/**
+	 * Extracts the submitted values this denylist needs to check, and the string
+	 * forms those values are compared against.
+	 *
+	 * The values depend on the denylist configuration, not on the word or file line
+	 * being compared, so they are extracted once here and carried on the denylist.
+	 * The shipped denylist files hold tens of thousands of lines and a large form
+	 * posts more than a thousand values, so extracting per line is quadratic.
+	 *
+	 * @since x.x
+	 *
+	 * @param array $denylist Denylist data, with the defaults already filled in.
+	 *
+	 * @return bool False if this submission has no values for this denylist to check.
+	 */
+	protected function add_values_to_check( &$denylist ) {
+		$values_to_check = $this->get_values_to_check( $denylist );
+
+		if ( ! $values_to_check ) {
+			return false;
+		}
+
+		$values_string = $this->convert_values_to_string( $values_to_check );
+
+		$denylist['values_to_check']     = $values_to_check;
+		$denylist['values_string']       = $values_string;
+		$denylist['values_string_lower'] = $this->convert_to_lowercase( $values_string );
+
+		return true;
+	}
+
+	/**
 	 * Gets words from setting.
 	 *
 	 * @param string $setting_key Setting key.
@@ -255,7 +291,8 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 	 * Checks the values against each single word.
 	 *
 	 * @param string $line Single line.
-	 * @param array  $args Check args.
+	 * @param array  $args Check args. Carries the values to check when they have
+	 *                     already been extracted by {@see FrmSpamCheckDenylist::add_values_to_check()}.
 	 *
 	 * @return bool
 	 */
@@ -267,19 +304,17 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 			return false;
 		}
 
-		$values_to_check = $this->get_values_to_check( $args );
-
-		if ( ! $values_to_check ) {
+		if ( ! isset( $args['values_to_check'] ) && ! $this->add_values_to_check( $args ) ) {
 			// Nothing needs to be checked.
 			return false;
 		}
 
 		if ( ! empty( $args['is_regex'] ) ) {
-			return preg_match( '/' . trim( $line, '/' ) . '/i', $this->convert_values_to_string( $values_to_check ) );
+			return preg_match( '/' . trim( $line, '/' ) . '/i', $args['values_string'] );
 		}
 
 		if ( self::COMPARE_EQUALS === $args['compare'] ) {
-			foreach ( $values_to_check as $value ) {
+			foreach ( $args['values_to_check'] as $value ) {
 				$value = $this->convert_to_lowercase( $value );
 
 				if ( $line === $value ) {
@@ -290,8 +325,7 @@ class FrmSpamCheckDenylist extends FrmSpamCheck {
 			return false;
 		}
 
-		$values_str = strtolower( $this->convert_values_to_string( $values_to_check ) );
-		return str_contains( $values_str, $line );
+		return str_contains( $args['values_string_lower'], $line );
 	}
 
 	/**

--- a/tests/phpunit/misc/test_FrmSpamCheckDenylist.php
+++ b/tests/phpunit/misc/test_FrmSpamCheckDenylist.php
@@ -397,13 +397,18 @@ class test_FrmSpamCheckDenylist extends FrmUnitTest {
 	/**
 	 * Runs check_values() against the given denylist data.
 	 *
-	 * @param array $denylist_data Array of denylists.
+	 * @param array                     $denylist_data Array of denylists.
+	 * @param FrmSpamCheckDenylist|null $spam_check    The check to run, or null for the one built in setUp().
 	 *
 	 * @return bool
 	 */
-	private function check_values_with( $denylist_data ) {
-		$this->set_denylist_data( $denylist_data );
-		return $this->run_private_method( array( $this->spam_check, 'check_values' ) );
+	private function check_values_with( $denylist_data, $spam_check = null ) {
+		if ( null === $spam_check ) {
+			$spam_check = $this->spam_check;
+		}
+
+		$this->set_private_property( $spam_check, 'denylist', $denylist_data );
+		return $this->run_private_method( array( $spam_check, 'check_values' ) );
 	}
 
 	/**
@@ -648,5 +653,108 @@ class test_FrmSpamCheckDenylist extends FrmUnitTest {
 		$this->assertContains( 'wordpress', (array) get_transient( $transient_name ) );
 
 		delete_transient( $transient_name );
+	}
+
+	/**
+	 * The values are compared as a JSON string, which escapes forward slashes, and
+	 * they are unescaped again before the compare. Without that, no denylist entry
+	 * holding a slash could ever match.
+	 */
+	public function test_check_values_with_slashes_in_denylist_words() {
+		$values                                      = $this->default_values;
+		$values['item_meta'][ $this->text_field_id ] = 'go to spam/path/here and /joomla/ today';
+		$spam_check                                  = new FrmSpamCheckDenylist( $values );
+
+		$this->assertTrue( $this->check_values_with( array( array( 'words' => array( 'spam/path' ) ) ), $spam_check ) );
+		$this->assertTrue( $this->check_values_with( array( array( 'words' => array( '/joomla/' ) ) ), $spam_check ) );
+
+		// A slash in the word still has to be part of the value to match.
+		$this->assertFalse( $this->check_values_with( array( array( 'words' => array( 'spam/other' ) ) ), $spam_check ) );
+	}
+
+	/**
+	 * Option fields hold values the site author wrote, and password fields hold
+	 * secrets, so fill_default_denylist_data() always adds them to the skipped
+	 * field types. A denylisted word in one of them is not spam.
+	 */
+	public function test_check_values_skips_the_default_skipped_field_types() {
+		$form_id  = FrmField::getOne( $this->text_field_id )->form_id;
+		$denylist = array(
+			array(
+				'words' => array( 'zzspamword' ),
+			),
+		);
+
+		foreach ( array( 'radio', 'checkbox', 'select', 'password' ) as $type ) {
+			$field_id   = $this->factory->field->create(
+				array(
+					'type'    => $type,
+					'form_id' => $form_id,
+				)
+			);
+			$spam_check = new FrmSpamCheckDenylist(
+				array(
+					'form_id'   => $form_id,
+					'item_meta' => array( $field_id => 'zzspamword' ),
+				)
+			);
+
+			$this->assertFalse(
+				$this->check_values_with( $denylist, $spam_check ),
+				'A denylisted word in a ' . $type . ' field should not be spam.'
+			);
+		}
+
+		// The same word in a field type that is checked is spam.
+		$spam_check = new FrmSpamCheckDenylist(
+			array(
+				'form_id'   => $form_id,
+				'item_meta' => array( $this->text_field_id => 'zzspamword' ),
+			)
+		);
+		$this->assertTrue( $this->check_values_with( $denylist, $spam_check ) );
+	}
+
+	/**
+	 * The denylist check runs only while its setting is on, and the
+	 * frm_check_denylist filter can turn it off on its own.
+	 */
+	public function test_is_spam_respects_the_denylist_setting() {
+		$frm_settings = FrmAppHelper::get_settings();
+		$was_enabled  = $frm_settings->denylist_check;
+
+		add_filter( 'frm_denylist_data', array( $this, 'filter_denylist_to_one_word' ) );
+
+		$frm_settings->update_setting( 'denylist_check', 1, 'absint' );
+		$spam_check = new FrmSpamCheckDenylist( $this->default_values );
+		$this->assertNotFalse( $spam_check->is_spam() );
+
+		$frm_settings->update_setting( 'denylist_check', 0, 'absint' );
+		$spam_check = new FrmSpamCheckDenylist( $this->default_values );
+		$this->assertFalse( $spam_check->is_spam() );
+
+		// The filter turns the check off while the setting is still on.
+		$frm_settings->update_setting( 'denylist_check', 1, 'absint' );
+		add_filter( 'frm_check_denylist', '__return_false' );
+		$spam_check = new FrmSpamCheckDenylist( $this->default_values );
+		$this->assertFalse( $spam_check->is_spam() );
+		remove_filter( 'frm_check_denylist', '__return_false' );
+
+		remove_filter( 'frm_denylist_data', array( $this, 'filter_denylist_to_one_word' ) );
+		$frm_settings->update_setting( 'denylist_check', $was_enabled, 'absint' );
+	}
+
+	/**
+	 * Replaces the shipped denylist with a single word that is in the test values,
+	 * so the setting is what decides the result rather than the denylist files.
+	 *
+	 * @return array[]
+	 */
+	public function filter_denylist_to_one_word() {
+		return array(
+			array(
+				'words' => array( 'plugin' ),
+			),
+		);
 	}
 }


### PR DESCRIPTION
Related ticket https://secure.helpscout.net/conversation/3427613497/257227. There's an XML they share in the ticket that I tested against. The form has ~1,100 fields.

On my local site, changing between pages 1 and 2, I see page load times going from ~2.5 seconds to ~0.6 seconds with this update, saving about 2 seconds and most of the request time.

The issue is that it would iterate through each denylist line. This update exits early before the loop if there is nothing to actually check.

Regression tests added in https://github.com/Strategy11/formidable-forms/pull/3285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spam denylist matching for regular expressions, exact values, contained text, and values containing slashes.
  * Empty submissions are skipped earlier for more reliable handling of blank content.
  * Option and password fields are excluded from denylist checks by default.
  * Denylist settings and filtering are now respected consistently.
  * Optimized repeated denylist checks for faster scanning of submitted content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->