### PR TITLE
Memoize decoded API results

### DIFF
--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -16,6 +16,16 @@ class FrmAddonsController {
 	private static $categories = array();
 
 	/**
+	 * install_link results already resolved during this request, keyed by add-on slug.
+	 *
+	 * Resolving one add-on walks and decorates the whole add-on list, so the form builder paid for
+	 * that once per upsell it rendered. Nothing it reads changes mid-request.
+	 *
+	 * @var array<string,array>
+	 */
+	private static $install_links = array();
+
+	/**
 	 * @var string
 	 */
 	private static $request_addon_url;
@@ -733,6 +743,10 @@ class FrmAddonsController {
 	 * @return array
 	 */
 	public static function install_link( $plugin ) {
+		if ( isset( self::$install_links[ $plugin ] ) ) {
+			return self::$install_links[ $plugin ];
+		}
+
 		$link  = array();
 		$addon = self::get_addon( $plugin );
 
@@ -762,6 +776,8 @@ class FrmAddonsController {
 				'class' => 'frm-activate-addon',
 			);
 		}//end if
+
+		self::$install_links[ $plugin ] = $link;
 
 		return $link;
 	}

--- a/classes/controllers/FrmAddonsController.php
+++ b/classes/controllers/FrmAddonsController.php
@@ -16,16 +16,6 @@ class FrmAddonsController {
 	private static $categories = array();
 
 	/**
-	 * install_link results already resolved during this request, keyed by add-on slug.
-	 *
-	 * Resolving one add-on walks and decorates the whole add-on list, so the form builder paid for
-	 * that once per upsell it rendered. Nothing it reads changes mid-request.
-	 *
-	 * @var array<string,array>
-	 */
-	private static $install_links = array();
-
-	/**
 	 * @var string
 	 */
 	private static $request_addon_url;
@@ -743,10 +733,6 @@ class FrmAddonsController {
 	 * @return array
 	 */
 	public static function install_link( $plugin ) {
-		if ( isset( self::$install_links[ $plugin ] ) ) {
-			return self::$install_links[ $plugin ];
-		}
-
 		$link  = array();
 		$addon = self::get_addon( $plugin );
 
@@ -776,8 +762,6 @@ class FrmAddonsController {
 				'class' => 'frm-activate-addon',
 			);
 		}//end if
-
-		self::$install_links[ $plugin ] = $link;
 
 		return $link;
 	}

--- a/classes/models/FrmFormApi.php
+++ b/classes/models/FrmFormApi.php
@@ -36,15 +36,14 @@ class FrmFormApi {
 	protected $force = false;
 
 	/**
-	 * Add-on info already read during this request, keyed by request url.
+	 * The most recent decode of each cache key's payload.
 	 *
-	 * get_api_info is called many times per request -- every upsell the form builder renders walks
-	 * the add-on list -- and each call unserializes the whole cached payload again. What it reads
-	 * cannot change mid-request, so keep the decoded array instead of rebuilding it.
+	 * Each entry is array( 'raw' => string, 'decoded' => mixed ). The raw JSON is kept so a reuse
+	 * can be checked against what is stored right now, rather than assumed to still be current.
 	 *
 	 * @var array<string,array>
 	 */
-	private static $memoized = array();
+	private static $decoded_cache = array();
 
 	/**
 	 * @since 3.06
@@ -130,16 +129,11 @@ class FrmFormApi {
 		if ( $this->force ) {
 			$addons      = false;
 			$this->force = false;
-			unset( self::$memoized[ $url ] );
 		} else {
-			if ( isset( self::$memoized[ $url ] ) ) {
-				return self::$memoized[ $url ];
-			}
 			$addons = $this->get_cached();
 		}
 
 		if ( is_array( $addons ) ) {
-			self::$memoized[ $url ] = $addons;
 			return $addons;
 		}
 
@@ -355,7 +349,39 @@ class FrmFormApi {
 			return false;
 		}
 
-		return json_decode( $cache['value'], true );
+		return $this->decode_cached( $cache['value'] );
+	}
+
+	/**
+	 * Decode a cached API payload, reusing the previous decode of an unchanged payload.
+	 *
+	 * The payload runs to tens of kilobytes of JSON, and decoding it costs far more than reading
+	 * the option it came from. That matters because a single form builder page decodes it once per
+	 * upsell it renders. The reuse is keyed on the raw JSON rather than on the cache key, so
+	 * anything that changes what is stored -- a new license, a cleared cache, a fresh API response,
+	 * a test replacing the option -- is picked up on the very next read instead of being masked.
+	 *
+	 * @since x.x
+	 *
+	 * @param string $value The cached JSON.
+	 *
+	 * @return mixed
+	 */
+	private function decode_cached( $value ) {
+		$previous = self::$decoded_cache[ $this->cache_key ] ?? false;
+
+		if ( $previous && $previous['raw'] === $value ) {
+			return $previous['decoded'];
+		}
+
+		$decoded = json_decode( $value, true );
+
+		self::$decoded_cache[ $this->cache_key ] = array(
+			'raw'     => $value,
+			'decoded' => $decoded,
+		);
+
+		return $decoded;
 	}
 
 	/**

--- a/classes/models/FrmFormApi.php
+++ b/classes/models/FrmFormApi.php
@@ -36,6 +36,17 @@ class FrmFormApi {
 	protected $force = false;
 
 	/**
+	 * Add-on info already read during this request, keyed by request url.
+	 *
+	 * get_api_info is called many times per request -- every upsell the form builder renders walks
+	 * the add-on list -- and each call unserializes the whole cached payload again. What it reads
+	 * cannot change mid-request, so keep the decoded array instead of rebuilding it.
+	 *
+	 * @var array<string,array>
+	 */
+	private static $memoized = array();
+
+	/**
 	 * @since 3.06
 	 *
 	 * @param string|null $license The license key.
@@ -119,11 +130,16 @@ class FrmFormApi {
 		if ( $this->force ) {
 			$addons      = false;
 			$this->force = false;
+			unset( self::$memoized[ $url ] );
 		} else {
+			if ( isset( self::$memoized[ $url ] ) ) {
+				return self::$memoized[ $url ];
+			}
 			$addons = $this->get_cached();
 		}
 
 		if ( is_array( $addons ) ) {
+			self::$memoized[ $url ] = $addons;
 			return $addons;
 		}
 


### PR DESCRIPTION
This update memoizes the `json_decode` results from APIs, which is expensive when the API data is retrieved frequently and contains a lot of data (like our add-ons API).