### PR TITLE
Fix invalid HTML in stripe onboarding buttons

### DIFF
--- a/stripe/js/connect_settings.js
+++ b/stripe/js/connect_settings.js
@@ -1,8 +1,8 @@
 ( function() {
 	function setupStripeConnectListener() {
-		onclickPreventDefault( '#frm_disconnect_stripe', handleStripeDisconnectClick );
-		onclickPreventDefault( '#frm_reauth_stripe', handleStripeReauthClick );
-		onclickPreventDefault( '#frm_connect_with_oauth', handleConnectWithOauth );
+		onclickPreventDefault( '.frm_disconnect_stripe', handleStripeDisconnectClick );
+		onclickPreventDefault( '.frm_reauth_stripe', handleStripeReauthClick );
+		onclickPreventDefault( '.frm_connect_with_oauth', handleConnectWithOauth );
 		renderStripeConnectSettingsButton();
 	}
 

--- a/stripe/views/settings/connect.php
+++ b/stripe/views/settings/connect.php
@@ -18,16 +18,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php esc_html_e( 'Not connected!', 'formidable' ); ?>
 			</strong>
 			<br/><br/>
-			<a id="frm_reauth_stripe" class="button-primary frm-button-primary" href="#">
+			<a class="frm_reauth_stripe button-primary frm-button-primary" href="#">
 				<?php FrmStrpLiteConnectHelper::stripe_icon(); ?> &nbsp;
 				<?php esc_html_e( 'Finish Stripe Setup', 'formidable' ); ?>
 			</a>
 			or
 		<?php } ?>
-		<a id="frm_disconnect_stripe" href="#" style="font-size:13px"><?php esc_html_e( 'Disconnect', 'formidable' ); ?></a>
+		<a class="frm_disconnect_stripe" href="#" style="font-size:13px"><?php esc_html_e( 'Disconnect', 'formidable' ); ?></a>
 	<?php } else { ?>
 		<br/><br/>
-		<a id="frm_connect_with_oauth" class="button-primary frm-button-primary">
+		<a class="frm_connect_with_oauth button-primary frm-button-primary">
 			<?php FrmStrpLiteConnectHelper::stripe_icon(); ?> &nbsp;
 			<?php esc_html_e( 'Connect to Stripe', 'formidable' ); ?>
 		</a>


### PR DESCRIPTION
Fixes https://github.com/Strategy11/formidable-pro/issues/6568

This has been breaking the e2e tests for a while. The duplicate IDs are invalid HTML.

**What changed**
Instead of IDs (`#frm_disconnect_stripe`, `#frm_connect_with_oauth`), where no two elements should have the same ID, the oauth buttons now use classes (`.frm_disconnect_stripe`, `.frm_connect_with_oauth`).

**What to test?**
Just that the oauth connect/disconnect buttons all still work as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe connection settings controls so setup, reconnection, and disconnection actions continue to work reliably.
  * Updated button and link targeting for Stripe connection actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->