### PR TITLE
Remove defered hook changes

### DIFF
--- a/classes/controllers/FrmHooksController.php
+++ b/classes/controllers/FrmHooksController.php
@@ -104,7 +104,6 @@ class FrmHooksController {
 		// Simple Blocks Controller.
 		add_action( 'init', 'FrmSimpleBlocksController::register_simple_form_block' );
 
-		FrmUsageController::add_schedules_filter();
 		add_action( 'formidable_send_usage', 'FrmUsageController::send_snapshot' );
 
 		/**

--- a/classes/controllers/FrmOnboardingWizardController.php
+++ b/classes/controllers/FrmOnboardingWizardController.php
@@ -126,33 +126,18 @@ class FrmOnboardingWizardController {
 	public static function load_admin_hooks() {
 		self::set_page_url();
 		add_action( 'admin_init', self::class . '::do_admin_redirects' );
-		self::load_translated_admin_hooks();
-	}
-
-	/**
-	 * Initializes the hooks that depend on translated strings.
-	 *
-	 * Defers itself to init when called earlier, because add_wizard_to_floating_links()
-	 * translates and maybe_load_page() reads the inbox option, which applies that filter.
-	 * Translating before the text domain is loaded triggers a _load_textdomain_just_in_time
-	 * notice in WordPress 6.7+.
-	 *
-	 * @since x.x
-	 *
-	 * @return void
-	 */
-	public static function load_translated_admin_hooks() {
-		if ( ! did_action( 'init' ) ) {
-			add_action( 'init', self::class . '::load_translated_admin_hooks' );
-			return;
-		}
 
 		if ( self::has_onboarding_been_skipped() ) {
 			add_filter( 'option_frm_inbox', self::class . '::add_wizard_to_floating_links' );
 		}
 
-		// Load page if admin page is Onboarding Wizard.
-		self::maybe_load_page();
+		/**
+		 * Load page if admin page is Onboarding Wizard.
+		 * This waits for init because it reads the inbox option, and the filter above translates
+		 * when it does. Translating before the text domain is loaded triggers a
+		 * _load_textdomain_just_in_time notice in WordPress 6.7+.
+		 */
+		add_action( 'init', self::class . '::maybe_load_page' );
 	}
 
 	/**

--- a/classes/controllers/FrmUsageController.php
+++ b/classes/controllers/FrmUsageController.php
@@ -54,39 +54,21 @@ class FrmUsageController {
 	}
 
 	/**
-	 * Registers the filter that adds our custom cron schedule.
-	 *
-	 * The filter callback translates the schedule label, and 'cron_schedules' can be applied
-	 * at any point in the request, so this defers itself until the text domain has loaded.
-	 * Priority 0 keeps the schedule available to _wp_cron(), which runs on init at 10.
-	 *
-	 * @since x.x
-	 *
-	 * @return void
-	 */
-	public static function add_schedules_filter() {
-		if ( ! did_action( 'init' ) ) {
-			add_action( 'init', self::class . '::add_schedules_filter', 0 );
-			return;
-		}
-
-		add_filter( 'cron_schedules', self::class . '::add_schedules' );
-	}
-
-	/**
 	 * Adds once weekly to the existing schedules.
 	 *
-	 * @since 3.06.04
+	 * WordPress core registers an identical 'weekly' schedule of its own, so this adds nothing.
+	 * The 'cron_schedules' registration is gone, and with it the translated label that made
+	 * this run before the text domain loaded.
 	 *
-	 * @param array $schedules Schedules.
+	 * @since 3.06.04
+	 * @deprecated x.x
+	 *
+	 * @param array $schedules Unused. The registered cron schedules, keyed by schedule name.
 	 *
 	 * @return array
 	 */
 	public static function add_schedules( $schedules = array() ) {
-		$schedules['weekly'] = array(
-			'interval' => DAY_IN_SECONDS * 7,
-			'display'  => __( 'Once Weekly', 'formidable' ),
-		);
+		_deprecated_function( __METHOD__, 'x.x' );
 		return $schedules;
 	}
 


### PR DESCRIPTION
I just made this change to attempt to fix some early translation issues https://github.com/Strategy11/formidable-forms/pull/3311

But it felt like an anti-pattern.

This update simplifies things. It looks like WP has had `weekly` for long enough that we don't need to define it ourselves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved onboarding page loading by ensuring related setup actions run at the appropriate initialization stage.
  - Removed redundant custom scheduling behavior where the platform already provides an equivalent weekly schedule.

- **Refactor**
  - Simplified onboarding setup and usage tracking hook registration without changing the usage snapshot process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->