### PR TITLE
Fix deprecated null passed to str_replace in get_field_value_for_new_entry

### DIFF
--- a/classes/helpers/FrmEntriesHelper.php
+++ b/classes/helpers/FrmEntriesHelper.php
@@ -128,8 +128,12 @@ class FrmEntriesHelper {
 			self::get_posted_value( $field, $new_value, $args );
 		}
 
+		// A field with no default value has a null default_value, and a field type
+		// whose value is not posted back leaves it null too. str_replace() warns on
+		// a null subject in PHP 8.1+, so cast first: this keeps returning the empty
+		// string the caller already relied on.
 		if ( ! is_array( $new_value ) ) {
-			return str_replace( '"', '&quot;', $new_value );
+			return str_replace( '"', '&quot;', (string) $new_value );
 		}
 
 		return $new_value;


### PR DESCRIPTION
## What this fixes

`FrmEntriesHelper::get_field_value_for_new_entry()` passes a possibly-null value to `str_replace()`, which emits a deprecation notice on PHP 8.1+:

```
Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
in /wp-content/plugins/formidable/classes/helpers/FrmEntriesHelper.php on line 132
```

`$new_value` starts as `$field->default_value`, which is `null` for a field that has no default value. It stays `null` when the field's value is not posted back either, and the `! is_array()` branch then hands that `null` straight to `str_replace()`.

It shows up on the front end of any form containing such a field whenever `WP_DEBUG_DISPLAY` is on.

## The change

```diff
+		// A field with no default value has a null default_value, and a field type
+		// whose value is not posted back leaves it null too. str_replace() warns on
+		// a null subject in PHP 8.1+, so cast first: this keeps returning the empty
+		// string the caller already relied on.
 		if ( ! is_array( $new_value ) ) {
-			return str_replace( '"', '&quot;', $new_value );
+			return str_replace( '"', '&quot;', (string) $new_value );
 		}
```

The cast rather than an early `return $new_value` is deliberate: the caller assigns the result to `$field_array['value']`, and PHP already coerced `null` to `''` here, so casting preserves the existing behaviour exactly instead of introducing `null` where callers expect a string.

## Verification

Checked with `error_reporting( E_ALL )` that the new expression returns the identical value to the old one for every input that reaches this branch:

| Input | Before | After | Same |
|---|---|---|---|
| `null` (no default value) | `''` + deprecation | `''` | yes |
| `''` | `''` | `''` | yes |
| `'Hello'` | `'Hello'` | `'Hello'` | yes |
| `'He said "hi"'` | `'He said &quot;hi&quot;'` | `'He said &quot;hi&quot;'` | yes |
| `0` | `'0'` | `'0'` | yes |
| `'0'` | `'0'` | `'0'` | yes |

Reported from a WordPress 7.1 / PHP 8.3 environment with Formidable 6.35; the same line is present on `master` today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented PHP 8.1+ warnings when creating new entries with empty or non-array field values.
  * Preserved existing empty-string behavior for affected fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->