### PR TITLE
Update how paypal commerce action limit is set

### DIFF
--- a/classes/views/frm-form-actions/_action_icon.php
+++ b/classes/views/frm-form-actions/_action_icon.php
@@ -5,11 +5,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $limit = $action_control->action_options['limit'];
 
-if ( 'paypal' === $action_control->id_base ) {
-	// The PayPal add-on may overwrite this so change it back.
-	$limit = 1;
-}
-
 // Remove limit for Stripe action when Stripe add-on is active
 if ( 'stripe' === $action_control->id_base && class_exists( 'FrmStrpAppHelper' ) ) {
 	$limit = 99;

--- a/paypal/controllers/FrmPayPalLiteHooksController.php
+++ b/paypal/controllers/FrmPayPalLiteHooksController.php
@@ -50,6 +50,12 @@ class FrmPayPalLiteHooksController {
 			function ( $options ) {
 				// Make actions using the PayPal add-on use the same icon we use in Lite.
 				$options['classes'] = 'frmfont frm_paypal_icon';
+
+				// The PayPal add-on registers its own action for the 'paypal' id_base with a
+				// limit of 99. PayPal Commerce uses that id_base too, so set the limit back to
+				// one instead of inheriting the add-on's.
+				$options['limit'] = 1;
+
 				return $options;
 			}
 		);


### PR DESCRIPTION
This way we can filter it in Pro.

Related PR https://github.com/Strategy11/formidable-pro/pull/6612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - PayPal actions now respect their configured processing limits instead of being incorrectly restricted to one item.
  - PayPal Lite actions retain their one-item limit and no longer inherit the higher limit used by PayPal Commerce.
  - Stripe actions continue to use their existing limit behavior when the Stripe add-on is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->